### PR TITLE
Fix v0.28.0 package missing build_utils.zig

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0x246cb614beb913ae,
     .name = .labelle_engine,
-    .version = "0.28.0",
+    .version = "0.28.1",
     .minimum_zig_version = "0.15.2",
     .releases_url = "https://api.github.com/repos/labelle-toolkit/labelle-engine/releases/latest",
     .dependencies = .{
@@ -41,6 +41,7 @@
     .paths = .{
         "build.zig",
         "build.zig.zon",
+        "build_utils.zig",
         "src",
         "test",
         "usage",


### PR DESCRIPTION
## Summary
- Add `build_utils.zig` to the `.paths` array in `build.zig.zon`
- Bump version to 0.28.1

## Problem
The v0.28.0 release is broken because `build_utils.zig` was not included in the package paths. When projects try to use labelle-engine v0.28.0 as a dependency, they get:

```
error: unable to load 'build_utils.zig': FileNotFound
```

## Fix
Include `build_utils.zig` in the `.paths` array so it's part of the published package.

## Test plan
- [x] Verified build_utils.zig exists in the repo
- [ ] After merge, tag v0.28.1 and verify projects can use it

🤖 Generated with [Claude Code](https://claude.com/claude-code)