### PR TITLE
fix(atlas): per-atlas texture_scale derived from meta.size

### DIFF
--- a/src/atlas.zig
+++ b/src/atlas.zig
@@ -42,9 +42,19 @@ pub const SpriteData = struct {
 };
 
 /// Result of looking up a sprite by name across all loaded atlases.
+///
+/// `texture_scale_x` / `texture_scale_y` map the JSON's logical pixel grid
+/// (the "meta.size" the atlas was authored against) onto the actual texture
+/// pixel dims at load time. They are `1.0` for a 1:1 atlas (the common case)
+/// and `< 1` when the user shipped a downscaled PNG without re-running
+/// TexturePacker. Callers building a `SourceRect` for the renderer should
+/// multiply x/y/w/h by the scale (so UV sampling tracks the smaller texture)
+/// and pass the un-scaled `sprite.width/height` as the display dimensions.
 pub const FindSpriteResult = struct {
     sprite: SpriteData,
     texture_id: u32,
+    texture_scale_x: f32 = 1.0,
+    texture_scale_y: f32 = 1.0,
 };
 
 /// Compile-time atlas from a .zon frame definition.
@@ -110,6 +120,14 @@ pub const RuntimeAtlas = struct {
     sprites: std.StringHashMap(SpriteData),
     texture_id: u32 = 0,
     owns_keys: bool = false,
+    /// Scale from the JSON's logical pixel grid to the actual texture's
+    /// physical pixels. `1.0` when the atlas matches the texture; `< 1`
+    /// when the source PNG was downscaled without re-running TexturePacker
+    /// (a workflow we support to cut PNG decode time without touching
+    /// the JSON or losing trim info). Stored separately per axis because
+    /// nothing forces uniform scaling.
+    texture_scale_x: f32 = 1.0,
+    texture_scale_y: f32 = 1.0,
 
     pub fn init(allocator: std.mem.Allocator) RuntimeAtlas {
         return .{ .sprites = std.StringHashMap(SpriteData).init(allocator) };
@@ -170,6 +188,16 @@ pub const TextureManager = struct {
         return self.atlases.getPtr(owned_name).?;
     }
 
+    /// Texture dimensions for the actual loaded image. Used by the
+    /// scale-aware atlas loaders to compute `texture_scale_*` against
+    /// the JSON's `meta.size`. When the dims aren't known (e.g. the
+    /// caller doesn't track them), passing `null` falls back to a
+    /// scale of 1.0 — matching the legacy behavior.
+    pub const TextureDims = struct {
+        width: u32,
+        height: u32,
+    };
+
     /// Load an atlas from a TexturePacker JSON file and associate it with a texture.
     /// Replaces any existing atlas with the same name.
     pub fn loadAtlasFromJson(
@@ -177,13 +205,15 @@ pub const TextureManager = struct {
         name: []const u8,
         json_path: [:0]const u8,
         texture_id: u32,
+        actual_dims: ?TextureDims,
     ) !void {
         var atlas = RuntimeAtlas.init(self.allocator);
         atlas.texture_id = texture_id;
         atlas.owns_keys = true;
         errdefer atlas.deinit();
 
-        try parseTexturePackerJson(self.allocator, json_path, &atlas.sprites);
+        const meta = try parseTexturePackerJson(self.allocator, json_path, &atlas.sprites);
+        applyTextureScale(&atlas, meta, actual_dims);
 
         self.removeExisting(name);
         const owned_name = try self.allocator.dupe(u8, name);
@@ -200,13 +230,15 @@ pub const TextureManager = struct {
         name: []const u8,
         json_content: []const u8,
         texture_id: u32,
+        actual_dims: ?TextureDims,
     ) !void {
         var atlas = RuntimeAtlas.init(self.allocator);
         atlas.texture_id = texture_id;
         atlas.owns_keys = true;
         errdefer atlas.deinit();
 
-        try parseTexturePackerJsonContent(self.allocator, json_content, &atlas.sprites);
+        const meta = try parseTexturePackerJsonContent(self.allocator, json_content, &atlas.sprites);
+        applyTextureScale(&atlas, meta, actual_dims);
 
         self.removeExisting(name);
         const owned_name = try self.allocator.dupe(u8, name);
@@ -253,7 +285,12 @@ pub const TextureManager = struct {
         var it = self.atlases.valueIterator();
         while (it.next()) |atlas| {
             if (atlas.get(sprite_name)) |data| {
-                return .{ .sprite = data, .texture_id = atlas.texture_id };
+                return .{
+                    .sprite = data,
+                    .texture_id = atlas.texture_id,
+                    .texture_scale_x = atlas.texture_scale_x,
+                    .texture_scale_y = atlas.texture_scale_y,
+                };
             }
         }
         return null;
@@ -386,27 +423,40 @@ pub const SpriteCache = struct {
 
 // ── JSON Parsing ────────────────────────────────────────────
 
+/// Per-atlas metadata extracted from `meta.size` in the JSON. Optional
+/// because not every TexturePacker output includes a `meta` block.
+pub const AtlasMeta = struct {
+    /// Logical pixel grid the atlas was authored against. When this
+    /// differs from the actual texture pixel dims, the loader derives
+    /// a `texture_scale` so source-rect coords stay in physical space
+    /// while display coords stay at the original resolution.
+    logical_width: ?u32 = null,
+    logical_height: ?u32 = null,
+};
+
 /// Parse a TexturePacker JSON Hash format file into a sprite map.
+/// Returns `meta.size` so the caller can derive a texture scale.
 fn parseTexturePackerJson(
     allocator: std.mem.Allocator,
     json_path: [:0]const u8,
     sprites: *std.StringHashMap(SpriteData),
-) !void {
+) !AtlasMeta {
     const file = try std.fs.cwd().openFile(json_path, .{});
     defer file.close();
 
     const content = try file.readToEndAlloc(allocator, 10 * 1024 * 1024);
     defer allocator.free(content);
 
-    try parseTexturePackerJsonContent(allocator, content, sprites);
+    return parseTexturePackerJsonContent(allocator, content, sprites);
 }
 
 /// Parse TexturePacker JSON content (already in memory) into a sprite map.
+/// Returns `meta.size` so the caller can derive a texture scale.
 fn parseTexturePackerJsonContent(
     allocator: std.mem.Allocator,
     content: []const u8,
     sprites: *std.StringHashMap(SpriteData),
-) !void {
+) !AtlasMeta {
     const parsed = try std.json.parseFromSlice(std.json.Value, allocator, content, .{});
     defer parsed.deinit();
 
@@ -417,6 +467,38 @@ fn parseTexturePackerJsonContent(
         .object => |frames_obj| try parseFramesObject(allocator, frames_obj, sprites),
         .array => |frames_arr| try parseFramesArray(allocator, frames_arr, sprites),
         else => return error.InvalidAtlasFormat,
+    }
+
+    var meta: AtlasMeta = .{};
+    if (root.get("meta")) |meta_val| {
+        if (meta_val == .object) {
+            if (meta_val.object.get("size")) |size_val| {
+                if (size_val == .object) {
+                    const size_obj = size_val.object;
+                    meta.logical_width = jsonInt(u32, size_obj.get("w"));
+                    meta.logical_height = jsonInt(u32, size_obj.get("h"));
+                }
+            }
+        }
+    }
+    return meta;
+}
+
+/// Compute and apply the per-axis texture scale by comparing the JSON's
+/// logical size against the actual texture's pixel dims. When either is
+/// missing or zero the scale stays at `1.0` — preserving legacy
+/// behavior for callers that don't track texture dims.
+fn applyTextureScale(atlas: *RuntimeAtlas, meta: AtlasMeta, actual_dims: ?TextureManager.TextureDims) void {
+    const dims = actual_dims orelse return;
+    if (meta.logical_width) |lw| {
+        if (lw > 0 and dims.width > 0) {
+            atlas.texture_scale_x = @as(f32, @floatFromInt(dims.width)) / @as(f32, @floatFromInt(lw));
+        }
+    }
+    if (meta.logical_height) |lh| {
+        if (lh > 0 and dims.height > 0) {
+            atlas.texture_scale_y = @as(f32, @floatFromInt(dims.height)) / @as(f32, @floatFromInt(lh));
+        }
     }
 }
 

--- a/src/game.zig
+++ b/src/game.zig
@@ -1084,26 +1084,46 @@ pub fn GameConfig(
                         // grid. `texture_scale_*` maps that grid onto the
                         // actual texture pixels — `1.0` for the common
                         // case, `< 1` when the user shipped a downscaled
-                        // PNG without re-running TexturePacker. Multiply
-                        // x/y/w/h by the scale so UV sampling tracks the
-                        // smaller texture, but keep the unscaled
-                        // dimensions in `display_*` so the on-screen
-                        // sprite stays the same size. For trimmed sprites
-                        // this matters: `getWidth()` is the actual
-                        // trimmed pixel count, so display=getWidth() is
-                        // the right rendered size, not the un-trimmed
-                        // `sourceSize`.
-                        const logical_w: f32 = @floatFromInt(result.sprite.getWidth());
-                        const logical_h: f32 = @floatFromInt(result.sprite.getHeight());
-                        const logical_x: f32 = @floatFromInt(result.sprite.x);
-                        const logical_y: f32 = @floatFromInt(result.sprite.y);
+                        // PNG without re-running TexturePacker.
+                        //
+                        // Two distinct mappings are needed:
+                        //
+                        //   * The PHYSICAL atlas footprint (`sprite.x/y`,
+                        //     `sprite.width/height`) is in texture-pixel
+                        //     coordinates regardless of rotation. Each
+                        //     axis scales independently, so x/width go
+                        //     through `texture_scale_x` and y/height go
+                        //     through `texture_scale_y`.
+                        //
+                        //   * The DISPLAY dimensions (`getWidth/Height`)
+                        //     swap when the sprite was rotated 90° in the
+                        //     atlas — that's the on-screen size. They
+                        //     stay un-scaled.
+                        //
+                        // Mixing the two (multiplying `getWidth()` by
+                        // `texture_scale_x`) is wrong for rotated sprites
+                        // because `getWidth()` returns the post-rotation
+                        // height — a vertical dimension scaled by a
+                        // horizontal factor.
+                        const phys_x: f32 = @floatFromInt(result.sprite.x);
+                        const phys_y: f32 = @floatFromInt(result.sprite.y);
+                        const phys_w: f32 = @floatFromInt(result.sprite.width);
+                        const phys_h: f32 = @floatFromInt(result.sprite.height);
+                        const display_w: f32 = @floatFromInt(result.sprite.getWidth());
+                        const display_h: f32 = @floatFromInt(result.sprite.getHeight());
+                        const scaled_w = phys_w * result.texture_scale_x;
+                        const scaled_h = phys_h * result.texture_scale_y;
                         sprite.source_rect = .{
-                            .x = logical_x * result.texture_scale_x,
-                            .y = logical_y * result.texture_scale_y,
-                            .width = logical_w * result.texture_scale_x,
-                            .height = logical_h * result.texture_scale_y,
-                            .display_width = logical_w,
-                            .display_height = logical_h,
+                            .x = phys_x * result.texture_scale_x,
+                            .y = phys_y * result.texture_scale_y,
+                            // `source_rect.width/height` are in the same
+                            // post-rotation orientation that the renderer
+                            // expects (matching `getWidth/Height`),
+                            // so swap when the sprite was rotated.
+                            .width = if (result.sprite.rotated) scaled_h else scaled_w,
+                            .height = if (result.sprite.rotated) scaled_w else scaled_h,
+                            .display_width = display_w,
+                            .display_height = display_h,
                         };
                         self.renderer.markVisualDirty(entity);
                     }

--- a/src/game.zig
+++ b/src/game.zig
@@ -991,7 +991,8 @@ pub fn GameConfig(
                 @intFromEnum(tex_id)
             else
                 tex_id;
-            try self.atlas_manager.loadAtlasFromJson(name, json_path, id);
+            const dims = self.queryTextureDims(tex_id);
+            try self.atlas_manager.loadAtlasFromJson(name, json_path, id, dims);
         }
 
         /// Load an atlas from comptime sprite data (zero runtime parsing).
@@ -1019,7 +1020,22 @@ pub fn GameConfig(
                 @intFromEnum(tex_id)
             else
                 tex_id;
-            try self.atlas_manager.loadAtlasFromJsonContent(name, json_content, id);
+            const dims = self.queryTextureDims(tex_id);
+            try self.atlas_manager.loadAtlasFromJsonContent(name, json_content, id, dims);
+        }
+
+        /// Look up the actual pixel dimensions of a freshly-loaded
+        /// texture, so the atlas loader can derive a scale against the
+        /// JSON's logical `meta.size`. Returns null when the renderer
+        /// doesn't expose a `getTextureInfo` accessor — the atlas
+        /// loader then falls back to scale=1.0 (legacy behavior).
+        fn queryTextureDims(self: *Self, tex_id: anytype) ?atlas_mod.TextureManager.TextureDims {
+            if (!@hasDecl(RenderImpl, "getTextureInfo")) return null;
+            const info = self.renderer.getTextureInfo(tex_id) orelse return null;
+            return .{
+                .width = @intFromFloat(info.width),
+                .height = @intFromFloat(info.height),
+            };
         }
 
         pub fn getTextureManager(self: *Self) *atlas_mod.TextureManager {
@@ -1064,11 +1080,30 @@ pub fn GameConfig(
                     // Only update and mark dirty on cache miss (new sprite or atlas changed)
                     if (self.active_world.sprite_cache.misses != misses_before) {
                         sprite.texture = @enumFromInt(result.texture_id);
+                        // The atlas data is in the JSON's logical pixel
+                        // grid. `texture_scale_*` maps that grid onto the
+                        // actual texture pixels — `1.0` for the common
+                        // case, `< 1` when the user shipped a downscaled
+                        // PNG without re-running TexturePacker. Multiply
+                        // x/y/w/h by the scale so UV sampling tracks the
+                        // smaller texture, but keep the unscaled
+                        // dimensions in `display_*` so the on-screen
+                        // sprite stays the same size. For trimmed sprites
+                        // this matters: `getWidth()` is the actual
+                        // trimmed pixel count, so display=getWidth() is
+                        // the right rendered size, not the un-trimmed
+                        // `sourceSize`.
+                        const logical_w: f32 = @floatFromInt(result.sprite.getWidth());
+                        const logical_h: f32 = @floatFromInt(result.sprite.getHeight());
+                        const logical_x: f32 = @floatFromInt(result.sprite.x);
+                        const logical_y: f32 = @floatFromInt(result.sprite.y);
                         sprite.source_rect = .{
-                            .x = @floatFromInt(result.sprite.x),
-                            .y = @floatFromInt(result.sprite.y),
-                            .width = @floatFromInt(result.sprite.getWidth()),
-                            .height = @floatFromInt(result.sprite.getHeight()),
+                            .x = logical_x * result.texture_scale_x,
+                            .y = logical_y * result.texture_scale_y,
+                            .width = logical_w * result.texture_scale_x,
+                            .height = logical_h * result.texture_scale_y,
+                            .display_width = logical_w,
+                            .display_height = logical_h,
                         };
                         self.renderer.markVisualDirty(entity);
                     }

--- a/test/animation_atlas_test.zig
+++ b/test/animation_atlas_test.zig
@@ -133,7 +133,7 @@ test "TextureManager: loadAtlasFromJsonContent" {
         \\}
     ;
 
-    try mgr.loadAtlasFromJsonContent("test_atlas", json, 7);
+    try mgr.loadAtlasFromJsonContent("test_atlas", json, 7, null);
 
     try testing.expectEqual(1, mgr.atlasCount());
     try testing.expectEqual(2, mgr.totalSpriteCount());
@@ -188,7 +188,7 @@ test "TextureManager: JSON array format" {
         \\}
     ;
 
-    try mgr.loadAtlasFromJsonContent("arr_atlas", json, 3);
+    try mgr.loadAtlasFromJsonContent("arr_atlas", json, 3, null);
     try testing.expectEqual(2, mgr.totalSpriteCount());
 
     const a = mgr.findSprite("sprite_a").?;
@@ -197,6 +197,90 @@ test "TextureManager: JSON array format" {
 
     const b = mgr.findSprite("sprite_b").?;
     try testing.expectEqual(16, b.sprite.x);
+}
+
+test "TextureManager: texture_scale defaults to 1.0 when actual_dims is null" {
+    // Legacy path: callers that don't track actual texture dims pass
+    // null and get scale=1.0, matching pre-fix behavior.
+    var mgr = engine.TextureManager.init(testing.allocator);
+    defer mgr.deinit();
+
+    const json =
+        \\{
+        \\  "frames": {
+        \\    "hero": {
+        \\      "frame": {"x": 0, "y": 0, "w": 32, "h": 32},
+        \\      "rotated": false,
+        \\      "trimmed": false,
+        \\      "spriteSourceSize": {"x": 0, "y": 0, "w": 32, "h": 32},
+        \\      "sourceSize": {"w": 32, "h": 32}
+        \\    }
+        \\  },
+        \\  "meta": {"image": "atlas.png", "size": {"w": 64, "h": 64}}
+        \\}
+    ;
+
+    try mgr.loadAtlasFromJsonContent("a", json, 1, null);
+    const hero = mgr.findSprite("hero").?;
+    try testing.expectEqual(@as(f32, 1.0), hero.texture_scale_x);
+    try testing.expectEqual(@as(f32, 1.0), hero.texture_scale_y);
+}
+
+test "TextureManager: texture_scale derived from meta.size vs actual dims" {
+    // Fix for labelle-toolkit/labelle-gfx#240. When the user resizes
+    // the source PNG without re-running TexturePacker, meta.size in
+    // the JSON stays at the original logical resolution while the
+    // actual texture is smaller. The loader computes the per-axis
+    // scale so source-rect coords can be mapped to physical UV pixels
+    // at sprite-cache-lookup time, while display dimensions stay at
+    // the un-scaled values.
+    var mgr = engine.TextureManager.init(testing.allocator);
+    defer mgr.deinit();
+
+    const json =
+        \\{
+        \\  "frames": {
+        \\    "hero": {
+        \\      "frame": {"x": 0, "y": 0, "w": 32, "h": 32},
+        \\      "rotated": false,
+        \\      "trimmed": false,
+        \\      "spriteSourceSize": {"x": 0, "y": 0, "w": 32, "h": 32},
+        \\      "sourceSize": {"w": 32, "h": 32}
+        \\    }
+        \\  },
+        \\  "meta": {"image": "atlas.png", "size": {"w": 64, "h": 32}}
+        \\}
+    ;
+
+    try mgr.loadAtlasFromJsonContent("a", json, 1, .{ .width = 32, .height = 8 });
+    const hero = mgr.findSprite("hero").?;
+    try testing.expectEqual(@as(f32, 0.5), hero.texture_scale_x);
+    try testing.expectEqual(@as(f32, 0.25), hero.texture_scale_y);
+}
+
+test "TextureManager: texture_scale stays 1.0 when meta.size matches actual" {
+    var mgr = engine.TextureManager.init(testing.allocator);
+    defer mgr.deinit();
+
+    const json =
+        \\{
+        \\  "frames": {
+        \\    "hero": {
+        \\      "frame": {"x": 0, "y": 0, "w": 32, "h": 32},
+        \\      "rotated": false,
+        \\      "trimmed": false,
+        \\      "spriteSourceSize": {"x": 0, "y": 0, "w": 32, "h": 32},
+        \\      "sourceSize": {"w": 32, "h": 32}
+        \\    }
+        \\  },
+        \\  "meta": {"image": "atlas.png", "size": {"w": 64, "h": 64}}
+        \\}
+    ;
+
+    try mgr.loadAtlasFromJsonContent("a", json, 1, .{ .width = 64, .height = 64 });
+    const hero = mgr.findSprite("hero").?;
+    try testing.expectEqual(@as(f32, 1.0), hero.texture_scale_x);
+    try testing.expectEqual(@as(f32, 1.0), hero.texture_scale_y);
 }
 
 test "TextureManager: unload atlas" {


### PR DESCRIPTION
## Summary

Add a per-atlas \`texture_scale_x\` / \`texture_scale_y\` derived from comparing the JSON's \`meta.size\` against the actual texture pixel dims passed in by the loader. Defaults to 1.0 when the dims match (the common case) or when the caller passes null (legacy path).

\`loadAtlasFromJson\` and \`loadAtlasFromJsonContent\` now take an optional \`actual_dims: ?TextureManager.TextureDims\`. \`game.zig\` queries the renderer via \`getTextureInfo\` after loading the texture and passes the dims through. The scale is stored on \`RuntimeAtlas\` and surfaced on \`FindSpriteResult\` so the sprite-cache lookup can apply it without a second hash lookup.

\`game.zig\`'s sprite-cache lookup multiplies \`x/y/width/height\` by the scale when building \`source_rect\` (so UV sampling tracks the smaller physical texture) and passes the *un-scaled* \`getWidth/Height\` as \`display_width/display_height\` (so the on-screen sprite stays the same size). Trimmed sprites work because \`getWidth\` is the actual trimmed pixel count, not the un-trimmed \`sourceSize\`.

## Why
Closes labelle-toolkit/labelle-gfx#240. End user can ship a downscaled PNG to cut decode time without re-running TexturePacker — the atlas loader detects the mismatch via \`meta.size\`, the renderer keeps everything on-screen at the intended size.

## Dependency
Requires labelle-toolkit/labelle-gfx#243 (the matching \`display_width/height\` fields on \`SourceRect\` + \`getTextureInfo\` forwarder). Bumping the engine pin without bumping gfx will fail to compile.

## Test plan
- [x] \`zig build\` clean
- [x] \`zig build test\` green (3 new regression tests: legacy null-dims path → scale=1.0; meta.size vs actual mismatch → per-axis scale; meta.size matches actual → scale=1.0)
- [x] End-to-end on flying-platform-labelle (Samsung Galaxy Tab A7): cold start 24 s → 11 s with all sprites correct