### PR TITLE
fix(game): populate atlas display_size on sprite cache lookup

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -1067,8 +1067,18 @@ pub fn GameConfig(
                         sprite.source_rect = .{
                             .x = @floatFromInt(result.sprite.x),
                             .y = @floatFromInt(result.sprite.y),
+                            // `width`/`height` are texture-pixel coords used
+                            // for UV sampling. `display_*` carry the original
+                            // artwork's design-space size (TexturePacker
+                            // `sourceSize`) — when the atlas PNG has been
+                            // downscaled relative to the source artwork they
+                            // diverge, and the renderer uses `display_*` for
+                            // the destination rect so the on-screen sprite
+                            // size stays the same.
                             .width = @floatFromInt(result.sprite.getWidth()),
                             .height = @floatFromInt(result.sprite.getHeight()),
+                            .display_width = @floatFromInt(result.sprite.getSourceWidth()),
+                            .display_height = @floatFromInt(result.sprite.getSourceHeight()),
                         };
                         self.renderer.markVisualDirty(entity);
                     }


### PR DESCRIPTION
## Summary
Sprite cache lookup now passes the atlas \`SpriteData.getSourceWidth/Height()\` (TexturePacker \`sourceSize\`) into the new \`SourceRect.display_width/display_height\` fields added in labelle-toolkit/labelle-gfx#242. The renderer uses those for the destination rect when set, so sprites stay the same on-screen size even when the atlas PNG has been downscaled relative to the source artwork.

For 1:1 atlases (where artwork is authored at the same resolution as the texture, the common case) \`getSourceWidth\` returns \`getWidth\` so \`display_width == width\` and the renderer falls back to its legacy behavior. **No behavior change for existing games.**

Closes labelle-toolkit/labelle-gfx#240.

## Dependency
Requires labelle-toolkit/labelle-gfx#242 (the matching \`display_width\`/\`display_height\` fields on \`SourceRect\`). Bumping the engine pin in a project without also bumping gfx will fail to compile because the struct literal references unknown fields.

## Test plan
- [x] \`zig build\` clean (engine doesn't directly depend on gfx, so the struct literal isn't validated here)
- [x] \`zig build test\` green
- [ ] End-to-end: re-apply the 2K atlas resize on flying-platform-labelle (with this PR + #242 both wired in via local: paths) and confirm cold start drops 24s → ~8s while sprites render at the correct on-screen size