### PR TITLE
Add resetEcsBackend() for atomic world reset

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -502,16 +502,18 @@ pub fn GameConfig(
         /// Call clearActiveSceneEntities() first if the scene's entity list
         /// should also be cleared.
         pub fn resetEcsBackend(self: *Self) void {
-            // Tear down
+            // Tear down (reverse of init order, matching deinit convention)
+            self.gizmo_state.deinit(self.allocator);
+            self.sprite_cache.deinit();
             self.renderer.deinit();
             self.ecs_backend.deinit();
-            self.sprite_cache.deinit();
             _ = self.nested_entity_arena.reset(.retain_capacity);
 
             // Reinitialize
             self.ecs_backend = EcsImpl.init(self.allocator);
             self.renderer = RenderImpl.init(self.allocator);
             self.sprite_cache = atlas_mod.SpriteCache.init(self.allocator);
+            self.gizmo_state = gizmo_draws_mod.GizmoState(Entity).init(self.allocator);
         }
 
         pub fn teardownActiveScene(self: *Self) void {


### PR DESCRIPTION
## Summary
Add `game.resetEcsBackend()` — destroys all entities and visuals atomically by deinit+reinit of the ECS backend, renderer, and sprite cache. No per-entity iteration needed.

This is Phase 1 of the multiple ECS worlds RFC (#387).

## Motivation
The iterate-and-destroy approach for save/load crashes due to zig-ecs destruction signals corrupting internal state (#388). `resetEcsBackend` sidesteps the entire issue by doing bulk deinit without iterating entities.

## API
```zig
game.clearActiveSceneEntities();  // clear scene tracking
game.resetEcsBackend();           // destroy everything atomically
// now create new entities from save file...
```

## Test plan
- [x] Engine tests pass
- [x] flying-platform-labelle: F5 save, F8 restart (3x), F9 load (2x) — all clean, zero errors
- [x] Pathfinder rebuilds correctly after reset

Relates to #387, works around #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)