### PR TITLE
Add standalone plugin support for path-based deps

### DIFF
--- a/tools/generator/build_files.zig
+++ b/tools/generator/build_files.zig
@@ -225,18 +225,26 @@ fn generateBuildZigRaylibWasm(allocator: std.mem.Allocator, config: ProjectConfi
         defer if (allocated_module) allocator.free(plugin_module_name);
 
         // Use appropriate template based on plugin type:
-        // - Path-based: use b.createModule() to avoid duplicate engine dependencies
+        // - Path-based standalone: use b.dependency() to let plugin manage its own deps
+        // - Path-based (default): use b.createModule() to avoid duplicate engine dependencies
         // - URL-based: use b.dependency() with only target/optimize (fixes #256)
         if (plugin.isPathBased()) {
-            // Path-based plugin: create module manually
-            // Adjust path for subfolder structure (.labelle/target/)
-            // Plugin paths in project.labelle are relative to project root,
-            // but generated files are in .labelle/target/, so add ../../
-            const adjusted_plugin_path = try std.fmt.allocPrint(allocator, "../../{s}", .{plugin.path.?});
-            defer allocator.free(adjusted_plugin_path);
+            if (plugin.standalone) {
+                // Standalone path-based plugin: use b.dependency() so the plugin's own
+                // build.zig handles dependency wiring (for plugins that don't depend on labelle-engine)
+                // Template args: zig_name, plugin_name, zig_name, zig_name, module_name
+                try zts.print(build_raylib_wasm_tmpl, "plugin_dep_path_standalone", .{ plugin_zig_name, plugin.name, plugin_zig_name, plugin_zig_name, plugin_module_name }, writer);
+            } else {
+                // Path-based plugin: create module manually
+                // Adjust path for subfolder structure (.labelle/target/)
+                // Plugin paths in project.labelle are relative to project root,
+                // but generated files are in .labelle/target/, so add ../../
+                const adjusted_plugin_path = try std.fmt.allocPrint(allocator, "../../{s}", .{plugin.path.?});
+                defer allocator.free(adjusted_plugin_path);
 
-            // Template args: zig_name, adjusted_path, zig_name, zig_name, module_name
-            try zts.print(build_raylib_wasm_tmpl, "plugin_dep_path", .{ plugin_zig_name, adjusted_plugin_path, plugin_zig_name, plugin_zig_name, plugin_module_name }, writer);
+                // Template args: zig_name, adjusted_path, zig_name, zig_name, module_name
+                try zts.print(build_raylib_wasm_tmpl, "plugin_dep_path", .{ plugin_zig_name, adjusted_plugin_path, plugin_zig_name, plugin_zig_name, plugin_module_name }, writer);
+            }
         } else {
             // Remote plugin: get module from dependency
             // Template args: zig_name, plugin_name, zig_name, zig_name, module_name
@@ -361,18 +369,26 @@ pub fn generateBuildZig(allocator: std.mem.Allocator, config: ProjectConfig, tar
         defer if (allocated_module) allocator.free(plugin_module_name);
 
         // Use appropriate template based on plugin type:
-        // - Path-based: use b.createModule() to avoid duplicate engine dependencies
+        // - Path-based standalone: use b.dependency() to let plugin manage its own deps
+        // - Path-based (default): use b.createModule() to avoid duplicate engine dependencies
         // - URL-based: use b.dependency() with only target/optimize (fixes #256)
         if (plugin.isPathBased()) {
-            // Path-based plugin: create module manually
-            // Adjust path for subfolder structure (.labelle/target/)
-            // Plugin paths in project.labelle are relative to project root,
-            // but generated files are in .labelle/target/, so add ../../
-            const adjusted_plugin_path = try std.fmt.allocPrint(allocator, "../../{s}", .{plugin.path.?});
-            defer allocator.free(adjusted_plugin_path);
+            if (plugin.standalone) {
+                // Standalone path-based plugin: use b.dependency() so the plugin's own
+                // build.zig handles dependency wiring (for plugins that don't depend on labelle-engine)
+                // Template args: zig_name, plugin_name, zig_name, zig_name, module_name
+                try zts.print(build_zig_tmpl, "plugin_dep_path_standalone", .{ plugin_zig_name, plugin.name, plugin_zig_name, plugin_zig_name, plugin_module_name }, writer);
+            } else {
+                // Path-based plugin: create module manually
+                // Adjust path for subfolder structure (.labelle/target/)
+                // Plugin paths in project.labelle are relative to project root,
+                // but generated files are in .labelle/target/, so add ../../
+                const adjusted_plugin_path = try std.fmt.allocPrint(allocator, "../../{s}", .{plugin.path.?});
+                defer allocator.free(adjusted_plugin_path);
 
-            // Template args: zig_name, adjusted_path, zig_name, zig_name, module_name
-            try zts.print(build_zig_tmpl, "plugin_dep_path", .{ plugin_zig_name, adjusted_plugin_path, plugin_zig_name, plugin_zig_name, plugin_module_name }, writer);
+                // Template args: zig_name, adjusted_path, zig_name, zig_name, module_name
+                try zts.print(build_zig_tmpl, "plugin_dep_path", .{ plugin_zig_name, adjusted_plugin_path, plugin_zig_name, plugin_zig_name, plugin_module_name }, writer);
+            }
         } else {
             // Remote plugin: get module from dependency
             // Template args: zig_name, plugin_name, zig_name, zig_name, module_name

--- a/tools/project_config.zig
+++ b/tools/project_config.zig
@@ -182,6 +182,11 @@ pub const Plugin = struct {
     /// Must be host/path format without scheme (no "https://")
     /// Ignored when path is set.
     url: ?[]const u8 = null,
+    /// If true, the plugin manages its own dependencies and does NOT depend on labelle-engine.
+    /// Path-based standalone plugins use b.dependency() instead of b.createModule(),
+    /// letting the plugin's own build.zig handle dependency wiring.
+    /// Example: a pathfinder library that depends on labelle-core + zig-utils, not labelle-engine.
+    standalone: bool = false,
     /// Module name exported by the package (e.g., "pathfinding" for labelle-pathfinding)
     /// If not provided, defaults to the plugin name with hyphens replaced by underscores
     module: ?[]const u8 = null,

--- a/tools/templates/build/raylib_wasm_build.txt
+++ b/tools/templates/build/raylib_wasm_build.txt
@@ -71,6 +71,12 @@ pub fn build(b: *std.Build) !void {{
     {s}_mod.addImport("ecs", engine_dep.module("ecs"));
     _ = "{s}"; // unused: module_name
 
+.plugin_dep_path_standalone
+    // Standalone path-based plugin: manages its own dependencies (does not depend on labelle-engine).
+    // Uses b.dependency() so the plugin's own build.zig handles dependency wiring.
+    const {s}_dep = b.dependency("{s}", .{{ .target = target, .optimize = optimize }});
+    const {s}_mod = {s}_dep.module("{s}");
+
 .plugin_remote
     // URL-based plugin: pass backend options to ensure module deduplication
     // when the plugin also depends on labelle-engine

--- a/tools/templates/build_zig.txt
+++ b/tools/templates/build_zig.txt
@@ -71,6 +71,12 @@ pub fn build(b: *std.Build) !void {{
     {s}_mod.addImport("ecs", engine_dep.module("ecs"));
     _ = "{s}"; // unused: module_name
 
+.plugin_dep_path_standalone
+    // Standalone path-based plugin: manages its own dependencies (does not depend on labelle-engine).
+    // Uses b.dependency() so the plugin's own build.zig handles dependency wiring.
+    const {s}_dep = b.dependency("{s}", .{{ .target = target, .optimize = optimize }});
+    const {s}_mod = {s}_dep.module("{s}");
+
 .plugin_remote
     // URL-based plugin: pass backend options to ensure module deduplication
     // when the plugin also depends on labelle-engine


### PR DESCRIPTION
## Summary
- Adds `.standalone = true` option to `Plugin` struct for path-based plugins that don't depend on labelle-engine
- Standalone plugins use `b.dependency()` instead of `b.createModule()`, letting the plugin's own `build.zig` handle dependency wiring
- Applied to both desktop and WASM build templates

## Context
The `plugin_dep_path` template hardcodes `labelle-engine` + `ecs` imports for all path-based plugins. This breaks plugins like `pathfinder` that depend on `labelle-core` + `zig-utils` instead.

Usage in `project.labelle`:
```zig
.plugins = .{
    .{ .name = "pathfinder", .path = "libs/pathfinder", .standalone = true },
},
```

Closes #343

## Test plan
- [x] Verified bakery-game builds and runs with pathfinder as a standalone plugin via `labelle build --target raylib_desktop --engine-path=../labelle-engine`
- [ ] Verify existing non-standalone plugins still work (labelle-tasks, labelle-needs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)