### PR TITLE
Fix transitive dependency chains for graphics backends

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -97,9 +97,15 @@ pub fn build(b: *std.Build) void {
         @panic("sokol backend selected but sokol module not exported by labelle-gfx");
     }
 
-    // Export sokol for consumers when present
+    // Re-export all backend modules for consumer projects.
+    // This allows consumers to use engine_dep.builder.modules.get("sokol") etc.
+    // without reaching into engine internals via transitive dependency chains.
     if (sokol) |sk| {
         b.modules.put("sokol", sk) catch @panic("Failed to export sokol module");
+    }
+    b.modules.put("labelle-gfx", labelle) catch @panic("Failed to export labelle-gfx module");
+    if (raylib) |rl| {
+        b.modules.put("raylib", rl) catch @panic("Failed to export raylib module");
     }
 
     // Note: sokol_dep is null because sokol is provided by labelle-gfx.
@@ -111,6 +117,17 @@ pub fn build(b: *std.Build) void {
         deps_graphics.loadDesktopDeps(labelle_dep, b, target, optimize, backend)
     else
         deps_graphics.emptyDeps();
+
+    // Re-export desktop graphics modules for consumers
+    if (gfx_deps.zbgfx) |zb| {
+        b.modules.put("zbgfx", zb) catch @panic("Failed to export zbgfx module");
+    }
+    if (gfx_deps.zglfw) |zg| {
+        b.modules.put("zglfw", zg) catch @panic("Failed to export zglfw module");
+    }
+    if (gfx_deps.wgpu_native) |wn| {
+        b.modules.put("wgpu_native", wn) catch @panic("Failed to export wgpu_native module");
+    }
 
     // ==========================================================================
     // Other Dependencies
@@ -363,6 +380,15 @@ pub fn build(b: *std.Build) void {
 
     if (physics_module) |physics| {
         engine_mod.addImport("physics", physics);
+    }
+
+    // Link C library artifacts to the engine module for transitive linking.
+    // Consumer executables importing labelle-engine get these linked automatically.
+    if (gfx_deps.zbgfx_dep) |dep| {
+        engine_mod.linkLibrary(dep.artifact("bgfx"));
+    }
+    if (gfx_deps.zglfw_dep) |dep| {
+        engine_mod.linkLibrary(dep.artifact("glfw"));
     }
 
     // ==========================================================================

--- a/build_helpers/deps_graphics.zig
+++ b/build_helpers/deps_graphics.zig
@@ -24,6 +24,9 @@ pub const GraphicsDeps = struct {
     zglfw: ?*std.Build.Module,
     zaudio: ?*std.Build.Module,
     zaudio_dep: ?*std.Build.Dependency,
+    // Dependency objects for C artifact linking (re-exported to consumers)
+    zbgfx_dep: ?*std.Build.Dependency,
+    zglfw_dep: ?*std.Build.Dependency,
 };
 
 /// Load desktop-only graphics dependencies from labelle-gfx
@@ -38,13 +41,14 @@ pub fn loadDesktopDeps(
         _ = @field(@TypeOf(backend), "wgpu_native");
     }
     // zbgfx — only fetch when bgfx backend is selected
-    const zbgfx: ?*std.Build.Module = if (backend == .bgfx)
+    const zbgfx_dep: ?*std.Build.Dependency = if (backend == .bgfx)
         labelle_dep.builder.dependency("zbgfx", .{
             .target = target,
             .optimize = optimize,
-        }).module("zbgfx")
+        })
     else
         null;
+    const zbgfx: ?*std.Build.Module = if (zbgfx_dep) |dep| dep.module("zbgfx") else null;
 
     // wgpu_native — lazy dependency (marked .lazy in labelle-gfx build.zig.zon)
     const wgpu_native: ?*std.Build.Module = if (backend == .wgpu_native)
