### PR TITLE
Add allocator to game_init hook payload

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,7 +256,7 @@ The engine provides a type-safe, comptime-based hook system for observing engine
 - `scene_load` / `scene_unload` - Scene transitions
 - `entity_created` / `entity_destroyed` - Entity lifecycle
 
-> **Note on `game_init`:** This hook fires during `Game.init()` before the struct is in its final memory location. Handlers should not store or use `*Game` pointers. For logic requiring a stable Game pointer, use `scene_load` or call after `game.fixPointers()`.
+> **Note on `game_init`:** This hook fires during `Game.init()` before the struct is in its final memory location. Handlers should not store or use `*Game` pointers. For logic requiring a stable Game pointer, use `scene_load` or call after `game.fixPointers()`. The `game_init` payload includes an allocator for initializing subsystems.
 
 **Basic usage:**
 ```zig
@@ -264,7 +264,10 @@ const engine = @import("labelle-engine");
 
 // Define hook handlers
 const MyHooks = struct {
-    pub fn game_init(_: engine.HookPayload) void {
+    pub fn game_init(payload: engine.HookPayload) void {
+        const info = payload.game_init;
+        // Allocator available for early initialization
+        _ = info.allocator;
         std.log.info("Game started!", .{});
     }
 
@@ -285,7 +288,10 @@ const Game = engine.GameWith(MyHooks);
 const std = @import("std");
 const engine = @import("labelle-engine");
 
-pub fn game_init(_: engine.HookPayload) void {
+pub fn game_init(payload: engine.HookPayload) void {
+    const info = payload.game_init;
+    // Use allocator for early subsystem initialization
+    _ = info.allocator;
     std.log.info("Game started!", .{});
 }
 

--- a/src/game.zig
+++ b/src/game.zig
@@ -186,8 +186,8 @@ pub fn GameWith(comptime Hooks: type) type {
             .running = true,
         };
 
-        // Emit game_init hook
-        emitHook(.{ .game_init = {} });
+        // Emit game_init hook with allocator for early subsystem initialization
+        emitHook(.{ .game_init = .{ .allocator = allocator } });
 
         return game;
     }

--- a/src/hooks.zig
+++ b/src/hooks.zig
@@ -66,6 +66,7 @@ pub const FrameInfo = types.FrameInfo;
 pub const SceneInfo = types.SceneInfo;
 pub const EntityInfo = types.EntityInfo;
 pub const ComponentPayload = types.ComponentPayload;
+pub const GameInitInfo = types.GameInitInfo;
 
 // Re-export dispatcher
 pub const HookDispatcher = dispatcher.HookDispatcher;

--- a/src/hooks/types.zig
+++ b/src/hooks/types.zig
@@ -3,6 +3,7 @@
 //! Defines the core hook enum and payload union for engine lifecycle events.
 
 const std = @import("std");
+const Allocator = std.mem.Allocator;
 
 /// Built-in hooks for engine lifecycle events.
 /// Games can register handlers for any of these hooks.
@@ -54,10 +55,16 @@ pub const ComponentPayload = struct {
     entity_id: u64,
 };
 
+/// Game initialization info passed to game_init hook.
+pub const GameInitInfo = struct {
+    /// The allocator used by the game, available for initializing subsystems.
+    allocator: Allocator,
+};
+
 /// Type-safe payload union for engine hooks.
 /// Each hook type has its corresponding payload type.
 pub const HookPayload = union(EngineHook) {
-    game_init: void,
+    game_init: GameInitInfo,
     game_deinit: void,
     frame_start: FrameInfo,
     frame_end: FrameInfo,

--- a/src/scene.zig
+++ b/src/scene.zig
@@ -116,6 +116,7 @@ pub const FrameInfo = hooks.FrameInfo;
 pub const SceneInfo = hooks.SceneInfo;
 pub const EntityInfo = hooks.EntityInfo;
 pub const ComponentPayload = hooks.ComponentPayload;
+pub const GameInitInfo = hooks.GameInitInfo;
 
 /// Context passed to prefab lifecycle functions and scene loading
 /// Uses Game facade for unified access to ECS, pipeline, and engine

--- a/test/hooks_test.zig
+++ b/test/hooks_test.zig
@@ -12,6 +12,7 @@ const SceneInfo = hooks.SceneInfo;
 const EntityInfo = hooks.EntityInfo;
 const HookDispatcher = hooks.HookDispatcher;
 const EmptyDispatcher = hooks.EmptyDispatcher;
+const GameInitInfo = hooks.GameInitInfo;
 
 // Import factory definitions from .zon file
 const hook_payloads = @import("factories/hook_payloads.zon");
@@ -136,8 +137,17 @@ pub const ENTITY_INFO = struct {
 pub const HOOK_PAYLOAD = struct {
     pub const CREATION = struct {
         test "can create game_init payload" {
-            const payload: HookPayload = .{ .game_init = {} };
+            const payload: HookPayload = .{ .game_init = .{ .allocator = std.testing.allocator } };
             try expect.equal(std.meta.activeTag(payload), .game_init);
+        }
+
+        test "game_init payload has allocator" {
+            const payload: HookPayload = .{ .game_init = .{ .allocator = std.testing.allocator } };
+            const info = payload.game_init;
+            // Verify allocator is accessible and usable
+            const ptr = try info.allocator.alloc(u8, 16);
+            defer info.allocator.free(ptr);
+            try expect.equal(ptr.len, 16);
         }
 
         test "can create game_deinit payload" {
@@ -186,7 +196,7 @@ pub const HOOK_PAYLOAD = struct {
 
     test "all 8 payload types can be created" {
         const payloads = [_]HookPayload{
-            .{ .game_init = {} },
+            .{ .game_init = .{ .allocator = std.testing.allocator } },
             .{ .game_deinit = {} },
             .{ .frame_start = FirstFrameFactory.build(.{}) },
             .{ .frame_end = FirstFrameFactory.build(.{}) },
@@ -500,7 +510,7 @@ pub const MODULE_EXPORTS = struct {
     }
 
     test "hooks module exports HookPayload" {
-        const payload: engine.HookPayload = .{ .game_init = {} };
+        const payload: engine.HookPayload = .{ .game_init = .{ .allocator = std.testing.allocator } };
         _ = payload;
     }
 
@@ -516,6 +526,11 @@ pub const MODULE_EXPORTS = struct {
 
     test "hooks module exports EntityInfo" {
         const info = engine.EntityInfo{ .entity_id = 42 };
+        _ = info;
+    }
+
+    test "hooks module exports GameInitInfo" {
+        const info = engine.GameInitInfo{ .allocator = std.testing.allocator };
         _ = info;
     }
 


### PR DESCRIPTION
## Summary

- Add `GameInitInfo` struct with an `allocator` field to the `game_init` hook payload
- This enables subsystems to be initialized early in `game_init`, before component callbacks fire
- Export `GameInitInfo` from hooks module for user access as `engine.GameInitInfo`

Closes #89

## Motivation

When using component lifecycle callbacks (`onAdd`), components may need access to shared state that requires dynamic memory allocation. Previously, there was no way to get an allocator during `game_init`, which meant initialization had to be deferred to `scene_load` or later.

With this change, the `game_init` hook receives `GameInitInfo` with an allocator, allowing early initialization of plugins and shared state before any component callbacks fire.

## Usage

```zig
pub fn game_init(payload: engine.HookPayload) void {
    const info = payload.game_init;
    // Use info.allocator for early subsystem initialization
    my_subsystem.init(info.allocator);
}
```

## Test plan

- [x] All 335 tests pass
- [x] Updated existing tests that used `game_init = {}`
- [x] Added new test verifying allocator is accessible and usable
- [x] bakery-game builds successfully with the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)