### PR TITLE
feat(input): touch accessors + screenToDesign forwarder

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -575,6 +575,22 @@ pub fn GameConfig(
         pub const getMouseY = InputMixin.getMouseY;
         pub const getMouse = InputMixin.getMouse;
         pub const getMouseWheelMove = InputMixin.getMouseWheelMove;
+        pub const getTouchCount = InputMixin.getTouchCount;
+        pub const getTouchX = InputMixin.getTouchX;
+        pub const getTouchY = InputMixin.getTouchY;
+        pub const getTouchId = InputMixin.getTouchId;
+
+        /// Convert a physical-pixel screen coordinate (raw touch / mouse
+        /// event coords from the backend) to a design-pixel coordinate
+        /// inside the pillarboxed/letterboxed canvas. Use this before
+        /// feeding touch / mouse coords to `cam.screenToWorld` so the
+        /// math lines up with the game's design coordinate system.
+        ///
+        /// Backends without a design/physical distinction (raylib) get
+        /// a passthrough — the input is returned unchanged.
+        pub fn screenToDesign(self: *Self, px: f32, py: f32) RenderImpl.ScreenPoint {
+            return self.renderer.screenToDesign(px, py);
+        }
 
         // ── Audio (mixin) ────────────────────────────────────────
         pub const playSound = AudioMixin.playSound;

--- a/src/game/input_mixin.zig
+++ b/src/game/input_mixin.zig
@@ -56,6 +56,7 @@ pub fn Mixin(comptime Game: type) type {
         /// Stable per-touch identifier from the OS — useful when matching
         /// touches across frames (e.g. for gesture recognition that needs
         /// to know which finger is which).
+        /// Returns 0 if `index >= getTouchCount()`.
         pub fn getTouchId(_: *Game, index: u32) u64 {
             return Input.getTouchId(index);
         }

--- a/src/game/input_mixin.zig
+++ b/src/game/input_mixin.zig
@@ -32,5 +32,32 @@ pub fn Mixin(comptime Game: type) type {
         pub fn getMouseWheelMove(_: *Game) f32 {
             return Input.getMouseWheelMove();
         }
+
+        // ── Touch ────────────────────────────────────────────────
+
+        /// Number of currently-active touches reported by the backend.
+        /// 0 on platforms without touch input. Up to MAX_TOUCHES.
+        pub fn getTouchCount(_: *Game) u32 {
+            return Input.getTouchCount();
+        }
+
+        /// X position (physical framebuffer pixels) of touch `index`.
+        /// Returns 0 if `index >= getTouchCount()`.
+        pub fn getTouchX(_: *Game, index: u32) f32 {
+            return Input.getTouchX(index);
+        }
+
+        /// Y position (physical framebuffer pixels) of touch `index`.
+        /// Returns 0 if `index >= getTouchCount()`.
+        pub fn getTouchY(_: *Game, index: u32) f32 {
+            return Input.getTouchY(index);
+        }
+
+        /// Stable per-touch identifier from the OS — useful when matching
+        /// touches across frames (e.g. for gesture recognition that needs
+        /// to know which finger is which).
+        pub fn getTouchId(_: *Game, index: u32) u64 {
+            return Input.getTouchId(index);
+        }
     };
 }


### PR DESCRIPTION
## Summary
Plumbs touch input from the backend's \`InputInterface\` (which already exposes \`getTouchCount\` / \`getTouchX\` / \`getTouchY\` / \`getTouchId\` on every backend including \`StubInput\`) up through the engine's input mixin and into the public \`Game\` API. Game scripts can now do:

\`\`\`zig
const count = game.getTouchCount();
if (count >= 2) {
    const x = game.getTouchX(0);
    const y = game.getTouchY(0);
    ...
}
\`\`\`

without reaching into backend internals.

Also adds \`Game.screenToDesign(px, py)\` — a forwarder around \`renderer.screenToDesign\` (labelle-toolkit/labelle-gfx#239) that converts physical framebuffer coordinates (the unit touch / mouse events arrive in) to design canvas coordinates (the unit \`cam.screenToWorld\` and sprite positions use). Backends without a design/physical distinction (raylib) fall through to a passthrough.

## Use case: pinch-around-midpoint zoom

Together these enable a clean implementation in user scripts:

\`\`\`zig
const t1 = game.screenToDesign(game.getTouchX(0), game.getTouchY(0));
const t2 = game.screenToDesign(game.getTouchX(1), game.getTouchY(1));
const mid_x = (t1.x + t2.x) * 0.5;
const mid_y = (t1.y + t2.y) * 0.5;
const before = cam.screenToWorld(mid_x, mid_y);
cam.setZoom(cam.zoom * pinch_scale);
const after = cam.screenToWorld(mid_x, mid_y);
cam.setPosition(cam.x + before.x - after.x, cam.y + before.y - after.y);
\`\`\`

The world point under the pinch midpoint stays under the user's fingers — the standard "zoom into where you're touching" feel.

## Why a named return type?
The forwarder uses \`RenderImpl.ScreenPoint\` rather than an anon struct so the type matches the renderer's \`pub const\` exactly. Zig treats two anon structs with identical fields as distinct types and the forwarder chain wouldn't compile (same gotcha as labelle-toolkit/labelle-assembler#37).

## Test plan
- [x] \`zig build test\` in labelle-engine
- [ ] Downstream: flying-platform-labelle pinch-around-midpoint camera control on the Android emulator

## Dependencies
- Needs labelle-toolkit/labelle-gfx#239 for the renderer's \`screenToDesign\` forwarder + \`ScreenPoint\` type. Without it the return type lookup fails.
- Optionally pairs with labelle-toolkit/labelle-assembler#42 for the sokol backend impl that does the actual pillarbox-aware conversion. With raylib (no impl) the chain returns its inputs unchanged.