### PR TITLE
Fix example_gui_sokol invalid fingerprint and missing sokol import

### DIFF
--- a/tools/generator/targets/sokol_desktop.zig
+++ b/tools/generator/targets/sokol_desktop.zig
@@ -120,6 +120,7 @@ pub fn generateMainZigSokol(
         // No plugins - use simple ComponentRegistry
         if (components.len == 0) {
             try zts.print(main_sokol_tmpl, "component_registry_empty", .{}, writer);
+            try zts.print(main_sokol_tmpl, "component_registry_empty_end", .{}, writer);
         } else {
             try zts.print(main_sokol_tmpl, "component_registry_start", .{}, writer);
             for (component_type_names) |type_name| {

--- a/usage/example_gui_sokol/build.zig
+++ b/usage/example_gui_sokol/build.zig
@@ -49,6 +49,10 @@ pub fn build(b: *std.Build) void {
     });
     const engine_mod = engine_dep.module("labelle-engine");
 
+    // Get sokol module (re-exported by engine)
+    const sokol_mod = engine_dep.builder.modules.get("sokol") orelse
+        @panic("sokol module not found - ensure backend=sokol is set");
+
     const exe = b.addExecutable(.{
         .name = "example_gui_sokol",
         .root_module = b.createModule(.{
@@ -57,6 +61,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
             .imports = &.{
                 .{ .name = "labelle-engine", .module = engine_mod },
+                .{ .name = "sokol", .module = sokol_mod },
             },
         }),
     });

--- a/usage/example_gui_sokol/build.zig.zon
+++ b/usage/example_gui_sokol/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .fingerprint = 0xa3b1c2d4e5f60718,
+    .fingerprint = 0xdc937ebfee7c33a4,
     .name = .example_gui_sokol,
     .version = "0.1.0",
     .dependencies = .{


### PR DESCRIPTION
## Summary

- Update invalid fingerprint in `build.zig.zon` to match Zig 0.15 requirements
- Add sokol module import to `build.zig` (generated main.zig uses `@import("sokol")`)
- Fix sokol_desktop generator: add missing `component_registry_empty_end` template section

Note: The sokol+imgui combination still has a deeper C header path issue (`sokol_gfx.h` not found by `gui/sokol_imgui.zig`) that is separate from this fix.

## Test plan

- [x] 94/94 engine tests pass
- [x] Fingerprint error resolved
- [x] Build progresses past fingerprint and module resolution stages

Closes #324