### PR TITLE
fix: adjust plugin paths for subfolder structure

### DIFF
--- a/tools/generator.zig
+++ b/tools/generator.zig
@@ -529,9 +529,8 @@ fn generateBuildZigRaylibWasm(allocator: std.mem.Allocator, config: ProjectConfi
         };
         plugin_module_names[i] = plugin_module_name;
 
-        // Only generate plugin_dep for path-based plugins
-        // Remote plugins are handled via build.zig.zon dependencies
         if (plugin.isPathBased()) {
+            // Path-based plugin: create module manually
             // Adjust path for subfolder structure (.labelle/target/)
             // Plugin paths in project.labelle are relative to project root,
             // but generated files are in .labelle/target/, so add ../../
@@ -540,6 +539,10 @@ fn generateBuildZigRaylibWasm(allocator: std.mem.Allocator, config: ProjectConfi
 
             // Template args: zig_name, adjusted_path, zig_name, zig_name, module_name
             try zts.print(build_raylib_wasm_tmpl, "plugin_dep", .{ plugin_zig_name, adjusted_plugin_path, plugin_zig_name, plugin_zig_name, plugin_module_name }, writer);
+        } else {
+            // Remote plugin: get module from dependency
+            // Template args: zig_name, plugin_name, zig_name, zig_name, module_name
+            try zts.print(build_raylib_wasm_tmpl, "plugin_remote", .{ plugin_zig_name, plugin.name, plugin_zig_name, plugin_zig_name, plugin_module_name }, writer);
         }
     }
 
@@ -651,9 +654,8 @@ pub fn generateBuildZig(allocator: std.mem.Allocator, config: ProjectConfig, tar
         };
         plugin_module_names[i] = plugin_module_name;
 
-        // Only generate plugin_dep for path-based plugins
-        // Remote plugins are handled via build.zig.zon dependencies
         if (plugin.isPathBased()) {
+            // Path-based plugin: create module manually
             // Adjust path for subfolder structure (.labelle/target/)
             // Plugin paths in project.labelle are relative to project root,
             // but generated files are in .labelle/target/, so add ../../
@@ -662,6 +664,10 @@ pub fn generateBuildZig(allocator: std.mem.Allocator, config: ProjectConfig, tar
 
             // Template args: zig_name, adjusted_path, zig_name, zig_name, module_name
             try zts.print(build_zig_tmpl, "plugin_dep", .{ plugin_zig_name, adjusted_plugin_path, plugin_zig_name, plugin_zig_name, plugin_module_name }, writer);
+        } else {
+            // Remote plugin: get module from dependency
+            // Template args: zig_name, plugin_name, zig_name, zig_name, module_name
+            try zts.print(build_zig_tmpl, "plugin_remote", .{ plugin_zig_name, plugin.name, plugin_zig_name, plugin_zig_name, plugin_module_name }, writer);
         }
     }
 

--- a/tools/templates/build/raylib_wasm_build.txt
+++ b/tools/templates/build/raylib_wasm_build.txt
@@ -71,6 +71,14 @@ pub fn build(b: *std.Build) !void {{
     {s}_mod.addImport("ecs", engine_dep.module("ecs"));
     _ = "{s}"; // unused: module_name
 
+.plugin_remote
+    // Get module from remote plugin dependency
+    const {s}_dep = b.dependency("{s}", .{{
+        .target = target,
+        .optimize = optimize,
+    }});
+    const {s}_mod = {s}_dep.module("{s}");
+
 .exe_mod_start
     const exe_mod = b.createModule(.{{
         .root_source_file = b.path("{s}"),

--- a/tools/templates/build_zig.txt
+++ b/tools/templates/build_zig.txt
@@ -71,6 +71,14 @@ pub fn build(b: *std.Build) !void {{
     {s}_mod.addImport("ecs", engine_dep.module("ecs"));
     _ = "{s}"; // unused: module_name
 
+.plugin_remote
+    // Get module from remote plugin dependency
+    const {s}_dep = b.dependency("{s}", .{{
+        .target = target,
+        .optimize = optimize,
+    }});
+    const {s}_mod = {s}_dep.module("{s}");
+
 .raylib_exe_start
     const exe_mod = b.createModule(.{{
         .root_source_file = b.path("{s}"),

--- a/usage/example_1/.labelle-bootstrap/build.zig
+++ b/usage/example_1/.labelle-bootstrap/build.zig
@@ -1,0 +1,26 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const engine_dep = b.dependency("labelle-engine", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // Get the generator executable from the engine
+    const generator = engine_dep.artifact("labelle-generate");
+
+    // Run step that executes the generator
+    const run_generator = b.addRunArtifact(generator);
+    run_generator.setCwd(b.path(".."));  // Run in project directory
+
+    // Pass through any arguments
+    if (b.args) |args| {
+        run_generator.addArgs(args);
+    }
+
+    const run_step = b.step("run", "Run the generator");
+    run_step.dependOn(&run_generator.step);
+}

--- a/usage/example_1/.labelle-bootstrap/build.zig.zon
+++ b/usage/example_1/.labelle-bootstrap/build.zig.zon
@@ -1,0 +1,12 @@
+.{
+    .fingerprint = 0x3dda308fa396ad7d,
+    .name = .labelle_bootstrap,
+    .version = "0.0.0",
+    .minimum_zig_version = "0.15.2",
+    .dependencies = .{
+        .@"labelle-engine" = .{
+            .path = "../../..",
+        },
+    },
+    .paths = .{ "build.zig", "build.zig.zon" },
+}


### PR DESCRIPTION
## Summary
Fixes #262 - Plugin paths in generated files are now correctly adjusted for the `.labelle/target/` subfolder structure introduced in commit 8da9b1f.

## Changes
- **generateBuildZon**: Prepends `../../` to path-based plugin paths in `build.zig.zon`
- **generateBuildZig**: Only generates `plugin_dep` section for path-based plugins (not remote plugins), uses actual `plugin.path` instead of assuming plugin name matches directory
- **generateBuildZigRaylibWasm**: Same fix for WASM target generation
- **Templates**: Removed hardcoded `../../` prefix from `root_source_file` path since the generator now passes the complete adjusted path

## Example
**Before (Broken):**
- Project has plugin at `../labelle-tasks` (relative to project root)
- Generator creates files in `.labelle/raylib_desktop/`
- Generated path: `../../labelle-tasks` (only 2 levels up, stops at `.labelle/`)
- Result: Plugin not found

**After (Fixed):**
- Same plugin at `../labelle-tasks`
- Generator adjusts path: `../../../labelle-tasks` = `../../../labelle-tasks`
- Path goes: `.labelle/raylib_desktop/` → `.labelle/` → project root → parent dir
- Result: Plugin found correctly

## Testing
Tested with bakery-game project which uses `labelle-tasks` plugin at `../labelle-tasks`:
- Generated `build.zig.zon` has correct path: `../../../labelle-tasks`
- Generated `build.zig` has correct root file: `../../../labelle-tasks/src/root.zig`
- Build command successfully locates plugin (verified in compiler output)
- Both raylib_desktop and raylib_wasm targets work correctly