### PR TITLE
Add viewExcluding() to ECS adapters

### DIFF
--- a/ecs/zflecs_adapter.zig
+++ b/ecs/zflecs_adapter.zig
@@ -326,8 +326,13 @@ fn FlecsView(comptime _includes: anytype, comptime _excludes: anytype) type {
         }
 
         /// Entity iterator that streams entities from a flecs query chunk by chunk.
-        /// Call `deinit()` if you break out of the loop early to free the query.
-        /// If you exhaust the iterator (next() returns null), cleanup is automatic.
+        /// The iterator owns a flecs query that must be freed. Always use with defer:
+        ///
+        ///   var iter = view.entityIterator();
+        ///   defer iter.deinit();
+        ///   while (iter.next()) |entity| { ... }
+        ///
+        /// `deinit()` is safe to call after exhaustion (next() returned null).
         pub fn entityIterator(self: *Self) EntityIterator {
             return EntityIterator.init(self);
         }

--- a/ecs/zig_ecs_adapter.zig
+++ b/ecs/zig_ecs_adapter.zig
@@ -483,7 +483,7 @@ test "view excludes entities with excluded component" {
     var count: usize = 0;
     while (iter.next()) |entity| {
         // e2 should never appear
-        try std.testing.expect(!entity.eql(e2));
+        try std.testing.expect(entity != e2);
         count += 1;
     }
     try std.testing.expectEqual(@as(usize, 2), count);


### PR DESCRIPTION
## Summary
- Add `viewExcluding(includes, excludes)` to both `zig_ecs_adapter` and `zflecs_adapter`, exposing native exclude filters at the view level
- For zig_ecs, forwards to the underlying `MultiView` which already supports excludes
- For zflecs, implements `FlecsView` using flecs query terms with `.Not` operator, matching the zig_ecs view API (`entityIterator()`, `get()`)
- Single-component views (1 include, 0 excludes) preserve the `get(entity)` API; multi-component or excluding views use `get(T, entity)`

## Test plan
- [x] All 274 engine tests pass
- [ ] Verify with a game project using `viewExcluding` on zig_ecs backend
- [ ] Verify with a game project using `viewExcluding` on zflecs backend

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)