### PR TITLE
fix: cache Zig global package directory instead of local .zig-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Cache Zig dependencies
         uses: actions/cache@v4
         with:
-          path: .zig-cache
+          path: ~/.cache/zig
           key: zig-cache-${{ runner.os }}-${{ hashFiles('**/build.zig.zon') }}
           restore-keys: |
             zig-cache-${{ runner.os }}-

--- a/.github/workflows/cli-integration.yml
+++ b/.github/workflows/cli-integration.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Cache Zig dependencies
         uses: actions/cache@v4
         with:
-          path: .zig-cache
+          path: ~/.cache/zig
           key: zig-cache-${{ runner.os }}-${{ hashFiles('**/build.zig.zon') }}
           restore-keys: |
             zig-cache-${{ runner.os }}-

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Cache Zig dependencies
         uses: actions/cache@v4
         with:
-          path: .zig-cache
+          path: ~/.cache/zig
           key: zig-cache-${{ runner.os }}-${{ hashFiles('**/build.zig.zon') }}
           restore-keys: |
             zig-cache-${{ runner.os }}-
@@ -150,7 +150,7 @@ jobs:
       - name: Cache Zig dependencies
         uses: actions/cache@v4
         with:
-          path: .zig-cache
+          path: ~/Library/Caches/zig
           key: zig-cache-${{ runner.os }}-${{ hashFiles('**/build.zig.zon') }}
           restore-keys: |
             zig-cache-${{ runner.os }}-
@@ -308,7 +308,7 @@ jobs:
       - name: Cache Zig dependencies
         uses: actions/cache@v4
         with:
-          path: .zig-cache
+          path: ~/.cache/zig
           key: zig-cache-${{ runner.os }}-${{ hashFiles('**/build.zig.zon') }}
           restore-keys: |
             zig-cache-${{ runner.os }}-


### PR DESCRIPTION
## Summary

Fixes the cache path from PR #274 review feedback. The CI cache was targeting `.zig-cache` (local build artifacts) but Zig stores fetched package dependencies in the **global** cache:

- Linux: `~/.cache/zig`
- macOS: `~/Library/Caches/zig`

This is the directory that actually prevents transient network failures when re-downloading deps like `sokol-tools-bin` via Git LFS.

### Changes

| Workflow | Job | OS | Old path | New path |
|----------|-----|-----|----------|----------|
| `ci.yml` | build-and-test | ubuntu | `.zig-cache` | `~/.cache/zig` |
| `cli-integration.yml` | cli-integration | ubuntu | `.zig-cache` | `~/.cache/zig` |
| `mobile-build.yml` | android-build | ubuntu | `.zig-cache` | `~/.cache/zig` |
| `mobile-build.yml` | ios-build | macos-14 | `.zig-cache` | `~/Library/Caches/zig` |
| `mobile-build.yml` | native-physics-test | ubuntu | `.zig-cache` | `~/.cache/zig` |

## Test plan

- [ ] CI run with cache miss (first run) fetches deps and saves to global cache
- [ ] Re-run gets cache hit and skips dependency downloads