@@ -56,13 +60,14 @@ pub fn loadDesktopDeps(
         null;
 
     // zglfw — only fetch when bgfx, wgpu_native, or sdl backends are selected
-    const zglfw: ?*std.Build.Module = if (backend == .bgfx or backend == .wgpu_native or backend == .sdl)
+    const zglfw_dep: ?*std.Build.Dependency = if (backend == .bgfx or backend == .wgpu_native or backend == .sdl)
         labelle_dep.builder.dependency("zglfw", .{
             .target = target,
             .optimize = optimize,
-        }).module("root")
+        })
     else
         null;
+    const zglfw: ?*std.Build.Module = if (zglfw_dep) |dep| dep.module("root") else null;
 
     // zaudio
     const zaudio_dep = b.dependency("zaudio", .{
@@ -77,6 +82,8 @@ pub fn loadDesktopDeps(
         .zglfw = zglfw,
         .zaudio = zaudio,
         .zaudio_dep = zaudio_dep,
+        .zbgfx_dep = zbgfx_dep,
+        .zglfw_dep = zglfw_dep,
     };
 }
 
@@ -88,6 +95,8 @@ pub fn emptyDeps() GraphicsDeps {
         .zglfw = null,
         .zaudio = null,
         .zaudio_dep = null,
+        .zbgfx_dep = null,
+        .zglfw_dep = null,
     };
 }
 

--- a/tools/templates/build_zig.txt
+++ b/tools/templates/build_zig.txt
@@ -105,17 +105,11 @@ pub fn build(b: *std.Build) !void {{
             .root_module = exe_mod,
         }});
 .sokol_exe_start
