### PR TITLE
feat(assets): AssetWorker + bounded SPSC ring buffers

### DIFF
--- a/src/assets/catalog.zig
+++ b/src/assets/catalog.zig
@@ -29,30 +29,87 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 
 const loader_mod = @import("loader.zig");
+const worker_mod = @import("worker.zig");
 
 pub const LoaderKind = loader_mod.LoaderKind;
 pub const DecodedPayload = loader_mod.DecodedPayload;
 pub const AssetLoaderVTable = loader_mod.AssetLoaderVTable;
 pub const AssetState = loader_mod.AssetState;
 pub const AssetEntry = loader_mod.AssetEntry;
+pub const WorkRequest = worker_mod.WorkRequest;
+pub const WorkResult = worker_mod.WorkResult;
 
 pub const AssetCatalog = struct {
     allocator: Allocator,
     entries: std.StringHashMap(AssetEntry),
+    /// Main → worker ring. The catalog is the sole producer (from
+    /// `acquire`); the worker is the sole consumer.
+    requests: worker_mod.RequestRing,
+    /// Worker → main ring. The worker is the sole producer; `pump()`
+    /// (#442) will be the sole consumer. For now `deinit` drains it.
+    results: worker_mod.ResultRing,
+    worker: worker_mod.AssetWorker,
+    worker_started: bool,
 
+    /// Builds the catalog. The worker thread is spawned lazily on
+    /// the first `acquire` — this keeps `init`'s signature infallible
+    /// relative to `std.Thread.spawn` failures *and* dodges the
+    /// classic "return-by-value captures a stack pointer" trap: the
+    /// rings need to live at a stable address before the worker
+    /// captures `&self.requests`, and the stable address only exists
+    /// once the caller has moved the returned value into its own
+    /// slot.
     pub fn init(allocator: Allocator) AssetCatalog {
         return .{
             .allocator = allocator,
             .entries = std.StringHashMap(AssetEntry).init(allocator),
+            .requests = worker_mod.RequestRing.init(),
+            .results = worker_mod.ResultRing.init(),
+            .worker = undefined,
+            .worker_started = false,
         };
     }
 
+    /// Ensures the background worker is running. Idempotent. Called
+    /// from `acquire` on the first `0 → 1` refcount transition so
+    /// catalogs that never `acquire` (e.g. most unit tests) don't
+    /// pay the thread-spawn cost at all.
+    fn ensureWorker(self: *AssetCatalog) !void {
+        if (self.worker_started) return;
+        self.worker = worker_mod.AssetWorker.init(
+            self.allocator,
+            &self.requests,
+            &self.results,
+        );
+        try self.worker.start();
+        self.worker_started = true;
+    }
+
     pub fn deinit(self: *AssetCatalog) void {
-        // TODO(#446): iterate and call entry.loader.free / loader.drop
-        // for any entry whose decoded payload is non-null before the
-        // real loaders land (image pixels, audio handles, font glyphs).
-        // For now placeholder loaders have no-op drop/free, so this is
-        // safe. Add the loop here once #440/#441 provide real cleanup.
+        // 1. Stop the worker (sets the shutdown flag and joins).
+        //    Only meaningful if `acquire` ever ran and kicked the
+        //    lazy spawn — otherwise `worker` is undefined.
+        if (self.worker_started) {
+            self.worker.stop();
+            self.worker_started = false;
+        }
+
+        // 2. Drain any in-flight results. Real loaders (Phase 4) will
+        //    have allocator-owned CPU payloads here; placeholders are
+        //    no-ops but the contract is already wired so #440 / #441
+        //    can drop the TODOs.
+        while (self.results.tryDequeue()) |result| {
+            if (result.decoded) |payload| {
+                if (self.entries.getPtr(result.entry_name)) |entry| {
+                    entry.loader.drop(self.allocator, payload);
+                }
+            }
+        }
+
+        // TODO(#446): iterate and call entry.loader.free for any entry
+        // that is still `.ready` so GPU/audio/font handles go back to
+        // their backends. Current placeholder loaders have no-op free,
+        // so this is safe until real loaders arrive.
         self.entries.deinit();
     }
 
@@ -89,15 +146,37 @@ pub const AssetCatalog = struct {
     /// rehash invalidates pointers); call sites must not retain it
     /// across catalog mutations.
     ///
-    /// TODO(#439): on the *first* acquire (refcount transitions
-    /// 0 → 1) of a non-`.ready` entry, enqueue a `WorkRequest` on the
-    /// worker SPSC ring and transition the state to `.queued`. The
-    /// transition is intentionally absent until the worker lands —
-    /// adding it now would dead-end into a worker that does not yet
-    /// exist.
+    /// On the *first* acquire (refcount transitions 0 → 1) of a
+    /// `.registered` entry, a `WorkRequest` is enqueued on the
+    /// main→worker ring and the state moves to `.queued`. If the
+    /// ring is full we log and leave the state at `.registered` —
+    /// `pump()` (#442) will retry on its next tick. The pointer is
+    /// still returned either way; callers can keep polling `isReady`.
     pub fn acquire(self: *AssetCatalog, name: []const u8) !*AssetEntry {
         const entry = self.entries.getPtr(name) orelse return error.AssetNotRegistered;
+        const was_zero = entry.refcount == 0;
         entry.refcount += 1;
+
+        if (was_zero and entry.state == .registered) {
+            try self.ensureWorker();
+            const request: WorkRequest = .{
+                .entry_name = name,
+                .vtable = entry.loader,
+                .file_type = entry.file_type,
+                .bytes = entry.raw_bytes,
+            };
+            if (self.requests.tryEnqueue(request)) |_| {
+                entry.state = .queued;
+            } else |err| switch (err) {
+                // Ring saturated — pump() will retry the transition
+                // on its next tick (#442). Leave the state at
+                // `.registered` so the retry can fire naturally.
+                error.QueueFull => std.log.debug(
+                    "assets: request ring full, deferring acquire of '{s}'",
+                    .{name},
+                ),
+            }
+        }
         return entry;
     }
 
@@ -189,7 +268,7 @@ const testing = std.testing;
 const dummy_bytes: []const u8 = "PNG-fake-bytes";
 const dummy_file_type: [:0]const u8 = "png";
 
-test "register then acquire bumps refcount and leaves state at registered" {
+test "register then acquire bumps refcount and enqueues work" {
     var catalog = AssetCatalog.init(testing.allocator);
     defer catalog.deinit();
 
@@ -197,7 +276,10 @@ test "register then acquire bumps refcount and leaves state at registered" {
 
     const entry = try catalog.acquire("background");
     try testing.expectEqual(@as(u32, 1), entry.refcount);
-    try testing.expectEqual(AssetState.registered, entry.state);
+    // First acquire moved the entry to `.queued` — the worker ring
+    // has taken ownership of the request and will eventually publish
+    // an `error.NotImplemented` result on the stub loader.
+    try testing.expectEqual(AssetState.queued, entry.state);
     try testing.expectEqual(LoaderKind.image, entry.loader_kind);
     try testing.expectEqual(@as(?DecodedPayload, null), entry.decoded);
 }
@@ -217,7 +299,10 @@ test "double acquire then release ordering" {
 
     catalog.release("ship");
     try testing.expectEqual(@as(u32, 0), e1.refcount);
-    try testing.expectEqual(AssetState.registered, e1.state);
+    // State stays at `.queued` until `pump()` (#442) drains the
+    // worker result — `release` on a non-`.ready` entry only touches
+    // the refcount.
+    try testing.expectEqual(AssetState.queued, e1.state);
 }
 
 test "release on already-zero entry is a no-op" {
@@ -310,4 +395,40 @@ test "pump is a no-op until the worker lands (#442)" {
     try catalog.register("background", .image, dummy_file_type, dummy_bytes);
     catalog.pump();
     try testing.expect(!catalog.isReady("background"));
+}
+
+test "acquire spawns worker which produces NotImplemented for stub loader" {
+    var catalog = AssetCatalog.init(testing.allocator);
+    defer catalog.deinit();
+
+    try catalog.register("background", .image, dummy_file_type, dummy_bytes);
+    _ = try catalog.acquire("background");
+
+    // Spin up to 200ms waiting for the worker to publish a result.
+    // `pump()` is still a no-op (#442) so we peek at the ring
+    // directly to verify the machinery.
+    const deadline_ns: u64 = 200 * std.time.ns_per_ms;
+    var waited_ns: u64 = 0;
+    const step_ns: u64 = 1 * std.time.ns_per_ms;
+    const result = while (waited_ns < deadline_ns) {
+        if (catalog.results.tryDequeue()) |r| break r;
+        std.Thread.sleep(step_ns);
+        waited_ns += step_ns;
+    } else {
+        return error.WorkerDidNotRespond;
+    };
+
+    try testing.expectEqualStrings("background", result.entry_name);
+    try testing.expectEqual(@as(?DecodedPayload, null), result.decoded);
+    try testing.expectEqual(@as(?anyerror, error.NotImplemented), result.err);
+}
+
+test "deinit with a pending acquire shuts down cleanly" {
+    var catalog = AssetCatalog.init(testing.allocator);
+    defer catalog.deinit();
+
+    try catalog.register("background", .image, dummy_file_type, dummy_bytes);
+    _ = try catalog.acquire("background");
+    // Intentionally do not drain — deinit must join the worker and
+    // drop any in-flight results without deadlocking or leaking.
 }

--- a/src/assets/catalog.zig
+++ b/src/assets/catalog.zig
@@ -100,9 +100,10 @@ pub const AssetCatalog = struct {
         //    can drop the TODOs.
         while (self.results.tryDequeue()) |result| {
             if (result.decoded) |payload| {
-                if (self.entries.getPtr(result.entry_name)) |entry| {
-                    entry.loader.drop(self.allocator, payload);
-                }
+                // Use the vtable carried on the result itself — avoids
+                // a hashmap lookup and survives the case where an entry
+                // was removed after its WorkRequest was submitted.
+                result.vtable.drop(self.allocator, payload);
             }
         }
 
@@ -153,14 +154,23 @@ pub const AssetCatalog = struct {
     /// `pump()` (#442) will retry on its next tick. The pointer is
     /// still returned either way; callers can keep polling `isReady`.
     pub fn acquire(self: *AssetCatalog, name: []const u8) !*AssetEntry {
-        const entry = self.entries.getPtr(name) orelse return error.AssetNotRegistered;
-        const was_zero = entry.refcount == 0;
-        entry.refcount += 1;
+        // Resolve the stable hashmap-owned key up front: `name` itself may
+        // be a temporary (stack buffer, formatted string, etc.), so the
+        // worker must never borrow it directly — use `kv.key_ptr.*`, which
+        // is the original `register`-time slice and therefore program-
+        // lifetime per the `@embedFile` invariant at the top of this file.
+        const kv = self.entries.getEntry(name) orelse return error.AssetNotRegistered;
+        const entry = kv.value_ptr;
+        const needs_enqueue = entry.refcount == 0 and entry.state == .registered;
 
-        if (was_zero and entry.state == .registered) {
+        if (needs_enqueue) {
+            // Spawn the worker BEFORE touching the refcount. If thread
+            // spawn fails, `try` bubbles the error with the catalog
+            // state unchanged — no leaked refcount that would trap the
+            // entry at `.registered` with `refcount > 0` forever.
             try self.ensureWorker();
             const request: WorkRequest = .{
-                .entry_name = name,
+                .entry_name = kv.key_ptr.*,
                 .vtable = entry.loader,
                 .file_type = entry.file_type,
                 .bytes = entry.raw_bytes,
@@ -173,10 +183,11 @@ pub const AssetCatalog = struct {
                 // `.registered` so the retry can fire naturally.
                 error.QueueFull => std.log.debug(
                     "assets: request ring full, deferring acquire of '{s}'",
-                    .{name},
+                    .{kv.key_ptr.*},
                 ),
             }
         }
+        entry.refcount += 1;
         return entry;
     }
 

--- a/src/assets/worker.zig
+++ b/src/assets/worker.zig
@@ -1,18 +1,48 @@
-//! Asset worker request / result message types.
+//! Asset worker thread + bounded SPSC ring buffers.
 //!
-//! This file declares **types only** — no thread, no SPSC ring
-//! buffers, no decode loop. Ticket #439 adds the `std.Thread`
-//! worker plus the bounded SPSC rings that the catalog will use to
-//! hand off requests and drain results from `pump()`.
+//! This file pairs two data structures with a background thread:
 //!
-//! The shapes are pinned here so that the catalog (#438), the legacy
-//! shim (#443), and the future scene wiring (#444+) can all reference
-//! them without waiting on the threading work to land.
+//! 1. `SpscRing(T, capacity)` — a tiny lock-free single-producer /
+//!    single-consumer ring buffer. The main thread produces
+//!    `WorkRequest`s on one instance and consumes `WorkResult`s from
+//!    another; the worker thread does the mirror. Head/tail are
+//!    `std.atomic.Value(u32)` and the ordering follows the usual SPSC
+//!    recipe: the producer publishes its write with a
+//!    `release` store and the consumer reads the published head with
+//!    an `acquire` load (and vice-versa). No mutex, no allocation.
+//!
+//! 2. `AssetWorker` — a single `std.Thread` that loops over the
+//!    request ring, calls `request.vtable.decode` on the snapshot it
+//!    pulled, and pushes the outcome onto the result ring. The worker
+//!    *never* touches an `AssetEntry` directly; it only sees the
+//!    borrowed fields packed into the `WorkRequest`. This is the
+//!    threading invariant documented at the top of `catalog.zig`.
+//!
+//! Ticket #442 will drain the result ring from `AssetCatalog.pump()`
+//! and apply the outcome to the matching entry. Until then the rings
+//! and the worker are still live: `acquire()` enqueues work on the
+//! first `0 → 1` refcount transition, the worker decodes it and
+//! parks on the result ring, and `deinit()` joins the worker cleanly
+//! after draining any in-flight results via `loader.drop`.
+//!
+//! ## Ring sizing
+//!
+//! `ring_capacity` is a power of two so the modulo folds into a mask.
+//! 64 covers flying-platform's six atlases with plenty of headroom
+//! (see RFC Open Questions §6); revisit when a project actually hits
+//! the ceiling.
 
-const loader = @import("loader.zig");
+const std = @import("std");
+const Allocator = std.mem.Allocator;
 
-const AssetLoaderVTable = loader.AssetLoaderVTable;
-const DecodedPayload = loader.DecodedPayload;
+const loader_mod = @import("loader.zig");
+
+const AssetLoaderVTable = loader_mod.AssetLoaderVTable;
+const DecodedPayload = loader_mod.DecodedPayload;
+
+/// Default capacity for the request and result rings. Power of two so
+/// `index & (cap - 1)` replaces the modulo. Keep in sync with the RFC.
+pub const ring_capacity: u32 = 64;
 
 /// Snapshot handed to the worker thread. Every field is borrowed —
 /// `entry_name`, `file_type` and `bytes` all live for the program's
@@ -27,9 +57,299 @@ pub const WorkRequest = struct {
 
 /// Worker → main message. Either `decoded` is set (success) or
 /// `err` is set (failure); `pump()` discriminates and routes to
-/// `loader.upload` / `loader.drop` accordingly. Lands in #442.
+/// `loader.upload` / `loader.drop` accordingly. Drained in #442.
 pub const WorkResult = struct {
     entry_name: []const u8,
     decoded: ?DecodedPayload,
     err: ?anyerror,
 };
+
+// ---------------------------------------------------------------------
+// SpscRing
+// ---------------------------------------------------------------------
+
+/// Bounded lock-free single-producer / single-consumer ring buffer.
+///
+/// - Exactly one thread may call `tryEnqueue`.
+/// - Exactly one thread may call `tryDequeue`.
+/// - `capacity` must be a power of two.
+///
+/// Memory ordering:
+///
+/// - The producer reads its own `head` with `monotonic` (it wrote it),
+///   reads the consumer's `tail` with `acquire` (to observe freed
+///   slots), writes the payload, then publishes the new head with
+///   `release`.
+/// - The consumer mirrors: `monotonic` for its own `tail`, `acquire`
+///   for the producer's `head` (to observe the published payload),
+///   then a `release` store when it advances `tail`.
+pub fn SpscRing(comptime T: type, comptime capacity: u32) type {
+    comptime {
+        if (capacity == 0 or (capacity & (capacity - 1)) != 0) {
+            @compileError("SpscRing capacity must be a power of two");
+        }
+    }
+
+    return struct {
+        const Self = @This();
+        const mask: u32 = capacity - 1;
+
+        head: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+        tail: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+        buffer: [capacity]T = undefined,
+
+        pub fn init() Self {
+            return .{};
+        }
+
+        /// Producer side. Returns `error.QueueFull` if no slot is free.
+        pub fn tryEnqueue(self: *Self, item: T) error{QueueFull}!void {
+            const head = self.head.load(.monotonic);
+            const tail = self.tail.load(.acquire);
+            if (head -% tail == capacity) return error.QueueFull;
+            self.buffer[head & mask] = item;
+            self.head.store(head +% 1, .release);
+        }
+
+        /// Consumer side. Returns `null` if the ring is empty.
+        pub fn tryDequeue(self: *Self) ?T {
+            const tail = self.tail.load(.monotonic);
+            const head = self.head.load(.acquire);
+            if (head == tail) return null;
+            const item = self.buffer[tail & mask];
+            self.tail.store(tail +% 1, .release);
+            return item;
+        }
+
+        /// Non-atomic snapshot — only safe from the consumer side or
+        /// while both threads are quiesced. Used by `deinit` drain.
+        pub fn isEmpty(self: *const Self) bool {
+            return self.head.load(.acquire) == self.tail.load(.acquire);
+        }
+    };
+}
+
+// ---------------------------------------------------------------------
+// AssetWorker
+// ---------------------------------------------------------------------
+
+pub const RequestRing = SpscRing(WorkRequest, ring_capacity);
+pub const ResultRing = SpscRing(WorkResult, ring_capacity);
+
+/// Single background worker. Owns neither ring — the catalog holds
+/// both and hands pointers to the worker so the main thread can keep
+/// enqueueing requests and draining results without extra plumbing.
+pub const AssetWorker = struct {
+    allocator: Allocator,
+    requests: *RequestRing,
+    results: *ResultRing,
+    shutdown: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    thread: ?std.Thread = null,
+
+    /// Worker park time when the request ring is empty. Short enough
+    /// to keep latency tight on a bursty load, long enough to stay
+    /// below `~1%` CPU while idle.
+    const idle_park_ns: u64 = 100 * std.time.ns_per_us;
+
+    pub fn init(
+        allocator: Allocator,
+        requests: *RequestRing,
+        results: *ResultRing,
+    ) AssetWorker {
+        return .{
+            .allocator = allocator,
+            .requests = requests,
+            .results = results,
+        };
+    }
+
+    /// Spawns the background thread. Must be called exactly once,
+    /// after `init`. Catalogs call this from their own `init`.
+    pub fn start(self: *AssetWorker) !void {
+        std.debug.assert(self.thread == null);
+        self.thread = try std.Thread.spawn(.{}, runLoop, .{self});
+    }
+
+    /// Signals shutdown and joins the background thread. Idempotent —
+    /// safe to call from `deinit` regardless of whether `start`
+    /// succeeded. Does NOT drain the result ring; the caller owns
+    /// that step so it can invoke `loader.drop` on any in-flight
+    /// payload before the allocator goes away.
+    pub fn stop(self: *AssetWorker) void {
+        self.shutdown.store(true, .release);
+        if (self.thread) |t| {
+            t.join();
+            self.thread = null;
+        }
+    }
+
+    fn runLoop(self: *AssetWorker) void {
+        while (!self.shutdown.load(.acquire)) {
+            const request = self.requests.tryDequeue() orelse {
+                std.Thread.sleep(idle_park_ns);
+                continue;
+            };
+
+            const result = blk: {
+                const decoded_or_err = request.vtable.decode(
+                    request.file_type,
+                    request.bytes,
+                    self.allocator,
+                );
+                if (decoded_or_err) |decoded| {
+                    break :blk WorkResult{
+                        .entry_name = request.entry_name,
+                        .decoded = decoded,
+                        .err = null,
+                    };
+                } else |err| {
+                    break :blk WorkResult{
+                        .entry_name = request.entry_name,
+                        .decoded = null,
+                        .err = err,
+                    };
+                }
+            };
+
+            // The result ring is the same size as the request ring, so
+            // a full result ring implies the main thread has not
+            // drained in a very long time. Spin until space is free or
+            // shutdown is requested — dropping a decoded payload
+            // silently here would leak the allocator-owned pixels.
+            while (true) {
+                if (self.results.tryEnqueue(result)) |_| {
+                    break;
+                } else |_| {
+                    if (self.shutdown.load(.acquire)) {
+                        // Shutdown path: hand the payload back to the
+                        // loader's drop hook so the allocator can
+                        // reclaim it before the catalog tears down.
+                        if (result.decoded) |payload| {
+                            request.vtable.drop(self.allocator, payload);
+                        }
+                        return;
+                    }
+                    std.Thread.sleep(idle_park_ns);
+                }
+            }
+        }
+    }
+};
+
+// ---------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------
+
+const testing = std.testing;
+
+test "SpscRing empty dequeue returns null" {
+    var ring = SpscRing(u32, 4).init();
+    try testing.expectEqual(@as(?u32, null), ring.tryDequeue());
+}
+
+test "SpscRing fills to capacity then returns QueueFull" {
+    var ring = SpscRing(u32, 4).init();
+    try ring.tryEnqueue(10);
+    try ring.tryEnqueue(20);
+    try ring.tryEnqueue(30);
+    try ring.tryEnqueue(40);
+    try testing.expectError(error.QueueFull, ring.tryEnqueue(50));
+
+    try testing.expectEqual(@as(?u32, 10), ring.tryDequeue());
+    try ring.tryEnqueue(50); // slot freed
+    try testing.expectEqual(@as(?u32, 20), ring.tryDequeue());
+    try testing.expectEqual(@as(?u32, 30), ring.tryDequeue());
+    try testing.expectEqual(@as(?u32, 40), ring.tryDequeue());
+    try testing.expectEqual(@as(?u32, 50), ring.tryDequeue());
+    try testing.expectEqual(@as(?u32, null), ring.tryDequeue());
+}
+
+test "SpscRing preserves order across producer/consumer threads" {
+    const Ring = SpscRing(u32, 8);
+    var ring = Ring.init();
+
+    const total: u32 = 10_000;
+
+    const Producer = struct {
+        fn run(r: *Ring, n: u32) void {
+            var i: u32 = 0;
+            while (i < n) {
+                r.tryEnqueue(i) catch {
+                    std.Thread.yield() catch {};
+                    continue;
+                };
+                i += 1;
+            }
+        }
+    };
+
+    const producer = try std.Thread.spawn(.{}, Producer.run, .{ &ring, total });
+
+    var expected: u32 = 0;
+    while (expected < total) {
+        if (ring.tryDequeue()) |value| {
+            try testing.expectEqual(expected, value);
+            expected += 1;
+        } else {
+            std.Thread.yield() catch {};
+        }
+    }
+    producer.join();
+    try testing.expect(ring.isEmpty());
+}
+
+test "AssetWorker decodes a stub request and publishes a result" {
+    var requests = RequestRing.init();
+    var results = ResultRing.init();
+
+    var worker = AssetWorker.init(testing.allocator, &requests, &results);
+    try worker.start();
+    defer worker.stop();
+
+    const image_loader = @import("loaders/image.zig");
+    try requests.tryEnqueue(.{
+        .entry_name = "stub",
+        .vtable = &image_loader.vtable,
+        .file_type = "png",
+        .bytes = "not-really-png",
+    });
+
+    // Spin up to 200ms waiting for the worker to publish.
+    const deadline_ns: u64 = 200 * std.time.ns_per_ms;
+    var waited_ns: u64 = 0;
+    const step_ns: u64 = 1 * std.time.ns_per_ms;
+    const result = while (waited_ns < deadline_ns) {
+        if (results.tryDequeue()) |r| break r;
+        std.Thread.sleep(step_ns);
+        waited_ns += step_ns;
+    } else {
+        return error.WorkerDidNotRespond;
+    };
+
+    try testing.expectEqualStrings("stub", result.entry_name);
+    try testing.expectEqual(@as(?DecodedPayload, null), result.decoded);
+    try testing.expectEqual(@as(?anyerror, error.NotImplemented), result.err);
+}
+
+test "AssetWorker shuts down cleanly with a request still in flight" {
+    var requests = RequestRing.init();
+    var results = ResultRing.init();
+
+    var worker = AssetWorker.init(testing.allocator, &requests, &results);
+    try worker.start();
+
+    const image_loader = @import("loaders/image.zig");
+    // Drop a pending request in and immediately stop without draining.
+    try requests.tryEnqueue(.{
+        .entry_name = "pending",
+        .vtable = &image_loader.vtable,
+        .file_type = "png",
+        .bytes = "",
+    });
+
+    worker.stop(); // must not deadlock, must not leak
+    // The result may or may not have landed depending on scheduling;
+    // either way we should be able to drain what's there without
+    // tripping the testing allocator.
+    while (results.tryDequeue()) |_| {}
+}

--- a/src/assets/worker.zig
+++ b/src/assets/worker.zig
@@ -58,8 +58,14 @@ pub const WorkRequest = struct {
 /// Worker → main message. Either `decoded` is set (success) or
 /// `err` is set (failure); `pump()` discriminates and routes to
 /// `loader.upload` / `loader.drop` accordingly. Drained in #442.
+///
+/// `vtable` is carried through from the originating `WorkRequest` so
+/// consumers (`deinit` drain, future `pump()`) can drop or upload the
+/// payload without a hashmap lookup — and still do the right thing
+/// even if the entry was removed between enqueue and dequeue.
 pub const WorkResult = struct {
     entry_name: []const u8,
+    vtable: *const AssetLoaderVTable,
     decoded: ?DecodedPayload,
     err: ?anyerror,
 };
@@ -93,9 +99,14 @@ pub fn SpscRing(comptime T: type, comptime capacity: u32) type {
     return struct {
         const Self = @This();
         const mask: u32 = capacity - 1;
+        // Align head and tail to separate cache lines so the producer
+        // (writing head) and consumer (writing tail) don't ping-pong a
+        // shared cache line on every publish/consume — classic SPSC
+        // false-sharing mitigation.
+        const cache_line: usize = 64;
 
-        head: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
-        tail: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+        head: std.atomic.Value(u32) align(cache_line) = std.atomic.Value(u32).init(0),
+        tail: std.atomic.Value(u32) align(cache_line) = std.atomic.Value(u32).init(0),
         buffer: [capacity]T = undefined,
 
         pub fn init() Self {
@@ -199,12 +210,14 @@ pub const AssetWorker = struct {
                 if (decoded_or_err) |decoded| {
                     break :blk WorkResult{
                         .entry_name = request.entry_name,
+                        .vtable = request.vtable,
                         .decoded = decoded,
                         .err = null,
                     };
                 } else |err| {
                     break :blk WorkResult{
                         .entry_name = request.entry_name,
+                        .vtable = request.vtable,
                         .decoded = null,
                         .err = err,
                     };

--- a/test/asset_catalog_test.zig
+++ b/test/asset_catalog_test.zig
@@ -22,7 +22,10 @@ test "engine re-exports AssetCatalog and friends" {
 
     const entry = try catalog.acquire("background");
     try testing.expectEqual(@as(u32, 1), entry.refcount);
-    try testing.expectEqual(engine.AssetState.registered, entry.state);
+    // First acquire spawns the worker and moves the entry to
+    // `.queued` — the real `.ready` transition lands with #442's
+    // pump() body.
+    try testing.expectEqual(engine.AssetState.queued, entry.state);
     try testing.expectEqual(engine.LoaderKind.image, entry.loader_kind);
 
     catalog.release("background");


### PR DESCRIPTION
## Summary

Phase 1 of the [Asset Streaming RFC (#437)](https://github.com/labelle-toolkit/labelle-engine/pull/437). Adds the background decode worker and the two bounded lock-free rings that plug it into `AssetCatalog`.

- `SpscRing(T, capacity)` — a small power-of-two single-producer / single-consumer ring in `src/assets/worker.zig`. Head/tail are `std.atomic.Value(u32)`; the producer reads its own head relaxed, reads the consumer's tail with `acquire`, writes the payload, and publishes the new head with `release`. The consumer mirrors. `error.QueueFull` on a full enqueue, `null` on an empty dequeue, no allocation.
- `AssetWorker` — one `std.Thread` per catalog. Pops a `WorkRequest`, calls `vtable.decode(file_type, bytes, allocator)`, and pushes the outcome (success or error) onto the result ring. Parks 100µs on an empty request ring, spin-retries a full result ring, checks a `std.atomic.Value(bool)` shutdown flag every iteration. Never touches `AssetEntry` directly — the snapshot in the request is everything it sees.
- `AssetCatalog` now owns both rings and the worker. `init` stays infallible and lazily spawns the worker on the first `0 → 1` acquire (so the rings have a stable address by the time the thread captures pointers to them). `acquire` enqueues a `WorkRequest` and moves the entry to `.queued`; a full request ring logs and leaves the state at `.registered` for the next `pump()` retry. `deinit` joins the worker, drains the result ring through `loader.drop`, then tears down the entry map.

Ring size is 64 as spec'd by the RFC — enough headroom for flying-platform's six atlases with room to spare.

## Scope

- `pump()` stays a no-op — the frame-drain body lands in #442. Integration tests therefore peek at the result ring directly and assert a `WorkResult` with `err == error.NotImplemented` appears within a 200ms spin loop against the placeholder image loader. The end-to-end `.ready` transition tests will land with #442.
- Real image/audio/font decode (#440 / #441), the legacy shim rewrite (#443), and scene wiring (#444+) are all out of scope.

## Test plan

- [x] `zig build test` green (ran 5× back-to-back in Debug plus once in ReleaseFast — no flakes).
- [x] `SpscRing` unit tests: empty dequeue → null, fill-to-capacity → `error.QueueFull`, 10k-item ordered handoff across a spawned producer thread.
- [x] `AssetWorker` unit test: enqueue a stub image request, spin up to 200ms for the result, assert `err == error.NotImplemented`.
- [x] Catalog integration test: `catalog.acquire("background")` spins up the worker lazily, worker produces a `WorkResult` on the ring within the spin window.
- [x] Shutdown under pending load: `deinit` with a pending `acquire` joins the worker cleanly and drains the result ring with no leaks (verified under the testing allocator).

Closes #439

Refs: #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)