### PR TITLE
Expose getMouseWheelMove in input mixin

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -379,6 +379,7 @@ pub fn GameConfig(
         pub const getMouseX = InputMixin.getMouseX;
         pub const getMouseY = InputMixin.getMouseY;
         pub const getMouse = InputMixin.getMouse;
+        pub const getMouseWheelMove = InputMixin.getMouseWheelMove;
 
         // ── Audio (mixin) ────────────────────────────────────────
         pub const playSound = AudioMixin.playSound;

--- a/src/game/input_mixin.zig
+++ b/src/game/input_mixin.zig
@@ -26,5 +26,9 @@ pub fn Mixin(comptime Game: type) type {
         pub fn getMouse(_: *Game) Position {
             return .{ .x = Input.getMouseX(), .y = Input.getMouseY() };
         }
+
+        pub fn getMouseWheelMove(_: *Game) f32 {
+            return Input.getMouseWheelMove();
+        }
     };
 }


### PR DESCRIPTION
## Summary
- Add `getMouseWheelMove()` to the engine's input mixin and game struct
- All backends (raylib, SDL, sokol, bgfx) already implement it via `InputInterface`
- Scripts can now call `game.getMouseWheelMove()` instead of reaching through `@TypeOf(game.*).Input.getMouseWheelMove()`

Closes #382

## Test plan
- [x] Engine tests pass (`zig build test`)
- [x] Verified in flying-platform-labelle with mouse wheel camera zoom

🤖 Generated with [Claude Code](https://claude.com/claude-code)