### PR TITLE
fix: use lazyDependency for wgpu_native_zig to prevent build crash

### DIFF
--- a/build_helpers/deps_graphics.zig
+++ b/build_helpers/deps_graphics.zig
@@ -44,12 +44,12 @@ pub fn loadDesktopDeps(
     });
     const zbgfx = zbgfx_dep.module("zbgfx");
 
-    // wgpu_native — only fetch when needed
+    // wgpu_native — lazy dependency (marked .lazy in labelle-gfx build.zig.zon)
     const wgpu_native: ?*std.Build.Module = if (backend == .wgpu_native)
-        labelle_dep.builder.dependency("wgpu_native_zig", .{
+        if (labelle_dep.builder.lazyDependency("wgpu_native_zig", .{
             .target = target,
             .optimize = optimize,
-        }).module("wgpu")
+        })) |dep| dep.module("wgpu") else null
     else
         null;
 

--- a/build_helpers/deps_gui.zig
+++ b/build_helpers/deps_gui.zig
@@ -310,11 +310,11 @@ fn setupWgpuNativeImgui(
     gui_interface: *std.Build.Module,
     zgui_dep: *std.Build.Dependency,
 ) void {
-    // Get wgpu_native dependency
-    const wgpu_native_dep = ctx.labelle_dep.builder.dependency("wgpu_native_zig", .{
+    // Get wgpu_native dependency (lazy in labelle-gfx build.zig.zon)
+    const wgpu_native_dep = ctx.labelle_dep.builder.lazyDependency("wgpu_native_zig", .{
         .target = ctx.target,
         .optimize = ctx.optimize,
-    });
+    }) orelse return;
     const zglfw_dep = ctx.labelle_dep.builder.dependency("zglfw", .{
         .target = ctx.target,
         .optimize = ctx.optimize,

--- a/tools/templates/build_zig.txt
+++ b/tools/templates/build_zig.txt
@@ -211,10 +211,10 @@ pub fn build(b: *std.Build) !void {{
         .target = target,
         .optimize = optimize,
     }});
-    const wgpu_native_dep = labelle_dep.builder.dependency("wgpu_native_zig", .{{
+    const wgpu_native_dep = labelle_dep.builder.lazyDependency("wgpu_native_zig", .{{
         .target = target,
         .optimize = optimize,
-    }});
+    }}) orelse @panic("wgpu_native_zig dependency not available");
     const zglfw_dep = labelle_dep.builder.dependency("zglfw", .{{
         .target = target,
         .optimize = optimize,


### PR DESCRIPTION
## Summary
- Use `lazyDependency()` instead of `dependency()` for `wgpu_native_zig` in `deps_graphics.zig` and `deps_gui.zig`
- `wgpu_native_zig` is marked as `.lazy = true` in labelle-gfx's build.zig.zon, requiring lazy resolution
- The eager call caused a panic during `zig build` in example_gui even when wgpu wasn't the selected backend
- Also fixed the build template for generated projects

## Test plan
- [x] `zig build test` — all 274 tests pass
- [x] `cd usage/example_gui && CI_TEST=1 zig build run` — no longer crashes
- [ ] CI passes

Closes #296