### PR TITLE
fix: correct module names and add library linking for bgfx/zgpu backends

### DIFF
--- a/tools/templates/build_zig.txt
+++ b/tools/templates/build_zig.txt
@@ -122,7 +122,7 @@ pub fn build(b: *std.Build) void {{
         .optimize = optimize,
     }});
     const zbgfx_mod = zbgfx_dep.module("zbgfx");
-    const zglfw_mod = zglfw_dep.module("zglfw");
+    const zglfw_mod = zglfw_dep.module("root");
     const labelle_gfx_mod = labelle_dep.module("labelle");
 
     const exe = b.addExecutable(.{{
@@ -140,6 +140,8 @@ pub fn build(b: *std.Build) void {{
             }},
         }}),
     }});
+    exe.linkLibrary(zbgfx_dep.artifact("bgfx"));
+    exe.linkLibrary(zglfw_dep.artifact("glfw"));
 .zgpu_exe_start
     // Get labelle-gfx dependency for zgpu bindings
     const labelle_dep = engine_dep.builder.dependency("labelle-gfx", .{{
@@ -154,8 +156,8 @@ pub fn build(b: *std.Build) void {{
         .target = target,
         .optimize = optimize,
     }});
-    const zgpu_mod = zgpu_dep.module("zgpu");
-    const zglfw_mod = zglfw_dep.module("zglfw");
+    const zgpu_mod = zgpu_dep.module("root");
+    const zglfw_mod = zglfw_dep.module("root");
     const labelle_gfx_mod = labelle_dep.module("labelle");
 
     const exe = b.addExecutable(.{{
@@ -173,6 +175,7 @@ pub fn build(b: *std.Build) void {{
             }},
         }}),
     }});
+    exe.linkLibrary(zglfw_dep.artifact("glfw"));
 .plugin_import
                 .{{ .name = "{s}", .module = {s}_mod }},
 .footer


### PR DESCRIPTION
## Summary
- Fixed zglfw module name from `"zglfw"` to `"root"` (matching labelle-gfx)
- Fixed zgpu module name from `"zgpu"` to `"root"` (matching labelle-gfx)
- Added library linking for bgfx backend (bgfx + glfw)
- Added library linking for zgpu backend (glfw)

## Issue Status

| Issue | Status |
|-------|--------|
| #188 (bgfx missing zglfw) | ✅ Fixed |
| #189 (zgpu missing zgpu) | ⚠️ Partially fixed |

The bgfx example now builds successfully.

The zgpu example progresses past module resolution but fails on a **separate issue** in labelle-gfx - `zgpu_backend.zig` has a `loadTexture` signature mismatch. This is a labelle-gfx bug, not a generator issue.

## Test plan
- [x] Regenerate bgfx example: `cd usage/example_bgfx && zig build generate`
- [x] Build bgfx example: `cd .labelle && zig build` - ✅ Success
- [x] Regenerate zgpu example: `cd usage/example_zgpu && zig build generate`
- [x] Build zgpu example: Module resolution works, but fails on labelle-gfx bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)