### PR TITLE
refactor: split build.zig into modular helpers

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,4 +1,7 @@
 const std = @import("std");
+const platform_ios = @import("build_helpers/platform_ios.zig");
+const deps_gui = @import("build_helpers/deps_gui.zig");
+const deps_graphics = @import("build_helpers/deps_graphics.zig");
 
 /// Graphics backend selection
 pub const Backend = enum {
@@ -31,18 +34,10 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    // Detect iOS target (raylib, SDL, etc. not supported on iOS)
+    // Platform detection
     const is_ios = target.result.os.tag == .ios;
-
-    // Detect iOS simulator on ARM - needs special handling for NEON intrinsics
-    // iOS simulator on Apple Silicon (aarch64) doesn't fully support all NEON intrinsics
-    // Note: Only apply ARM-specific workarounds on aarch64, not x86_64 simulators
     const is_ios_simulator = is_ios and target.result.abi == .simulator and target.result.cpu.arch == .aarch64;
-
-    // Detect WASM/Emscripten target (only sokol backend supported)
     const is_wasm = target.result.os.tag == .emscripten or target.result.cpu.arch == .wasm32;
-
-    // Desktop-only flag (not iOS and not WASM)
     const is_desktop = !is_ios and !is_wasm;
 
     // Build options
@@ -51,62 +46,47 @@ pub fn build(b: *std.Build) void {
     const gui_backend = b.option(GuiBackend, "gui_backend", "GUI backend to use (default: none)") orelse .none;
     const physics_enabled = b.option(bool, "physics", "Enable physics module (Box2D)") orelse false;
 
-    // ECS dependencies
-    // zig_ecs is pure Zig - always available
-    const ecs_dep = b.dependency("zig_ecs", .{
-        .target = target,
-        .optimize = optimize,
-    });
+    // ==========================================================================
+    // ECS Dependencies
+    // ==========================================================================
+
+    // zig_ecs - pure Zig, always available
+    const ecs_dep = b.dependency("zig_ecs", .{ .target = target, .optimize = optimize });
     const zig_ecs_module = ecs_dep.module("zig-ecs");
 
-    // zflecs contains C code (flecs.c) that requires libc
-    // Skip for WASM since Emscripten's libc handling is problematic with Zig
+    // zflecs - C code, skip on WASM
     const zflecs_dep: ?*std.Build.Dependency = if (!is_wasm) b.dependency("zflecs", .{
         .target = target,
         .optimize = optimize,
     }) else null;
     const zflecs_module: ?*std.Build.Module = if (zflecs_dep) |dep| dep.module("root") else null;
 
-    // For iOS, add SDK paths to zflecs artifact (C library needs system headers)
-    // Note: getSdk() returns null for cross-compilation, so we use explicit paths
+    // Configure zflecs for iOS
     if (is_ios and zflecs_dep != null) {
-        const zflecs_artifact = zflecs_dep.?.artifact("flecs");
-
-        // Select SDK based on target ABI (simulator vs device)
-        if (target.result.abi == .simulator) {
-            zflecs_artifact.root_module.addSystemIncludePath(.{ .cwd_relative = "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/usr/include" });
-            zflecs_artifact.root_module.addLibraryPath(.{ .cwd_relative = "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/usr/lib" });
-        } else {
-            zflecs_artifact.root_module.addSystemIncludePath(.{ .cwd_relative = "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/include" });
-            zflecs_artifact.root_module.addLibraryPath(.{ .cwd_relative = "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/lib" });
-        }
+        platform_ios.configureZflecs(zflecs_dep.?, target.result);
     }
 
-    // mr_ecs module - only loaded when explicitly selected and not on WASM (requires Zig 0.16+)
-    // Note: mr_ecs may have C dependencies, skip for WASM
+    // mr_ecs - only when selected, skip on WASM
     const mr_ecs_module: ?*std.Build.Module = if (ecs_backend == .mr_ecs and !is_wasm) blk: {
-        const mr_ecs_dep = b.dependency("mr_ecs", .{
-            .target = target,
-            .optimize = optimize,
-        });
+        const mr_ecs_dep = b.dependency("mr_ecs", .{ .target = target, .optimize = optimize });
         break :blk mr_ecs_dep.module("mr_ecs");
     } else null;
 
-    // labelle-gfx dependency - handles iOS internally (skips raylib for iOS)
-    const labelle_dep = b.dependency("labelle-gfx", .{
-        .target = target,
-        .optimize = optimize,
-    });
+    // ==========================================================================
+    // Graphics Dependencies
+    // ==========================================================================
+
+    // labelle-gfx - handles iOS internally
+    const labelle_dep = b.dependency("labelle-gfx", .{ .target = target, .optimize = optimize });
     const labelle = labelle_dep.module("labelle");
 
-    // raylib module - get from labelle-gfx's re-exported module (desktop only)
-    // labelle-gfx uses the raylib-zig fork with getGLFWWindow() for ImGui integration
+    // raylib - from labelle-gfx (desktop only)
     const raylib: ?*std.Build.Module = if (is_desktop) labelle_dep.builder.modules.get("raylib") else null;
 
-    // sokol dependency - DO NOT pass with_sokol_imgui here as it changes the
-    // dependency hash and conflicts with labelle-gfx's sokol. For ImGui support,
-    // we'll compile sokol_imgui separately (similar to rlImGui approach).
-    // For iOS/WASM, we need to pass dont_link_system_libs and handle SDK/sysroot manually.
+    // SDL - from labelle-gfx (desktop only)
+    const sdl: ?*std.Build.Module = if (is_desktop) labelle_dep.builder.modules.get("sdl") else null;
+
+    // sokol - for iOS/WASM, don't link system libs
     const sokol_dep = b.dependency("sokol", .{
         .target = target,
         .optimize = optimize,
@@ -114,99 +94,39 @@ pub fn build(b: *std.Build) void {
     });
     const sokol = sokol_dep.module("sokol");
 
-    // For iOS, add SDK paths to sokol_clib artifact
-    // Workaround for Zig bug #22704 where sysroot doesn't affect framework search paths
-    // Note: getSdk() returns null for cross-compilation, so we use explicit paths
+    // Configure sokol for iOS
     if (is_ios) {
-        const sokol_clib = sokol_dep.artifact("sokol_clib");
-
-        // Select SDK based on target ABI (simulator vs device)
-        if (target.result.abi == .simulator) {
-            sokol_clib.root_module.addSystemFrameworkPath(.{ .cwd_relative = "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/Frameworks" });
-            sokol_clib.root_module.addSystemFrameworkPath(.{ .cwd_relative = "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/System/Library/SubFrameworks" });
-            sokol_clib.root_module.addSystemIncludePath(.{ .cwd_relative = "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/usr/include" });
-            sokol_clib.root_module.addLibraryPath(.{ .cwd_relative = "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/usr/lib" });
-        } else {
-            sokol_clib.root_module.addSystemFrameworkPath(.{ .cwd_relative = "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/Frameworks" });
-            sokol_clib.root_module.addSystemFrameworkPath(.{ .cwd_relative = "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/System/Library/SubFrameworks" });
-            sokol_clib.root_module.addSystemIncludePath(.{ .cwd_relative = "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/include" });
-            sokol_clib.root_module.addLibraryPath(.{ .cwd_relative = "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/lib" });
-        }
+        platform_ios.configureSokol(sokol_dep, target.result);
     }
 
-    // SDL module - get from labelle-gfx's re-exported module (desktop only)
-    // labelle-gfx v0.15.0+ re-exports SDL to avoid Zig module conflicts
-    const sdl: ?*std.Build.Module = if (is_desktop) labelle_dep.builder.modules.get("sdl") else null;
+    // Desktop-only graphics deps (zbgfx, zgpu, wgpu_native, zglfw, zaudio)
+    const gfx_deps = if (is_desktop)
+        deps_graphics.loadDesktopDeps(labelle_dep, b, target, optimize)
+    else
+        deps_graphics.emptyDeps();
 
-    // zbgfx, zgpu, wgpu_native, zglfw - desktop only
-    const zbgfx: ?*std.Build.Module = if (is_desktop) blk: {
-        const zbgfx_dep = labelle_dep.builder.dependency("zbgfx", .{
-            .target = target,
-            .optimize = optimize,
-        });
-        break :blk zbgfx_dep.module("zbgfx");
-    } else null;
+    // ==========================================================================
+    // Other Dependencies
+    // ==========================================================================
 
-    const zgpu: ?*std.Build.Module = if (is_desktop) blk: {
-        const zgpu_dep = labelle_dep.builder.dependency("zgpu", .{
-            .target = target,
-            .optimize = optimize,
-        });
-        break :blk zgpu_dep.module("root");
-    } else null;
-
-    // wgpu_native - lower-level WebGPU bindings (alternative to zgpu)
-    const wgpu_native: ?*std.Build.Module = if (is_desktop) blk: {
-        const wgpu_native_dep = labelle_dep.builder.dependency("wgpu_native_zig", .{
-            .target = target,
-            .optimize = optimize,
-        });
-        break :blk wgpu_native_dep.module("wgpu");
-    } else null;
-
-    // zglfw - GLFW bindings for zgpu/wgpu_native (desktop only)
-    const zglfw: ?*std.Build.Module = if (is_desktop) blk: {
-        const zglfw_dep = labelle_dep.builder.dependency("zglfw", .{
-            .target = target,
-            .optimize = optimize,
-        });
-        break :blk zglfw_dep.module("root");
-    } else null;
-
-    // zaudio (miniaudio wrapper) for sokol/SDL audio backends
-    // Note: zaudio is disabled on iOS/WASM because miniaudio requires Objective-C compilation
-    // for AVFoundation.h, but zaudio compiles it as C. Will need Sokol audio backend for iOS/WASM.
-    const zaudio_dep: ?*std.Build.Dependency = if (is_desktop) b.dependency("zaudio", .{
-        .target = target,
-        .optimize = optimize,
-    }) else null;
-    const zaudio: ?*std.Build.Module = if (zaudio_dep) |dep| dep.module("root") else null;
-
-    const zspec_dep = b.dependency("zspec", .{
-        .target = target,
-        .optimize = optimize,
-    });
+    const zspec_dep = b.dependency("zspec", .{ .target = target, .optimize = optimize });
     const zspec = zspec_dep.module("zspec");
 
-    const zts_dep = b.dependency("zts", .{
-        .target = target,
-        .optimize = optimize,
-    });
+    const zts_dep = b.dependency("zts", .{ .target = target, .optimize = optimize });
     const zts = zts_dep.module("zts");
 
-    // Clay UI dependency (Zig bindings)
-    // Skip for WASM - Clay is a C library that requires libc
-    // Skip for iOS simulator - Clay's SIMD code doesn't work on the simulator and
-    // zclay doesn't expose its clay artifact for us to add CLAY_DISABLE_SIMD
-    const zclay_dep: ?*std.Build.Dependency = if (!is_wasm and !is_ios_simulator) b.dependency("zclay", .{
-        .target = target,
-        .optimize = optimize,
-    }) else null;
+    // Clay UI - skip on WASM and iOS simulator (SIMD issues)
+    const zclay_dep: ?*std.Build.Dependency = if (!is_wasm and !is_ios_simulator)
+        b.dependency("zclay", .{ .target = target, .optimize = optimize })
+    else
+        null;
     const zclay: ?*std.Build.Module = if (zclay_dep) |dep| dep.module("zclay") else null;
 
-    // Build options module for compile-time configuration (create once, reuse everywhere)
-    const build_options = b.addOptions();
+    // ==========================================================================
+    // Build Options Module
+    // ==========================================================================
 
+    const build_options = b.addOptions();
     build_options.addOption(Backend, "backend", backend);
     build_options.addOption(EcsBackend, "ecs_backend", ecs_backend);
     build_options.addOption(GuiBackend, "gui_backend", gui_backend);
@@ -218,22 +138,22 @@ pub fn build(b: *std.Build) void {
     build_options.addOption(bool, "has_zflecs", zflecs_module != null);
     const build_options_mod = build_options.createModule();
 
-    // Physics module (optional, enabled with -Dphysics=true)
+    // ==========================================================================
+    // Physics Module (optional)
+    // ==========================================================================
+
     var physics_module: ?*std.Build.Module = null;
     if (physics_enabled) {
-        const box2d_dep = b.dependency("box2d", .{
-            .target = target,
-            .optimize = optimize,
-        });
+        const box2d_dep = b.dependency("box2d", .{ .target = target, .optimize = optimize });
 
-        const box2d_artifact = box2d_dep.artifact("box2d");
-
-        // For iOS simulator, disable SIMD to avoid NEON intrinsic issues
-        if (is_ios_simulator) {
-            box2d_artifact.root_module.addCMacro("BOX2D_DISABLE_SIMD", "1");
+        // Configure Box2D for iOS
+        if (is_ios) {
+            platform_ios.configureBox2d(box2d_dep, target.result, is_ios_simulator);
+        } else if (is_ios_simulator) {
+            // Disable SIMD on iOS simulator
+            box2d_dep.artifact("box2d").root_module.addCMacro("BOX2D_DISABLE_SIMD", "1");
         }
 
-        // Create physics module first (needed for iOS SDK path addition below)
         physics_module = b.addModule("labelle-physics", .{
             .root_source_file = b.path("physics/mod.zig"),
             .target = target,
@@ -242,24 +162,17 @@ pub fn build(b: *std.Build) void {
         physics_module.?.addImport("box2d", box2d_dep.module("box2d"));
         physics_module.?.linkLibrary(box2d_dep.artifact("box2d"));
 
-        // For iOS (device or simulator), add SDK paths to box2d artifact (C library needs system headers)
+        // Add iOS SDK include path for @cImport
         if (is_ios) {
-            const ios_sdk_path = std.zig.system.darwin.getSdk(b.allocator, &target.result);
-            if (ios_sdk_path) |sdk| {
-                const inc_path = b.pathJoin(&.{ sdk, "usr", "include" });
-                const lib_path = b.pathJoin(&.{ sdk, "usr", "lib" });
-
-                box2d_artifact.root_module.addSystemIncludePath(.{ .cwd_relative = inc_path });
-                box2d_artifact.root_module.addLibraryPath(.{ .cwd_relative = lib_path });
-
-                // Also add to the physics module for @cImport
-                physics_module.?.addSystemIncludePath(.{ .cwd_relative = inc_path });
-            }
+            platform_ios.addModuleIncludePath(physics_module.?, target.result);
         }
     }
 
-    // Create the ECS interface module that wraps the selected backend
-    // For WASM, only zig_ecs is available (no C-based backends)
+    // ==========================================================================
+    // Interface Modules
+    // ==========================================================================
+
+    // ECS interface
     const ecs_interface = b.addModule("ecs", .{
         .root_source_file = b.path("ecs/interface.zig"),
         .target = target,
@@ -269,401 +182,114 @@ pub fn build(b: *std.Build) void {
             .{ .name = "zig_ecs", .module = zig_ecs_module },
         },
     });
-    // Add zflecs if available (not on WASM - C code requires libc)
-    if (zflecs_module) |m| {
-        ecs_interface.addImport("zflecs", m);
-    }
-    // Add mr_ecs if selected (requires Zig 0.16+, not on WASM)
-    if (mr_ecs_module) |m| {
-        ecs_interface.addImport("mr_ecs", m);
-    }
+    if (zflecs_module) |m| ecs_interface.addImport("zflecs", m);
+    if (mr_ecs_module) |m| ecs_interface.addImport("mr_ecs", m);
 
-    // Create the Input interface module that wraps the selected backend
-    // Imports are conditional based on platform (iOS/WASM only have sokol)
-    const input_interface = b.addModule("input", .{
-        .root_source_file = b.path("input/interface.zig"),
-        .target = target,
-        .optimize = optimize,
-        .imports = if (is_desktop) &.{
-            .{ .name = "build_options", .module = build_options_mod },
-            .{ .name = "raylib", .module = raylib.? },
-            .{ .name = "sokol", .module = sokol },
-            .{ .name = "sdl2", .module = sdl.? },
-            .{ .name = "zglfw", .module = zglfw.? }, // For zgpu/wgpu_native input
-        } else &.{
-            .{ .name = "build_options", .module = build_options_mod },
-            .{ .name = "sokol", .module = sokol },
-        },
-    });
+    // Input interface
+    const input_interface = deps_graphics.createInputModule(
+        b,
+        target,
+        optimize,
+        build_options_mod,
+        raylib,
+        sokol,
+        sdl,
+        gfx_deps.zglfw,
+        is_desktop,
+    );
 
-    // Create the Graphics interface module that wraps the selected backend
-    // This allows plugins to use graphics types without pulling in specific backend modules
-    // Note: labelle-gfx handles iOS internally (only sokol backend available on iOS)
-    const graphics_interface = b.addModule("graphics", .{
-        .root_source_file = b.path("graphics/interface.zig"),
-        .target = target,
-        .optimize = optimize,
-        .imports = &.{
-            .{ .name = "build_options", .module = build_options_mod },
-            .{ .name = "labelle", .module = labelle },
-        },
-    });
+    // Graphics interface
+    const graphics_interface = deps_graphics.createGraphicsModule(
+        b,
+        target,
+        optimize,
+        build_options_mod,
+        labelle,
+    );
 
-    // Create the Audio interface module that wraps the selected backend
-    // On iOS/WASM, uses sokol_audio backend (no zaudio - miniaudio requires Objective-C/special build)
-    const audio_interface = b.addModule("audio", .{
-        .root_source_file = b.path("audio/interface.zig"),
-        .target = target,
-        .optimize = optimize,
-        .imports = if (is_desktop) &.{
-            .{ .name = "build_options", .module = build_options_mod },
-            .{ .name = "raylib", .module = raylib.? },
-            .{ .name = "zaudio", .module = zaudio.? },
-        } else &.{
-            // iOS/WASM: uses sokol_audio backend
-            .{ .name = "build_options", .module = build_options_mod },
-            .{ .name = "sokol", .module = sokol },
-        },
-    });
+    // Audio interface
+    const audio_interface = deps_graphics.createAudioModule(
+        b,
+        target,
+        optimize,
+        build_options_mod,
+        raylib,
+        sokol,
+        gfx_deps.zaudio,
+        is_desktop,
+    );
 
-    // Link miniaudio library for audio module (only needed for sokol/SDL backends on desktop)
-    if (backend != .raylib and zaudio_dep != null) {
-        audio_interface.linkLibrary(zaudio_dep.?.artifact("miniaudio"));
+    // Link miniaudio for sokol/SDL backends on desktop
+    if (backend != .raylib and gfx_deps.zaudio_dep != null) {
+        deps_graphics.configureAudioMiniaudio(audio_interface, gfx_deps.zaudio_dep.?);
     }
 
-    // Link sokol library for iOS/WASM audio (sokol_audio backend)
+    // Link sokol_audio for iOS/WASM
     if (is_ios or is_wasm) {
-        audio_interface.linkLibrary(sokol_dep.artifact("sokol_clib"));
+        deps_graphics.configureAudioSokol(audio_interface, sokol_dep);
     }
 
-    // Nuklear module (optional, loaded when gui_backend is nuklear)
-    const nuklear_module: ?*std.Build.Module = if (gui_backend == .nuklear) blk: {
-        const nuklear_dep = b.dependency("nuklear", .{
-            .target = target,
-            .optimize = optimize,
-            .link_libc = true,
-            .vertex_backend = true,
-            .font_baking = true,
-            .default_font = true,
-            .no_stb_rect_pack = true, // Raylib already provides stb_rect_pack
-        });
-        break :blk nuklear_dep.module("nuklear");
-    } else null;
+    // ==========================================================================
+    // GUI Module
+    // ==========================================================================
 
-    // zgui/ImGui dependency (optional, loaded when gui_backend is imgui)
-    // Note: sokol uses dcimgui instead of zgui for ImGui integration
-    const zgui_dep: ?*std.Build.Dependency = if (gui_backend == .imgui and backend != .sokol) blk: {
-        // zgui backend enum matches zgui/build.zig Backend enum
-        const ZguiBackend = enum {
-            no_backend,
-            glfw_wgpu,
-            glfw_opengl3,
-            glfw_vulkan,
-            glfw_dx12,
-            win32_dx12,
-            glfw,
-            sdl2_opengl3,
-            osx_metal,
-            sdl2,
-            sdl2_renderer,
-            sdl3,
-            sdl3_opengl3,
-            sdl3_renderer,
-            sdl3_gpu,
-        };
+    // Load GUI backend dependencies
+    const nuklear_module: ?*std.Build.Module = if (gui_backend == .nuklear)
+        deps_gui.loadNuklear(b, target, optimize)
+    else
+        null;
 
-        // Select appropriate zgui backend based on graphics backend
-        const zgui_backend: ZguiBackend = switch (backend) {
-            .raylib => .no_backend, // raylib uses rlImGui for ImGui integration
-            .sokol => unreachable, // sokol uses dcimgui, not zgui
-            .sdl => .sdl2_renderer, // SDL uses SDL2 renderer
-            .bgfx => .glfw, // bgfx uses GLFW (rendering handled separately)
-            .zgpu => .glfw_wgpu, // zgpu uses GLFW+WebGPU
-            .wgpu_native => .no_backend, // wgpu_native uses custom ImGui adapter
-        };
+    const zgui_dep: ?*std.Build.Dependency = if (gui_backend == .imgui and backend != .sokol)
+        deps_gui.loadZgui(b, target, optimize, @as(deps_gui.Backend, @enumFromInt(@intFromEnum(backend))))
+    else
+        null;
 
-        // SDL2 renderer backend needs obsolete functions (GetTexDataAsRGBA32, SetTexID)
-        const needs_obsolete = (zgui_backend == .sdl2_renderer);
+    const cimgui_dep: ?*std.Build.Dependency = if (gui_backend == .imgui and backend == .sokol)
+        deps_gui.loadCimgui(b, target, optimize)
+    else
+        null;
 
-        break :blk b.dependency("zgui", .{
-            .target = target,
-            .optimize = optimize,
-            .backend = zgui_backend,
-            .disable_obsolete = !needs_obsolete,
-        });
-    } else null;
-
-    // dcimgui dependency for sokol + ImGui integration
-    // sokol uses dcimgui + sokol_imgui instead of zgui
-    // Note: We compile sokol_imgui.c separately to avoid modifying sokol's dependency hash
-    const cimgui_dep: ?*std.Build.Dependency = if (gui_backend == .imgui and backend == .sokol) blk: {
-        break :blk b.dependency("cimgui", .{
-            .target = target,
-            .optimize = optimize,
-        });
-    } else null;
-
-    // Create the GUI interface module that wraps the selected backend
-    // Imports are conditional based on platform (iOS/WASM only have sokol)
-    // zclay is skipped for WASM (C library requires libc)
-    const gui_interface = b.addModule("gui", .{
-        .root_source_file = b.path("gui/mod.zig"),
+    // Create GUI module
+    const gui_context = deps_gui.GuiContext{
+        .b = b,
         .target = target,
         .optimize = optimize,
-        .imports = if (is_desktop) &.{
-            .{ .name = "build_options", .module = build_options_mod },
-            .{ .name = "raylib", .module = raylib.? },
-            .{ .name = "sokol", .module = sokol },
-            .{ .name = "sdl2", .module = sdl.? },
-            .{ .name = "zbgfx", .module = zbgfx.? },
-            .{ .name = "zgpu", .module = zgpu.? },
-            .{ .name = "wgpu", .module = wgpu_native.? }, // For wgpu_native ImGui adapter
-            .{ .name = "labelle", .module = labelle }, // For zgpu/wgpu_native context access
-            .{ .name = "zglfw", .module = zglfw.? }, // For GLFW window access
-        } else &.{
-            // iOS/WASM: reduced imports, only sokol backend
-            .{ .name = "build_options", .module = build_options_mod },
-            .{ .name = "sokol", .module = sokol },
-        },
-    });
-    // Add zclay if available (not on WASM - C code requires libc)
-    if (zclay) |m| {
-        gui_interface.addImport("zclay", m);
-    }
+        .gui_backend = @as(deps_gui.GuiBackend, @enumFromInt(@intFromEnum(gui_backend))),
+        .graphics_backend = @as(deps_gui.Backend, @enumFromInt(@intFromEnum(backend))),
+        .is_desktop = is_desktop,
+        .is_ios = is_ios,
+        .is_wasm = is_wasm,
+        .labelle_dep = labelle_dep,
+        .sokol_dep = sokol_dep,
+        .raylib = raylib,
+        .sdl = sdl,
+        .zbgfx = gfx_deps.zbgfx,
+        .zgpu = gfx_deps.zgpu,
+        .wgpu_native = gfx_deps.wgpu_native,
+        .zglfw = gfx_deps.zglfw,
+        .labelle = labelle,
+        .sokol = sokol,
+        .zclay = zclay,
+        .build_options_mod = build_options_mod,
+    };
 
-    // Add nuklear module to GUI if using nuklear backend
+    const gui_interface = deps_gui.createGuiModule(gui_context);
+
+    // Configure GUI backend
     if (nuklear_module) |nk| {
-        gui_interface.addImport("nuklear", nk);
+        deps_gui.configureNuklear(gui_interface, nk);
     }
-
-    // Add zgui module and link library to GUI if using imgui backend
     if (zgui_dep) |dep| {
-        gui_interface.addImport("zgui", dep.module("root"));
-        gui_interface.linkLibrary(dep.artifact("imgui"));
-
-        // Link OpenGL framework on macOS for glfw_opengl3 backend
-        // Note: sokol uses cimgui_dep instead of zgui_dep, so only raylib is relevant here
-        if (target.result.os.tag == .macos and backend == .raylib) {
-            gui_interface.linkFramework("OpenGL", .{});
-        }
-
-        // For raylib backend, compile and link rlImGui (raylib + ImGui bridge)
-        if (backend == .raylib) {
-            const rlimgui_dep = b.dependency("rlimgui", .{});
-            const raylib_zig_dep = labelle_dep.builder.dependency("raylib_zig", .{
-                .target = target,
-                .optimize = optimize,
-            });
-
-            // Create a module for rlImGui C++ sources
-            const rlimgui_mod = b.createModule(.{
-                .target = target,
-                .optimize = optimize,
-                .link_libcpp = true,
-            });
-
-            // Add rlImGui source file
-            rlimgui_mod.addCSourceFile(.{
-                .file = rlimgui_dep.path("rlImGui.cpp"),
-                .flags = &.{
-                    "-std=c++11",
-                    "-fno-sanitize=undefined",
-                    "-DNO_FONT_AWESOME", // Disable Font Awesome (optional feature)
-                },
-            });
-
-            // Add include paths for ImGui (from zgui) and rlImGui headers
-            rlimgui_mod.addIncludePath(dep.path("libs/imgui"));
-            rlimgui_mod.addIncludePath(rlimgui_dep.path(""));
-
-            // Add raylib include path - raylib headers are in the raylib submodule
-            const raylib_c_dep = raylib_zig_dep.builder.dependency("raylib", .{
-                .target = target,
-                .optimize = optimize,
-            });
-            rlimgui_mod.addIncludePath(raylib_c_dep.path("src"));
-
-            // Link against imgui
-            rlimgui_mod.linkLibrary(dep.artifact("imgui"));
-
-            // Create static library from the module
-            const rlimgui_lib = b.addLibrary(.{
-                .name = "rlimgui",
-                .root_module = rlimgui_mod,
-            });
-
-            // Link rlImGui to GUI interface
-            gui_interface.linkLibrary(rlimgui_lib);
-
-            // Add rlimgui include path so cImport can find rlImGui.h
-            gui_interface.addIncludePath(rlimgui_dep.path(""));
-            gui_interface.addIncludePath(dep.path("libs/imgui"));
-            gui_interface.addIncludePath(raylib_c_dep.path("src"));
-        }
+        deps_gui.configureZgui(gui_context, gui_interface, dep);
     }
-
-    // Add cimgui module and link library to GUI if using imgui backend with sokol
-    // sokol uses dcimgui + sokol_imgui instead of zgui
     if (cimgui_dep) |dep| {
-        gui_interface.addImport("cimgui", dep.module("cimgui"));
-        gui_interface.linkLibrary(dep.artifact("cimgui_clib"));
-
-        // Add include paths for cImport to find cimgui.h
-        gui_interface.addIncludePath(dep.path("src"));
-
-        // Compile sokol_imgui.c as a separate library
-        // sokol_imgui provides the bridge between ImGui and sokol_gfx
-        const sokol_imgui_mod = b.createModule(.{
-            .target = target,
-            .optimize = optimize,
-        });
-
-        // Determine sokol backend define based on target platform
-        // Supported: macOS/iOS (Metal), Windows (D3D11), Linux/BSD (OpenGL), Web (GLES3)
-        // Other platforms default to OpenGL Core which may not work
-        const sokol_backend_define: []const u8 = switch (target.result.os.tag) {
-            .macos, .ios => "-DSOKOL_METAL",
-            .windows => "-DSOKOL_D3D11",
-            .linux, .freebsd, .openbsd => "-DSOKOL_GLCORE",
-            .emscripten => "-DSOKOL_GLES3",
-            else => "-DSOKOL_GLCORE", // Fallback, may not work on all platforms
-        };
-
-        // Add sokol_imgui.c source file
-        sokol_imgui_mod.addCSourceFile(.{
-            .file = sokol_dep.path("src/sokol/c/sokol_imgui.c"),
-            .flags = &.{
-                "-DIMPL",
-                sokol_backend_define,
-                "-fno-sanitize=undefined",
-            },
-        });
-
-        // Add include paths for sokol headers and cimgui headers
-        sokol_imgui_mod.addIncludePath(sokol_dep.path("src/sokol/c"));
-        sokol_imgui_mod.addIncludePath(dep.path("src"));
-
-        // Link against cimgui
-        sokol_imgui_mod.linkLibrary(dep.artifact("cimgui_clib"));
-
-        // Link against sokol (for sokol_gfx)
-        sokol_imgui_mod.linkLibrary(sokol_dep.artifact("sokol_clib"));
-
-        // Create static library from the module
-        const sokol_imgui_lib = b.addLibrary(.{
-            .name = "sokol_imgui",
-            .root_module = sokol_imgui_mod,
-        });
-
-        // Link sokol_imgui to GUI interface
-        gui_interface.linkLibrary(sokol_imgui_lib);
-
-        // Add sokol headers include path for sokol_imgui.zig cImport
-        gui_interface.addIncludePath(sokol_dep.path("src/sokol/c"));
+        deps_gui.configureCimgui(gui_context, gui_interface, dep);
     }
 
-    // Compile imgui_impl_wgpu.cpp for wgpu_native backend
-    // wgpu_native needs IMGUI_IMPL_WEBGPU_BACKEND_WGPU define (not Dawn)
-    // Desktop only (not iOS/WASM)
-    if (zgui_dep) |dep| {
-        if (backend == .wgpu_native and is_desktop) {
-            // Fetch wgpu_native and zglfw dependencies here since they're not available on iOS
-            const local_wgpu_native_dep = labelle_dep.builder.dependency("wgpu_native_zig", .{
-                .target = target,
-                .optimize = optimize,
-            });
-            const local_zglfw_dep = labelle_dep.builder.dependency("zglfw", .{
-                .target = target,
-                .optimize = optimize,
-            });
+    // ==========================================================================
+    // Core Modules
+    // ==========================================================================
 
-            // Get wgpu_native's include path from the target-specific dependency
-            // wgpu_native_zig uses lazy dependencies like "wgpu_macos_aarch64_release"
-            // We need to compute the same target name to get the headers
-            const target_res = target.result;
-            const os_str = @tagName(target_res.os.tag);
-            const arch_str = @tagName(target_res.cpu.arch);
-            const mode_str = switch (optimize) {
-                .Debug => "debug",
-                else => "release",
-            };
-            const abi_str: [:0]const u8 = switch (target_res.os.tag) {
-                .ios => switch (target_res.abi) {
-                    .simulator => "_simulator",
-                    else => "",
-                },
-                .windows => switch (target_res.abi) {
-                    .msvc => "_msvc",
-                    else => "_gnu",
-                },
-                else => "",
-            };
-
-            // Format: wgpu_<os>_<arch><abi>_<mode>
-            const target_name_slices = [_][:0]const u8{ "wgpu_", os_str, "_", arch_str, abi_str, "_", mode_str };
-            const wgpu_target_name = std.mem.concatWithSentinel(b.allocator, u8, &target_name_slices, 0) catch @panic("OOM");
-
-            // Get the wgpu binary package through wgpu_native_zig's builder
-            const wgpu_binary_dep = local_wgpu_native_dep.builder.lazyDependency(wgpu_target_name, .{});
-            const wgpu_include_path = if (wgpu_binary_dep) |wdep|
-                wdep.path("include")
-            else blk: {
-                std.log.warn("Could not find wgpu binary dependency '{s}' for ImGui backend", .{wgpu_target_name});
-                break :blk local_wgpu_native_dep.path("include"); // Fallback (will fail at compile time)
-            };
-
-            // Create a module for ImGui wgpu_native backend sources
-            const imgui_wgpu_mod = b.createModule(.{
-                .target = target,
-                .optimize = optimize,
-                .link_libcpp = true,
-            });
-
-            // Compile imgui_impl_wgpu.cpp with IMGUI_IMPL_WEBGPU_BACKEND_WGPU define
-            imgui_wgpu_mod.addCSourceFile(.{
-                .file = dep.path("libs/imgui/backends/imgui_impl_wgpu.cpp"),
-                .flags = &.{
-                    "-std=c++11",
-                    "-fno-sanitize=undefined",
-                    "-DIMGUI_IMPL_WEBGPU_BACKEND_WGPU", // Use wgpu-native API, not Dawn
-                },
-            });
-
-            // Compile imgui_impl_glfw.cpp for input handling
-            imgui_wgpu_mod.addCSourceFile(.{
-                .file = dep.path("libs/imgui/backends/imgui_impl_glfw.cpp"),
-                .flags = &.{
-                    "-std=c++11",
-                    "-fno-sanitize=undefined",
-                },
-            });
-
-            // Add include paths
-            imgui_wgpu_mod.addIncludePath(dep.path("libs/imgui")); // ImGui headers
-            imgui_wgpu_mod.addIncludePath(wgpu_include_path); // wgpu_native WebGPU headers
-            imgui_wgpu_mod.addIncludePath(local_zglfw_dep.path("libs/glfw/include")); // GLFW headers
-
-            // Link against zgui's imgui library for core ImGui symbols
-            imgui_wgpu_mod.linkLibrary(dep.artifact("imgui"));
-
-            // Create static library from the module
-            const imgui_wgpu_lib = b.addLibrary(.{
-                .name = "imgui_wgpu_native",
-                .root_module = imgui_wgpu_mod,
-            });
-
-            // Link to GUI interface
-            gui_interface.linkLibrary(imgui_wgpu_lib);
-
-            // Add include paths for Zig cImport
-            gui_interface.addIncludePath(dep.path("libs/imgui"));
-            gui_interface.addIncludePath(dep.path("libs/imgui/backends"));
-            gui_interface.addIncludePath(wgpu_include_path);
-            gui_interface.addIncludePath(local_zglfw_dep.path("libs/glfw/include"));
-        }
-    }
-
-    // Core module - foundation types (entity utils, zon coercion)
     const core_mod = b.addModule("labelle-core", .{
         .root_source_file = b.path("core/mod.zig"),
         .target = target,
@@ -673,15 +299,12 @@ pub fn build(b: *std.Build) void {
         },
     });
 
-    // Hooks module - event/hook system
     _ = b.addModule("labelle-hooks", .{
         .root_source_file = b.path("hooks/mod.zig"),
         .target = target,
         .optimize = optimize,
     });
 
-    // Render module - visual rendering pipeline
-    // Uses graphics interface instead of labelle directly to avoid module collisions
     _ = b.addModule("labelle-render", .{
         .root_source_file = b.path("render/mod.zig"),
         .target = target,
@@ -693,8 +316,7 @@ pub fn build(b: *std.Build) void {
         },
     });
 
-    // Main module (unified entry point with namespaced submodules)
-    // Note: labelle-gfx handles iOS internally (only sokol backend available on iOS)
+    // Main engine module
     const engine_mod = b.addModule("labelle-engine", .{
         .root_source_file = b.path("root.zig"),
         .target = target,
@@ -710,30 +332,33 @@ pub fn build(b: *std.Build) void {
         },
     });
 
-    // Add physics module to engine if enabled
     if (physics_module) |physics| {
         engine_mod.addImport("physics", physics);
     }
 
-    // Unit tests (standard zig test) - desktop only
-    const unit_tests = if (is_desktop) b.addTest(.{
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("root.zig"),
-            .target = target,
-            .optimize = optimize,
-            .imports = &.{
-                .{ .name = "labelle", .module = labelle },
-                .{ .name = "graphics", .module = graphics_interface },
-                .{ .name = "ecs", .module = ecs_interface },
-                .{ .name = "input", .module = input_interface },
-                .{ .name = "audio", .module = audio_interface },
-                .{ .name = "build_options", .module = build_options_mod },
-            },
-        }),
-    }) else null;
+    // ==========================================================================
+    // Tests
+    // ==========================================================================
 
-    if (unit_tests) |tests| {
-        const run_unit_tests = b.addRunArtifact(tests);
+    // Unit tests (desktop only)
+    if (is_desktop) {
+        const unit_tests = b.addTest(.{
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("root.zig"),
+                .target = target,
+                .optimize = optimize,
+                .imports = &.{
+                    .{ .name = "labelle", .module = labelle },
+                    .{ .name = "graphics", .module = graphics_interface },
+                    .{ .name = "ecs", .module = ecs_interface },
+                    .{ .name = "input", .module = input_interface },
+                    .{ .name = "audio", .module = audio_interface },
+                    .{ .name = "build_options", .module = build_options_mod },
+                },
+            }),
+        });
+
+        const run_unit_tests = b.addRunArtifact(unit_tests);
         const unit_test_step = b.step("unit-test", "Run unit tests");
         unit_test_step.dependOn(&run_unit_tests.step);
     }
@@ -756,7 +381,7 @@ pub fn build(b: *std.Build) void {
     const core_test_step = b.step("core-test", "Run core module tests");
     core_test_step.dependOn(&run_core_tests.step);
 
-    // ZSpec tests and main test step - desktop only
+    // ZSpec tests (desktop only)
     if (is_desktop) {
         const zspec_tests = b.addTest(.{
             .root_module = b.createModule(.{
@@ -781,54 +406,53 @@ pub fn build(b: *std.Build) void {
         const zspec_test_step = b.step("zspec", "Run zspec tests");
         zspec_test_step.dependOn(&run_zspec_tests.step);
 
-        // Main test step runs all module tests
         const test_step = b.step("test", "Run all tests");
         test_step.dependOn(&run_core_tests.step);
         test_step.dependOn(&run_zspec_tests.step);
     }
 
-    // Note: Examples have their own build.zig and are built separately
-    // To run example_1: cd usage/example_1 && zig build run
+    // ==========================================================================
+    // Generator
+    // ==========================================================================
 
-    // Build.zig.zon module for version info (needed before generator_exe)
-    const build_zon_mod = b.createModule(.{
-        .root_source_file = b.path("build.zig.zon"),
-    });
+    // Generator - always builds for host (native), not cross-compilation target
+    if (is_desktop) {
+        const build_zon_mod = b.createModule(.{
+            .root_source_file = b.path("build.zig.zon"),
+        });
 
-    // Generator executable - generates project files from project.labelle
-    const generator_exe = b.addExecutable(.{
-        .name = "labelle-generate",
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("tools/generator_cli.zig"),
-            .target = target,
-            .optimize = optimize,
-            .imports = &.{
-                .{ .name = "zts", .module = zts },
-                .{ .name = "build_zon", .module = build_zon_mod },
-            },
-        }),
-    });
+        const generator_exe = b.addExecutable(.{
+            .name = "labelle-generate",
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("tools/generator_cli.zig"),
+                .target = target,
+                .optimize = optimize,
+                .imports = &.{
+                    .{ .name = "zts", .module = zts },
+                    .{ .name = "build_zon", .module = build_zon_mod },
+                },
+            }),
+        });
 
-    b.installArtifact(generator_exe);
+        b.installArtifact(generator_exe);
 
-    const run_generator = b.addRunArtifact(generator_exe);
-    run_generator.step.dependOn(b.getInstallStep());
+        const run_generator = b.addRunArtifact(generator_exe);
+        run_generator.step.dependOn(b.getInstallStep());
+        if (b.args) |args| run_generator.addArgs(args);
 
-    // Pass arguments to generator
-    if (b.args) |args| {
-        run_generator.addArgs(args);
+        const generate_step = b.step("generate", "Generate project files from project.labelle");
+        generate_step.dependOn(&run_generator.step);
     }
 
-    const generate_step = b.step("generate", "Generate project files from project.labelle");
-    generate_step.dependOn(&run_generator.step);
+    // ==========================================================================
+    // Benchmarks (skip on WASM)
+    // ==========================================================================
 
-    // Benchmark executable - compares ECS backend performance
-    // Skip for WASM (benchmarks need native backends including zflecs which uses C code)
-    if (!is_wasm) {
+    if (!is_wasm and zflecs_module != null) {
         const bench_module = b.createModule(.{
             .root_source_file = b.path("ecs/benchmark.zig"),
             .target = target,
-            .optimize = .ReleaseFast, // Always use ReleaseFast for benchmarks
+            .optimize = .ReleaseFast,
             .imports = &.{
                 .{ .name = "ecs", .module = ecs_interface },
                 .{ .name = "build_options", .module = build_options_mod },
@@ -836,10 +460,8 @@ pub fn build(b: *std.Build) void {
                 .{ .name = "zflecs", .module = zflecs_module.? },
             },
         });
-        // Add mr_ecs if selected (requires Zig 0.16+)
-        if (mr_ecs_module) |m| {
-            bench_module.addImport("mr_ecs", m);
-        }
+        if (mr_ecs_module) |m| bench_module.addImport("mr_ecs", m);
+
         const bench_exe = b.addExecutable(.{
             .name = "ecs-benchmark",
             .root_module = bench_module,
@@ -850,7 +472,7 @@ pub fn build(b: *std.Build) void {
         const run_bench = b.addRunArtifact(bench_exe);
         run_bench.step.dependOn(b.getInstallStep());
 
-        const bench_step = b.step("bench", "Run ECS benchmarks (use -Decs_backend=zig_ecs or -Decs_backend=zflecs)");
+        const bench_step = b.step("bench", "Run ECS benchmarks");
         bench_step.dependOn(&run_bench.step);
     }
 }

--- a/build_helpers/deps_graphics.zig
+++ b/build_helpers/deps_graphics.zig
@@ -1,0 +1,184 @@
+//! Graphics Backend Build Helpers
+//!
+//! Handles graphics backend dependencies:
+//! - zbgfx (bgfx wrapper)
+//! - zgpu (WebGPU via Dawn)
+//! - wgpu_native (WebGPU via wgpu-native)
+//! - zglfw (GLFW bindings)
+//! - zaudio (miniaudio wrapper)
+
+const std = @import("std");
+
+/// Graphics backend selection (mirrors build.zig)
+pub const Backend = enum {
+    raylib,
+    sokol,
+    sdl,
+    bgfx,
+    zgpu,
+    wgpu_native,
+};
+
+/// Graphics dependencies loaded from labelle-gfx
+pub const GraphicsDeps = struct {
+    zbgfx: ?*std.Build.Module,
+    zgpu: ?*std.Build.Module,
+    wgpu_native: ?*std.Build.Module,
+    zglfw: ?*std.Build.Module,
+    zaudio: ?*std.Build.Module,
+    zaudio_dep: ?*std.Build.Dependency,
+};
+
+/// Load desktop-only graphics dependencies from labelle-gfx
+pub fn loadDesktopDeps(
+    labelle_dep: *std.Build.Dependency,
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+) GraphicsDeps {
+    // zbgfx
+    const zbgfx_dep = labelle_dep.builder.dependency("zbgfx", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const zbgfx = zbgfx_dep.module("zbgfx");
+
+    // zgpu
+    const zgpu_dep = labelle_dep.builder.dependency("zgpu", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const zgpu = zgpu_dep.module("root");
+
+    // wgpu_native
+    const wgpu_native_dep = labelle_dep.builder.dependency("wgpu_native_zig", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const wgpu_native = wgpu_native_dep.module("wgpu");
+
+    // zglfw
+    const zglfw_dep = labelle_dep.builder.dependency("zglfw", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const zglfw = zglfw_dep.module("root");
+
+    // zaudio
+    const zaudio_dep = b.dependency("zaudio", .{
+        .target = target,
+        .optimize = optimize,
+    });
+    const zaudio = zaudio_dep.module("root");
+
+    return .{
+        .zbgfx = zbgfx,
+        .zgpu = zgpu,
+        .wgpu_native = wgpu_native,
+        .zglfw = zglfw,
+        .zaudio = zaudio,
+        .zaudio_dep = zaudio_dep,
+    };
+}
+
+/// Return empty deps for non-desktop platforms (iOS, WASM)
+pub fn emptyDeps() GraphicsDeps {
+    return .{
+        .zbgfx = null,
+        .zgpu = null,
+        .wgpu_native = null,
+        .zglfw = null,
+        .zaudio = null,
+        .zaudio_dep = null,
+    };
+}
+
+/// Create the input interface module
+pub fn createInputModule(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    build_options_mod: *std.Build.Module,
+    raylib: ?*std.Build.Module,
+    sokol: *std.Build.Module,
+    sdl: ?*std.Build.Module,
+    zglfw: ?*std.Build.Module,
+    is_desktop: bool,
+) *std.Build.Module {
+    return b.addModule("input", .{
+        .root_source_file = b.path("input/interface.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = if (is_desktop) &.{
+            .{ .name = "build_options", .module = build_options_mod },
+            .{ .name = "raylib", .module = raylib.? },
+            .{ .name = "sokol", .module = sokol },
+            .{ .name = "sdl2", .module = sdl.? },
+            .{ .name = "zglfw", .module = zglfw.? },
+        } else &.{
+            .{ .name = "build_options", .module = build_options_mod },
+            .{ .name = "sokol", .module = sokol },
+        },
+    });
+}
+
+/// Create the graphics interface module
+pub fn createGraphicsModule(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    build_options_mod: *std.Build.Module,
+    labelle: *std.Build.Module,
+) *std.Build.Module {
+    return b.addModule("graphics", .{
+        .root_source_file = b.path("graphics/interface.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "build_options", .module = build_options_mod },
+            .{ .name = "labelle", .module = labelle },
+        },
+    });
+}
+
+/// Create the audio interface module
+pub fn createAudioModule(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    build_options_mod: *std.Build.Module,
+    raylib: ?*std.Build.Module,
+    sokol: *std.Build.Module,
+    zaudio: ?*std.Build.Module,
+    is_desktop: bool,
+) *std.Build.Module {
+    return b.addModule("audio", .{
+        .root_source_file = b.path("audio/interface.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = if (is_desktop) &.{
+            .{ .name = "build_options", .module = build_options_mod },
+            .{ .name = "raylib", .module = raylib.? },
+            .{ .name = "zaudio", .module = zaudio.? },
+        } else &.{
+            .{ .name = "build_options", .module = build_options_mod },
+            .{ .name = "sokol", .module = sokol },
+        },
+    });
+}
+
+/// Configure audio module with miniaudio library (for sokol/SDL backends on desktop)
+pub fn configureAudioMiniaudio(
+    audio_interface: *std.Build.Module,
+    zaudio_dep: *std.Build.Dependency,
+) void {
+    audio_interface.linkLibrary(zaudio_dep.artifact("miniaudio"));
+}
+
+/// Configure audio module with sokol_audio (for iOS/WASM)
+pub fn configureAudioSokol(
+    audio_interface: *std.Build.Module,
+    sokol_dep: *std.Build.Dependency,
+) void {
+    audio_interface.linkLibrary(sokol_dep.artifact("sokol_clib"));
+}

--- a/build_helpers/deps_gui.zig
+++ b/build_helpers/deps_gui.zig
@@ -1,0 +1,404 @@
+//! GUI Backend Build Helpers
+//!
+//! Handles GUI backend dependencies and module setup for:
+//! - Nuklear (immediate mode GUI)
+//! - ImGui via zgui (raylib, SDL, bgfx, zgpu)
+//! - ImGui via dcimgui + sokol_imgui (sokol backend)
+//! - rlImGui bridge (raylib + ImGui integration)
+//! - wgpu_native ImGui adapter
+
+const std = @import("std");
+
+/// GUI backend selection (mirrors build.zig)
+pub const GuiBackend = enum {
+    none,
+    raygui,
+    microui,
+    nuklear,
+    imgui,
+    clay,
+};
+
+/// Graphics backend selection (mirrors build.zig)
+pub const Backend = enum {
+    raylib,
+    sokol,
+    sdl,
+    bgfx,
+    zgpu,
+    wgpu_native,
+};
+
+/// Context for GUI module setup
+pub const GuiContext = struct {
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    gui_backend: GuiBackend,
+    graphics_backend: Backend,
+    is_desktop: bool,
+    is_ios: bool,
+    is_wasm: bool,
+
+    // Dependencies (may be null based on platform)
+    labelle_dep: *std.Build.Dependency,
+    sokol_dep: *std.Build.Dependency,
+
+    // Modules (may be null based on platform)
+    raylib: ?*std.Build.Module,
+    sdl: ?*std.Build.Module,
+    zbgfx: ?*std.Build.Module,
+    zgpu: ?*std.Build.Module,
+    wgpu_native: ?*std.Build.Module,
+    zglfw: ?*std.Build.Module,
+    labelle: *std.Build.Module,
+    sokol: *std.Build.Module,
+    zclay: ?*std.Build.Module,
+    build_options_mod: *std.Build.Module,
+};
+
+/// Load Nuklear dependency if gui_backend is nuklear
+pub fn loadNuklear(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+) ?*std.Build.Module {
+    const nuklear_dep = b.dependency("nuklear", .{
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+        .vertex_backend = true,
+        .font_baking = true,
+        .default_font = true,
+        .no_stb_rect_pack = true, // Raylib already provides stb_rect_pack
+    });
+    return nuklear_dep.module("nuklear");
+}
+
+/// zgui backend enum (matches zgui/build.zig)
+const ZguiBackend = enum {
+    no_backend,
+    glfw_wgpu,
+    glfw_opengl3,
+    glfw_vulkan,
+    glfw_dx12,
+    win32_dx12,
+    glfw,
+    sdl2_opengl3,
+    osx_metal,
+    sdl2,
+    sdl2_renderer,
+    sdl3,
+    sdl3_opengl3,
+    sdl3_renderer,
+    sdl3_gpu,
+};
+
+/// Get appropriate zgui backend for graphics backend
+fn getZguiBackend(graphics_backend: Backend) ZguiBackend {
+    return switch (graphics_backend) {
+        .raylib => .no_backend, // raylib uses rlImGui
+        .sokol => unreachable, // sokol uses dcimgui
+        .sdl => .sdl2_renderer,
+        .bgfx => .glfw,
+        .zgpu => .glfw_wgpu,
+        .wgpu_native => .no_backend, // uses custom adapter
+    };
+}
+
+/// Load zgui dependency for ImGui (non-sokol backends)
+pub fn loadZgui(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    graphics_backend: Backend,
+) ?*std.Build.Dependency {
+    if (graphics_backend == .sokol) return null;
+
+    const zgui_backend = getZguiBackend(graphics_backend);
+    const needs_obsolete = (zgui_backend == .sdl2_renderer);
+
+    return b.dependency("zgui", .{
+        .target = target,
+        .optimize = optimize,
+        .backend = zgui_backend,
+        .disable_obsolete = !needs_obsolete,
+    });
+}
+
+/// Load dcimgui dependency for sokol + ImGui
+pub fn loadCimgui(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+) *std.Build.Dependency {
+    return b.dependency("cimgui", .{
+        .target = target,
+        .optimize = optimize,
+    });
+}
+
+/// Create the GUI interface module with all necessary imports
+pub fn createGuiModule(ctx: GuiContext) *std.Build.Module {
+    const gui_interface = ctx.b.addModule("gui", .{
+        .root_source_file = ctx.b.path("gui/mod.zig"),
+        .target = ctx.target,
+        .optimize = ctx.optimize,
+        .imports = if (ctx.is_desktop) &.{
+            .{ .name = "build_options", .module = ctx.build_options_mod },
+            .{ .name = "raylib", .module = ctx.raylib.? },
+            .{ .name = "sokol", .module = ctx.sokol },
+            .{ .name = "sdl2", .module = ctx.sdl.? },
+            .{ .name = "zbgfx", .module = ctx.zbgfx.? },
+            .{ .name = "zgpu", .module = ctx.zgpu.? },
+            .{ .name = "wgpu", .module = ctx.wgpu_native.? },
+            .{ .name = "labelle", .module = ctx.labelle },
+            .{ .name = "zglfw", .module = ctx.zglfw.? },
+        } else &.{
+            .{ .name = "build_options", .module = ctx.build_options_mod },
+            .{ .name = "sokol", .module = ctx.sokol },
+        },
+    });
+
+    // Add zclay if available
+    if (ctx.zclay) |m| {
+        gui_interface.addImport("zclay", m);
+    }
+
+    return gui_interface;
+}
+
+/// Configure GUI module with Nuklear backend
+pub fn configureNuklear(gui_interface: *std.Build.Module, nuklear_module: *std.Build.Module) void {
+    gui_interface.addImport("nuklear", nuklear_module);
+}
+
+/// Configure GUI module with zgui/ImGui backend
+pub fn configureZgui(
+    ctx: GuiContext,
+    gui_interface: *std.Build.Module,
+    zgui_dep: *std.Build.Dependency,
+) void {
+    gui_interface.addImport("zgui", zgui_dep.module("root"));
+    gui_interface.linkLibrary(zgui_dep.artifact("imgui"));
+
+    // Link OpenGL on macOS for raylib backend
+    if (ctx.target.result.os.tag == .macos and ctx.graphics_backend == .raylib) {
+        gui_interface.linkFramework("OpenGL", .{});
+    }
+
+    // For raylib backend, setup rlImGui bridge
+    if (ctx.graphics_backend == .raylib) {
+        setupRlImGui(ctx, gui_interface, zgui_dep);
+    }
+
+    // For wgpu_native backend, setup ImGui adapter
+    if (ctx.graphics_backend == .wgpu_native and ctx.is_desktop) {
+        setupWgpuNativeImgui(ctx, gui_interface, zgui_dep);
+    }
+}
+
+/// Setup rlImGui bridge for raylib + ImGui integration
+fn setupRlImGui(
+    ctx: GuiContext,
+    gui_interface: *std.Build.Module,
+    zgui_dep: *std.Build.Dependency,
+) void {
+    const rlimgui_dep = ctx.b.dependency("rlimgui", .{});
+    const raylib_zig_dep = ctx.labelle_dep.builder.dependency("raylib_zig", .{
+        .target = ctx.target,
+        .optimize = ctx.optimize,
+    });
+
+    // Create module for rlImGui C++ sources
+    const rlimgui_mod = ctx.b.createModule(.{
+        .target = ctx.target,
+        .optimize = ctx.optimize,
+        .link_libcpp = true,
+    });
+
+    // Add rlImGui source
+    rlimgui_mod.addCSourceFile(.{
+        .file = rlimgui_dep.path("rlImGui.cpp"),
+        .flags = &.{
+            "-std=c++11",
+            "-fno-sanitize=undefined",
+            "-DNO_FONT_AWESOME",
+        },
+    });
+
+    // Include paths
+    rlimgui_mod.addIncludePath(zgui_dep.path("libs/imgui"));
+    rlimgui_mod.addIncludePath(rlimgui_dep.path(""));
+
+    // Raylib headers
+    const raylib_c_dep = raylib_zig_dep.builder.dependency("raylib", .{
+        .target = ctx.target,
+        .optimize = ctx.optimize,
+    });
+    rlimgui_mod.addIncludePath(raylib_c_dep.path("src"));
+
+    // Link imgui
+    rlimgui_mod.linkLibrary(zgui_dep.artifact("imgui"));
+
+    // Create static library
+    const rlimgui_lib = ctx.b.addLibrary(.{
+        .name = "rlimgui",
+        .root_module = rlimgui_mod,
+    });
+
+    // Link to GUI interface
+    gui_interface.linkLibrary(rlimgui_lib);
+    gui_interface.addIncludePath(rlimgui_dep.path(""));
+    gui_interface.addIncludePath(zgui_dep.path("libs/imgui"));
+    gui_interface.addIncludePath(raylib_c_dep.path("src"));
+}
+
+/// Configure GUI module with dcimgui + sokol_imgui backend
+pub fn configureCimgui(
+    ctx: GuiContext,
+    gui_interface: *std.Build.Module,
+    cimgui_dep: *std.Build.Dependency,
+) void {
+    gui_interface.addImport("cimgui", cimgui_dep.module("cimgui"));
+    gui_interface.linkLibrary(cimgui_dep.artifact("cimgui_clib"));
+    gui_interface.addIncludePath(cimgui_dep.path("src"));
+
+    // Compile sokol_imgui.c
+    const sokol_imgui_mod = ctx.b.createModule(.{
+        .target = ctx.target,
+        .optimize = ctx.optimize,
+    });
+
+    // Determine sokol backend define
+    const sokol_backend_define: []const u8 = switch (ctx.target.result.os.tag) {
+        .macos, .ios => "-DSOKOL_METAL",
+        .windows => "-DSOKOL_D3D11",
+        .linux, .freebsd, .openbsd => "-DSOKOL_GLCORE",
+        .emscripten => "-DSOKOL_GLES3",
+        else => "-DSOKOL_GLCORE",
+    };
+
+    sokol_imgui_mod.addCSourceFile(.{
+        .file = ctx.sokol_dep.path("src/sokol/c/sokol_imgui.c"),
+        .flags = &.{
+            "-DIMPL",
+            sokol_backend_define,
+            "-fno-sanitize=undefined",
+        },
+    });
+
+    // Include paths
+    sokol_imgui_mod.addIncludePath(ctx.sokol_dep.path("src/sokol/c"));
+    sokol_imgui_mod.addIncludePath(cimgui_dep.path("src"));
+
+    // Link libraries
+    sokol_imgui_mod.linkLibrary(cimgui_dep.artifact("cimgui_clib"));
+    sokol_imgui_mod.linkLibrary(ctx.sokol_dep.artifact("sokol_clib"));
+
+    // Create static library
+    const sokol_imgui_lib = ctx.b.addLibrary(.{
+        .name = "sokol_imgui",
+        .root_module = sokol_imgui_mod,
+    });
+
+    // Link to GUI interface
+    gui_interface.linkLibrary(sokol_imgui_lib);
+    gui_interface.addIncludePath(ctx.sokol_dep.path("src/sokol/c"));
+}
+
+/// Setup wgpu_native ImGui adapter
+fn setupWgpuNativeImgui(
+    ctx: GuiContext,
+    gui_interface: *std.Build.Module,
+    zgui_dep: *std.Build.Dependency,
+) void {
+    // Get wgpu_native dependency
+    const wgpu_native_dep = ctx.labelle_dep.builder.dependency("wgpu_native_zig", .{
+        .target = ctx.target,
+        .optimize = ctx.optimize,
+    });
+    const zglfw_dep = ctx.labelle_dep.builder.dependency("zglfw", .{
+        .target = ctx.target,
+        .optimize = ctx.optimize,
+    });
+
+    // Compute wgpu target name for lazy dependency
+    const target_res = ctx.target.result;
+    const os_str = @tagName(target_res.os.tag);
+    const arch_str = @tagName(target_res.cpu.arch);
+    const mode_str = switch (ctx.optimize) {
+        .Debug => "debug",
+        else => "release",
+    };
+    const abi_str: [:0]const u8 = switch (target_res.os.tag) {
+        .ios => switch (target_res.abi) {
+            .simulator => "_simulator",
+            else => "",
+        },
+        .windows => switch (target_res.abi) {
+            .msvc => "_msvc",
+            else => "_gnu",
+        },
+        else => "",
+    };
+
+    const target_name_slices = [_][:0]const u8{ "wgpu_", os_str, "_", arch_str, abi_str, "_", mode_str };
+    const wgpu_target_name = std.mem.concatWithSentinel(ctx.b.allocator, u8, &target_name_slices, 0) catch @panic("OOM");
+
+    // Get wgpu binary package
+    const wgpu_binary_dep = wgpu_native_dep.builder.lazyDependency(wgpu_target_name, .{});
+    const wgpu_include_path = if (wgpu_binary_dep) |wdep|
+        wdep.path("include")
+    else blk: {
+        std.log.warn("Could not find wgpu binary dependency '{s}' for ImGui backend", .{wgpu_target_name});
+        break :blk wgpu_native_dep.path("include");
+    };
+
+    // Create module for ImGui wgpu backend
+    const imgui_wgpu_mod = ctx.b.createModule(.{
+        .target = ctx.target,
+        .optimize = ctx.optimize,
+        .link_libcpp = true,
+    });
+
+    // Compile imgui_impl_wgpu.cpp
+    imgui_wgpu_mod.addCSourceFile(.{
+        .file = zgui_dep.path("libs/imgui/backends/imgui_impl_wgpu.cpp"),
+        .flags = &.{
+            "-std=c++11",
+            "-fno-sanitize=undefined",
+            "-DIMGUI_IMPL_WEBGPU_BACKEND_WGPU",
+        },
+    });
+
+    // Compile imgui_impl_glfw.cpp
+    imgui_wgpu_mod.addCSourceFile(.{
+        .file = zgui_dep.path("libs/imgui/backends/imgui_impl_glfw.cpp"),
+        .flags = &.{
+            "-std=c++11",
+            "-fno-sanitize=undefined",
+        },
+    });
+
+    // Include paths
+    imgui_wgpu_mod.addIncludePath(zgui_dep.path("libs/imgui"));
+    imgui_wgpu_mod.addIncludePath(wgpu_include_path);
+    imgui_wgpu_mod.addIncludePath(zglfw_dep.path("libs/glfw/include"));
+
+    // Link imgui
+    imgui_wgpu_mod.linkLibrary(zgui_dep.artifact("imgui"));
+
+    // Create static library
+    const imgui_wgpu_lib = ctx.b.addLibrary(.{
+        .name = "imgui_wgpu_native",
+        .root_module = imgui_wgpu_mod,
+    });
+
+    // Link to GUI interface
+    gui_interface.linkLibrary(imgui_wgpu_lib);
+    gui_interface.addIncludePath(zgui_dep.path("libs/imgui"));
+    gui_interface.addIncludePath(zgui_dep.path("libs/imgui/backends"));
+    gui_interface.addIncludePath(wgpu_include_path);
+    gui_interface.addIncludePath(zglfw_dep.path("libs/glfw/include"));
+}

--- a/build_helpers/platform_ios.zig
+++ b/build_helpers/platform_ios.zig
@@ -1,0 +1,94 @@
+//! iOS Platform Build Helpers
+//!
+//! Handles iOS-specific SDK paths and configurations for cross-compilation.
+//! Workaround for Zig issues where getSdk() returns null for cross-compilation
+//! and sysroot doesn't affect framework search paths.
+
+const std = @import("std");
+
+/// iOS SDK paths (comptime constants)
+pub const Sdk = struct {
+    pub const simulator_base = "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk";
+    pub const device_base = "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk";
+
+    // Simulator paths
+    pub const simulator_include = simulator_base ++ "/usr/include";
+    pub const simulator_lib = simulator_base ++ "/usr/lib";
+    pub const simulator_frameworks = simulator_base ++ "/System/Library/Frameworks";
+    pub const simulator_subframeworks = simulator_base ++ "/System/Library/SubFrameworks";
+
+    // Device paths
+    pub const device_include = device_base ++ "/usr/include";
+    pub const device_lib = device_base ++ "/usr/lib";
+    pub const device_frameworks = device_base ++ "/System/Library/Frameworks";
+    pub const device_subframeworks = device_base ++ "/System/Library/SubFrameworks";
+};
+
+/// Add iOS SDK paths to a C library artifact (for headers and libraries)
+pub fn addSdkPathsToArtifact(artifact: *std.Build.Step.Compile, target: std.Target) void {
+    if (target.abi == .simulator) {
+        artifact.root_module.addSystemIncludePath(.{ .cwd_relative = Sdk.simulator_include });
+        artifact.root_module.addLibraryPath(.{ .cwd_relative = Sdk.simulator_lib });
+    } else {
+        artifact.root_module.addSystemIncludePath(.{ .cwd_relative = Sdk.device_include });
+        artifact.root_module.addLibraryPath(.{ .cwd_relative = Sdk.device_lib });
+    }
+}
+
+/// Add iOS SDK framework paths to a C library artifact (for Metal, UIKit, etc.)
+pub fn addFrameworkPathsToArtifact(artifact: *std.Build.Step.Compile, target: std.Target) void {
+    if (target.abi == .simulator) {
+        artifact.root_module.addSystemFrameworkPath(.{ .cwd_relative = Sdk.simulator_frameworks });
+        artifact.root_module.addSystemFrameworkPath(.{ .cwd_relative = Sdk.simulator_subframeworks });
+    } else {
+        artifact.root_module.addSystemFrameworkPath(.{ .cwd_relative = Sdk.device_frameworks });
+        artifact.root_module.addSystemFrameworkPath(.{ .cwd_relative = Sdk.device_subframeworks });
+    }
+}
+
+/// Add all iOS SDK paths (includes, libs, frameworks) to an artifact
+pub fn addAllSdkPaths(artifact: *std.Build.Step.Compile, target: std.Target) void {
+    addSdkPathsToArtifact(artifact, target);
+    addFrameworkPathsToArtifact(artifact, target);
+}
+
+/// Configure sokol dependency for iOS
+/// Adds framework and include paths needed for Metal backend
+pub fn configureSokol(sokol_dep: *std.Build.Dependency, target: std.Target) void {
+    const sokol_clib = sokol_dep.artifact("sokol_clib");
+    addAllSdkPaths(sokol_clib, target);
+}
+
+/// Configure zflecs dependency for iOS
+/// Adds include and library paths needed for C compilation
+pub fn configureZflecs(zflecs_dep: *std.Build.Dependency, target: std.Target) void {
+    const flecs_artifact = zflecs_dep.artifact("flecs");
+    addSdkPathsToArtifact(flecs_artifact, target);
+}
+
+/// Configure Box2D dependency for iOS
+/// Adds include paths and optionally disables SIMD for simulator
+pub fn configureBox2d(
+    box2d_dep: *std.Build.Dependency,
+    target: std.Target,
+    is_simulator: bool,
+) void {
+    const box2d_artifact = box2d_dep.artifact("box2d");
+
+    // Disable SIMD on iOS simulator (ARM) - NEON intrinsics issues
+    if (is_simulator and target.cpu.arch == .aarch64) {
+        box2d_artifact.root_module.addCMacro("BOX2D_DISABLE_SIMD", "1");
+    }
+
+    // Add SDK paths for C headers
+    addSdkPathsToArtifact(box2d_artifact, target);
+}
+
+/// Add iOS SDK include path to a module (for @cImport)
+pub fn addModuleIncludePath(module: *std.Build.Module, target: std.Target) void {
+    if (target.abi == .simulator) {
+        module.addSystemIncludePath(.{ .cwd_relative = Sdk.simulator_include });
+    } else {
+        module.addSystemIncludePath(.{ .cwd_relative = Sdk.device_include });
+    }
+}


### PR DESCRIPTION
## Summary
- Extract iOS platform handling to `build_helpers/platform_ios.zig` with comptime SDK paths
- Extract GUI backend setup to `build_helpers/deps_gui.zig` (nuklear, zgui, dcimgui, rlImGui, wgpu_native)
- Extract graphics dependencies to `build_helpers/deps_graphics.zig` (zbgfx, zgpu, wgpu_native, zglfw, zaudio)
- Skip generator/benchmark build for non-desktop targets (host tools don't need cross-compilation)

## Test plan
- [x] Native desktop build (`zig build`)
- [x] Sokol backend (`zig build -Dbackend=sokol`)
- [x] ImGui with raylib (`zig build -Dgui_backend=imgui`)
- [x] ImGui with sokol (`zig build -Dbackend=sokol -Dgui_backend=imgui`)
- [x] iOS simulator cross-compilation (`zig build -Dbackend=sokol -Dtarget=aarch64-ios-simulator`)

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)