### PR TITLE
fix: make clay GUI adapter compile on non-raylib backends

### DIFF
--- a/gui/clay/adapter_stub.zig
+++ b/gui/clay/adapter_stub.zig
@@ -1,0 +1,45 @@
+//! Clay UI Stub Adapter
+//!
+//! No-op implementation for non-raylib graphics backends.
+//! Clay GUI currently only supports the raylib graphics backend.
+//! This stub allows compilation on other backends without errors.
+
+const std = @import("std");
+const types = @import("../types.zig");
+
+const Self = @This();
+
+pub fn init() Self {
+    std.log.warn("[clay] Clay GUI is only supported on the raylib graphics backend. GUI will be non-functional.", .{});
+    return .{};
+}
+
+pub fn fixPointers(_: *Self) void {}
+
+pub fn deinit(_: *Self) void {}
+
+pub fn beginFrame(_: *Self) void {}
+
+pub fn endFrame(_: *Self) void {}
+
+pub fn label(_: *Self, _: types.Label) void {}
+
+pub fn button(_: *Self, _: types.Button) bool {
+    return false;
+}
+
+pub fn progressBar(_: *Self, _: types.ProgressBar) void {}
+
+pub fn beginPanel(_: *Self, _: types.Panel) void {}
+
+pub fn endPanel(_: *Self) void {}
+
+pub fn image(_: *Self, _: types.Image) void {}
+
+pub fn checkbox(_: *Self, _: types.Checkbox) bool {
+    return false;
+}
+
+pub fn slider(_: *Self, sl: types.Slider) f32 {
+    return sl.value;
+}

--- a/gui/interface.zig
+++ b/gui/interface.zig
@@ -58,13 +58,21 @@ fn selectImguiAdapter() type {
     };
 }
 
+/// Select clay adapter based on graphics backend
+fn selectClayAdapter() type {
+    return switch (gfx_backend) {
+        .raylib => @import("clay/adapter.zig"),
+        else => @import("clay/adapter_stub.zig"),
+    };
+}
+
 /// Backend implementation selected at build time
 const BackendImpl = switch (gui_backend) {
     .raygui => @import("raygui_adapter.zig"),
     .microui => @import("microui_adapter.zig"),
     .nuklear => selectNuklearAdapter(),
     .imgui => selectImguiAdapter(),
-    .clay => @import("clay/adapter.zig"),
+    .clay => selectClayAdapter(),
     .none => @import("stub_adapter.zig"),
 };
 


### PR DESCRIPTION
## Summary
- Add `selectClayAdapter()` function in `gui/interface.zig` following the nuklear/imgui pattern
- Create `gui/clay/adapter_stub.zig` — no-op implementation for non-raylib backends
- Clay GUI currently only supports raylib rendering; stub logs a warning at init
- Prevents compilation errors when building with sokol/bgfx/wgpu + clay

## Test plan
- [x] `zig build test` — all 274 tests pass
- [ ] CI passes

Closes #295