### PR TITLE
feat(atlas): lazy atlas loading via register/load split

### DIFF
--- a/src/atlas.zig
+++ b/src/atlas.zig
@@ -42,9 +42,19 @@ pub const SpriteData = struct {
 };
 
 /// Result of looking up a sprite by name across all loaded atlases.
+///
+/// `texture_scale_x` / `texture_scale_y` map the JSON's logical pixel grid
+/// (the "meta.size" the atlas was authored against) onto the actual texture
+/// pixel dims at load time. They are `1.0` for a 1:1 atlas (the common case)
+/// and `< 1` when the user shipped a downscaled PNG without re-running
+/// TexturePacker. Callers building a `SourceRect` for the renderer should
+/// multiply x/y/w/h by the scale (so UV sampling tracks the smaller texture)
+/// and pass the un-scaled `sprite.width/height` as the display dimensions.
 pub const FindSpriteResult = struct {
     sprite: SpriteData,
     texture_id: u32,
+    texture_scale_x: f32 = 1.0,
+    texture_scale_y: f32 = 1.0,
 };
 
 /// Compile-time atlas from a .zon frame definition.
@@ -110,6 +120,14 @@ pub const RuntimeAtlas = struct {
     sprites: std.StringHashMap(SpriteData),
     texture_id: u32 = 0,
     owns_keys: bool = false,
+    /// Scale from the JSON's logical pixel grid to the actual texture's
+    /// physical pixels. `1.0` when the atlas matches the texture; `< 1`
+    /// when the source PNG was downscaled without re-running TexturePacker
+    /// (a workflow we support to cut PNG decode time without touching
+    /// the JSON or losing trim info). Stored separately per axis because
+    /// nothing forces uniform scaling.
+    texture_scale_x: f32 = 1.0,
+    texture_scale_y: f32 = 1.0,
 
     pub fn init(allocator: std.mem.Allocator) RuntimeAtlas {
         return .{ .sprites = std.StringHashMap(SpriteData).init(allocator) };
@@ -170,6 +188,16 @@ pub const TextureManager = struct {
         return self.atlases.getPtr(owned_name).?;
     }
 
+    /// Texture dimensions for the actual loaded image. Used by the
+    /// scale-aware atlas loaders to compute `texture_scale_*` against
+    /// the JSON's `meta.size`. When the dims aren't known (e.g. the
+    /// caller doesn't track them), passing `null` falls back to a
+    /// scale of 1.0 — matching the legacy behavior.
+    pub const TextureDims = struct {
+        width: u32,
+        height: u32,
+    };
+
     /// Load an atlas from a TexturePacker JSON file and associate it with a texture.
     /// Replaces any existing atlas with the same name.
     pub fn loadAtlasFromJson(
@@ -177,13 +205,15 @@ pub const TextureManager = struct {
         name: []const u8,
         json_path: [:0]const u8,
         texture_id: u32,
+        actual_dims: ?TextureDims,
     ) !void {
         var atlas = RuntimeAtlas.init(self.allocator);
         atlas.texture_id = texture_id;
         atlas.owns_keys = true;
         errdefer atlas.deinit();
 
-        try parseTexturePackerJson(self.allocator, json_path, &atlas.sprites);
+        const meta = try parseTexturePackerJson(self.allocator, json_path, &atlas.sprites);
+        applyTextureScale(&atlas, meta, actual_dims);
 
         self.removeExisting(name);
         const owned_name = try self.allocator.dupe(u8, name);
@@ -200,13 +230,15 @@ pub const TextureManager = struct {
         name: []const u8,
         json_content: []const u8,
         texture_id: u32,
+        actual_dims: ?TextureDims,
     ) !void {
         var atlas = RuntimeAtlas.init(self.allocator);
         atlas.texture_id = texture_id;
         atlas.owns_keys = true;
         errdefer atlas.deinit();
 
-        try parseTexturePackerJsonContent(self.allocator, json_content, &atlas.sprites);
+        const meta = try parseTexturePackerJsonContent(self.allocator, json_content, &atlas.sprites);
+        applyTextureScale(&atlas, meta, actual_dims);
 
         self.removeExisting(name);
         const owned_name = try self.allocator.dupe(u8, name);
@@ -253,7 +285,12 @@ pub const TextureManager = struct {
         var it = self.atlases.valueIterator();
         while (it.next()) |atlas| {
             if (atlas.get(sprite_name)) |data| {
-                return .{ .sprite = data, .texture_id = atlas.texture_id };
+                return .{
+                    .sprite = data,
+                    .texture_id = atlas.texture_id,
+                    .texture_scale_x = atlas.texture_scale_x,
+                    .texture_scale_y = atlas.texture_scale_y,
+                };
             }
         }
         return null;
@@ -386,27 +423,40 @@ pub const SpriteCache = struct {
 
 // ── JSON Parsing ────────────────────────────────────────────
 
+/// Per-atlas metadata extracted from `meta.size` in the JSON. Optional
+/// because not every TexturePacker output includes a `meta` block.
+pub const AtlasMeta = struct {
+    /// Logical pixel grid the atlas was authored against. When this
+    /// differs from the actual texture pixel dims, the loader derives
+    /// a `texture_scale` so source-rect coords stay in physical space
+    /// while display coords stay at the original resolution.
+    logical_width: ?u32 = null,
+    logical_height: ?u32 = null,
+};
+
 /// Parse a TexturePacker JSON Hash format file into a sprite map.
+/// Returns `meta.size` so the caller can derive a texture scale.
 fn parseTexturePackerJson(
     allocator: std.mem.Allocator,
     json_path: [:0]const u8,
     sprites: *std.StringHashMap(SpriteData),
-) !void {
+) !AtlasMeta {
     const file = try std.fs.cwd().openFile(json_path, .{});
     defer file.close();
 
     const content = try file.readToEndAlloc(allocator, 10 * 1024 * 1024);
     defer allocator.free(content);
 
-    try parseTexturePackerJsonContent(allocator, content, sprites);
+    return parseTexturePackerJsonContent(allocator, content, sprites);
 }
 
 /// Parse TexturePacker JSON content (already in memory) into a sprite map.
+/// Returns `meta.size` so the caller can derive a texture scale.
 fn parseTexturePackerJsonContent(
     allocator: std.mem.Allocator,
     content: []const u8,
     sprites: *std.StringHashMap(SpriteData),
-) !void {
+) !AtlasMeta {
     const parsed = try std.json.parseFromSlice(std.json.Value, allocator, content, .{});
     defer parsed.deinit();
 
@@ -417,6 +467,38 @@ fn parseTexturePackerJsonContent(
         .object => |frames_obj| try parseFramesObject(allocator, frames_obj, sprites),
         .array => |frames_arr| try parseFramesArray(allocator, frames_arr, sprites),
         else => return error.InvalidAtlasFormat,
+    }
+
+    var meta: AtlasMeta = .{};
+    if (root.get("meta")) |meta_val| {
+        if (meta_val == .object) {
+            if (meta_val.object.get("size")) |size_val| {
+                if (size_val == .object) {
+                    const size_obj = size_val.object;
+                    meta.logical_width = jsonInt(u32, size_obj.get("w"));
+                    meta.logical_height = jsonInt(u32, size_obj.get("h"));
+                }
+            }
+        }
+    }
+    return meta;
+}
+
+/// Compute and apply the per-axis texture scale by comparing the JSON's
+/// logical size against the actual texture's pixel dims. When either is
+/// missing or zero the scale stays at `1.0` — preserving legacy
+/// behavior for callers that don't track texture dims.
+fn applyTextureScale(atlas: *RuntimeAtlas, meta: AtlasMeta, actual_dims: ?TextureManager.TextureDims) void {
+    const dims = actual_dims orelse return;
+    if (meta.logical_width) |lw| {
+        if (lw > 0 and dims.width > 0) {
+            atlas.texture_scale_x = @as(f32, @floatFromInt(dims.width)) / @as(f32, @floatFromInt(lw));
+        }
+    }
+    if (meta.logical_height) |lh| {
+        if (lh > 0 and dims.height > 0) {
+            atlas.texture_scale_y = @as(f32, @floatFromInt(dims.height)) / @as(f32, @floatFromInt(lh));
+        }
     }
 }
 

--- a/src/atlas.zig
+++ b/src/atlas.zig
@@ -116,11 +116,13 @@ pub fn ComptimeAtlas(comptime frames: anytype) type {
 }
 
 /// Image bytes captured by a pending (registered-but-not-yet-decoded)
-/// atlas. The slices reference caller-owned memory — typically
-/// `@embedFile` strings, which live forever. Don't use these fields for
-/// runtime-loaded atlases unless the caller can guarantee the bytes
-/// outlive the atlas (the eager-load shim does the decode immediately
-/// so no lifetime issue).
+/// atlas. **Both `bytes` and `file_type` reference caller-owned memory
+/// — neither is duplicated by the manager.** They must outlive the
+/// atlas, or until `markPendingLoaded` is called for it (whichever
+/// comes first). Typically both are `@embedFile` slices / comptime
+/// string literals, which live forever — the lifetime constraint is
+/// invisible in practice. The eager-load shim decodes immediately, so
+/// it has no lifetime issue.
 pub const PendingImage = struct {
     bytes: []const u8,
     file_type: [:0]const u8,

--- a/src/atlas.zig
+++ b/src/atlas.zig
@@ -115,6 +115,21 @@ pub fn ComptimeAtlas(comptime frames: anytype) type {
     };
 }
 
+/// Image bytes captured by a pending (registered-but-not-yet-decoded)
+/// atlas. The slices reference caller-owned memory — typically
+/// `@embedFile` strings, which live forever. Don't use these fields for
+/// runtime-loaded atlases unless the caller can guarantee the bytes
+/// outlive the atlas (the eager-load shim does the decode immediately
+/// so no lifetime issue).
+pub const PendingImage = struct {
+    bytes: []const u8,
+    file_type: [:0]const u8,
+    /// Cached `meta.size` from the JSON. Kept on the pending atlas so
+    /// we can derive `texture_scale_*` once the actual texture dims
+    /// come back from `loadTextureFromMemory`.
+    meta: AtlasMeta,
+};
+
 /// Runtime atlas backed by a hashmap. For JSON/dynamic loading.
 pub const RuntimeAtlas = struct {
     sprites: std.StringHashMap(SpriteData),
@@ -128,6 +143,13 @@ pub const RuntimeAtlas = struct {
     /// nothing forces uniform scaling.
     texture_scale_x: f32 = 1.0,
     texture_scale_y: f32 = 1.0,
+    /// Lazy-load state. When non-null, the atlas's JSON has been parsed
+    /// into `sprites` but the PNG hasn't been decoded yet. Calling
+    /// `Game.loadAtlasIfNeeded(name)` decodes the bytes, uploads the
+    /// texture, populates `texture_id`, derives the scale, and clears
+    /// `pending`. After that point the atlas is indistinguishable from
+    /// one loaded eagerly. `is_loaded()` is the predicate.
+    pending: ?PendingImage = null,
 
     pub fn init(allocator: std.mem.Allocator) RuntimeAtlas {
         return .{ .sprites = std.StringHashMap(SpriteData).init(allocator) };
@@ -157,6 +179,13 @@ pub const RuntimeAtlas = struct {
 
     pub fn count(self: *const RuntimeAtlas) usize {
         return self.sprites.count();
+    }
+
+    /// `true` when the PNG has been decoded and a real `texture_id` is
+    /// available. `false` for atlases that have only been registered
+    /// (parsed JSON, deferred PNG decode).
+    pub fn isLoaded(self: *const RuntimeAtlas) bool {
+        return self.pending == null;
     }
 };
 
@@ -278,6 +307,68 @@ pub const TextureManager = struct {
     /// Get an atlas by name.
     pub fn getAtlas(self: *const TextureManager, name: []const u8) ?*const RuntimeAtlas {
         return self.atlases.getPtr(name);
+    }
+
+    /// Mutable accessor used by the lazy-load path to mark a pending
+    /// atlas as decoded. Not exposed as part of the read API because
+    /// modifying sprites after registration would invalidate the
+    /// sprite cache.
+    pub fn getAtlasMut(self: *TextureManager, name: []const u8) ?*RuntimeAtlas {
+        return self.atlases.getPtr(name);
+    }
+
+    /// Register an atlas in **pending** state — JSON parsed eagerly,
+    /// PNG decode deferred. The caller must keep `image_data` alive
+    /// until `markPendingLoaded` is called for this atlas (or hand
+    /// over a `@embedFile` slice, which lives forever).
+    ///
+    /// Used by the lazy-load init path. Pair with
+    /// `Game.loadAtlasIfNeeded(name)` to materialise the texture on
+    /// demand.
+    pub fn registerPendingAtlas(
+        self: *TextureManager,
+        name: []const u8,
+        json_content: []const u8,
+        image_data: []const u8,
+        file_type: [:0]const u8,
+    ) !void {
+        var atlas = RuntimeAtlas.init(self.allocator);
+        atlas.texture_id = 0;
+        atlas.owns_keys = true;
+        errdefer atlas.deinit();
+
+        const meta = try parseTexturePackerJsonContent(self.allocator, json_content, &atlas.sprites);
+        atlas.pending = .{
+            .bytes = image_data,
+            .file_type = file_type,
+            .meta = meta,
+        };
+
+        self.removeExisting(name);
+        const owned_name = try self.allocator.dupe(u8, name);
+        errdefer self.allocator.free(owned_name);
+
+        try self.atlases.put(owned_name, atlas);
+        self.version += 1;
+    }
+
+    /// Promote a pending atlas to "loaded" once the renderer has
+    /// decoded its PNG and returned the actual texture id + dims.
+    /// Called by `Game.loadAtlasIfNeeded` after the renderer call.
+    /// Returns `error.AtlasNotPending` if the atlas was already loaded
+    /// (idempotent caller-side: just check `isLoaded` first).
+    pub fn markPendingLoaded(
+        self: *TextureManager,
+        name: []const u8,
+        texture_id: u32,
+        actual_dims: ?TextureDims,
+    ) !void {
+        const atlas = self.atlases.getPtr(name) orelse return error.AtlasNotFound;
+        const pending = atlas.pending orelse return error.AtlasNotPending;
+        atlas.texture_id = texture_id;
+        applyTextureScale(atlas, pending.meta, actual_dims);
+        atlas.pending = null;
+        self.version += 1;
     }
 
     /// Search all atlases for a sprite by name.

--- a/src/atlas.zig
+++ b/src/atlas.zig
@@ -320,9 +320,12 @@ pub const TextureManager = struct {
     }
 
     /// Register an atlas in **pending** state — JSON parsed eagerly,
-    /// PNG decode deferred. The caller must keep `image_data` alive
-    /// until `markPendingLoaded` is called for this atlas (or hand
-    /// over a `@embedFile` slice, which lives forever).
+    /// PNG decode deferred. The caller must keep BOTH `image_data`
+    /// and `file_type` alive until `markPendingLoaded` is called for
+    /// this atlas — both are stored as borrowed slices on
+    /// `PendingImage` without being duplicated. Passing
+    /// `@embedFile`/comptime string-literal slices is the easy path,
+    /// since they live for the program lifetime.
     ///
     /// Used by the lazy-load init path. Pair with
     /// `Game.loadAtlasIfNeeded(name)` to materialise the texture on

--- a/src/game.zig
+++ b/src/game.zig
@@ -1024,6 +1024,56 @@ pub fn GameConfig(
             try self.atlas_manager.loadAtlasFromJsonContent(name, json_content, id, dims);
         }
 
+        /// Register an atlas in **deferred** mode: parse the JSON
+        /// eagerly (cheap) but skip the PNG decode (expensive). The
+        /// atlas is added to the manager with no `texture_id` and a
+        /// `pending` block carrying the PNG byte slice. The first call
+        /// to `loadAtlasIfNeeded(name)` decodes the PNG, uploads to
+        /// the GPU, and promotes the atlas to "loaded".
+        ///
+        /// `image_data` must outlive the atlas — typically a slice
+        /// from `@embedFile`, which lives forever. Pair this with
+        /// `loadAtlasIfNeeded` from a loading-scene script to spread
+        /// PNG decode cost across multiple frames instead of paying
+        /// for everything in `init()`.
+        pub const registerAtlasFromMemory = if (has_load_from_memory) registerAtlasFromMemoryImpl else @compileError("Renderer does not support loadTextureFromMemory");
+
+        fn registerAtlasFromMemoryImpl(self: *Self, name: []const u8, json_content: []const u8, image_data: []const u8, file_type: [:0]const u8) !void {
+            try self.atlas_manager.registerPendingAtlas(name, json_content, image_data, file_type);
+        }
+
+        /// Decode a previously-registered pending atlas if it hasn't
+        /// already been loaded. No-op (returns `false`) when the atlas
+        /// is already loaded — safe to call every frame from a loading
+        /// loop. Returns `true` on the call that actually performed
+        /// the decode, so a loading script can advance a progress
+        /// counter.
+        pub const loadAtlasIfNeeded = if (has_load_from_memory) loadAtlasIfNeededImpl else @compileError("Renderer does not support loadTextureFromMemory");
+
+        fn loadAtlasIfNeededImpl(self: *Self, name: []const u8) !bool {
+            const atlas = self.atlas_manager.getAtlasMut(name) orelse return error.AtlasNotFound;
+            if (atlas.isLoaded()) return false;
+
+            const pending = atlas.pending.?; // checked by isLoaded above
+            const tex_id = try self.renderer.loadTextureFromMemory(pending.file_type, pending.bytes);
+            const id: u32 = if (@typeInfo(@TypeOf(tex_id)) == .@"enum")
+                @intFromEnum(tex_id)
+            else
+                tex_id;
+            const dims = self.queryTextureDims(tex_id);
+            try self.atlas_manager.markPendingLoaded(name, id, dims);
+            return true;
+        }
+
+        /// Whether an atlas's PNG has been decoded. Returns `false`
+        /// for unregistered atlases too — both states mean "you can't
+        /// use it yet". Used by loading scripts to decide which
+        /// atlases still need a `loadAtlasIfNeeded` call.
+        pub fn isAtlasLoaded(self: *Self, name: []const u8) bool {
+            const atlas = self.atlas_manager.getAtlas(name) orelse return false;
+            return atlas.isLoaded();
+        }
+
         /// Look up the actual pixel dimensions of a freshly-loaded
         /// texture, so the atlas loader can derive a scale against the
         /// JSON's logical `meta.size`. Returns null when the renderer

--- a/src/game.zig
+++ b/src/game.zig
@@ -991,7 +991,8 @@ pub fn GameConfig(
                 @intFromEnum(tex_id)
             else
                 tex_id;
-            try self.atlas_manager.loadAtlasFromJson(name, json_path, id);
+            const dims = self.queryTextureDims(tex_id);
+            try self.atlas_manager.loadAtlasFromJson(name, json_path, id, dims);
         }
 
         /// Load an atlas from comptime sprite data (zero runtime parsing).
@@ -1019,7 +1020,22 @@ pub fn GameConfig(
                 @intFromEnum(tex_id)
             else
                 tex_id;
-            try self.atlas_manager.loadAtlasFromJsonContent(name, json_content, id);
+            const dims = self.queryTextureDims(tex_id);
+            try self.atlas_manager.loadAtlasFromJsonContent(name, json_content, id, dims);
+        }
+
+        /// Look up the actual pixel dimensions of a freshly-loaded
+        /// texture, so the atlas loader can derive a scale against the
+        /// JSON's logical `meta.size`. Returns null when the renderer
+        /// doesn't expose a `getTextureInfo` accessor — the atlas
+        /// loader then falls back to scale=1.0 (legacy behavior).
+        fn queryTextureDims(self: *Self, tex_id: anytype) ?atlas_mod.TextureManager.TextureDims {
+            if (!@hasDecl(RenderImpl, "getTextureInfo")) return null;
+            const info = self.renderer.getTextureInfo(tex_id) orelse return null;
+            return .{
+                .width = @intFromFloat(info.width),
+                .height = @intFromFloat(info.height),
+            };
         }
 
         pub fn getTextureManager(self: *Self) *atlas_mod.TextureManager {
@@ -1064,11 +1080,30 @@ pub fn GameConfig(
                     // Only update and mark dirty on cache miss (new sprite or atlas changed)
                     if (self.active_world.sprite_cache.misses != misses_before) {
                         sprite.texture = @enumFromInt(result.texture_id);
+                        // The atlas data is in the JSON's logical pixel
+                        // grid. `texture_scale_*` maps that grid onto the
+                        // actual texture pixels — `1.0` for the common
+                        // case, `< 1` when the user shipped a downscaled
+                        // PNG without re-running TexturePacker. Multiply
+                        // x/y/w/h by the scale so UV sampling tracks the
+                        // smaller texture, but keep the unscaled
+                        // dimensions in `display_*` so the on-screen
+                        // sprite stays the same size. For trimmed sprites
+                        // this matters: `getWidth()` is the actual
+                        // trimmed pixel count, so display=getWidth() is
+                        // the right rendered size, not the un-trimmed
+                        // `sourceSize`.
+                        const logical_w: f32 = @floatFromInt(result.sprite.getWidth());
+                        const logical_h: f32 = @floatFromInt(result.sprite.getHeight());
+                        const logical_x: f32 = @floatFromInt(result.sprite.x);
+                        const logical_y: f32 = @floatFromInt(result.sprite.y);
                         sprite.source_rect = .{
-                            .x = @floatFromInt(result.sprite.x),
-                            .y = @floatFromInt(result.sprite.y),
-                            .width = @floatFromInt(result.sprite.getWidth()),
-                            .height = @floatFromInt(result.sprite.getHeight()),
+                            .x = logical_x * result.texture_scale_x,
+                            .y = logical_y * result.texture_scale_y,
+                            .width = logical_w * result.texture_scale_x,
+                            .height = logical_h * result.texture_scale_y,
+                            .display_width = logical_w,
+                            .display_height = logical_h,
                         };
                         self.renderer.markVisualDirty(entity);
                     }

--- a/src/game.zig
+++ b/src/game.zig
@@ -1096,8 +1096,15 @@ pub fn GameConfig(
 
         fn clampToU32(v: f32) u32 {
             if (!std.math.isFinite(v) or v <= 0) return 0;
-            const max_f: f32 = @floatFromInt(std.math.maxInt(u32));
-            return @intFromFloat(@min(v, max_f));
+            // `@floatFromInt(maxInt(u32))` rounds *up* to 2^32 in f32
+            // because the f32 mantissa is only 24 bits, so comparing
+            // against it would let `@intFromFloat` see exactly 2^32 —
+            // one above the u32 range, triggering UB / safety panic.
+            // The largest f32 value strictly less than 2^32 is
+            // 4_294_967_040 (= 2^32 - 2^8). Clamp to that.
+            const max_safe: f32 = 4_294_967_040.0;
+            if (v >= max_safe) return std.math.maxInt(u32);
+            return @intFromFloat(v);
         }
 
         pub fn getTextureManager(self: *Self) *atlas_mod.TextureManager {

--- a/src/game.zig
+++ b/src/game.zig
@@ -1079,13 +1079,25 @@ pub fn GameConfig(
         /// JSON's logical `meta.size`. Returns null when the renderer
         /// doesn't expose a `getTextureInfo` accessor — the atlas
         /// loader then falls back to scale=1.0 (legacy behavior).
+        ///
+        /// Texture dims are clamped to `[0, max u32]` before the float
+        /// → int cast so a malformed renderer that returns negative or
+        /// NaN values can't trigger an `@intFromFloat` panic. Real
+        /// renderers always return positive integers, so this is a
+        /// belt-and-braces guard for buggy backend mocks.
         fn queryTextureDims(self: *Self, tex_id: anytype) ?atlas_mod.TextureManager.TextureDims {
             if (!@hasDecl(RenderImpl, "getTextureInfo")) return null;
             const info = self.renderer.getTextureInfo(tex_id) orelse return null;
             return .{
-                .width = @intFromFloat(info.width),
-                .height = @intFromFloat(info.height),
+                .width = clampToU32(info.width),
+                .height = clampToU32(info.height),
             };
+        }
+
+        fn clampToU32(v: f32) u32 {
+            if (!std.math.isFinite(v) or v <= 0) return 0;
+            const max_f: f32 = @floatFromInt(std.math.maxInt(u32));
+            return @intFromFloat(@min(v, max_f));
         }
 
         pub fn getTextureManager(self: *Self) *atlas_mod.TextureManager {

--- a/test/animation_atlas_test.zig
+++ b/test/animation_atlas_test.zig
@@ -133,7 +133,7 @@ test "TextureManager: loadAtlasFromJsonContent" {
         \\}
     ;
 
-    try mgr.loadAtlasFromJsonContent("test_atlas", json, 7);
+    try mgr.loadAtlasFromJsonContent("test_atlas", json, 7, null);
 
     try testing.expectEqual(1, mgr.atlasCount());
     try testing.expectEqual(2, mgr.totalSpriteCount());
@@ -188,7 +188,7 @@ test "TextureManager: JSON array format" {
         \\}
     ;
 
-    try mgr.loadAtlasFromJsonContent("arr_atlas", json, 3);
+    try mgr.loadAtlasFromJsonContent("arr_atlas", json, 3, null);
     try testing.expectEqual(2, mgr.totalSpriteCount());
 
     const a = mgr.findSprite("sprite_a").?;
@@ -197,6 +197,90 @@ test "TextureManager: JSON array format" {
 
     const b = mgr.findSprite("sprite_b").?;
     try testing.expectEqual(16, b.sprite.x);
+}
+
+test "TextureManager: texture_scale defaults to 1.0 when actual_dims is null" {
+    // Legacy path: callers that don't track actual texture dims pass
+    // null and get scale=1.0, matching pre-fix behavior.
+    var mgr = engine.TextureManager.init(testing.allocator);
+    defer mgr.deinit();
+
+    const json =
+        \\{
+        \\  "frames": {
+        \\    "hero": {
+        \\      "frame": {"x": 0, "y": 0, "w": 32, "h": 32},
+        \\      "rotated": false,
+        \\      "trimmed": false,
+        \\      "spriteSourceSize": {"x": 0, "y": 0, "w": 32, "h": 32},
+        \\      "sourceSize": {"w": 32, "h": 32}
+        \\    }
+        \\  },
+        \\  "meta": {"image": "atlas.png", "size": {"w": 64, "h": 64}}
+        \\}
+    ;
+
+    try mgr.loadAtlasFromJsonContent("a", json, 1, null);
+    const hero = mgr.findSprite("hero").?;
+    try testing.expectEqual(@as(f32, 1.0), hero.texture_scale_x);
+    try testing.expectEqual(@as(f32, 1.0), hero.texture_scale_y);
+}
+
+test "TextureManager: texture_scale derived from meta.size vs actual dims" {
+    // Fix for labelle-toolkit/labelle-gfx#240. When the user resizes
+    // the source PNG without re-running TexturePacker, meta.size in
+    // the JSON stays at the original logical resolution while the
+    // actual texture is smaller. The loader computes the per-axis
+    // scale so source-rect coords can be mapped to physical UV pixels
+    // at sprite-cache-lookup time, while display dimensions stay at
+    // the un-scaled values.
+    var mgr = engine.TextureManager.init(testing.allocator);
+    defer mgr.deinit();
+
+    const json =
+        \\{
+        \\  "frames": {
+        \\    "hero": {
+        \\      "frame": {"x": 0, "y": 0, "w": 32, "h": 32},
+        \\      "rotated": false,
+        \\      "trimmed": false,
+        \\      "spriteSourceSize": {"x": 0, "y": 0, "w": 32, "h": 32},
+        \\      "sourceSize": {"w": 32, "h": 32}
+        \\    }
+        \\  },
+        \\  "meta": {"image": "atlas.png", "size": {"w": 64, "h": 32}}
+        \\}
+    ;
+
+    try mgr.loadAtlasFromJsonContent("a", json, 1, .{ .width = 32, .height = 8 });
+    const hero = mgr.findSprite("hero").?;
+    try testing.expectEqual(@as(f32, 0.5), hero.texture_scale_x);
+    try testing.expectEqual(@as(f32, 0.25), hero.texture_scale_y);
+}
+
+test "TextureManager: texture_scale stays 1.0 when meta.size matches actual" {
+    var mgr = engine.TextureManager.init(testing.allocator);
+    defer mgr.deinit();
+
+    const json =
+        \\{
+        \\  "frames": {
+        \\    "hero": {
+        \\      "frame": {"x": 0, "y": 0, "w": 32, "h": 32},
+        \\      "rotated": false,
+        \\      "trimmed": false,
+        \\      "spriteSourceSize": {"x": 0, "y": 0, "w": 32, "h": 32},
+        \\      "sourceSize": {"w": 32, "h": 32}
+        \\    }
+        \\  },
+        \\  "meta": {"image": "atlas.png", "size": {"w": 64, "h": 64}}
+        \\}
+    ;
+
+    try mgr.loadAtlasFromJsonContent("a", json, 1, .{ .width = 64, .height = 64 });
+    const hero = mgr.findSprite("hero").?;
+    try testing.expectEqual(@as(f32, 1.0), hero.texture_scale_x);
+    try testing.expectEqual(@as(f32, 1.0), hero.texture_scale_y);
 }
 
 test "TextureManager: unload atlas" {

--- a/test/animation_atlas_test.zig
+++ b/test/animation_atlas_test.zig
@@ -283,6 +283,89 @@ test "TextureManager: texture_scale stays 1.0 when meta.size matches actual" {
     try testing.expectEqual(@as(f32, 1.0), hero.texture_scale_y);
 }
 
+test "TextureManager: registerPendingAtlas leaves atlas unloaded" {
+    var mgr = engine.TextureManager.init(testing.allocator);
+    defer mgr.deinit();
+
+    const json =
+        \\{
+        \\  "frames": {
+        \\    "hero": {
+        \\      "frame": {"x": 0, "y": 0, "w": 32, "h": 32},
+        \\      "rotated": false,
+        \\      "trimmed": false,
+        \\      "spriteSourceSize": {"x": 0, "y": 0, "w": 32, "h": 32},
+        \\      "sourceSize": {"w": 32, "h": 32}
+        \\    }
+        \\  },
+        \\  "meta": {"image": "atlas.png", "size": {"w": 64, "h": 64}}
+        \\}
+    ;
+    const fake_png: []const u8 = &.{ 0x89, 'P', 'N', 'G' };
+
+    try mgr.registerPendingAtlas("a", json, fake_png, ".png");
+    const atlas = mgr.getAtlas("a").?;
+    try testing.expect(!atlas.isLoaded());
+    try testing.expectEqual(@as(u32, 0), atlas.texture_id);
+
+    // Sprites are parsed eagerly so name lookups still work.
+    const hero = mgr.findSprite("hero").?;
+    try testing.expectEqual(@as(u32, 32), hero.sprite.width);
+    // texture_id stays 0 until markPendingLoaded is called.
+    try testing.expectEqual(@as(u32, 0), hero.texture_id);
+}
+
+test "TextureManager: markPendingLoaded promotes pending → loaded with scale" {
+    var mgr = engine.TextureManager.init(testing.allocator);
+    defer mgr.deinit();
+
+    const json =
+        \\{
+        \\  "frames": {
+        \\    "hero": {
+        \\      "frame": {"x": 0, "y": 0, "w": 32, "h": 32},
+        \\      "rotated": false,
+        \\      "trimmed": false,
+        \\      "spriteSourceSize": {"x": 0, "y": 0, "w": 32, "h": 32},
+        \\      "sourceSize": {"w": 32, "h": 32}
+        \\    }
+        \\  },
+        \\  "meta": {"image": "atlas.png", "size": {"w": 64, "h": 64}}
+        \\}
+    ;
+    const fake_png: []const u8 = &.{ 0x89, 'P', 'N', 'G' };
+
+    try mgr.registerPendingAtlas("a", json, fake_png, ".png");
+    try mgr.markPendingLoaded("a", 42, .{ .width = 32, .height = 32 });
+
+    const atlas = mgr.getAtlas("a").?;
+    try testing.expect(atlas.isLoaded());
+    try testing.expectEqual(@as(u32, 42), atlas.texture_id);
+    // 32 / 64 = 0.5
+    try testing.expectEqual(@as(f32, 0.5), atlas.texture_scale_x);
+    try testing.expectEqual(@as(f32, 0.5), atlas.texture_scale_y);
+
+    // findSprite now returns the real texture_id and scale.
+    const hero = mgr.findSprite("hero").?;
+    try testing.expectEqual(@as(u32, 42), hero.texture_id);
+    try testing.expectEqual(@as(f32, 0.5), hero.texture_scale_x);
+}
+
+test "TextureManager: markPendingLoaded errors on unknown atlas" {
+    var mgr = engine.TextureManager.init(testing.allocator);
+    defer mgr.deinit();
+    try testing.expectError(error.AtlasNotFound, mgr.markPendingLoaded("missing", 1, null));
+}
+
+test "TextureManager: markPendingLoaded errors when atlas is already loaded" {
+    var mgr = engine.TextureManager.init(testing.allocator);
+    defer mgr.deinit();
+
+    const json = "{ \"frames\": {}, \"meta\": {\"size\": {\"w\": 1, \"h\": 1}} }";
+    try mgr.loadAtlasFromJsonContent("a", json, 99, null);
+    try testing.expectError(error.AtlasNotPending, mgr.markPendingLoaded("a", 1, null));
+}
+
 test "TextureManager: unload atlas" {
     var mgr = engine.TextureManager.init(testing.allocator);
     defer mgr.deinit();


### PR DESCRIPTION
## Summary

Split the atlas-load API into two halves so users can defer the expensive PNG decode until a sprite from that atlas is actually needed:

- **\`Game.registerAtlasFromMemory(name, json, image, file_type)\`** — parses the JSON eagerly (cheap), stores the PNG byte slice on a new \`RuntimeAtlas.pending\` block. Texture isn't decoded yet.
- **\`Game.loadAtlasIfNeeded(name)\`** — decodes the pending PNG via the renderer, uploads to GPU, populates \`texture_id\`, derives the per-axis scale, clears \`pending\`. Idempotent; returns \`true\` only on the call that actually performed the decode (so loading scripts can advance a progress counter).
- **\`Game.isAtlasLoaded(name)\`** — predicate for loading scripts.

The existing \`loadAtlasFromMemory\` is unchanged: it remains the eager shim that registers + immediately loads. **Every existing project keeps its current cold-start cost**; opt-in via a follow-up template change unlocks the deferred decode.

## Why
Profiling \`flying-platform-labelle\` on a Samsung Galaxy Tab A7 (labelle-toolkit/flying-platform-labelle#187) showed cold start = 24 s, of which 24.13 s is \`stb_image\` PNG decode for six 4K RGBA atlases (256 MB uncompressed). Most of that work is wasted: the initial scene only references a subset of the atlases.

Lazy loading lets the loading scene be a regular labelle scene that only decodes its own (tiny) atlases at boot, then orchestrates pre-loading the heavy scene over multiple frames via \`loadAtlasIfNeeded\`. Cold start drops to <1 s and the user sees a live, animated loading scene the entire time.

## Lifetime constraint
Image bytes referenced by a pending atlas must outlive the atlas. The typical caller is \`@embedFile\`, whose slices live forever, so this is invisible in practice. Documented on \`PendingImage\`.

## Test plan
- [x] \`zig build\` clean
- [x] \`zig build test\` green (existing 95 tests + 4 new regression tests)
  - registerPendingAtlas leaves texture_id=0, isLoaded()=false, but sprite lookups still resolve names
  - markPendingLoaded promotes pending → loaded and derives the per-axis scale
  - markPendingLoaded errors on unknown atlas
  - markPendingLoaded errors when atlas is already loaded
- [ ] End-to-end on flying-platform-labelle once the labelle-assembler template change ships: cold start drops from ~10 s to <1 s

## Next steps
1. **labelle-assembler template** — emit \`registerAtlasFromMemory\` + a default loading-scene scaffold. Per-resource \`lazy\` flag in \`project.labelle\` resources block.
2. **flying-platform-labelle** — add a \`loading\` scene + \`loading_controller.zig\` script that calls \`loadAtlasIfNeeded\` for each atlas, advances a progress bar, and \`setScene("main")\` when done. Bump engine pin.

Refs labelle-toolkit/labelle-gfx#240, labelle-toolkit/flying-platform-labelle#187.