### PR TITLE
fix: link bgfx ImGui rendering backend for gui_bgfx example

### DIFF
--- a/build_helpers/deps_gui.zig
+++ b/build_helpers/deps_gui.zig
@@ -185,6 +185,11 @@ pub fn configureZgui(
         setupRlImGui(ctx, gui_interface, zgui_dep);
     }
 
+    // For bgfx backend, setup ImGui adapter
+    if (ctx.graphics_backend == .bgfx and ctx.is_desktop) {
+        setupBgfxImgui(ctx, gui_interface, zgui_dep);
+    }
+
     // For wgpu_native backend, setup ImGui adapter
     if (ctx.graphics_backend == .wgpu_native and ctx.is_desktop) {
         setupWgpuNativeImgui(ctx, gui_interface, zgui_dep);
@@ -302,6 +307,87 @@ pub fn configureCimgui(
     // Link to GUI interface
     gui_interface.linkLibrary(sokol_imgui_lib);
     gui_interface.addIncludePath(sokol_dep.path("src/sokol/c"));
+}
+
+/// Setup bgfx ImGui adapter
+/// Compiles bgfx's built-in ImGui rendering backend (imgui.cpp) which provides
+/// ImGui_ImplBgfx_Init/Shutdown/NewFrame/RenderDrawData C functions.
+fn setupBgfxImgui(
+    ctx: GuiContext,
+    gui_interface: *std.Build.Module,
+    zgui_dep: *std.Build.Dependency,
+) void {
+    // Get zbgfx dependency for include paths and source files
+    const zbgfx_dep = ctx.labelle_dep.builder.dependency("zbgfx", .{
+        .target = ctx.target,
+        .optimize = ctx.optimize,
+    });
+
+    // Create C++ module for bgfx imgui backend
+    const imgui_bgfx_mod = ctx.b.createModule(.{
+        .target = ctx.target,
+        .optimize = ctx.optimize,
+        .link_libcpp = true,
+    });
+
+    // Compile bgfx's imgui.cpp (the ImGui rendering backend for bgfx)
+    imgui_bgfx_mod.addCSourceFile(.{
+        .file = zbgfx_dep.path("libs/bgfx/examples/common/imgui/imgui.cpp"),
+        .flags = &.{
+            "-std=c++20",
+            "-fno-sanitize=undefined",
+            "-fno-strict-aliasing",
+            "-fno-exceptions",
+            "-fno-rtti",
+            "-ffast-math",
+        },
+    });
+
+    // bx macros (mirrors zbgfx bxInclude)
+    imgui_bgfx_mod.addCMacro("__STDC_LIMIT_MACROS", "1");
+    imgui_bgfx_mod.addCMacro("__STDC_FORMAT_MACROS", "1");
+    imgui_bgfx_mod.addCMacro("__STDC_CONSTANT_MACROS", "1");
+    imgui_bgfx_mod.addCMacro("BX_CONFIG_DEBUG", if (ctx.optimize == .Debug) "1" else "0");
+
+    // Platform-specific bx compat headers
+    switch (ctx.target.result.os.tag) {
+        .freebsd => imgui_bgfx_mod.addIncludePath(zbgfx_dep.path("libs/bx/include/compat/freebsd")),
+        .linux => imgui_bgfx_mod.addIncludePath(zbgfx_dep.path("libs/bx/include/compat/linux")),
+        .ios => imgui_bgfx_mod.addIncludePath(zbgfx_dep.path("libs/bx/include/compat/ios")),
+        .macos => imgui_bgfx_mod.addIncludePath(zbgfx_dep.path("libs/bx/include/compat/osx")),
+        .windows => switch (ctx.target.result.abi) {
+            .gnu => imgui_bgfx_mod.addIncludePath(zbgfx_dep.path("libs/bx/include/compat/mingw")),
+            .msvc => imgui_bgfx_mod.addIncludePath(zbgfx_dep.path("libs/bx/include/compat/msvc")),
+            else => {},
+        },
+        else => {},
+    }
+
+    // bx headers (bx/allocator.h, bx/math.h, bx/timer.h, tinystl)
+    imgui_bgfx_mod.addIncludePath(zbgfx_dep.path("libs/bx/include"));
+    imgui_bgfx_mod.addIncludePath(zbgfx_dep.path("libs/bx/3rdparty"));
+    // bimg headers
+    imgui_bgfx_mod.addIncludePath(zbgfx_dep.path("libs/bimg/include"));
+    // bgfx headers (bgfx/bgfx.h, bgfx/embedded_shader.h)
+    imgui_bgfx_mod.addIncludePath(zbgfx_dep.path("libs/bgfx/include"));
+    imgui_bgfx_mod.addIncludePath(zbgfx_dep.path("libs/bgfx/3rdparty"));
+    // bgfx examples common (bgfx_utils.h, args.h)
+    imgui_bgfx_mod.addIncludePath(zbgfx_dep.path("libs/bgfx/examples/common"));
+    // imgui headers as <imgui/imgui.h> (zgui stores at libs/imgui/)
+    imgui_bgfx_mod.addIncludePath(zgui_dep.path("libs"));
+
+    // Link imgui and bgfx libraries
+    imgui_bgfx_mod.linkLibrary(zgui_dep.artifact("imgui"));
+    imgui_bgfx_mod.linkLibrary(zbgfx_dep.artifact("bgfx"));
+
+    // Create static library
+    const imgui_bgfx_lib = ctx.b.addLibrary(.{
+        .name = "imgui_bgfx",
+        .root_module = imgui_bgfx_mod,
+    });
+
+    // Link to GUI interface
+    gui_interface.linkLibrary(imgui_bgfx_lib);
 }
 
 /// Setup wgpu_native ImGui adapter

--- a/gui/imgui_bgfx_adapter.zig
+++ b/gui/imgui_bgfx_adapter.zig
@@ -1,22 +1,28 @@
 //! ImGui bgfx Adapter
 //!
 //! GUI backend using Dear ImGui with bgfx rendering.
-//! Uses zgui for Zig bindings to ImGui and zbgfx's imgui_backend for rendering.
+//! Uses zgui for Zig bindings to ImGui and bgfx's built-in ImGui rendering backend.
+//! Input handling via zgui's GLFW backend.
 //!
 //! Build with: zig build -Dbackend=bgfx -Dgui_backend=imgui
 
 const std = @import("std");
 const types = @import("types.zig");
 const zgui = @import("zgui");
-const zbgfx = @import("zbgfx");
 const labelle = @import("labelle");
 
 const BgfxBackend = labelle.BgfxBackend;
 
+// C functions from bgfx's ImGui rendering backend (compiled from bgfx/examples/common/imgui/imgui.cpp)
+extern fn ImGui_ImplBgfx_Init() void;
+extern fn ImGui_ImplBgfx_Shutdown() void;
+extern fn ImGui_ImplBgfx_NewFrame(view_id: u16) void;
+extern fn ImGui_ImplBgfx_RenderDrawData() void;
+
 const Self = @This();
 
 // View ID for ImGui rendering (use a dedicated view to not conflict with main rendering)
-const IMGUI_VIEW_ID: zbgfx.bgfx.ViewId = 255;
+const IMGUI_VIEW_ID: u16 = 255;
 
 // Window counter for unique IDs
 window_counter: u32,
@@ -68,8 +74,8 @@ fn initBackend(self: *Self) void {
     // Initialize zgui's GLFW backend for input handling
     zgui.backend.init(@ptrCast(window));
 
-    // Initialize zbgfx's ImGui rendering backend
-    zbgfx.imgui_backend.init();
+    // Initialize bgfx's ImGui rendering backend
+    ImGui_ImplBgfx_Init();
 
     // Register render callback with the backend
     BgfxBackend.registerGuiRenderCallback(guiRenderCallback);
@@ -80,8 +86,8 @@ fn initBackend(self: *Self) void {
 
 /// Render callback invoked by BgfxBackend during endDrawing()
 fn guiRenderCallback() void {
-    // Render ImGui draw data using zbgfx's backend
-    zbgfx.imgui_backend.draw();
+    // Render ImGui draw data using bgfx's backend
+    ImGui_ImplBgfx_RenderDrawData();
 }
 
 pub fn fixPointers(self: *Self) void {
@@ -91,7 +97,7 @@ pub fn fixPointers(self: *Self) void {
 pub fn deinit(self: *Self) void {
     if (self.backend_initialized) {
         BgfxBackend.unregisterGuiRenderCallback();
-        zbgfx.imgui_backend.deinit();
+        ImGui_ImplBgfx_Shutdown();
         zgui.backend.deinit();
     }
 
@@ -109,7 +115,7 @@ pub fn beginFrame(self: *Self) void {
     if (!self.backend_initialized) return;
 
     // Start new ImGui frame
-    zbgfx.imgui_backend.newFrame(IMGUI_VIEW_ID);
+    ImGui_ImplBgfx_NewFrame(IMGUI_VIEW_ID);
     zgui.backend.newFrame();
     zgui.newFrame();
 }


### PR DESCRIPTION
## Summary
- Fixes `undefined symbol: _ImGui_ImplBgfx_Shutdown` linker error in `example_gui_bgfx`
- Adds `setupBgfxImgui()` in `deps_gui.zig` that compiles bgfx's built-in ImGui rendering backend (`imgui.cpp`) with all required include paths (bx, bimg, bgfx, imgui headers + platform compat)
- Replaces phantom `zbgfx.imgui_backend.*` calls in `imgui_bgfx_adapter.zig` with `extern fn` declarations for the actual C functions exported by bgfx's imgui.cpp

Closes #334

## Test plan
- [x] `zig build` in example_gui_bgfx succeeds (binary produced at ~24MB)
- [x] Engine tests pass (`zig build test` — 94/94)