### PR TITLE
fix: standalone gizmo rendering with correct coordinate transform

### DIFF
--- a/usage/example_gizmos/scenes/main.zon
+++ b/usage/example_gizmos/scenes/main.zon
@@ -1,7 +1,7 @@
 .{
     .name = "main",
     .scripts = .{"gizmo_toggle"},
-    .camera = .{ .x = -400, .y = -300 },
+    .camera = .{ .x = 400, .y = 300 },
     .entities = .{
         // Player at center
         .{ .prefab = "player", .components = .{ .Position = .{ .x = 400, .y = 300 } } },

--- a/usage/example_gizmos/scripts/gizmo_toggle.zig
+++ b/usage/example_gizmos/scripts/gizmo_toggle.zig
@@ -16,8 +16,8 @@ const Color = engine.Color;
 var show_arrows: bool = true;
 var show_rays: bool = true;
 var time: f32 = 0;
-var camera_x: f32 = -400;
-var camera_y: f32 = -300;
+var camera_x: f32 = 400;
+var camera_y: f32 = 300;
 
 pub fn init(game: *Game, scene: *Scene) void {
     _ = game;


### PR DESCRIPTION
## Summary
- Fix standalone gizmos (drawArrow, drawRay, drawLine, drawCircle, drawRect) being invisible due to coordinate space mismatch — game Y-up positions were passed directly to `drawShapeWorld` without conversion to the retained engine's Y-down space
- Replace `drawShapeWorld` with `camera.worldToScreen()` + `drawShapeScreen()` for correct camera-aware rendering, including zoom-scaled shape vectors
- Fix example camera position from (-400, -300) to (400, 300) to center on entities

## Test plan
- [x] Run `usage/example_gizmos` and verify arrows, rays, circles, and rectangles are visible
- [ ] Toggle gizmos with G key — standalone gizmos should appear/disappear
- [ ] Toggle arrows (A) and rays (R) independently
- [ ] Pan camera with arrow keys — standalone gizmos should move with the world
- [ ] Verify entity-bound gizmos (text labels, bounding boxes, origin markers) still render correctly