### PR TITLE
feat(sokol): Update to labelle-gfx v0.17.0 with lazy sgl init

### DIFF
--- a/src/templates/build_zig.txt
+++ b/src/templates/build_zig.txt
@@ -71,6 +71,7 @@ pub fn build(b: *std.Build) void {{
         .optimize = optimize,
     }});
     const sokol_mod = sokol_dep.module("sokol");
+    const labelle_gfx_mod = labelle_dep.module("labelle");
 
     const exe = b.addExecutable(.{{
         .name = "{s}",
@@ -81,6 +82,7 @@ pub fn build(b: *std.Build) void {{
             .imports = &.{{
                 .{{ .name = "labelle-engine", .module = engine_mod }},
                 .{{ .name = "sokol", .module = sokol_mod }},
+                .{{ .name = "labelle-gfx", .module = labelle_gfx_mod }},
 .sokol_exe_end
             }},
         }}),


### PR DESCRIPTION
## Summary

Updates the sokol backend integration to use labelle-gfx v0.17.0 which includes lazy initialization of sokol_gl.

### Changes

**build.zig.zon:**
- Updated labelle-gfx dependency from v0.16.0 to v0.17.0

**src/templates/main_sokol.txt:**
- Removed manual `sgl.setup()` call in init callback
- Use `SokolBackend.beginDrawing()` instead of manual sgl matrix setup
- Use `SokolBackend.endDrawing()` instead of `sgl.draw()`
- Use `SokolBackend.shutdown()` instead of `sgl.shutdown()`
- Updated example to use `SokolBackend.drawRectangleV()` instead of raw sgl calls

**src/templates/build_zig.txt:**
- Added `labelle-gfx` module import for sokol projects

## Test plan

- [x] All 338 tests pass
- [x] Build compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)