### PR TITLE
chore: update labelle-gfx to v0.35.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -14,7 +14,7 @@
             .hash = "zflecs-0.2.0-dev-1PN3ysolPAABJMgsIgYPrs0G278g-f7mCt9kNG9IMq8V",
         },
         .@"labelle-gfx" = .{
-            .url = "git+https://github.com/labelle-toolkit/labelle-gfx#32e59802e8d98f443c15bf0eced634f9dc975e92",
+            .url = "git+https://github.com/labelle-toolkit/labelle-gfx#v0.35.0",
             .hash = "labelle_gfx-0.35.0-WZ2XcFrjCwAK0B7pL848L1rxG9Tqb08MvV5lgwuCocqy",
         },
         .zspec = .{


### PR DESCRIPTION
## Summary
- Bump labelle-gfx dependency from v0.34.3 to v0.35.0
- zig-utils v0.6.0 is pulled in transitively
- No code changes needed — RetainedEngine API is unchanged

Closes #345