### PR TITLE
fix: use correct sdl.TouchFingerEvent type in SDL input handler

### DIFF
--- a/input/sdl_input.zig
+++ b/input/sdl_input.zig
@@ -141,7 +141,7 @@ fn processEvent(self: *Self, event: sdl.Event) void {
 }
 
 /// Handle SDL finger/touch events
-fn handleFingerEvent(self: *Self, finger: sdl.FingerEvent, phase: TouchPhase) void {
+fn handleFingerEvent(self: *Self, finger: sdl.TouchFingerEvent, phase: TouchPhase) void {
     // SDL finger coordinates are normalized (0-1), convert to screen coords
     // Note: SDL requires window dimensions for proper conversion, for now use raw coords
     const touch = Touch{


### PR DESCRIPTION
## Summary
- Replace `sdl.FingerEvent` with `sdl.TouchFingerEvent` in `input/sdl_input.zig`
- The zsdl binding defines the struct as `TouchFingerEvent`, not `FingerEvent`

## Test plan
- [ ] `cd usage/example_sdl2 && zig build` (compile check)
- [ ] CI passes

Closes #298