### PR TITLE
chore: Update labelle-gfx dependency to v0.19.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -14,8 +14,8 @@
             .hash = "zflecs-0.2.0-dev-1PN3ym9mOgCyE8w0DdK_Uf7FAob-nm0Dp_lZKR3QyJaC",
         },
         .@"labelle-gfx" = .{
-            .url = "git+https://github.com/labelle-toolkit/labelle-gfx?ref=v0.17.0#3b8475a8c67139ba341a72aaf0f5aaaee7344455",
-            .hash = "labelle_gfx-0.17.0-WZ2XcABoBwApqTqj-CgwuAwUVG43Z9uaox1UFiJ3d8o4",
+            .url = "git+https://github.com/labelle-toolkit/labelle-gfx?ref=v0.19.0#7aab329a11f0b896da84eb5d5e9303c5b5fd807f",
+            .hash = "labelle_gfx-0.19.0-WZ2XcLDGCQBXE7vt4mWicpPZi1R6PVPPL9g_NltGjNdu",
         },
         .zspec = .{
             .url = "git+https://github.com/apotema/zspec#71c901d6e74b2d5a8c556d4c74ced9b91446d8a4",


### PR DESCRIPTION
## Summary
Updates labelle-gfx from v0.17.0 to v0.19.0.

## Changes in labelle-gfx

### v0.18.0 - bgfx Backend
- New bgfx rendering backend with Metal/DirectX/OpenGL/Vulkan support
- fix(sokol): Lazy initialize sokol_gl before use
- perf(bgfx): Improve texture loading with shared allocator

### v0.19.0 - zgpu Backend (WebGPU)
- New zgpu backend for WebGPU rendering via Dawn
- Sprite batching to reduce draw calls
- Shape vertex/index buffer reuse across frames

## Test plan
- [x] All 348 tests pass

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)