### PR TITLE
Fix loader to support components with required fields

### DIFF
--- a/src/zon_coercion.zig
+++ b/src/zon_coercion.zig
@@ -51,6 +51,7 @@ pub fn coerceValue(comptime FieldType: type, comptime data_value: anytype) Field
 
 /// Build a struct from comptime anonymous struct data.
 /// Recursively coerces nested fields.
+/// Raises compile error for missing required fields (fields without defaults).
 pub fn buildStruct(comptime StructType: type, comptime data: anytype) StructType {
     const fields = std.meta.fields(StructType);
     var result: StructType = undefined;
@@ -63,7 +64,7 @@ pub fn buildStruct(comptime StructType: type, comptime data: anytype) StructType
             const default_ptr: *const field.type = @ptrCast(@alignCast(ptr));
             @field(result, field.name) = default_ptr.*;
         } else {
-            @field(result, field.name) = std.mem.zeroes(field.type);
+            @compileError("Missing required field '" ++ field.name ++ "' for struct '" ++ @typeName(StructType) ++ "'");
         }
     }
 

--- a/test/nested_prefab_test.zig
+++ b/test/nested_prefab_test.zig
@@ -152,6 +152,16 @@ pub const ZON_COERCION = struct {
         try expect.equal(result.count, 5);
     }
 
+    test "buildStruct works with required fields when all provided" {
+        const TestStruct = struct {
+            required_value: i32, // No default - required
+            optional_value: u32 = 10,
+        };
+        const result = comptime zon.buildStruct(TestStruct, .{ .required_value = 42 });
+        try expect.equal(result.required_value, 42);
+        try expect.equal(result.optional_value, 10);
+    }
+
     test "tupleToSlice converts tuple to slice" {
         const result = comptime zon.tupleToSlice(i32, .{ 1, 2, 3 });
         try expect.equal(result.len, 3);


### PR DESCRIPTION
## Summary

- Changes component initialization from `.{}` to `undefined`
- Explicitly handles each field: provided value → default value → compile error
- Provides clear compile-time error message for missing required fields

## Before

```zig
// Components with required fields (no default) would fail:
pub const TaskItem = struct {
    item_type: ItemType,  // No default - causes ".{}" to fail
};
```

## After

```zig
// Now works - required fields must be provided in .zon:
.{ .components = .{ .TaskItem = .{ .item_type = .water } } }

// Missing required field gives clear error:
// error: Missing required field 'item_type' for component 'TaskItem'
```

## Test plan

- [x] All 138 tests pass
- [x] example_1 runs successfully

Fixes #51

🤖 Generated with [Claude Code](https://claude.ai/code)