### PR TITLE
Re-export MergeHookPayloads from core

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -93,6 +93,7 @@ pub const ComponentPayload = hooks_types_mod.ComponentPayload;
 
 // ── Hook Dispatcher ──
 pub const MergeHooks = core.MergeHooks;
+pub const MergeHookPayloads = core.MergeHookPayloads;
 
 // ── Scene System ──
 pub const Scene = scene_mod.Scene;


### PR DESCRIPTION
One-line re-export. Enables the assembler to merge plugin hook payloads with engine payloads.

Part of labelle-toolkit/labelle-cli#64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)