### PR TITLE
feat(scene): SceneEntry.assets field wired from assembler manifest

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -110,6 +110,13 @@ pub fn GameConfig(
         pub const SceneEntry = struct {
             loader_fn: *const fn (*Self) anyerror!void,
             hooks: SceneHooks,
+            /// Declared asset manifest for this scene — the slice of asset names
+            /// the scene needs loaded before it runs. Populated by the assembler
+            /// from each scene's `"assets": [...]` block (see Asset Streaming
+            /// RFC #437 / issue #445). Defaults to an empty slice for scenes
+            /// registered via the legacy (non-manifest) path; scripts can then
+            /// do `game.scenes.get("main").?.assets` without a null check.
+            assets: []const []const u8 = &.{},
         };
 
         /// Runtime JSONC scene path info.
@@ -634,6 +641,8 @@ pub fn GameConfig(
         // ── Scene Management (mixin) ─────────────────────────────
         pub const registerScene = SceneMixin.registerScene;
         pub const registerSceneSimple = SceneMixin.registerSceneSimple;
+        pub const registerSceneWithAssets = SceneMixin.registerSceneWithAssets;
+        pub const setSceneAssets = SceneMixin.setSceneAssets;
         pub const setScene = SceneMixin.setScene;
         pub const setSceneAtomic = SceneMixin.setSceneAtomic;
         pub const queueSceneChange = SceneMixin.queueSceneChange;

--- a/src/game/scene_mixin.zig
+++ b/src/game/scene_mixin.zig
@@ -29,6 +29,48 @@ pub fn Mixin(comptime Game: type) type {
             self.registerScene(name, loader_fn, .{});
         }
 
+        /// Register a scene together with its declared asset manifest.
+        /// This is the manifest-aware overload emitted by the assembler for
+        /// scenes with an `"assets": [...]` block — it's equivalent to
+        /// `registerSceneSimple` followed by `setSceneAssets`, but avoids a
+        /// second map lookup. The slice must live at least as long as the
+        /// `Game` (the assembler passes a comptime slice from
+        /// `SceneAssetManifests.entries`, which is file-scope in the generated
+        /// `main.zig`, so this is always the case in practice).
+        pub fn registerSceneWithAssets(
+            self: *Game,
+            comptime name: []const u8,
+            comptime loader_fn: fn (*Game) anyerror!void,
+            assets: []const []const u8,
+        ) void {
+            const wrapper = struct {
+                fn load(game: *Game) anyerror!void {
+                    return loader_fn(game);
+                }
+            }.load;
+            self.scenes.put(name, .{
+                .loader_fn = wrapper,
+                .hooks = .{},
+                .assets = assets,
+            }) catch {};
+        }
+
+        /// Attach an asset manifest to a previously-registered scene.
+        /// Returns `error.SceneNotFound` if `name` was never registered.
+        /// Used by the assembler to thread `SceneAssetManifests.entries` into
+        /// `SceneEntry.assets` after the normal `registerSceneSimple` loop
+        /// (keeps the codegen diff to a single extra inline-for in the
+        /// generated `main.zig`). Scripts can then read
+        /// `game.scenes.get("main").?.assets` at runtime.
+        pub fn setSceneAssets(
+            self: *Game,
+            name: []const u8,
+            assets: []const []const u8,
+        ) error{SceneNotFound}!void {
+            const entry = self.scenes.getPtr(name) orelse return error.SceneNotFound;
+            entry.assets = assets;
+        }
+
         pub fn setScene(self: *Game, name: []const u8) !void {
             self.unloadCurrentScene();
 

--- a/src/game/scene_mixin.zig
+++ b/src/game/scene_mixin.zig
@@ -30,29 +30,27 @@ pub fn Mixin(comptime Game: type) type {
         }
 
         /// Register a scene together with its declared asset manifest.
-        /// This is the manifest-aware overload emitted by the assembler for
-        /// scenes with an `"assets": [...]` block — it's equivalent to
-        /// `registerSceneSimple` followed by `setSceneAssets`, but avoids a
-        /// second map lookup. The slice must live at least as long as the
-        /// `Game` (the assembler passes a comptime slice from
-        /// `SceneAssetManifests.entries`, which is file-scope in the generated
-        /// `main.zig`, so this is always the case in practice).
+        /// Manifest-aware overload emitted by the assembler for scenes with
+        /// an `"assets": [...]` block. Delegates to `registerSceneSimple`
+        /// so any future change to scene-entry construction only lives in
+        /// one place, then attaches the slice via `getPtr`.
+        ///
+        /// Lifetime: `assets` is stored by reference on the `SceneEntry`
+        /// and must outlive the `Game`. The assembler passes a file-scope
+        /// slice from `SceneAssetManifests.entries` in the generated
+        /// `main.zig`, which is program-lifetime. Runtime callers passing
+        /// a stack-allocated slice would leave `SceneEntry.assets`
+        /// dangling — prefer an allocator-owned or static slice.
         pub fn registerSceneWithAssets(
             self: *Game,
             comptime name: []const u8,
             comptime loader_fn: fn (*Game) anyerror!void,
             assets: []const []const u8,
         ) void {
-            const wrapper = struct {
-                fn load(game: *Game) anyerror!void {
-                    return loader_fn(game);
-                }
-            }.load;
-            self.scenes.put(name, .{
-                .loader_fn = wrapper,
-                .hooks = .{},
-                .assets = assets,
-            }) catch {};
+            self.registerSceneSimple(name, loader_fn);
+            if (self.scenes.getPtr(name)) |entry| {
+                entry.assets = assets;
+            }
         }
 
         /// Attach an asset manifest to a previously-registered scene.
@@ -62,6 +60,10 @@ pub fn Mixin(comptime Game: type) type {
         /// (keeps the codegen diff to a single extra inline-for in the
         /// generated `main.zig`). Scripts can then read
         /// `game.scenes.get("main").?.assets` at runtime.
+        ///
+        /// Lifetime: `assets` is stored by reference and must outlive the
+        /// `Game`. See `registerSceneWithAssets` for the usual caller
+        /// pattern (file-scope slice from `SceneAssetManifests.entries`).
         pub fn setSceneAssets(
             self: *Game,
             name: []const u8,

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -142,6 +142,83 @@ test "Game: scene management" {
     try testing.expectEqual(1, game.entityCount());
 }
 
+test "Game: SceneEntry.assets defaults to empty for legacy registration" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const emptyLoader = struct {
+        fn load(_: *Game) anyerror!void {}
+    }.load;
+
+    game.registerSceneSimple("legacy", emptyLoader);
+
+    const entry = game.scenes.get("legacy").?;
+    try testing.expectEqual(@as(usize, 0), entry.assets.len);
+}
+
+test "Game: registerSceneWithAssets attaches manifest slice" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const emptyLoader = struct {
+        fn load(_: *Game) anyerror!void {}
+    }.load;
+
+    const menu_assets: []const []const u8 = &.{ "background", "ship" };
+    game.registerSceneWithAssets("main", emptyLoader, menu_assets);
+
+    const entry = game.scenes.get("main").?;
+    try testing.expectEqual(@as(usize, 2), entry.assets.len);
+    try testing.expectEqualStrings("background", entry.assets[0]);
+    try testing.expectEqualStrings("ship", entry.assets[1]);
+}
+
+test "Game: setSceneAssets threads manifest into existing SceneEntry" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const emptyLoader = struct {
+        fn load(_: *Game) anyerror!void {}
+    }.load;
+
+    game.registerSceneSimple("menu", emptyLoader);
+
+    // Before — legacy default.
+    try testing.expectEqual(@as(usize, 0), game.scenes.get("menu").?.assets.len);
+
+    const menu_assets: []const []const u8 = &.{ "background", "ship" };
+    try game.setSceneAssets("menu", menu_assets);
+
+    const entry = game.scenes.get("menu").?;
+    try testing.expectEqual(@as(usize, 2), entry.assets.len);
+    try testing.expectEqualStrings("background", entry.assets[0]);
+    try testing.expectEqualStrings("ship", entry.assets[1]);
+
+    // Unknown scene returns an error instead of silently dropping.
+    try testing.expectError(error.SceneNotFound, game.setSceneAssets("nope", menu_assets));
+}
+
+test "Game: slash-named scene preserves original name for lookup" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const emptyLoader = struct {
+        fn load(_: *Game) anyerror!void {}
+    }.load;
+
+    // The assembler flattens "world/intro" to "world_intro" for the Zig ident
+    // in SceneAssetManifests, but the Entry.name field and the registerScene
+    // call both use the original slash-style name, so game.scenes.get lookup
+    // must use the slash form too.
+    const intro_assets: []const []const u8 = &.{ "hero_idle", "city_bg" };
+    game.registerSceneWithAssets("world/intro", emptyLoader, intro_assets);
+
+    const entry = game.scenes.get("world/intro").?;
+    try testing.expectEqual(@as(usize, 2), entry.assets.len);
+    try testing.expectEqualStrings("hero_idle", entry.assets[0]);
+    try testing.expectEqualStrings("city_bg", entry.assets[1]);
+}
+
 test "Game: hierarchy parent/child" {
     var game = Game.init(testing.allocator);
     defer game.deinit();

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -207,9 +207,9 @@ test "Game: slash-named scene preserves original name for lookup" {
     }.load;
 
     // The assembler flattens "world/intro" to "world_intro" for the Zig ident
-    // in SceneAssetManifests, but the Entry.name field and the registerScene
-    // call both use the original slash-style name, so game.scenes.get lookup
-    // must use the slash form too.
+    // in SceneAssetManifests, but the registerScene call and the `game.scenes`
+    // map key both use the original slash-style name, so game.scenes.get
+    // lookup must use the slash form too.
     const intro_assets: []const []const u8 = &.{ "hero_idle", "city_bg" };
     game.registerSceneWithAssets("world/intro", emptyLoader, intro_assets);
 


### PR DESCRIPTION
## Summary

Phase 2 of the Asset Streaming RFC (#437). Plumbs each scene's parsed `"assets": [...]` manifest into `SceneEntry.assets` so runtime code can do `game.scenes.get("main").?.assets` without touching generated code.

Closes #445.

- `SceneEntry` gains `assets: []const []const u8 = &.{}`. The empty default keeps the legacy `registerSceneSimple` path working with zero churn (scripts can `.assets.len == 0` to branch on non-streaming scenes without a null check).
- `registerSceneWithAssets(name, loader, assets)` — manifest-aware overload the assembler can call directly when it wants to avoid a second map lookup. Equivalent to `registerSceneSimple` plus `setSceneAssets`.
- `setSceneAssets(name, assets) error{SceneNotFound}!void` — the setter-after-registration helper.

## API choice

**Option A (add overload) + setter-after-registration.** Both new methods live alongside the untouched `registerSceneSimple`, so every existing call site keeps compiling with zero changes. The assembler emits a single `inline for (SceneAssetManifests.entries)` loop at the end of its existing `registerSceneSimple` block — one extra comptime loop per setup-code path, not per-scene churn.

## Assembler touch

Yes, minimum required. See **labelle-toolkit/labelle-assembler#52** — that PR adds the two-line comptime `inline for` loop in `buildSetupCode` and `buildCallbackInitCode`. **It is a required merge dependency:** this engine PR exposes `setSceneAssets`, and the assembler PR is the only caller.

## Back-compat

- Legacy `registerSceneSimple` scenes see `SceneEntry.assets == &.{}` (empty slice, not null) — verified by the new `SceneEntry.assets defaults to empty for legacy registration` test.
- Slash-named scenes like `"world/intro"` stay retrievable via their original name — the flatten-to-ident step only affects the `SceneAssetManifests.<ident>` decls, not `Entry.name` or the map key. Verified by the new `slash-named scene preserves original name for lookup` test.
- The new `SceneEntry.assets` field has a default, so any user code that builds a `SceneEntry` literal explicitly (none in tree) keeps compiling.

## Scope boundaries

Per the ticket:
- Did **not** touch `src/assets/` (Phase 1 territory — PRs #449/#450)
- Did **not** touch `loadAtlas*` / worker / catalog
- Did **not** implement `scene_assets_acquire/release` hooks (that's #444)
- Did touch the assembler — one extra comptime loop, separate PR linked above

## Test plan

- [x] `zig build test` green
- [x] New engine tests cover: defaults-to-empty for legacy, `registerSceneWithAssets`, `setSceneAssets` happy path + `SceneNotFound`, slash-name round-trip
- [ ] End-to-end wiring verified once labelle-assembler#52 merges

Refs: #445, #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)