### PR TITLE
Fix generator for plugins with parameterized or missing Components

### DIFF
--- a/src/project_config.zig
+++ b/src/project_config.zig
@@ -57,6 +57,12 @@ pub const Plugin = struct {
     /// Module name exported by the package (e.g., "pathfinding" for labelle-pathfinding)
     /// If not provided, defaults to the plugin name with hyphens replaced by underscores
     module: ?[]const u8 = null,
+    /// Components type exported by the plugin. If null, no Components are included.
+    /// Examples:
+    ///   - null: don't include any Components from this plugin (default)
+    ///   - "Components": use plugin.Components
+    ///   - "Components(MyItem)": use plugin.Components(MyItem) for parameterized types
+    components: ?[]const u8 = null,
 };
 
 /// Atlas resource declaration

--- a/src/templates/main_raylib.txt
+++ b/src/templates/main_raylib.txt
@@ -80,7 +80,7 @@ pub const Components = engine.ComponentRegistryMulti(.{{
 .component_registry_multi_base_end
     }},
 .component_registry_multi_plugin
-    {s}.Components,
+    {s}.{s},
 .component_registry_multi_end
 }});
 .script_registry_empty


### PR DESCRIPTION
## Summary

- Adds `components` field to Plugin struct to explicitly specify how to include plugin Components
- Generator now only uses `ComponentRegistryMulti` when at least one plugin specifies components
- Fixes compile errors when plugins don't export Components or use parameterized generic Components

## Usage

```zig
.plugins = .{
    // Plugin without Components - just omit the field (default: null)
    .{ .name = "labelle-pathfinding", .version = "2.5.0" },
    
    // Plugin with simple Components
    .{ .name = "labelle-physics", .version = "1.0.0", .components = "Components" },
    
    // Plugin with parameterized Components
    .{ .name = "labelle-tasks", .version = "0.3.0", .components = "Components(tasks.Item)" },
},
```

## Test plan

- [x] All 138 tests pass
- [x] example_1 (raylib) runs successfully
- [x] example_2 (sokol) runs successfully  
- [x] example_3 (raylib) runs successfully
- [x] example_4 (raylib) runs successfully
- [x] example_5 (raylib) runs successfully

Fixes #47

🤖 Generated with [Claude Code](https://claude.ai/code)