### PR TITLE
fix: resolve shape blinking in position inheritance example

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -14,8 +14,8 @@
             .hash = "zflecs-0.2.0-dev-1PN3ysolPAABJMgsIgYPrs0G278g-f7mCt9kNG9IMq8V",
         },
         .@"labelle-gfx" = .{
-            .url = "git+https://github.com/labelle-toolkit/labelle-gfx#v0.34.1",
-            .hash = "labelle_gfx-0.34.1-WZ2XcDSMCwCCEFGmxX0Nz_IXBDVXqmyNv2EYB0vFy2gd",
+            .url = "git+https://github.com/labelle-toolkit/labelle-gfx#v0.34.2",
+            .hash = "labelle_gfx-0.34.2-WZ2XcAeLCwC8OUEg_Dbjwvgzo1LkiHM8eEoiAKDN0Evd",
         },
         .zspec = .{
             .url = "git+https://github.com/apotema/zspec#71c901d6e74b2d5a8c556d4c74ced9b91446d8a4",


### PR DESCRIPTION
## Summary

- Updates labelle-gfx to v0.34.2 which disables viewport culling for shape primitives
- Shape viewport culling was intermittently culling shapes whose positions changed every frame, causing visual blinking

## Root Cause

Through systematic elimination, the blinking was traced to viewport culling in `shouldRenderShapeInViewport` (labelle-gfx render_subsystem.zig):

1. Fixed entities (never updated) → no blink
2. Entities updated with same values every frame → no blink
3. Moving entities on `.world` layer (viewport culled) → **blink**
4. Moving entities on `.ui` layer (no culling) → no blink
5. Moving entities with viewport culling disabled → no blink

Shape primitives (circle, rectangle, line) are trivially cheap to draw, making per-shape viewport culling overhead counterproductive. The fix disables both spatial grid checks and per-shape viewport bounds testing for shapes while keeping viewport culling active for sprites.

## labelle-gfx changes (v0.34.2)

- labelle-toolkit/labelle-gfx@c85ac3f

## Test plan

- [x] All engine tests pass (274/274)
- [x] All labelle-gfx tests pass
- [ ] Run `example_position_inheritance` — ball and child square should move smoothly without blinking

Fixes #292