### PR TITLE
feat: AnimationDef comptime generator + AnimationState component

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -41,6 +41,7 @@ pub fn build(b: *std.Build) void {
         "test/save_load_mixin_test.zig",
         "test/jsonc_bridge_leak_test.zig",
         "test/scene_ref_test.zig",
+        "test/animation_def_test.zig",
     };
 
     for (test_files) |test_file| {

--- a/codegen/main.zig.template
+++ b/codegen/main.zig.template
@@ -38,6 +38,6 @@ pub const Game = AssembledGame;
 {{#else}}const GameContext = struct {};
 {{/if}}const Runner = engine.ScriptRunner(AllScripts, GameContext, EcsBackend);
 
-{{view_registry_block}}{{gizmo_registry_block}}// Gizmo rendering is now handled by g.renderGizmos() — no generated code needed.
+{{view_registry_block}}{{gizmo_registry_block}}{{animation_registry_block}}// Gizmo rendering is now handled by g.renderGizmos() — no generated code needed.
 // The engine delegates to the renderer's renderGizmoDraws() method.
 {{lifecycle}}

--- a/codegen/manifest.zon
+++ b/codegen/manifest.zon
@@ -27,6 +27,7 @@
         "all_scripts_block",
         "view_registry_block",
         "gizmo_registry_block",
+        "animation_registry_block",
 
         // Lifecycle placeholder — the CLI fills this with the
         // backend-specific main/setup/tick/draw section.

--- a/src/animation_def.zig
+++ b/src/animation_def.zig
@@ -32,10 +32,18 @@ pub const ClipMeta = struct {
 };
 
 pub fn AnimationDef(comptime zon: anytype) type {
+    if (!@hasField(@TypeOf(zon), "clips")) @compileError("animation .zon must have a .clips field");
+    if (!@hasField(@TypeOf(zon), "variants")) @compileError("animation .zon must have a .variants field");
+
     const clip_fields = @typeInfo(@TypeOf(zon.clips)).@"struct".fields;
     const variant_list = zon.variants;
     const variant_count = variant_list.len;
     const clip_count = clip_fields.len;
+
+    comptime {
+        if (variant_count == 0) @compileError("animation .zon must define at least one variant");
+        if (clip_count == 0) @compileError("animation .zon must define at least one clip");
+    }
 
     // Build Clip enum fields
     const ClipEnumFields = blk: {
@@ -109,6 +117,9 @@ pub fn AnimationDef(comptime zon: anytype) type {
     // Format: "{folder}/{variant}_{frame:04}.png"
     const SpriteNameTable = [clip_count][variant_count][max_frames][]const u8;
 
+    // Precompute all sprite name strings at comptime. The branch quota scales
+    // with the table size because comptimePrint uses Writer internals that
+    // consume many branches per formatted string.
     const sprite_names: SpriteNameTable = blk: {
         @setEvalBranchQuota(clip_count * variant_count * max_frames * 2000);
         var table: SpriteNameTable = undefined;
@@ -145,6 +156,7 @@ pub fn AnimationDef(comptime zon: anytype) type {
         /// Look up the precomputed sprite name for a clip/variant/frame combination.
         /// Frame is 0-based.
         pub fn spriteName(clip: Clip, variant: Variant, frame: u8) []const u8 {
+            if (frame >= max_frames) return "";
             return sprite_names[@intFromEnum(clip)][@intFromEnum(variant)][frame];
         }
 

--- a/src/animation_def.zig
+++ b/src/animation_def.zig
@@ -1,0 +1,169 @@
+/// AnimationDef — comptime animation definition from .zon data.
+///
+/// Parses a .zon struct with `.variants` and `.clips` fields and generates:
+///   - A `Clip` enum with one tag per clip name
+///   - A `Variant` enum with one tag per variant name
+///   - A `ClipMeta` array indexed by clip ordinal (frame_count, speed, mode)
+///   - A precomputed sprite name table: `[clips][variants][max_frames][]const u8`
+///
+/// Usage:
+///   const WorkerAnim = AnimationDef(@import("animations/worker.zon"));
+///   const clip = WorkerAnim.Clip.walk;
+///   const meta = WorkerAnim.clipMeta(clip);
+///   const name = WorkerAnim.spriteName(.walk, .m_bald, 2); // "walk/m_bald_0003.png"
+
+const std = @import("std");
+
+pub const Mode = enum {
+    /// timer += dt * speed; frame cycles over time.
+    time,
+    /// Game writes timer from position delta; frame cycles over distance.
+    distance,
+    /// frame = 0 always.
+    static,
+};
+
+pub const ClipMeta = struct {
+    frame_count: u8,
+    speed: f32,
+    mode: Mode,
+    /// Sprite folder name (may differ from clip name, e.g. carry → "take").
+    folder: []const u8,
+};
+
+pub fn AnimationDef(comptime zon: anytype) type {
+    const clip_fields = @typeInfo(@TypeOf(zon.clips)).@"struct".fields;
+    const variant_list = zon.variants;
+    const variant_count = variant_list.len;
+    const clip_count = clip_fields.len;
+
+    // Build Clip enum fields
+    const ClipEnumFields = blk: {
+        var fields: [clip_count]std.builtin.Type.EnumField = undefined;
+        for (clip_fields, 0..) |f, i| {
+            fields[i] = .{ .name = f.name, .value = i };
+        }
+        break :blk fields;
+    };
+
+    const Clip = @Type(.{ .@"enum" = .{
+        .tag_type = u8,
+        .fields = &ClipEnumFields,
+        .decls = &.{},
+        .is_exhaustive = true,
+    } });
+
+    // Build Variant enum fields
+    const VariantEnumFields = blk: {
+        var fields: [variant_count]std.builtin.Type.EnumField = undefined;
+        for (0..variant_count) |i| {
+            fields[i] = .{ .name = variant_list[i], .value = i };
+        }
+        break :blk fields;
+    };
+
+    const Variant = @Type(.{ .@"enum" = .{
+        .tag_type = u8,
+        .fields = &VariantEnumFields,
+        .decls = &.{},
+        .is_exhaustive = true,
+    } });
+
+    // Build ClipMeta table
+    const clip_meta_table: [clip_count]ClipMeta = blk: {
+        var table: [clip_count]ClipMeta = undefined;
+        for (clip_fields, 0..) |f, i| {
+            const clip_data = @field(zon.clips, f.name);
+            const folder: []const u8 = if (@hasField(@TypeOf(clip_data), "folder"))
+                clip_data.folder
+            else
+                f.name;
+            const speed: f32 = if (@hasField(@TypeOf(clip_data), "speed"))
+                clip_data.speed
+            else
+                1.0;
+            const mode: Mode = if (@hasField(@TypeOf(clip_data), "mode"))
+                clip_data.mode
+            else
+                .static;
+            table[i] = .{
+                .frame_count = clip_data.frames,
+                .speed = speed,
+                .mode = mode,
+                .folder = folder,
+            };
+        }
+        break :blk table;
+    };
+
+    // Find max frames across all clips
+    const max_frames: usize = blk: {
+        var mx: usize = 1;
+        for (&clip_meta_table) |meta| {
+            if (meta.frame_count > mx) mx = meta.frame_count;
+        }
+        break :blk mx;
+    };
+
+    // Build precomputed sprite name table
+    // Format: "{folder}/{variant}_{frame:04}.png"
+    const SpriteNameTable = [clip_count][variant_count][max_frames][]const u8;
+
+    const sprite_names: SpriteNameTable = blk: {
+        @setEvalBranchQuota(clip_count * variant_count * max_frames * 2000);
+        var table: SpriteNameTable = undefined;
+        for (0..clip_count) |ci| {
+            const folder = clip_meta_table[ci].folder;
+            const fc = clip_meta_table[ci].frame_count;
+            for (0..variant_count) |vi| {
+                const vname: []const u8 = variant_list[vi];
+                for (0..max_frames) |fi| {
+                    if (fi < fc) {
+                        const frame_1 = fi + 1;
+                        table[ci][vi][fi] = std.fmt.comptimePrint("{s}/{s}_{d:0>4}.png", .{ folder, vname, frame_1 });
+                    } else {
+                        table[ci][vi][fi] = "";
+                    }
+                }
+            }
+        }
+        break :blk table;
+    };
+
+    return struct {
+        pub const clips = Clip;
+        pub const variants = Variant;
+        pub const clip_count_val = clip_count;
+        pub const variant_count_val = variant_count;
+        pub const max_frames_val = max_frames;
+
+        /// Get metadata for a clip (frame_count, speed, mode, folder).
+        pub fn clipMeta(clip: Clip) ClipMeta {
+            return clip_meta_table[@intFromEnum(clip)];
+        }
+
+        /// Look up the precomputed sprite name for a clip/variant/frame combination.
+        /// Frame is 0-based.
+        pub fn spriteName(clip: Clip, variant: Variant, frame: u8) []const u8 {
+            return sprite_names[@intFromEnum(clip)][@intFromEnum(variant)][frame];
+        }
+
+        /// Get variant name string.
+        pub fn variantName(variant: Variant) []const u8 {
+            return @tagName(variant);
+        }
+
+        /// Get clip name string.
+        pub fn clipName(clip: Clip) []const u8 {
+            return @tagName(clip);
+        }
+
+        /// Map an index to a variant, with fallback to the last variant.
+        pub fn variantFromIndex(idx: usize) Variant {
+            if (idx < variant_count) {
+                return @enumFromInt(idx);
+            }
+            return @enumFromInt(variant_count - 1);
+        }
+    };
+}

--- a/src/animation_state.zig
+++ b/src/animation_state.zig
@@ -1,0 +1,83 @@
+/// AnimationState — lightweight runtime animation component.
+///
+/// Stores the current clip, variant, frame, and timing state as integer
+/// indices into a comptime AnimationDef table. The engine's resolveAtlasSprites
+/// reads this to look up precomputed sprite names — no runtime string
+/// formatting or allocation needed.
+///
+/// Games add this component to entities that need sprite animation.
+/// Transitions are driven by calling `transition()` (from hooks or scripts).
+/// Frame advancement and sprite resolution are handled by the engine.
+
+const animation_def = @import("animation_def.zig");
+pub const Mode = animation_def.Mode;
+pub const ClipMeta = animation_def.ClipMeta;
+
+pub const AnimationState = struct {
+    /// Current clip index (into AnimationDef clip table).
+    clip: u8 = 0,
+
+    /// Character variant index (into AnimationDef variant table).
+    variant: u8 = 0,
+
+    /// Frame count for the current clip.
+    frame_count: u8 = 1,
+
+    /// Animation speed multiplier.
+    speed: f32 = 1.0,
+
+    /// How frames are advanced.
+    mode: Mode = .static,
+
+    /// Current frame index (0-based). Advanced each tick.
+    frame: u8 = 0,
+
+    /// Accumulated time/distance for cycling.
+    timer: f32 = 0.0,
+
+    /// Whether the sprite should be flipped horizontally.
+    flip_x: bool = false,
+
+    /// Set on clip transition, cleared after the sprite is resolved.
+    dirty: bool = true,
+
+    /// Advance the frame timer. Call once per tick.
+    pub fn advance(self: *AnimationState, dt: f32) void {
+        switch (self.mode) {
+            .time => {
+                self.timer += dt * self.speed;
+                if (self.frame_count > 0) {
+                    const fc: f32 = @floatFromInt(self.frame_count);
+                    const cycle = @mod(self.timer, fc);
+                    self.frame = @min(@as(u8, @intFromFloat(cycle)), self.frame_count - 1);
+                }
+            },
+            .distance => {
+                if (self.frame_count > 0) {
+                    const fc: f32 = @floatFromInt(self.frame_count);
+                    const cycle = @mod(self.timer, fc);
+                    self.frame = @min(@as(u8, @intFromFloat(cycle)), self.frame_count - 1);
+                }
+            },
+            .static => {
+                self.frame = 0;
+            },
+        }
+    }
+
+    /// Reset timer and frame for a new clip transition.
+    pub fn transition(self: *AnimationState, clip: u8, frame_count: u8, speed: f32, mode: Mode) void {
+        self.clip = clip;
+        self.frame_count = frame_count;
+        self.speed = speed;
+        self.mode = mode;
+        self.frame = 0;
+        self.timer = 0;
+        self.dirty = true;
+    }
+
+    /// Transition using metadata from an AnimationDef.
+    pub fn transitionFromMeta(self: *AnimationState, clip: u8, meta: ClipMeta) void {
+        self.transition(clip, meta.frame_count, meta.speed, meta.mode);
+    }
+};

--- a/src/root.zig
+++ b/src/root.zig
@@ -17,6 +17,8 @@ pub const sparse_set_mod = @import("sparse_set.zig");
 pub const query_mod = @import("query.zig");
 pub const hooks_types_mod = @import("hooks_types.zig");
 pub const animation_mod = @import("animation.zig");
+pub const animation_def_mod = @import("animation_def.zig");
+pub const animation_state_mod = @import("animation_state.zig");
 pub const atlas_mod = @import("atlas.zig");
 pub const jsonc_mod = @import("jsonc");
 
@@ -116,6 +118,10 @@ pub const ReferenceContext = scene_mod.ReferenceContext;
 pub const Animation = animation_mod.Animation;
 pub const AnimConfig = animation_mod.AnimConfig;
 pub const DefaultAnimationType = animation_mod.DefaultAnimationType;
+pub const AnimationDef = animation_def_mod.AnimationDef;
+pub const AnimationState = animation_state_mod.AnimationState;
+pub const AnimMode = animation_def_mod.Mode;
+pub const AnimClipMeta = animation_def_mod.ClipMeta;
 
 // ── Atlas ──
 pub const SpriteData = atlas_mod.SpriteData;

--- a/test/animation_def_test.zig
+++ b/test/animation_def_test.zig
@@ -1,0 +1,142 @@
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+
+const AnimationDef = engine.AnimationDef;
+const AnimationState = engine.AnimationState;
+
+// Test .zon data (inline struct matching the expected format)
+const test_zon = .{
+    .variants = .{ "m_bald", "m_beard", "w_india" },
+    .clips = .{
+        .idle = .{ .frames = 1, .mode = .static },
+        .walk = .{ .frames = 4, .mode = .distance, .speed = 15.0 },
+        .carry = .{ .frames = 4, .mode = .distance, .speed = 15.0, .folder = "take" },
+        .job1 = .{ .frames = 8, .mode = .time, .speed = 4.0 },
+    },
+};
+
+const TestAnim = AnimationDef(test_zon);
+
+// ── AnimationDef ──────────────────────────────────────────
+
+test "AnimationDef: generates Clip enum" {
+    try testing.expectEqual(@as(u8, 0), @intFromEnum(TestAnim.clips.idle));
+    try testing.expectEqual(@as(u8, 1), @intFromEnum(TestAnim.clips.walk));
+    try testing.expectEqual(@as(u8, 2), @intFromEnum(TestAnim.clips.carry));
+    try testing.expectEqual(@as(u8, 3), @intFromEnum(TestAnim.clips.job1));
+}
+
+test "AnimationDef: generates Variant enum" {
+    try testing.expectEqual(@as(u8, 0), @intFromEnum(TestAnim.variants.m_bald));
+    try testing.expectEqual(@as(u8, 1), @intFromEnum(TestAnim.variants.m_beard));
+    try testing.expectEqual(@as(u8, 2), @intFromEnum(TestAnim.variants.w_india));
+}
+
+test "AnimationDef: clipMeta returns correct metadata" {
+    const walk_meta = TestAnim.clipMeta(.walk);
+    try testing.expectEqual(@as(u8, 4), walk_meta.frame_count);
+    try testing.expectEqual(@as(f32, 15.0), walk_meta.speed);
+    try testing.expectEqual(engine.AnimMode.distance, walk_meta.mode);
+    try testing.expectEqualStrings("walk", walk_meta.folder);
+
+    const carry_meta = TestAnim.clipMeta(.carry);
+    try testing.expectEqualStrings("take", carry_meta.folder);
+
+    const idle_meta = TestAnim.clipMeta(.idle);
+    try testing.expectEqual(@as(u8, 1), idle_meta.frame_count);
+    try testing.expectEqual(engine.AnimMode.static, idle_meta.mode);
+}
+
+test "AnimationDef: spriteName produces correct names" {
+    try testing.expectEqualStrings("idle/m_bald_0001.png", TestAnim.spriteName(.idle, .m_bald, 0));
+    try testing.expectEqualStrings("walk/m_beard_0003.png", TestAnim.spriteName(.walk, .m_beard, 2));
+    try testing.expectEqualStrings("take/w_india_0001.png", TestAnim.spriteName(.carry, .w_india, 0));
+    try testing.expectEqualStrings("job1/m_bald_0008.png", TestAnim.spriteName(.job1, .m_bald, 7));
+}
+
+test "AnimationDef: folder override only affects carry" {
+    try testing.expectEqualStrings("walk/m_bald_0001.png", TestAnim.spriteName(.walk, .m_bald, 0));
+    try testing.expectEqualStrings("take/m_bald_0001.png", TestAnim.spriteName(.carry, .m_bald, 0));
+}
+
+test "AnimationDef: variantFromIndex with valid and out-of-range" {
+    try testing.expectEqual(TestAnim.variants.m_bald, TestAnim.variantFromIndex(0));
+    try testing.expectEqual(TestAnim.variants.w_india, TestAnim.variantFromIndex(2));
+    // Out of range falls back to last variant
+    try testing.expectEqual(TestAnim.variants.w_india, TestAnim.variantFromIndex(99));
+}
+
+test "AnimationDef: clipName and variantName" {
+    try testing.expectEqualStrings("walk", TestAnim.clipName(.walk));
+    try testing.expectEqualStrings("m_beard", TestAnim.variantName(.m_beard));
+}
+
+// ── AnimationState ────────────────────────────────────────
+
+test "AnimationState: advance in time mode" {
+    var state = AnimationState{
+        .clip = @intFromEnum(TestAnim.clips.job1),
+        .frame_count = 8,
+        .speed = 4.0,
+        .mode = .time,
+    };
+
+    try testing.expectEqual(@as(u8, 0), state.frame);
+    state.advance(0.5);
+    // timer = 0.5 * 4.0 = 2.0, frame = mod(2.0, 8.0) = 2
+    try testing.expectEqual(@as(u8, 2), state.frame);
+}
+
+test "AnimationState: advance in static mode stays at 0" {
+    var state = AnimationState{
+        .clip = 0,
+        .frame_count = 1,
+        .mode = .static,
+    };
+    state.advance(1.0);
+    try testing.expectEqual(@as(u8, 0), state.frame);
+}
+
+test "AnimationState: transition resets state" {
+    var state = AnimationState{
+        .clip = 0,
+        .frame = 5,
+        .timer = 10.0,
+        .dirty = false,
+    };
+
+    state.transition(1, 4, 15.0, .distance);
+    try testing.expectEqual(@as(u8, 1), state.clip);
+    try testing.expectEqual(@as(u8, 4), state.frame_count);
+    try testing.expectEqual(@as(f32, 15.0), state.speed);
+    try testing.expectEqual(engine.AnimMode.distance, state.mode);
+    try testing.expectEqual(@as(u8, 0), state.frame);
+    try testing.expectEqual(@as(f32, 0.0), state.timer);
+    try testing.expect(state.dirty);
+}
+
+test "AnimationState: transitionFromMeta uses clip metadata" {
+    var state = AnimationState{};
+    const meta = TestAnim.clipMeta(.walk);
+    state.transitionFromMeta(@intFromEnum(TestAnim.clips.walk), meta);
+
+    try testing.expectEqual(@intFromEnum(TestAnim.clips.walk), state.clip);
+    try testing.expectEqual(@as(u8, 4), state.frame_count);
+    try testing.expectEqual(@as(f32, 15.0), state.speed);
+    try testing.expectEqual(engine.AnimMode.distance, state.mode);
+}
+
+test "AnimationState: advance in distance mode uses timer directly" {
+    var state = AnimationState{
+        .frame_count = 4,
+        .speed = 10.0,
+        .mode = .distance,
+    };
+
+    // Game sets timer from distance traveled
+    state.timer = 2.5;
+    state.advance(0.0); // dt unused in distance mode
+    // mod(2.5, 4.0) = 2.5, frame = min(2, 3) = 2
+    try testing.expectEqual(@as(u8, 2), state.frame);
+}


### PR DESCRIPTION
## Summary

- New `AnimationDef(zon)` comptime function that parses `.zon` animation definitions and generates Clip/Variant enums, ClipMeta arrays, and a precomputed sprite name table (all comptime strings in static memory)
- New `AnimationState` lightweight runtime component (clip/variant/frame indices + timing)
- Exported from `root.zig` as `AnimationDef`, `AnimationState`, `AnimMode`, `AnimClipMeta`
- Engine template updated with `{{animation_registry_block}}` placeholder

Part of Flying-Platform/flying-platform-labelle#181 + Flying-Platform/flying-platform-labelle#182

## Test plan

- [x] `zig build test` — 14 new tests for AnimationDef and AnimationState
- [ ] Integration test with flying-platform-labelle game migration