### PR TITLE
ci: use labelle-cli install script for iOS build

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -86,15 +86,11 @@ jobs:
           echo "**NDK:** $ANDROID_NDK_HOME" >> $GITHUB_STEP_SUMMARY
 
   # ============================================================================
-  # iOS Build (Simulator)
-  # Uses Xcode SDK sysroot for C library headers required by box2d/sokol
-  # Uses -Dcpu=apple_a14 to enable NEON features required by box2d SIMD code
-  # NOTE: Compilation succeeds but linking fails - iOS frameworks (Metal,
-  #       AudioToolbox, AVFoundation) need Xcode/xcodebuild for proper linking.
+  # iOS Build (Simulator) - Using labelle-cli
+  # The CLI generates proper build.zig with sokol framework linking
   # ============================================================================
   ios-build:
     runs-on: macos-14  # macOS with Apple Silicon for iOS simulator
-    continue-on-error: true  # Known issue: iOS framework linking requires Xcode
 
     steps:
       - name: Checkout repository
@@ -115,41 +111,35 @@ jobs:
           xcodebuild -version
           xcrun --sdk iphonesimulator --show-sdk-path
 
-      - name: Configure iOS libc for Zig
+      - name: Install labelle-cli
         run: |
-          # Create libc configuration file for iOS Simulator ARM64
-          SYSROOT=$(xcrun --sdk iphonesimulator --show-sdk-path)
-          echo "include_dir=$SYSROOT/usr/include" > $GITHUB_WORKSPACE/ios-arm64-simulator-libc.txt
-          echo "sys_include_dir=$SYSROOT/usr/include" >> $GITHUB_WORKSPACE/ios-arm64-simulator-libc.txt
-          echo "crt_dir=$SYSROOT/usr/lib" >> $GITHUB_WORKSPACE/ios-arm64-simulator-libc.txt
-          echo "msvc_lib_dir=" >> $GITHUB_WORKSPACE/ios-arm64-simulator-libc.txt
-          echo "kernel32_lib_dir=" >> $GITHUB_WORKSPACE/ios-arm64-simulator-libc.txt
-          echo "gcc_dir=" >> $GITHUB_WORKSPACE/ios-arm64-simulator-libc.txt
-          echo "Created libc.txt:" && cat $GITHUB_WORKSPACE/ios-arm64-simulator-libc.txt
+          curl -fsSL https://labelle.games/install.sh | bash
+          echo "$HOME/.labelle/bin" >> $GITHUB_PATH
+          ~/.labelle/bin/labelle --version
 
-      - name: Build for iOS Simulator
+      - name: Generate and build for iOS Simulator
         run: |
           cd ci/mobile_physics_test
           echo "::group::Building for iOS Simulator"
-          # Build targeting iOS Simulator (ARM64) with SDK libc
-          # -Dcpu=apple_a14 enables NEON features required by box2d SIMD code
-          # NOTE: Linking fails due to missing iOS frameworks - full iOS builds require Xcode
-          zig build \
-            -Dtarget=aarch64-ios-simulator \
-            -Dcpu=apple_a14 \
-            -Doptimize=ReleaseSafe \
-            --libc $GITHUB_WORKSPACE/ios-arm64-simulator-libc.txt \
-            --summary all || echo "::warning::iOS linking failed (expected - requires Xcode for framework linking)"
+          # Generate project files and build for iOS simulator
+          ~/.labelle/bin/labelle generate --engine-path=../..
+          ~/.labelle/bin/labelle ios build --simulator --engine-path=../..
           echo "::endgroup::"
+
+      - name: Verify iOS build output
+        run: |
+          cd ci/mobile_physics_test
+          ls -la ios/zig-out/bin/ 2>/dev/null || echo "Checking for build artifacts..."
+          find . -name "*.app" -o -name "mobile_physics_test" 2>/dev/null | head -10 || true
 
       - name: Create iOS build summary
         run: |
-          echo "## iOS Build" >> $GITHUB_STEP_SUMMARY
+          echo "## iOS Build (CLI)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "iOS Simulator build target verified." >> $GITHUB_STEP_SUMMARY
+          echo "iOS Simulator build using labelle-cli." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Target:** aarch64-ios-simulator" >> $GITHUB_STEP_SUMMARY
-          echo "**SDK:** $(xcrun --sdk iphonesimulator --show-sdk-path)" >> $GITHUB_STEP_SUMMARY
+          echo "**Method:** labelle ios build --simulator" >> $GITHUB_STEP_SUMMARY
 
   # ============================================================================
   # Native Build with Physics (CI Test)

--- a/ci/mobile_physics_test/project.labelle
+++ b/ci/mobile_physics_test/project.labelle
@@ -1,6 +1,7 @@
 .{
     .version = 1,
     .name = "mobile_physics_test",
+    .engine_version = "latest",  // Ignored when using --engine-path
     .description = "CI test project for mobile builds with physics",
     .initial_scene = "main",
     .window = .{


### PR DESCRIPTION
## Summary
- Use `curl -fsSL https://labelle.games/install.sh | bash` to install CLI
- Downloads pre-built binary, no repo access needed
- Uses `--engine-path=../..` for local engine testing

## Changes
- Install CLI via install script
- Run `labelle generate --engine-path=../..`
- Run `labelle ios build --simulator --engine-path=../..`

## Test plan
- [ ] CI workflow passes
- [ ] iOS simulator binary is produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)