### PR TITLE
fix: resolve sokol_dep from labelle-gfx for imgui integration

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -108,9 +108,15 @@ pub fn build(b: *std.Build) void {
         b.modules.put("raylib", rl) catch @panic("Failed to export raylib module");
     }
 
-    // Note: sokol_dep is null because sokol is provided by labelle-gfx.
-    // iOS/Android sokol configuration is handled by labelle-gfx.
-    const sokol_dep: ?*std.Build.Dependency = null;
+    // sokol_dep is resolved from labelle-gfx's transitive dependencies.
+    // Needed by GUI (sokol_imgui) for include paths and library linking.
+    const sokol_dep: ?*std.Build.Dependency = if (backend == .sokol)
+        labelle_dep.builder.dependency("sokol", .{
+            .target = target,
+            .optimize = optimize,
+        })
+    else
+        null;
 
     // Desktop-only graphics deps (zbgfx, wgpu_native, zglfw, zaudio)
     const gfx_deps = if (is_desktop)


### PR DESCRIPTION
## Summary
- Resolve sokol_dep from labelle-gfx's transitive dependencies when using the sokol backend
- Previously sokol_dep was hardcoded to null, causing `configureCimgui` to silently skip setup — resulting in missing `sokol_gfx.h` include paths

Closes #349