### PR TITLE
fix: migrate deprecated .backend to .targets in project.labelle

### DIFF
--- a/usage/example_2/project.labelle
+++ b/usage/example_2/project.labelle
@@ -3,7 +3,7 @@
     .name = "example_2",
     .description = "labelle-engine example using Sokol graphics backend",
     .initial_scene = "main_scene",
-    .backend = .sokol,
+    .targets = .{.sokol_desktop},
     .window = .{
         .width = 800,
         .height = 600,

--- a/usage/example_bgfx/project.labelle
+++ b/usage/example_bgfx/project.labelle
@@ -3,7 +3,7 @@
     .name = "example_bgfx",
     .description = "Demonstrates bgfx backend with GLFW window management",
     .initial_scene = "main",
-    .backend = .bgfx,
+    .targets = .{.bgfx_desktop},
     .window = .{
         .width = 800,
         .height = 600,

--- a/usage/example_entity_refs/project.labelle
+++ b/usage/example_entity_refs/project.labelle
@@ -5,8 +5,7 @@
     .version = 1,
     .name = "entity_refs_example",
     .initial_scene = "main",
-    .backend = .raylib,
-    .ecs_backend = .zig_ecs,
+    .targets = .{.raylib_desktop},
     .window = .{
         .width = 800,
         .height = 600,

--- a/usage/example_parent_refs/project.labelle
+++ b/usage/example_parent_refs/project.labelle
@@ -2,8 +2,7 @@
     .version = 1,
     .name = "example_parent_refs",
     .initial_scene = "main",
-    .backend = .raylib,
-    .ecs_backend = .zig_ecs,
+    .targets = .{.raylib_desktop},
     .window = .{
         .width = 800,
         .height = 600,

--- a/usage/example_sokol/project.labelle
+++ b/usage/example_sokol/project.labelle
@@ -3,7 +3,7 @@
     .name = "example_sokol",
     .description = "Demonstrates Sokol backend with full hook support and shape rendering",
     .initial_scene = "main",
-    .backend = .sokol,
+    .targets = .{.sokol_desktop},
     .window = .{
         .width = 800,
         .height = 600,


### PR DESCRIPTION
## Summary
- Replace deprecated `.backend = .X` with `.targets = .{.X_desktop}` in 5 project.labelle files
- Remove redundant `.ecs_backend = .zig_ecs` (default) from example_entity_refs and example_parent_refs
- Affected examples: example_2, example_bgfx, example_entity_refs, example_parent_refs, example_sokol

## Test plan
- [ ] `CI_TEST=1 zig build run` in each affected example directory
- [ ] CI passes

Closes #293