### PR TITLE
fix(jsonc): reuse existing prefab cache in loadSceneFromSource

### DIFF
--- a/src/jsonc_scene_bridge.zig
+++ b/src/jsonc_scene_bridge.zig
@@ -34,8 +34,12 @@ pub fn JsoncSceneBridge(comptime GameType: type, comptime Components: type) type
 
         /// Load a JSONC scene file and instantiate all entities in the ECS.
         pub fn loadScene(game: *GameType, scene_path: []const u8, prefab_dir: []const u8) !void {
-            // Load prefab cache (tries .jsonc then .zon)
-            const prefab_cache = try initPersistentCache(game, prefab_dir);
+            // Reuse the existing prefab cache when available (preserves prefabs registered
+            // via addEmbeddedPrefab before this call).
+            const prefab_cache = if (game.prefab_cache_ptr) |ptr|
+                @as(*PrefabCache, @ptrCast(@alignCast(ptr)))
+            else
+                try initPersistentCache(game, prefab_dir);
 
             try loadSceneFile(game, scene_path, prefab_cache, 0);
 

--- a/src/jsonc_scene_bridge.zig
+++ b/src/jsonc_scene_bridge.zig
@@ -47,7 +47,14 @@ pub fn JsoncSceneBridge(comptime GameType: type, comptime Components: type) type
         /// Load a scene from an in-memory JSONC source string (for embedded/release builds).
         /// The source must outlive the loaded scene — typically a comptime `@embedFile` slice.
         pub fn loadSceneFromSource(game: *GameType, source: []const u8, prefab_dir: []const u8) !void {
-            const prefab_cache = try initPersistentCache(game, prefab_dir);
+            // Reuse the existing prefab cache when available (preserves prefabs registered
+            // via addEmbeddedPrefab). On platforms without a filesystem (Android), the
+            // PrefabCache.get() file fallback is unavailable, so discarding the embedded
+            // cache would leave all prefab lookups returning null.
+            const prefab_cache = if (game.prefab_cache_ptr) |ptr|
+                @as(*PrefabCache, @ptrCast(@alignCast(ptr)))
+            else
+                try initPersistentCache(game, prefab_dir);
 
             try loadSceneSource(game, source, prefab_cache);
 

--- a/src/jsonc_scene_bridge.zig
+++ b/src/jsonc_scene_bridge.zig
@@ -35,10 +35,14 @@ pub fn JsoncSceneBridge(comptime GameType: type, comptime Components: type) type
         /// Load a JSONC scene file and instantiate all entities in the ECS.
         pub fn loadScene(game: *GameType, scene_path: []const u8, prefab_dir: []const u8) !void {
             // Reuse the existing prefab cache when available (preserves prefabs registered
-            // via addEmbeddedPrefab before this call).
-            const prefab_cache = if (game.prefab_cache_ptr) |ptr|
-                @as(*PrefabCache, @ptrCast(@alignCast(ptr)))
-            else
+            // via addEmbeddedPrefab before this call). When reusing, refresh the cache's
+            // prefab_dir so PrefabCache.get()'s filesystem fallback resolves against the
+            // caller-specified directory rather than whatever dir seeded the cache.
+            const prefab_cache = if (game.prefab_cache_ptr) |ptr| blk: {
+                const cache = @as(*PrefabCache, @ptrCast(@alignCast(ptr)));
+                cache.prefab_dir = prefab_dir;
+                break :blk cache;
+            } else
                 try initPersistentCache(game, prefab_dir);
 
             try loadSceneFile(game, scene_path, prefab_cache, 0);
@@ -54,10 +58,14 @@ pub fn JsoncSceneBridge(comptime GameType: type, comptime Components: type) type
             // Reuse the existing prefab cache when available (preserves prefabs registered
             // via addEmbeddedPrefab). On platforms without a filesystem (Android), the
             // PrefabCache.get() file fallback is unavailable, so discarding the embedded
-            // cache would leave all prefab lookups returning null.
-            const prefab_cache = if (game.prefab_cache_ptr) |ptr|
-                @as(*PrefabCache, @ptrCast(@alignCast(ptr)))
-            else
+            // cache would leave all prefab lookups returning null. When reusing, refresh
+            // the cache's prefab_dir so the filesystem fallback resolves against the
+            // caller-specified directory rather than whatever dir seeded the cache.
+            const prefab_cache = if (game.prefab_cache_ptr) |ptr| blk: {
+                const cache = @as(*PrefabCache, @ptrCast(@alignCast(ptr)));
+                cache.prefab_dir = prefab_dir;
+                break :blk cache;
+            } else
                 try initPersistentCache(game, prefab_dir);
 
             try loadSceneSource(game, source, prefab_cache);

--- a/src/jsonc_scene_bridge.zig
+++ b/src/jsonc_scene_bridge.zig
@@ -32,18 +32,25 @@ pub fn JsoncSceneBridge(comptime GameType: type, comptime Components: type) type
             return cache;
         }
 
-        /// Load a JSONC scene file and instantiate all entities in the ECS.
-        pub fn loadScene(game: *GameType, scene_path: []const u8, prefab_dir: []const u8) !void {
-            // Reuse the existing prefab cache when available (preserves prefabs registered
-            // via addEmbeddedPrefab before this call). When reusing, refresh the cache's
-            // prefab_dir so PrefabCache.get()'s filesystem fallback resolves against the
-            // caller-specified directory rather than whatever dir seeded the cache.
-            const prefab_cache = if (game.prefab_cache_ptr) |ptr| blk: {
+        /// Return the game's persistent PrefabCache, creating it if needed.
+        /// Always refreshes the cache's `prefab_dir` to `prefab_dir` so that
+        /// PrefabCache.get()'s filesystem fallback resolves against the most
+        /// recent directory rather than whatever dir seeded the cache. This
+        /// lets addEmbeddedPrefab / loadScene / loadSceneFromSource be called
+        /// in any order with any dir — the most recent caller wins, and
+        /// embedded prefabs registered by earlier calls are preserved.
+        fn getOrCreateCache(game: *GameType, prefab_dir: []const u8) !*PrefabCache {
+            if (game.prefab_cache_ptr) |ptr| {
                 const cache = @as(*PrefabCache, @ptrCast(@alignCast(ptr)));
                 cache.prefab_dir = prefab_dir;
-                break :blk cache;
-            } else
-                try initPersistentCache(game, prefab_dir);
+                return cache;
+            }
+            return try initPersistentCache(game, prefab_dir);
+        }
+
+        /// Load a JSONC scene file and instantiate all entities in the ECS.
+        pub fn loadScene(game: *GameType, scene_path: []const u8, prefab_dir: []const u8) !void {
+            const prefab_cache = try getOrCreateCache(game, prefab_dir);
 
             try loadSceneFile(game, scene_path, prefab_cache, 0);
 
@@ -55,18 +62,7 @@ pub fn JsoncSceneBridge(comptime GameType: type, comptime Components: type) type
         /// Load a scene from an in-memory JSONC source string (for embedded/release builds).
         /// The source must outlive the loaded scene — typically a comptime `@embedFile` slice.
         pub fn loadSceneFromSource(game: *GameType, source: []const u8, prefab_dir: []const u8) !void {
-            // Reuse the existing prefab cache when available (preserves prefabs registered
-            // via addEmbeddedPrefab). On platforms without a filesystem (Android), the
-            // PrefabCache.get() file fallback is unavailable, so discarding the embedded
-            // cache would leave all prefab lookups returning null. When reusing, refresh
-            // the cache's prefab_dir so the filesystem fallback resolves against the
-            // caller-specified directory rather than whatever dir seeded the cache.
-            const prefab_cache = if (game.prefab_cache_ptr) |ptr| blk: {
-                const cache = @as(*PrefabCache, @ptrCast(@alignCast(ptr)));
-                cache.prefab_dir = prefab_dir;
-                break :blk cache;
-            } else
-                try initPersistentCache(game, prefab_dir);
+            const prefab_cache = try getOrCreateCache(game, prefab_dir);
 
             try loadSceneSource(game, source, prefab_cache);
 
@@ -79,10 +75,7 @@ pub fn JsoncSceneBridge(comptime GameType: type, comptime Components: type) type
         /// Call this before loadSceneFromSource to make prefabs available without file I/O.
         /// The source must outlive the game — typically a comptime `@embedFile` slice.
         pub fn addEmbeddedPrefab(game: *GameType, name: []const u8, source: []const u8, prefab_dir: []const u8) !void {
-            const prefab_cache = if (game.prefab_cache_ptr) |ptr|
-                @as(*PrefabCache, @ptrCast(@alignCast(ptr)))
-            else
-                try initPersistentCache(game, prefab_dir);
+            const prefab_cache = try getOrCreateCache(game, prefab_dir);
 
             const persistent = prefab_cache.persistent;
             var parser = JsoncParser.init(persistent, source);

--- a/test/jsonc_bridge_leak_test.zig
+++ b/test/jsonc_bridge_leak_test.zig
@@ -204,3 +204,50 @@ test "loadScene: children entities do not leak" {
 
     try Bridge.loadScene(&game, scene_path, prefab_path);
 }
+
+test "loadSceneFromSource: embedded prefabs are preserved across loadSceneFromSource" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    try tmp_dir.dir.makeDir("prefabs");
+    const prefab_path = try tmpPath(&tmp_dir, "prefabs");
+    defer testing.allocator.free(prefab_path);
+
+    // Embedded prefab — intentionally not written to disk so file fallback cannot help.
+    const prefab_source =
+        \\{
+        \\  "components": {
+        \\    "Health": { "current": 42, "max": 100 },
+        \\    "Position": { "x": 0, "y": 0 }
+        \\  }
+        \\}
+    ;
+
+    // Scene that references the embedded prefab by name.
+    const scene_source =
+        \\{
+        \\  "entities": [
+        \\    { "prefab": "hero", "components": { "Position": { "x": 10, "y": 20 } } }
+        \\  ]
+        \\}
+    ;
+
+    var game = engine.Game.init(testing.allocator);
+    defer game.deinit();
+
+    try Bridge.addEmbeddedPrefab(&game, "hero", prefab_source, prefab_path);
+    try Bridge.loadSceneFromSource(&game, scene_source, prefab_path);
+
+    // The entity must carry the Health component from the embedded prefab (current == 42).
+    // If the cache was discarded by loadSceneFromSource the component would be absent.
+    var found_health = false;
+    {
+        var view = game.ecs_backend.view(.{Health}, .{});
+        while (view.next()) |e| {
+            const h = game.ecs_backend.getComponent(e, Health).?;
+            if (h.current == 42) found_health = true;
+        }
+        view.deinit();
+    }
+    try testing.expect(found_health);
+}


### PR DESCRIPTION
Fixes #428

## Problem

`loadSceneFromSource` called `initPersistentCache` unconditionally, discarding any prefabs previously registered via `addEmbeddedPrefab`. On Android there is no filesystem fallback in `PrefabCache.get()`, so embedded prefabs registered before `setScene` were silently lost on every scene load — all prefab entity sprites appeared missing.

## Fix

Check for an existing cache before initializing a new one:

```zig
const prefab_cache = if (game.prefab_cache_ptr) |ptr|
    @as(*PrefabCache, @ptrCast(@alignCast(ptr)))
else
    try initPersistentCache(game, prefab_dir);
```

## Verified

Confirmed on flying-platform Android: prefab sprites load correctly on first and subsequent scene loads.