-    // Get labelle-gfx dependency for sokol bindings
-    const labelle_dep = engine_dep.builder.dependency("labelle-gfx", .{{
-        .target = target,
-        .optimize = optimize,
-    }});
-    const sokol_dep = labelle_dep.builder.dependency("sokol", .{{
-        .target = target,
-        .optimize = optimize,
-    }});
-    const sokol_mod = sokol_dep.module("sokol");
-    const labelle_gfx_mod = labelle_dep.module("labelle");
+    // Get sokol and labelle-gfx modules (re-exported by engine)
+    const sokol_mod = engine_dep.builder.modules.get("sokol") orelse
+        @panic("sokol module not found - ensure backend=sokol is set");
+    const labelle_gfx_mod = engine_dep.builder.modules.get("labelle-gfx") orelse
+        @panic("labelle-gfx module not found");
 
     const exe_mod = b.createModule(.{{
         .root_source_file = b.path("{s}"),
@@ -167,26 +161,13 @@ pub fn build(b: *std.Build) !void {{
         sdl_sdk.link(exe, .dynamic, .SDL2_ttf);
         exe.linkSystemLibrary("SDL2_image");
 .bgfx_exe_start
-    // Get labelle-gfx dependency for bgfx bindings
-    const labelle_dep = engine_dep.builder.dependency("labelle-gfx", .{{
-        .target = target,
-        .optimize = optimize,
-    }});
-    const zbgfx_dep = labelle_dep.builder.dependency("zbgfx", .{{
-        .target = target,
-        .optimize = optimize,
-    }});
-    const zglfw_dep = labelle_dep.builder.dependency("zglfw", .{{
-        .target = target,
-        .optimize = optimize,
-    }});
-    const zbgfx_mod = zbgfx_dep.module("zbgfx");
-    const zglfw_mod = zglfw_dep.module("root");
-    const labelle_gfx_mod = labelle_dep.module("labelle");
-
-    // Get native libraries for linking
-    const bgfx_lib = zbgfx_dep.artifact("bgfx");
-    const glfw_lib = zglfw_dep.artifact("glfw");
+    // Get bgfx, glfw, and labelle-gfx modules (re-exported by engine)
+    const zbgfx_mod = engine_dep.builder.modules.get("zbgfx") orelse
+        @panic("zbgfx module not found - ensure backend=bgfx is set");
+    const zglfw_mod = engine_dep.builder.modules.get("zglfw") orelse
+        @panic("zglfw module not found");
+    const labelle_gfx_mod = engine_dep.builder.modules.get("labelle-gfx") orelse
+        @panic("labelle-gfx module not found");
 
     const exe_mod = b.createModule(.{{
         .root_source_file = b.path("{s}"),
@@ -206,22 +187,13 @@ pub fn build(b: *std.Build) !void {{
             .root_module = exe_mod,
         }});
 .wgpu_native_exe_start
-    // Get labelle-gfx dependency for wgpu_native bindings
-    const labelle_dep = engine_dep.builder.dependency("labelle-gfx", .{{
-        .target = target,
-        .optimize = optimize,
-    }});
-    const wgpu_native_dep = labelle_dep.builder.lazyDependency("wgpu_native_zig", .{{
-        .target = target,
-        .optimize = optimize,
-    }}) orelse @panic("wgpu_native_zig dependency not available");
-    const zglfw_dep = labelle_dep.builder.dependency("zglfw", .{{
-        .target = target,
-        .optimize = optimize,
-    }});
-    const wgpu_mod = wgpu_native_dep.module("wgpu");
-    const zglfw_mod = zglfw_dep.module("root");
-    const labelle_gfx_mod = labelle_dep.module("labelle");
+    // Get wgpu, glfw, and labelle-gfx modules (re-exported by engine)
+    const wgpu_mod = engine_dep.builder.modules.get("wgpu_native") orelse
+        @panic("wgpu_native module not found - ensure backend=wgpu_native is set");
+    const zglfw_mod = engine_dep.builder.modules.get("zglfw") orelse
+        @panic("zglfw module not found");
+    const labelle_gfx_mod = engine_dep.builder.modules.get("labelle-gfx") orelse
+        @panic("labelle-gfx module not found");
 
     const exe_mod = b.createModule(.{{
         .root_source_file = b.path("{s}"),
@@ -240,15 +212,9 @@ pub fn build(b: *std.Build) !void {{
             .name = "{s}",
             .root_module = exe_mod,
         }});
-        exe.linkLibrary(zglfw_dep.artifact("glfw"));
-        exe.linkLibrary(wgpu_native_dep.artifact("wgpu_native"));
 .plugin_import
     exe_mod.addImport("{s}", {s}_mod);
 .bgfx_link
-    // Link bgfx and glfw native libraries
-    exe.linkLibrary(bgfx_lib);
-    exe.linkLibrary(glfw_lib);
-
 .ios_frameworks
         // Link iOS frameworks when targeting iOS
         if (is_ios) {{

--- a/usage/example_2/build.zig
+++ b/usage/example_2/build.zig
@@ -38,13 +38,9 @@ pub fn build(b: *std.Build) void {
     });
     const engine_mod = engine_dep.module("labelle-engine");
 
-    // Get sokol module from labelle-gfx (avoid duplicate module conflict)
-    const labelle_dep = engine_dep.builder.dependency("labelle-gfx", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const sokol_mod = labelle_dep.builder.modules.get("sokol") orelse
-        @panic("sokol module not found in labelle-gfx");
+    // Get sokol module (re-exported by engine)
+    const sokol_mod = engine_dep.builder.modules.get("sokol") orelse
+        @panic("sokol module not found - ensure backend=sokol is set");
 
     const exe = b.addExecutable(.{
         .name = "example_2",

--- a/usage/example_bgfx/build.zig
+++ b/usage/example_bgfx/build.zig
@@ -39,22 +39,13 @@ pub fn build(b: *std.Build) void {
     });
     const engine_mod = engine_dep.module("labelle-engine");
 
-    // Get labelle-gfx dependency for bgfx bindings
-    const labelle_dep = engine_dep.builder.dependency("labelle-gfx", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const zbgfx_dep = labelle_dep.builder.dependency("zbgfx", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const zglfw_dep = labelle_dep.builder.dependency("zglfw", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const zbgfx_mod = zbgfx_dep.module("zbgfx");
-    const zglfw_mod = zglfw_dep.module("root");
-    const labelle_gfx_mod = labelle_dep.module("labelle");
+    // Get bgfx, glfw, and labelle-gfx modules (re-exported by engine)
+    const zbgfx_mod = engine_dep.builder.modules.get("zbgfx") orelse
+        @panic("zbgfx module not found - ensure backend=bgfx is set");
+    const zglfw_mod = engine_dep.builder.modules.get("zglfw") orelse
+        @panic("zglfw module not found");
+    const labelle_gfx_mod = engine_dep.builder.modules.get("labelle-gfx") orelse
+        @panic("labelle-gfx module not found");
 
     const exe = b.addExecutable(.{
         .name = "example_bgfx",
@@ -70,8 +61,7 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
-    exe.linkLibrary(zbgfx_dep.artifact("bgfx"));
-    exe.linkLibrary(zglfw_dep.artifact("glfw"));
+    // bgfx and glfw C libraries are linked transitively through the engine module
     b.installArtifact(exe);
 
     const run_cmd = b.addRunArtifact(exe);

--- a/usage/example_gui_bgfx/build.zig
+++ b/usage/example_gui_bgfx/build.zig
@@ -49,22 +49,13 @@ pub fn build(b: *std.Build) void {
     });
     const engine_mod = engine_dep.module("labelle-engine");
 
-    // Get labelle-gfx dependency for bgfx bindings
-    const labelle_dep = engine_dep.builder.dependency("labelle-gfx", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const zbgfx_dep = labelle_dep.builder.dependency("zbgfx", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const zglfw_dep = labelle_dep.builder.dependency("zglfw", .{
-        .target = target,
-        .optimize = optimize,
-    });
-    const zbgfx_mod = zbgfx_dep.module("zbgfx");
-    const zglfw_mod = zglfw_dep.module("root");
-    const labelle_gfx_mod = labelle_dep.module("labelle");
+    // Get bgfx, glfw, and labelle-gfx modules (re-exported by engine)
+    const zbgfx_mod = engine_dep.builder.modules.get("zbgfx") orelse
+        @panic("zbgfx module not found - ensure backend=bgfx is set");
+    const zglfw_mod = engine_dep.builder.modules.get("zglfw") orelse
+        @panic("zglfw module not found");
+    const labelle_gfx_mod = engine_dep.builder.modules.get("labelle-gfx") orelse
+        @panic("labelle-gfx module not found");
 
     const exe = b.addExecutable(.{
         .name = "example_gui_bgfx",
@@ -80,8 +71,7 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
-    exe.linkLibrary(zbgfx_dep.artifact("bgfx"));
-    exe.linkLibrary(zglfw_dep.artifact("glfw"));
+    // bgfx and glfw C libraries are linked transitively through the engine module
     b.installArtifact(exe);
 
     const run_cmd = b.addRunArtifact(exe);


### PR DESCRIPTION
## Summary

- Re-export all graphics backend modules (sokol, raylib, zbgfx, zglfw, wgpu_native, labelle-gfx) from the engine via `b.modules.put()` so consumers access them with `engine_dep.builder.modules.get("name")`
- Link C library artifacts (bgfx, glfw) transitively through the engine module, eliminating manual `exe.linkLibrary()` calls in consumer projects
- Update generator template (`build_zig.txt`) to emit the new pattern for sokol, bgfx, and wgpu_native sections
- Simplify example build files (example_2, example_bgfx, example_gui_bgfx) by replacing multi-level transitive chains with direct module lookups

## Test plan

- [x] 94/94 engine tests pass
- [x] example_2 (sokol) builds and runs
- [x] example_sokol builds and runs
- [x] example_bgfx resolves modules correctly (pre-existing main.zig API issue unrelated)