### PR TITLE
Emit scene_before_load and scene_load hooks for initial scene

### DIFF
--- a/src/templates/main_raylib.txt
+++ b/src/templates/main_raylib.txt
@@ -157,8 +157,15 @@ pub fn main() !void {{
     }}
 
     const ctx = engine.SceneContext.init(&game);
+
+    // Emit scene_before_load hook for initial scene (mirrors Game.setScene behavior)
+    Game.HookDispatcher.emit(.{{ .scene_before_load = .{{ .name = initial_scene.name, .allocator = allocator }} }});
+
     var scene = try Loader.load(initial_scene, ctx);
     defer scene.deinit();
+
+    // Emit scene_load hook for initial scene (mirrors Game.setScene behavior)
+    Game.HookDispatcher.emit(.{{ .scene_load = .{{ .name = initial_scene.name }} }});
 
     if (ci_test) return;
 


### PR DESCRIPTION
## Summary
- Adds `scene_before_load` and `scene_load` hook emissions for the initial scene in the main template
- Ensures consistent hook behavior between initial scene loading and subsequent scene changes via `Game.setScene`
- Fixes issue #109

## Test plan
- [ ] Verify that `scene_before_load` hook is called before the initial scene loads
- [ ] Verify that `scene_load` hook is called after the initial scene loads
- [ ] Confirm hooks receive correct scene name and allocator parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)