### PR TITLE
feat(assets): AssetCatalog core + src/assets/ skeleton

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -41,6 +41,7 @@ pub fn build(b: *std.Build) void {
         "test/save_load_mixin_test.zig",
         "test/jsonc_bridge_leak_test.zig",
         "test/scene_ref_test.zig",
+        "test/asset_catalog_test.zig",
     };
 
     for (test_files) |test_file| {

--- a/src/assets/catalog.zig
+++ b/src/assets/catalog.zig
@@ -1,0 +1,330 @@
+//! AssetCatalog — metadata-only registry + refcounted handles for
+//! every streamable asset in the game (atlases, audio, fonts, …).
+//!
+//! This is the foundation of `src/assets/`. Subsequent tickets
+//! layer the worker thread (#439), real loaders (#440/#441), the
+//! frame-pump body (#442), the legacy atlas shim (#443), and the
+//! scene-transition wiring (#444/#445/#446) on top of it.
+//!
+//! ## Invariants
+//!
+//! 1. **Threading.** `AssetEntry` is owned exclusively by the main
+//!    thread. State transitions (`registered → queued → decoding →
+//!    ready/failed`) and refcount mutations happen only inside
+//!    `pump()` and the public methods on this struct. There is no
+//!    mutex on the catalog itself: future worker-thread interaction
+//!    (#439) flows through bounded SPSC ring buffers — the worker
+//!    never touches an `AssetEntry` directly.
+//!
+//! 2. **`@embedFile` lifetime.** `raw_bytes` and `file_type` on every
+//!    entry are *borrowed slices*, never copied. They originate from
+//!    `@embedFile` calls in the assembler-generated init code, which
+//!    means they live for the entire program. The same lifetime
+//!    guarantee that engine #434's `PendingImage` already relies on.
+//!    The asset *name* used as the hash-map key is borrowed under the
+//!    same contract — typically the resource name from
+//!    `project.labelle`.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const loader_mod = @import("loader.zig");
+
+pub const LoaderKind = loader_mod.LoaderKind;
+pub const DecodedPayload = loader_mod.DecodedPayload;
+pub const AssetLoaderVTable = loader_mod.AssetLoaderVTable;
+
+/// Lifecycle of a single entry.
+///
+/// `registered` — metadata is in the catalog, no decode in flight.
+/// `queued`     — refcount > 0, work request enqueued for the worker.
+/// `decoding`   — worker has picked up the request.
+/// `ready`      — `decoded` is populated and `upload` succeeded.
+/// `failed`     — `last_error` is set; `pump()` will not retry.
+pub const AssetState = enum { registered, queued, decoding, ready, failed };
+
+pub const AssetEntry = struct {
+    state: AssetState,
+    refcount: u32,
+    loader: *const AssetLoaderVTable,
+    loader_kind: LoaderKind,
+    /// Borrowed from `@embedFile` — program lifetime, never freed.
+    raw_bytes: []const u8,
+    /// Borrowed sentinel-terminated string — program lifetime.
+    file_type: [:0]const u8,
+    /// Populated by `pump()` on the success path; cleared back to
+    /// `null` when refcount returns to zero (ticket #446).
+    decoded: ?DecodedPayload,
+    last_error: ?anyerror,
+};
+
+pub const AssetCatalog = struct {
+    allocator: Allocator,
+    entries: std.StringHashMap(AssetEntry),
+
+    pub fn init(allocator: Allocator) AssetCatalog {
+        return .{
+            .allocator = allocator,
+            .entries = std.StringHashMap(AssetEntry).init(allocator),
+        };
+    }
+
+    pub fn deinit(self: *AssetCatalog) void {
+        self.entries.deinit();
+    }
+
+    /// Metadata-only registration. Does **not** decode and does **not**
+    /// allocate beyond the hash-map slot itself, so it is safe to call
+    /// during `Game.init` from assembler-generated code.
+    ///
+    /// `name`, `file_type` and `bytes` are borrowed — see the
+    /// `@embedFile` lifetime invariant at the top of this file.
+    /// Registering the same `name` twice is an error; the catalog
+    /// keeps the original entry and returns `error.AssetAlreadyRegistered`.
+    pub fn register(
+        self: *AssetCatalog,
+        name: []const u8,
+        loader_kind: LoaderKind,
+        file_type: [:0]const u8,
+        bytes: []const u8,
+    ) !void {
+        if (self.entries.contains(name)) return error.AssetAlreadyRegistered;
+        try self.entries.put(name, .{
+            .state = .registered,
+            .refcount = 0,
+            .loader = loaderForKind(loader_kind),
+            .loader_kind = loader_kind,
+            .raw_bytes = bytes,
+            .file_type = file_type,
+            .decoded = null,
+            .last_error = null,
+        });
+    }
+
+    /// Bumps the refcount and returns a pointer to the entry. The
+    /// pointer is stable until the next `register` call (StringHashMap
+    /// rehash invalidates pointers); call sites must not retain it
+    /// across catalog mutations.
+    ///
+    /// TODO(#439): on the *first* acquire (refcount transitions
+    /// 0 → 1) of a non-`.ready` entry, enqueue a `WorkRequest` on the
+    /// worker SPSC ring and transition the state to `.queued`. The
+    /// transition is intentionally absent until the worker lands —
+    /// adding it now would dead-end into a worker that does not yet
+    /// exist.
+    pub fn acquire(self: *AssetCatalog, name: []const u8) !*AssetEntry {
+        const entry = self.entries.getPtr(name) orelse return error.AssetNotRegistered;
+        entry.refcount += 1;
+        return entry;
+    }
+
+    /// Drops the refcount. When it hits zero on a `.ready` entry, the
+    /// CPU-side decoded payload is cleared and the entry is moved
+    /// back to `.registered`. The matching GPU/audio/font free via
+    /// `entry.loader.free` is wired in ticket #446.
+    ///
+    /// Releasing an unknown or already-zero entry is a no-op — the
+    /// catalog never panics on a stale handle.
+    pub fn release(self: *AssetCatalog, name: []const u8) void {
+        const entry = self.entries.getPtr(name) orelse return;
+        if (entry.refcount == 0) return;
+        entry.refcount -= 1;
+        if (entry.refcount != 0) return;
+
+        if (entry.state == .ready) {
+            // TODO(#446): entry.loader.free(entry); to release GPU /
+            // audio / font handle. For now we just drop the CPU-side
+            // payload reference and rewind the state.
+            entry.decoded = null;
+            entry.state = .registered;
+        }
+    }
+
+    pub fn isReady(self: *AssetCatalog, name: []const u8) bool {
+        const entry = self.entries.getPtr(name) orelse return false;
+        return entry.state == .ready;
+    }
+
+    /// `true` iff every name in `names` is currently `.ready`. An
+    /// empty slice trivially returns `true` so callers can use the
+    /// result directly as a "scene manifest is satisfied" check.
+    pub fn allReady(self: *AssetCatalog, names: []const []const u8) bool {
+        for (names) |name| {
+            if (!self.isReady(name)) return false;
+        }
+        return true;
+    }
+
+    /// Fraction of `names` currently `.ready`, in `[0.0, 1.0]`.
+    /// Empty slice returns `1.0` for the same reason `allReady`
+    /// returns `true`. Unknown names count as not-ready.
+    pub fn progress(self: *AssetCatalog, names: []const []const u8) f32 {
+        if (names.len == 0) return 1.0;
+        var ready: usize = 0;
+        for (names) |name| {
+            if (self.isReady(name)) ready += 1;
+        }
+        return @as(f32, @floatFromInt(ready)) / @as(f32, @floatFromInt(names.len));
+    }
+
+    pub fn lastError(self: *AssetCatalog, name: []const u8) ?anyerror {
+        const entry = self.entries.getPtr(name) orelse return null;
+        return entry.last_error;
+    }
+
+    /// Drains worker results and finalises uploads. The real body
+    /// lands in ticket #442 once #439's worker exists; for now this
+    /// is a no-op so callers (and the future legacy shim in #443)
+    /// can already wire it into their frame loop without churn.
+    pub fn pump(self: *AssetCatalog) void {
+        _ = self;
+    }
+};
+
+// ---------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------
+
+const image_loader = @import("loaders/image.zig");
+const audio_loader = @import("loaders/audio.zig");
+const font_loader = @import("loaders/font.zig");
+
+fn loaderForKind(kind: LoaderKind) *const AssetLoaderVTable {
+    return switch (kind) {
+        .image => &image_loader.vtable,
+        .audio => &audio_loader.vtable,
+        .font => &font_loader.vtable,
+    };
+}
+
+// ---------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------
+
+const testing = std.testing;
+
+const dummy_bytes: []const u8 = "PNG-fake-bytes";
+const dummy_file_type: [:0]const u8 = "png";
+
+test "register then acquire bumps refcount and leaves state at registered" {
+    var catalog = AssetCatalog.init(testing.allocator);
+    defer catalog.deinit();
+
+    try catalog.register("background", .image, dummy_file_type, dummy_bytes);
+
+    const entry = try catalog.acquire("background");
+    try testing.expectEqual(@as(u32, 1), entry.refcount);
+    try testing.expectEqual(AssetState.registered, entry.state);
+    try testing.expectEqual(LoaderKind.image, entry.loader_kind);
+    try testing.expectEqual(@as(?DecodedPayload, null), entry.decoded);
+}
+
+test "double acquire then release ordering" {
+    var catalog = AssetCatalog.init(testing.allocator);
+    defer catalog.deinit();
+
+    try catalog.register("ship", .image, dummy_file_type, dummy_bytes);
+
+    const e1 = try catalog.acquire("ship");
+    _ = try catalog.acquire("ship");
+    try testing.expectEqual(@as(u32, 2), e1.refcount);
+
+    catalog.release("ship");
+    try testing.expectEqual(@as(u32, 1), e1.refcount);
+
+    catalog.release("ship");
+    try testing.expectEqual(@as(u32, 0), e1.refcount);
+    try testing.expectEqual(AssetState.registered, e1.state);
+}
+
+test "release on already-zero entry is a no-op" {
+    var catalog = AssetCatalog.init(testing.allocator);
+    defer catalog.deinit();
+
+    try catalog.register("ship", .image, dummy_file_type, dummy_bytes);
+    catalog.release("ship");
+    catalog.release("ship");
+    catalog.release("unknown-asset");
+
+    const entry = catalog.entries.getPtr("ship").?;
+    try testing.expectEqual(@as(u32, 0), entry.refcount);
+}
+
+test "isReady is false for a fresh registration" {
+    var catalog = AssetCatalog.init(testing.allocator);
+    defer catalog.deinit();
+
+    try catalog.register("background", .image, dummy_file_type, dummy_bytes);
+    try testing.expect(!catalog.isReady("background"));
+    try testing.expect(!catalog.isReady("never-registered"));
+}
+
+test "allReady returns true for an empty slice" {
+    var catalog = AssetCatalog.init(testing.allocator);
+    defer catalog.deinit();
+
+    const names: []const []const u8 = &.{};
+    try testing.expect(catalog.allReady(names));
+    try testing.expectEqual(@as(f32, 1.0), catalog.progress(names));
+}
+
+test "progress reflects mixed ready states" {
+    var catalog = AssetCatalog.init(testing.allocator);
+    defer catalog.deinit();
+
+    try catalog.register("a", .image, dummy_file_type, dummy_bytes);
+    try catalog.register("b", .image, dummy_file_type, dummy_bytes);
+
+    const names: []const []const u8 = &.{ "a", "b" };
+    try testing.expectEqual(@as(f32, 0.0), catalog.progress(names));
+    try testing.expect(!catalog.allReady(names));
+
+    // Simulate the worker / pump path by forcing one entry to ready.
+    // The real transition lands with #442; for the unit test we just
+    // need a `.ready` entry to verify the bookkeeping.
+    const a = try catalog.acquire("a");
+    a.state = .ready;
+    try testing.expectEqual(@as(f32, 0.5), catalog.progress(names));
+    try testing.expect(!catalog.allReady(names));
+
+    const b = try catalog.acquire("b");
+    b.state = .ready;
+    try testing.expectEqual(@as(f32, 1.0), catalog.progress(names));
+    try testing.expect(catalog.allReady(names));
+}
+
+test "lastError is null for a never-failed entry" {
+    var catalog = AssetCatalog.init(testing.allocator);
+    defer catalog.deinit();
+
+    try catalog.register("background", .image, dummy_file_type, dummy_bytes);
+    try testing.expectEqual(@as(?anyerror, null), catalog.lastError("background"));
+    try testing.expectEqual(@as(?anyerror, null), catalog.lastError("unknown"));
+}
+
+test "duplicate register returns AssetAlreadyRegistered" {
+    var catalog = AssetCatalog.init(testing.allocator);
+    defer catalog.deinit();
+
+    try catalog.register("ship", .image, dummy_file_type, dummy_bytes);
+    try testing.expectError(
+        error.AssetAlreadyRegistered,
+        catalog.register("ship", .image, dummy_file_type, dummy_bytes),
+    );
+}
+
+test "acquire on unknown asset returns AssetNotRegistered" {
+    var catalog = AssetCatalog.init(testing.allocator);
+    defer catalog.deinit();
+
+    try testing.expectError(error.AssetNotRegistered, catalog.acquire("ghost"));
+}
+
+test "pump is a no-op until the worker lands (#442)" {
+    var catalog = AssetCatalog.init(testing.allocator);
+    defer catalog.deinit();
+
+    try catalog.register("background", .image, dummy_file_type, dummy_bytes);
+    catalog.pump();
+    try testing.expect(!catalog.isReady("background"));
+}

--- a/src/assets/catalog.zig
+++ b/src/assets/catalog.zig
@@ -33,30 +33,8 @@ const loader_mod = @import("loader.zig");
 pub const LoaderKind = loader_mod.LoaderKind;
 pub const DecodedPayload = loader_mod.DecodedPayload;
 pub const AssetLoaderVTable = loader_mod.AssetLoaderVTable;
-
-/// Lifecycle of a single entry.
-///
-/// `registered` — metadata is in the catalog, no decode in flight.
-/// `queued`     — refcount > 0, work request enqueued for the worker.
-/// `decoding`   — worker has picked up the request.
-/// `ready`      — `decoded` is populated and `upload` succeeded.
-/// `failed`     — `last_error` is set; `pump()` will not retry.
-pub const AssetState = enum { registered, queued, decoding, ready, failed };
-
-pub const AssetEntry = struct {
-    state: AssetState,
-    refcount: u32,
-    loader: *const AssetLoaderVTable,
-    loader_kind: LoaderKind,
-    /// Borrowed from `@embedFile` — program lifetime, never freed.
-    raw_bytes: []const u8,
-    /// Borrowed sentinel-terminated string — program lifetime.
-    file_type: [:0]const u8,
-    /// Populated by `pump()` on the success path; cleared back to
-    /// `null` when refcount returns to zero (ticket #446).
-    decoded: ?DecodedPayload,
-    last_error: ?anyerror,
-};
+pub const AssetState = loader_mod.AssetState;
+pub const AssetEntry = loader_mod.AssetEntry;
 
 pub const AssetCatalog = struct {
     allocator: Allocator,
@@ -70,6 +48,11 @@ pub const AssetCatalog = struct {
     }
 
     pub fn deinit(self: *AssetCatalog) void {
+        // TODO(#446): iterate and call entry.loader.free / loader.drop
+        // for any entry whose decoded payload is non-null before the
+        // real loaders land (image pixels, audio handles, font glyphs).
+        // For now placeholder loaders have no-op drop/free, so this is
+        // safe. Add the loop here once #440/#441 provide real cleanup.
         self.entries.deinit();
     }
 

--- a/src/assets/loader.zig
+++ b/src/assets/loader.zig
@@ -1,7 +1,12 @@
-//! Asset loader vtable + decoded payload union.
+//! Asset entry state, loader vtable + decoded payload union.
 //!
-//! Concrete loaders (image, audio, font) live in `loaders/` and provide
-//! a `pub const vtable: AssetLoaderVTable` that the catalog stores on
+//! Owns the shared types that both the catalog and the concrete loaders
+//! (image, audio, font) need. Keeping them here avoids a circular
+//! dependency: `catalog.zig` imports this file; this file does not
+//! import `catalog.zig`.
+//!
+//! Concrete loaders live in `loaders/` and provide a
+//! `pub const vtable: AssetLoaderVTable` that the catalog stores on
 //! each `AssetEntry` at registration time.
 //!
 //! This file declares **types only** — no implementations. The real
@@ -9,9 +14,6 @@
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
-
-const catalog = @import("catalog.zig");
-const AssetEntry = catalog.AssetEntry;
 
 /// Discriminator for `DecodedPayload` and for selecting a loader at
 /// `AssetCatalog.register` time. Stored on the entry; callers do not
@@ -30,6 +32,30 @@ pub const DecodedPayload = union(LoaderKind) {
     },
     audio: struct {}, // placeholder for Phase 4 (#441)
     font: struct {}, // placeholder for Phase 4 (#441)
+};
+
+/// Lifecycle of a single entry.
+///
+/// `registered` — metadata is in the catalog, no decode in flight.
+/// `queued`     — refcount > 0, work request enqueued for the worker.
+/// `decoding`   — worker has picked up the request.
+/// `ready`      — `decoded` is populated and `upload` succeeded.
+/// `failed`     — `last_error` is set; `pump()` will not retry.
+pub const AssetState = enum { registered, queued, decoding, ready, failed };
+
+pub const AssetEntry = struct {
+    state: AssetState,
+    refcount: u32,
+    loader: *const AssetLoaderVTable,
+    loader_kind: LoaderKind,
+    /// Borrowed from `@embedFile` — program lifetime, never freed.
+    raw_bytes: []const u8,
+    /// Borrowed sentinel-terminated string — program lifetime.
+    file_type: [:0]const u8,
+    /// Populated by `pump()` on the success path; cleared back to
+    /// `null` when refcount returns to zero (ticket #446).
+    decoded: ?DecodedPayload,
+    last_error: ?anyerror,
 };
 
 /// Per-asset-type plug-in. Every loader (image, audio, font, …)

--- a/src/assets/loader.zig
+++ b/src/assets/loader.zig
@@ -1,0 +1,63 @@
+//! Asset loader vtable + decoded payload union.
+//!
+//! Concrete loaders (image, audio, font) live in `loaders/` and provide
+//! a `pub const vtable: AssetLoaderVTable` that the catalog stores on
+//! each `AssetEntry` at registration time.
+//!
+//! This file declares **types only** — no implementations. The real
+//! image loader lands in ticket #440, audio/font in #441.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const catalog = @import("catalog.zig");
+const AssetEntry = catalog.AssetEntry;
+
+/// Discriminator for `DecodedPayload` and for selecting a loader at
+/// `AssetCatalog.register` time. Stored on the entry; callers do not
+/// need to namespace asset names per loader.
+pub const LoaderKind = enum { image, audio, font };
+
+/// Worker-thread output. Variants are populated on the worker, then
+/// either uploaded (success path) or dropped (refcount-zero discard
+/// path) on the main thread. Real payload shapes for `audio` and
+/// `font` arrive in Phase 4 — they are placeholders for now.
+pub const DecodedPayload = union(LoaderKind) {
+    image: struct {
+        pixels: []u8, // RGBA8, allocator-owned
+        width: u32,
+        height: u32,
+    },
+    audio: struct {}, // placeholder for Phase 4 (#441)
+    font: struct {}, // placeholder for Phase 4 (#441)
+};
+
+/// Per-asset-type plug-in. Every loader (image, audio, font, …)
+/// provides one of these. The catalog calls `decode` on the worker
+/// thread and `upload` / `drop` / `free` on the main thread — see
+/// the threading invariant in `catalog.zig`.
+pub const AssetLoaderVTable = struct {
+    /// Worker-thread CPU decode. Allocator-owned output stored on the
+    /// resulting `WorkResult.decoded`. May return error → result.err
+    /// is set and the entry transitions to `.failed` in `pump()`.
+    decode: *const fn (
+        file_type: [:0]const u8,
+        data: []const u8,
+        allocator: Allocator,
+    ) anyerror!DecodedPayload,
+
+    /// Main-thread finalise: GPU upload, audio device handle, font
+    /// glyph rasterise — whatever turns the worker output into the
+    /// `.ready` representation. Frees the CPU-side payload on the
+    /// success path.
+    upload: *const fn (entry: *AssetEntry, decoded: DecodedPayload) anyerror!void,
+
+    /// Discard path: refcount hit zero between decode and upload.
+    /// Frees the CPU-side payload without touching the GPU.
+    drop: *const fn (allocator: Allocator, decoded: DecodedPayload) void,
+
+    /// Unload path: refcount hit zero on a `.ready` asset. Releases
+    /// the GPU/audio/font resource that `upload` created. Wired up
+    /// in ticket #446.
+    free: *const fn (entry: *AssetEntry) void,
+};

--- a/src/assets/loaders/audio.zig
+++ b/src/assets/loaders/audio.zig
@@ -7,11 +7,10 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 
 const loader = @import("../loader.zig");
-const catalog = @import("../catalog.zig");
 
 const AssetLoaderVTable = loader.AssetLoaderVTable;
 const DecodedPayload = loader.DecodedPayload;
-const AssetEntry = catalog.AssetEntry;
+const AssetEntry = loader.AssetEntry;
 
 fn decode(
     file_type: [:0]const u8,

--- a/src/assets/loaders/audio.zig
+++ b/src/assets/loaders/audio.zig
@@ -1,0 +1,47 @@
+//! Placeholder audio loader vtable.
+//!
+//! Stub identical in shape to `loaders/image.zig`. Real `decodeAudio`
+//! / `uploadAudio` arrives in ticket #441 (Phase 4 of the RFC).
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const loader = @import("../loader.zig");
+const catalog = @import("../catalog.zig");
+
+const AssetLoaderVTable = loader.AssetLoaderVTable;
+const DecodedPayload = loader.DecodedPayload;
+const AssetEntry = catalog.AssetEntry;
+
+fn decode(
+    file_type: [:0]const u8,
+    data: []const u8,
+    allocator: Allocator,
+) anyerror!DecodedPayload {
+    _ = file_type;
+    _ = data;
+    _ = allocator;
+    return error.NotImplemented;
+}
+
+fn upload(entry: *AssetEntry, decoded: DecodedPayload) anyerror!void {
+    _ = entry;
+    _ = decoded;
+    return error.NotImplemented;
+}
+
+fn drop(allocator: Allocator, decoded: DecodedPayload) void {
+    _ = allocator;
+    _ = decoded;
+}
+
+fn free(entry: *AssetEntry) void {
+    _ = entry;
+}
+
+pub const vtable: AssetLoaderVTable = .{
+    .decode = decode,
+    .upload = upload,
+    .drop = drop,
+    .free = free,
+};

--- a/src/assets/loaders/font.zig
+++ b/src/assets/loaders/font.zig
@@ -7,11 +7,10 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 
 const loader = @import("../loader.zig");
-const catalog = @import("../catalog.zig");
 
 const AssetLoaderVTable = loader.AssetLoaderVTable;
 const DecodedPayload = loader.DecodedPayload;
-const AssetEntry = catalog.AssetEntry;
+const AssetEntry = loader.AssetEntry;
 
 fn decode(
     file_type: [:0]const u8,

--- a/src/assets/loaders/font.zig
+++ b/src/assets/loaders/font.zig
@@ -1,0 +1,47 @@
+//! Placeholder font loader vtable.
+//!
+//! Stub identical in shape to `loaders/image.zig`. Real `decodeFont`
+//! / glyph rasterise arrives in ticket #441 (Phase 4 of the RFC).
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const loader = @import("../loader.zig");
+const catalog = @import("../catalog.zig");
+
+const AssetLoaderVTable = loader.AssetLoaderVTable;
+const DecodedPayload = loader.DecodedPayload;
+const AssetEntry = catalog.AssetEntry;
+
+fn decode(
+    file_type: [:0]const u8,
+    data: []const u8,
+    allocator: Allocator,
+) anyerror!DecodedPayload {
+    _ = file_type;
+    _ = data;
+    _ = allocator;
+    return error.NotImplemented;
+}
+
+fn upload(entry: *AssetEntry, decoded: DecodedPayload) anyerror!void {
+    _ = entry;
+    _ = decoded;
+    return error.NotImplemented;
+}
+
+fn drop(allocator: Allocator, decoded: DecodedPayload) void {
+    _ = allocator;
+    _ = decoded;
+}
+
+fn free(entry: *AssetEntry) void {
+    _ = entry;
+}
+
+pub const vtable: AssetLoaderVTable = .{
+    .decode = decode,
+    .upload = upload,
+    .drop = drop,
+    .free = free,
+};

--- a/src/assets/loaders/image.zig
+++ b/src/assets/loaders/image.zig
@@ -1,0 +1,51 @@
+//! Placeholder image loader vtable.
+//!
+//! Every method is a stub: `decode` and `upload` return
+//! `error.NotImplemented`, `drop` and `free` are no-ops. The real
+//! implementation — backed by `gfx.decodeImage` / `gfx.uploadTexture`
+//! — lands in ticket #440. Until then this file exists so that the
+//! catalog can resolve `LoaderKind.image` to a concrete vtable
+//! pointer at registration time.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+const loader = @import("../loader.zig");
+const catalog = @import("../catalog.zig");
+
+const AssetLoaderVTable = loader.AssetLoaderVTable;
+const DecodedPayload = loader.DecodedPayload;
+const AssetEntry = catalog.AssetEntry;
+
+fn decode(
+    file_type: [:0]const u8,
+    data: []const u8,
+    allocator: Allocator,
+) anyerror!DecodedPayload {
+    _ = file_type;
+    _ = data;
+    _ = allocator;
+    return error.NotImplemented;
+}
+
+fn upload(entry: *AssetEntry, decoded: DecodedPayload) anyerror!void {
+    _ = entry;
+    _ = decoded;
+    return error.NotImplemented;
+}
+
+fn drop(allocator: Allocator, decoded: DecodedPayload) void {
+    _ = allocator;
+    _ = decoded;
+}
+
+fn free(entry: *AssetEntry) void {
+    _ = entry;
+}
+
+pub const vtable: AssetLoaderVTable = .{
+    .decode = decode,
+    .upload = upload,
+    .drop = drop,
+    .free = free,
+};

--- a/src/assets/loaders/image.zig
+++ b/src/assets/loaders/image.zig
@@ -11,11 +11,10 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 
 const loader = @import("../loader.zig");
-const catalog = @import("../catalog.zig");
 
 const AssetLoaderVTable = loader.AssetLoaderVTable;
 const DecodedPayload = loader.DecodedPayload;
-const AssetEntry = catalog.AssetEntry;
+const AssetEntry = loader.AssetEntry;
 
 fn decode(
     file_type: [:0]const u8,

--- a/src/assets/mod.zig
+++ b/src/assets/mod.zig
@@ -1,0 +1,33 @@
+//! Public surface of `src/assets/`.
+//!
+//! Re-exports the catalog, loader vtable shapes, and worker message
+//! types so that `engine.AssetCatalog` and friends can be reached
+//! through a single import path. Concrete loaders (image, audio,
+//! font) are intentionally *not* re-exported — the catalog resolves
+//! them internally via `LoaderKind`.
+
+const catalog_mod = @import("catalog.zig");
+const loader_mod = @import("loader.zig");
+const worker_mod = @import("worker.zig");
+
+pub const AssetCatalog = catalog_mod.AssetCatalog;
+pub const AssetEntry = catalog_mod.AssetEntry;
+pub const AssetState = catalog_mod.AssetState;
+
+pub const LoaderKind = loader_mod.LoaderKind;
+pub const DecodedPayload = loader_mod.DecodedPayload;
+pub const AssetLoaderVTable = loader_mod.AssetLoaderVTable;
+
+pub const WorkRequest = worker_mod.WorkRequest;
+pub const WorkResult = worker_mod.WorkResult;
+
+test {
+    // Pull every file in the module tree into the test binary so
+    // `zig build test` exercises the catalog test blocks.
+    _ = catalog_mod;
+    _ = loader_mod;
+    _ = worker_mod;
+    _ = @import("loaders/image.zig");
+    _ = @import("loaders/audio.zig");
+    _ = @import("loaders/font.zig");
+}

--- a/src/assets/worker.zig
+++ b/src/assets/worker.zig
@@ -1,0 +1,35 @@
+//! Asset worker request / result message types.
+//!
+//! This file declares **types only** — no thread, no SPSC ring
+//! buffers, no decode loop. Ticket #439 adds the `std.Thread`
+//! worker plus the bounded SPSC rings that the catalog will use to
+//! hand off requests and drain results from `pump()`.
+//!
+//! The shapes are pinned here so that the catalog (#438), the legacy
+//! shim (#443), and the future scene wiring (#444+) can all reference
+//! them without waiting on the threading work to land.
+
+const loader = @import("loader.zig");
+
+const AssetLoaderVTable = loader.AssetLoaderVTable;
+const DecodedPayload = loader.DecodedPayload;
+
+/// Snapshot handed to the worker thread. Every field is borrowed —
+/// `entry_name`, `file_type` and `bytes` all live for the program's
+/// entire lifetime (see the `@embedFile` invariant on the catalog),
+/// so the worker can read them without touching the catalog.
+pub const WorkRequest = struct {
+    entry_name: []const u8,
+    vtable: *const AssetLoaderVTable,
+    file_type: [:0]const u8,
+    bytes: []const u8,
+};
+
+/// Worker → main message. Either `decoded` is set (success) or
+/// `err` is set (failure); `pump()` discriminates and routes to
+/// `loader.upload` / `loader.drop` accordingly. Lands in #442.
+pub const WorkResult = struct {
+    entry_name: []const u8,
+    decoded: ?DecodedPayload,
+    err: ?anyerror,
+};

--- a/src/root.zig
+++ b/src/root.zig
@@ -18,6 +18,7 @@ pub const query_mod = @import("query.zig");
 pub const hooks_types_mod = @import("hooks_types.zig");
 pub const animation_mod = @import("animation.zig");
 pub const atlas_mod = @import("atlas.zig");
+pub const assets_mod = @import("assets/mod.zig");
 pub const jsonc_mod = @import("jsonc");
 
 // ── Game ──
@@ -124,6 +125,20 @@ pub const ComptimeAtlas = atlas_mod.ComptimeAtlas;
 pub const RuntimeAtlas = atlas_mod.RuntimeAtlas;
 pub const TextureManager = atlas_mod.TextureManager;
 pub const SpriteCache = atlas_mod.SpriteCache;
+
+// ── Assets (Asset Streaming RFC, Phase 1 — #438) ──
+// AssetCatalog is intentionally NOT yet wired into Game state — that
+// coupling lands in ticket #443's legacy shim. For now the module
+// just needs to compile cleanly and be importable so subsequent
+// tickets (#439–#446) can build on it.
+pub const AssetCatalog = assets_mod.AssetCatalog;
+pub const AssetEntry = assets_mod.AssetEntry;
+pub const AssetState = assets_mod.AssetState;
+pub const LoaderKind = assets_mod.LoaderKind;
+pub const DecodedPayload = assets_mod.DecodedPayload;
+pub const AssetLoaderVTable = assets_mod.AssetLoaderVTable;
+pub const AssetWorkRequest = assets_mod.WorkRequest;
+pub const AssetWorkResult = assets_mod.WorkResult;
 
 // ── JSONC Scene Bridge ──
 pub const JsoncSceneBridge = @import("jsonc_scene_bridge.zig").JsoncSceneBridge;

--- a/test/asset_catalog_test.zig
+++ b/test/asset_catalog_test.zig
@@ -1,0 +1,48 @@
+//! Integration test entry point for the `src/assets/` module.
+//!
+//! The catalog's behavioural tests live next to the implementation
+//! in `src/assets/catalog.zig`. This file pulls the module in via
+//! the `engine` import so `zig build test` exercises every test
+//! block under `src/assets/` (catalog + the loader / worker stubs
+//! re-exported through `assets/mod.zig`).
+
+const std = @import("std");
+const testing = std.testing;
+
+const engine = @import("engine");
+
+test "engine re-exports AssetCatalog and friends" {
+    // Catalog round-trip via the engine-level alias to make sure the
+    // module is wired into root.zig and reachable from outside.
+    var catalog = engine.AssetCatalog.init(testing.allocator);
+    defer catalog.deinit();
+
+    try catalog.register("background", engine.LoaderKind.image, "png", "fake-bytes");
+    try testing.expect(!catalog.isReady("background"));
+
+    const entry = try catalog.acquire("background");
+    try testing.expectEqual(@as(u32, 1), entry.refcount);
+    try testing.expectEqual(engine.AssetState.registered, entry.state);
+    try testing.expectEqual(engine.LoaderKind.image, entry.loader_kind);
+
+    catalog.release("background");
+    try testing.expectEqual(@as(u32, 0), entry.refcount);
+
+    // pump() is a no-op until #442; confirm the symbol is callable.
+    catalog.pump();
+}
+
+test "engine.AssetCatalog progress over an empty manifest is fully ready" {
+    var catalog = engine.AssetCatalog.init(testing.allocator);
+    defer catalog.deinit();
+
+    const empty: []const []const u8 = &.{};
+    try testing.expect(catalog.allReady(empty));
+    try testing.expectEqual(@as(f32, 1.0), catalog.progress(empty));
+}
+
+// Drag the in-source test blocks under `src/assets/` into this test
+// binary so they run together with the engine integration tests.
+test {
+    testing.refAllDecls(engine.assets_mod);
+}


### PR DESCRIPTION
## Summary

Phase 1 of the [Asset Streaming RFC](https://github.com/labelle-toolkit/labelle-engine/pull/437). Lays down `src/assets/` and fully implements `AssetCatalog` so the worker (#439), real loaders (#440 / #441), pump body (#442), legacy atlas shim (#443) and scene-transition wiring (#444 / #445 / #446) can all build on top of a stable surface.

Closes #438.

## What's in

- **`src/assets/catalog.zig`** — fully implemented public `AssetCatalog` API:
  - `register` / `acquire` / `release` / `isReady` / `allReady` / `progress` / `lastError` / `pump`.
  - `StringHashMap(AssetEntry)` keyed on the plain asset name; loader is selected via `LoaderKind` at registration time and stored on the entry (no `atlas:` prefix).
  - Refcount semantics: bump on acquire, drop on release; on zero-from-`.ready` the CPU-side payload is cleared and state rewinds to `.registered`.
  - Two non-negotiable invariants documented in the file header:
    1. `AssetEntry` is owned exclusively by the main thread; transitions happen only inside `pump()` and the public methods. No mutex on the catalog — the future worker (#439) talks through bounded SPSC rings.
    2. `raw_bytes` and `file_type` are borrowed slices that live for the program lifetime via `@embedFile`; the catalog never copies them.
- **`src/assets/loader.zig`** — types only: `LoaderKind`, `DecodedPayload` union, `AssetLoaderVTable { decode, upload, drop, free }`.
- **`src/assets/worker.zig`** — types only: `WorkRequest`, `WorkResult`. Comment notes that #439 adds the `std.Thread` worker plus the SPSC rings.
- **`src/assets/loaders/{image,audio,font}.zig`** — placeholder vtables whose `decode` and `upload` return `error.NotImplemented`; `drop` and `free` are no-ops. Real loaders land in #440 / #441.
- **`src/assets/mod.zig`** — single-import re-export of the public types.
- **`src/root.zig`** — exposes `assets_mod` plus convenience aliases (`AssetCatalog`, `AssetEntry`, `AssetState`, `LoaderKind`, `DecodedPayload`, `AssetLoaderVTable`, `AssetWorkRequest`, `AssetWorkResult`).
- **`build.zig`** — adds `test/asset_catalog_test.zig` to the test list.
- **`test/asset_catalog_test.zig`** — pulls every in-source test block under `src/assets/` into the test binary via `refAllDecls(engine.assets_mod)` and adds a small integration test that round-trips through the engine-level alias.

## What's deliberately NOT in (deferred to the follow-up tickets)

- Worker thread, SPSC ring buffers, real `pump()` body — `pump()` is currently a no-op (#439 / #442).
- Real image / audio / font loader implementations — vtables return `error.NotImplemented` (#440 / #441).
- Legacy atlas shim around `loadAtlasFromMemory` / `loadAtlasIfNeeded` (#443).
- `scene_assets_acquire` / `scene_assets_release` hooks and any change to `scene_mixin.zig` (#444).
- `SceneEntry.assets` field (#445).
- Refcount-zero `loader.free` GPU unload (#446).
- Wiring `AssetCatalog` into `Game` state. The module compiles and is importable, but `game.zig` is untouched — coupling lands with the legacy shim in #443.

## Test plan

- [x] `zig build test` — 106 / 106 tests passed
- [x] In-source tests in `src/assets/catalog.zig` cover: refcount on single + double acquire, release ordering back to zero, no-op release on a stale handle, `isReady` on a fresh entry, `allReady` / `progress` semantics on an empty slice, mixed-state `progress` (forces an entry to `.ready` to simulate the future pump path), null `lastError` on never-failed entries, duplicate-register error, unknown-name acquire error, and `pump()` no-op.
- [x] Engine-level integration test in `test/asset_catalog_test.zig` round-trips through `engine.AssetCatalog` to verify `root.zig` re-exports.

Refs: labelle-toolkit/labelle-engine#437

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>