### PR TITLE
feat(assets): image loader — real decodeImage/uploadTexture vtable

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -60,4 +60,22 @@ pub fn build(b: *std.Build) void {
         });
         test_step.dependOn(&b.addRunArtifact(t).step);
     }
+
+    // In-source tests under `src/assets/` (catalog, worker, loader,
+    // loaders/*) cannot be dragged into a `test/*` binary through the
+    // cross-module `engine` import — Zig only discovers top-level
+    // `test` blocks in files that belong to the **same** module as
+    // the test binary's root. Rooting an extra test binary directly
+    // at `src/assets/mod.zig` gives those files a module of their
+    // own where `_ = @import("...")` chains actually cascade the
+    // test blocks into the binary. Added as part of #440 while the
+    // real image loader started writing its own in-source tests.
+    const assets_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/assets/mod.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    test_step.dependOn(&b.addRunArtifact(assets_tests).step);
 }

--- a/src/assets/catalog.zig
+++ b/src/assets/catalog.zig
@@ -33,6 +33,8 @@ const worker_mod = @import("worker.zig");
 
 pub const LoaderKind = loader_mod.LoaderKind;
 pub const DecodedPayload = loader_mod.DecodedPayload;
+pub const UploadedResource = loader_mod.UploadedResource;
+pub const Texture = loader_mod.Texture;
 pub const AssetLoaderVTable = loader_mod.AssetLoaderVTable;
 pub const AssetState = loader_mod.AssetState;
 pub const AssetEntry = loader_mod.AssetEntry;
@@ -138,6 +140,7 @@ pub const AssetCatalog = struct {
             .raw_bytes = bytes,
             .file_type = file_type,
             .decoded = null,
+            .resource = null,
             .last_error = null,
         });
     }
@@ -289,7 +292,8 @@ test "register then acquire bumps refcount and enqueues work" {
     try testing.expectEqual(@as(u32, 1), entry.refcount);
     // First acquire moved the entry to `.queued` — the worker ring
     // has taken ownership of the request and will eventually publish
-    // an `error.NotImplemented` result on the stub loader.
+    // an `error.ImageBackendNotInitialized` result on the real image
+    // loader (no backend injected in the unit-test harness).
     try testing.expectEqual(AssetState.queued, entry.state);
     try testing.expectEqual(LoaderKind.image, entry.loader_kind);
     try testing.expectEqual(@as(?DecodedPayload, null), entry.decoded);
@@ -408,7 +412,13 @@ test "pump is a no-op until the worker lands (#442)" {
     try testing.expect(!catalog.isReady("background"));
 }
 
-test "acquire spawns worker which produces NotImplemented for stub loader" {
+test "acquire spawns worker which surfaces ImageBackendNotInitialized without a backend" {
+    // Make sure no previous test left a backend injected on this
+    // process-global slot — the assertions below rely on the loader
+    // returning the not-initialised error, not a mock success.
+    const image_loader_mod = @import("loaders/image.zig");
+    image_loader_mod.clearBackend();
+
     var catalog = AssetCatalog.init(testing.allocator);
     defer catalog.deinit();
 
@@ -431,7 +441,7 @@ test "acquire spawns worker which produces NotImplemented for stub loader" {
 
     try testing.expectEqualStrings("background", result.entry_name);
     try testing.expectEqual(@as(?DecodedPayload, null), result.decoded);
-    try testing.expectEqual(@as(?anyerror, error.NotImplemented), result.err);
+    try testing.expectEqual(@as(?anyerror, error.ImageBackendNotInitialized), result.err);
 }
 
 test "deinit with a pending acquire shuts down cleanly" {

--- a/src/assets/loader.zig
+++ b/src/assets/loader.zig
@@ -1,4 +1,5 @@
-//! Asset entry state, loader vtable + decoded payload union.
+//! Asset entry state, loader vtable + decoded payload / uploaded
+//! resource unions.
 //!
 //! Owns the shared types that both the catalog and the concrete loaders
 //! (image, audio, font) need. Keeping them here avoids a circular
@@ -9,8 +10,24 @@
 //! `pub const vtable: AssetLoaderVTable` that the catalog stores on
 //! each `AssetEntry` at registration time.
 //!
-//! This file declares **types only** — no implementations. The real
-//! image loader lands in ticket #440, audio/font in #441.
+//! ## Where does the uploaded GPU/device handle live?
+//!
+//! `AssetEntry.decoded` holds the worker-thread CPU-side payload
+//! (RGBA pixels for images, sample buffers for audio, glyph rasters
+//! for fonts). After `loader.upload` runs on the main thread, we also
+//! need a slot for the post-upload "real thing" — a GPU texture
+//! handle, an audio device id, a font atlas pointer, … — so `pump()`
+//! (#442), `isReady`, and the eventual unload path (#446) can see it
+//! without walking private loader state.
+//!
+//! Phase 1 picks **option 1** from the #440 ticket: extend `AssetEntry`
+//! with a second `resource: ?UploadedResource` field, parallel to the
+//! existing `decoded`. This keeps the CPU-side and GPU-side slots
+//! independent, matches the RFC §2 sketch ("decoded: union { texture,
+//! audio, font }"), and survives the #441 / #442 / #446 tickets cleanly.
+//! The alternative — reusing `decoded` as a "before OR after" union —
+//! was rejected because Zig unions are comptime-tagged so the variant
+//! types have to be decided up front.
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
@@ -19,6 +36,12 @@ const Allocator = std.mem.Allocator;
 /// `AssetCatalog.register` time. Stored on the entry; callers do not
 /// need to namespace asset names per loader.
 pub const LoaderKind = enum { image, audio, font };
+
+/// Opaque GPU texture handle used by the image loader. Matches the
+/// `u32` texture id convention in `src/atlas.zig` so existing atlas
+/// consumers can read it out of `entry.resource.?.image` without a
+/// conversion layer when the legacy shim lands in #443.
+pub const Texture = u32;
 
 /// Worker-thread output. Variants are populated on the worker, then
 /// either uploaded (success path) or dropped (refcount-zero discard
@@ -30,6 +53,17 @@ pub const DecodedPayload = union(LoaderKind) {
         width: u32,
         height: u32,
     },
+    audio: struct {}, // placeholder for Phase 4 (#441)
+    font: struct {}, // placeholder for Phase 4 (#441)
+};
+
+/// Main-thread "after upload" payload. Populated by `loader.upload`
+/// once the CPU-side `DecodedPayload` has been handed to the backend
+/// (GPU for images, audio device for sounds, atlas for fonts). Cleared
+/// by `loader.free` on the unload path (#446). The `audio` and `font`
+/// variants are placeholders until #441.
+pub const UploadedResource = union(LoaderKind) {
+    image: Texture,
     audio: struct {}, // placeholder for Phase 4 (#441)
     font: struct {}, // placeholder for Phase 4 (#441)
 };
@@ -52,9 +86,17 @@ pub const AssetEntry = struct {
     raw_bytes: []const u8,
     /// Borrowed sentinel-terminated string — program lifetime.
     file_type: [:0]const u8,
-    /// Populated by `pump()` on the success path; cleared back to
-    /// `null` when refcount returns to zero (ticket #446).
+    /// Populated by the worker's decode path and consumed by
+    /// `loader.upload`. Cleared back to `null` by `pump()` (#442) once
+    /// the upload has moved ownership into `resource`, or by
+    /// `loader.drop` on the refcount-zero discard path.
     decoded: ?DecodedPayload,
+    /// Populated by `loader.upload` on the success path — holds the
+    /// backend-side handle (GPU texture, audio device id, font atlas,
+    /// …) that `isReady` and the eventual unload path in #446 read.
+    /// Cleared by `loader.free` when refcount returns to zero on a
+    /// `.ready` entry.
+    resource: ?UploadedResource,
     last_error: ?anyerror,
 };
 
@@ -74,16 +116,26 @@ pub const AssetLoaderVTable = struct {
 
     /// Main-thread finalise: GPU upload, audio device handle, font
     /// glyph rasterise — whatever turns the worker output into the
-    /// `.ready` representation. Frees the CPU-side payload on the
-    /// success path.
-    upload: *const fn (entry: *AssetEntry, decoded: DecodedPayload) anyerror!void,
+    /// `.ready` representation. On success the loader stashes the
+    /// resulting handle on `entry.resource` AND frees the CPU-side
+    /// `decoded` payload via `allocator` — the labelle-gfx contract
+    /// says `uploadTexture` does NOT take ownership of the pixels.
+    /// On failure the loader leaves the CPU payload alive and
+    /// returns the error; `pump()` (#442) routes the entry to
+    /// `.failed`, and the CPU payload is freed via `drop` as part of
+    /// teardown.
+    upload: *const fn (
+        entry: *AssetEntry,
+        decoded: DecodedPayload,
+        allocator: Allocator,
+    ) anyerror!void,
 
     /// Discard path: refcount hit zero between decode and upload.
     /// Frees the CPU-side payload without touching the GPU.
     drop: *const fn (allocator: Allocator, decoded: DecodedPayload) void,
 
     /// Unload path: refcount hit zero on a `.ready` asset. Releases
-    /// the GPU/audio/font resource that `upload` created. Wired up
-    /// in ticket #446.
+    /// the GPU/audio/font resource that `upload` created and clears
+    /// `entry.resource` back to `null`. Wired up in ticket #446.
     free: *const fn (entry: *AssetEntry) void,
 };

--- a/src/assets/loaders/audio.zig
+++ b/src/assets/loaders/audio.zig
@@ -23,9 +23,10 @@ fn decode(
     return error.NotImplemented;
 }
 
-fn upload(entry: *AssetEntry, decoded: DecodedPayload) anyerror!void {
+fn upload(entry: *AssetEntry, decoded: DecodedPayload, allocator: Allocator) anyerror!void {
     _ = entry;
     _ = decoded;
+    _ = allocator;
     return error.NotImplemented;
 }
 

--- a/src/assets/loaders/font.zig
+++ b/src/assets/loaders/font.zig
@@ -23,9 +23,10 @@ fn decode(
     return error.NotImplemented;
 }
 
-fn upload(entry: *AssetEntry, decoded: DecodedPayload) anyerror!void {
+fn upload(entry: *AssetEntry, decoded: DecodedPayload, allocator: Allocator) anyerror!void {
     _ = entry;
     _ = decoded;
+    _ = allocator;
     return error.NotImplemented;
 }
 

--- a/src/assets/loaders/image.zig
+++ b/src/assets/loaders/image.zig
@@ -1,11 +1,56 @@
-//! Placeholder image loader vtable.
+//! Image loader — CPU-decode on the worker, GPU-upload on the main
+//! thread, backed by a runtime-injected `ImageBackend`.
 //!
-//! Every method is a stub: `decode` and `upload` return
-//! `error.NotImplemented`, `drop` and `free` are no-ops. The real
-//! implementation — backed by `gfx.decodeImage` / `gfx.uploadTexture`
-//! — lands in ticket #440. Until then this file exists so that the
-//! catalog can resolve `LoaderKind.image` to a concrete vtable
-//! pointer at registration time.
+//! ## Why a runtime backend hook instead of a direct `gfx` import?
+//!
+//! The engine crate does **not** depend on `labelle-gfx` — `build.zig`
+//! only wires `labelle-core`, `scene` and `jsonc` into the engine
+//! module. That is deliberate: every asset in the monorepo-plus-URL-
+//! fetch world has to be reachable through a chain of `path` / URL
+//! deps that also works for backend implementations fetched by the
+//! assembler, and `labelle-gfx/build.zig.zon` carries a path-relative
+//! `../labelle-core` dep which breaks URL fetches (see the #440
+//! ticket prologue). We do not want the engine to inherit that
+//! fragility.
+//!
+//! So instead of `@import("labelle-gfx")`, the image loader exposes a
+//! tiny `ImageBackend` struct of function pointers that the assembler
+//! populates at `Game.init` time via `setBackend`. The assembler
+//! already imports `labelle-gfx`, so the `decodeImage` /
+//! `uploadTexture` / `unloadTexture` values live on its side of the
+//! dependency boundary; the engine only ever sees plain function
+//! pointers to a local `DecodedImage` POD.
+//!
+//! This also side-steps the nominal-type collision described in the
+//! ticket: because the engine never imports labelle-gfx's
+//! `DecodedImage`, there is no way for two structurally-identical
+//! types to collide here — the backend adapter just marshals between
+//! whatever shape `gfx.decodeImage` returns and this module's
+//! `DecodedImage`, which is the shape the loader hands to the catalog.
+//!
+//! ## Threading
+//!
+//! * `decode` runs on the asset worker thread. It calls
+//!   `backend.decode(file_type, data, allocator)` — `stb_image` via
+//!   the backend adapter is pure CPU, no GL calls, so that is safe.
+//! * `upload`, `drop`, `free` all run on the main thread from
+//!   `AssetCatalog.pump()` / `AssetCatalog.deinit()` / the future
+//!   #446 unload path. `upload` and `free` call back into the backend
+//!   on the main thread for GL operations.
+//!
+//! ## Ownership of `DecodedImage.pixels`
+//!
+//! * `decode` allocates the pixel buffer through the provided
+//!   allocator — same allocator the worker hands in, same allocator
+//!   that later frees the buffer.
+//! * `upload` calls `backend.upload` (which **copies** the pixels to
+//!   the GPU) and then frees the CPU buffer via `allocator`. The
+//!   labelle-gfx contract explicitly says `uploadTexture` does NOT
+//!   take ownership.
+//! * `drop` is the refcount-zero-during-decode path: free the CPU
+//!   buffer, leave the GPU alone.
+//! * `free` is the refcount-zero-on-ready path: release the texture
+//!   handle through `backend.unload`; the CPU buffer is already gone.
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
@@ -14,32 +59,131 @@ const loader = @import("../loader.zig");
 
 const AssetLoaderVTable = loader.AssetLoaderVTable;
 const DecodedPayload = loader.DecodedPayload;
+const UploadedResource = loader.UploadedResource;
 const AssetEntry = loader.AssetEntry;
+const Texture = loader.Texture;
+
+/// CPU-side decoded pixels + dimensions, allocator-owned. Kept
+/// intentionally plain so the backend adapter can bridge it to
+/// whatever `DecodedImage` shape labelle-gfx uses on its side of the
+/// dependency boundary without a nominal-type conflict.
+pub const DecodedImage = struct {
+    pixels: []u8, // RGBA8, allocator-owned
+    width: u32,
+    height: u32,
+};
+
+/// Runtime backend hook. The assembler fills this in at `Game.init`
+/// by calling `setBackend` with adapters that forward to
+/// `labelle-gfx`'s `decodeImage` / `uploadTexture` / `unloadTexture`.
+/// Tests inject a mock implementation the same way — see
+/// `test "image loader: mock backend round-trip"` in this file.
+pub const ImageBackend = struct {
+    /// Worker-thread CPU decode. Returns a `DecodedImage` whose
+    /// `pixels` slice is owned by `allocator`. Errors bubble to
+    /// `WorkResult.err`.
+    decode: *const fn (
+        file_type: [:0]const u8,
+        data: []const u8,
+        allocator: Allocator,
+    ) anyerror!DecodedImage,
+
+    /// Main-thread GPU upload. Copies pixels to a new texture and
+    /// returns the handle. Does NOT take ownership of `decoded.pixels`
+    /// — the caller frees.
+    upload: *const fn (decoded: DecodedImage) anyerror!Texture,
+
+    /// Main-thread GPU release. The counterpart to `upload`.
+    unload: *const fn (texture: Texture) void,
+};
+
+/// Private module-level slot for the injected backend. `null` until
+/// the assembler calls `setBackend` — tests + catalog unit tests that
+/// do not touch the image loader can keep ignoring it, and any
+/// accidental `decode` / `upload` before initialisation surfaces as
+/// `error.ImageBackendNotInitialized` rather than a null deref.
+var backend: ?ImageBackend = null;
+
+/// Install the runtime backend. Call exactly once during game init,
+/// before any image asset is acquired. Idempotent enough for tests:
+/// the second call just overwrites the slot.
+pub fn setBackend(b: ImageBackend) void {
+    backend = b;
+}
+
+/// Clear the backend slot. Used by tests to return to a clean state
+/// between runs so one test's mock does not leak into the next.
+pub fn clearBackend() void {
+    backend = null;
+}
+
+/// Read-side accessor for tests / diagnostics.
+pub fn currentBackend() ?ImageBackend {
+    return backend;
+}
 
 fn decode(
     file_type: [:0]const u8,
     data: []const u8,
     allocator: Allocator,
 ) anyerror!DecodedPayload {
-    _ = file_type;
-    _ = data;
-    _ = allocator;
-    return error.NotImplemented;
+    const b = backend orelse return error.ImageBackendNotInitialized;
+    const decoded = try b.decode(file_type, data, allocator);
+    return .{ .image = .{
+        .pixels = decoded.pixels,
+        .width = decoded.width,
+        .height = decoded.height,
+    } };
 }
 
-fn upload(entry: *AssetEntry, decoded: DecodedPayload) anyerror!void {
-    _ = entry;
-    _ = decoded;
-    return error.NotImplemented;
+fn upload(
+    entry: *AssetEntry,
+    decoded_payload: DecodedPayload,
+    allocator: Allocator,
+) anyerror!void {
+    const b = backend orelse return error.ImageBackendNotInitialized;
+    const image = switch (decoded_payload) {
+        .image => |img| img,
+        else => return error.WrongDecodedPayloadKind,
+    };
+
+    // Hand the pixels to the GPU first — if this errors we still want
+    // the CPU buffer freed by `drop` on the teardown path, so leave it
+    // alive here and let the error propagate.
+    const texture = try b.upload(.{
+        .pixels = image.pixels,
+        .width = image.width,
+        .height = image.height,
+    });
+
+    // Upload succeeded: the GPU has its own copy, so we can release
+    // the allocator-owned CPU buffer now. The labelle-gfx contract
+    // says `uploadTexture` does NOT take ownership.
+    allocator.free(image.pixels);
+
+    entry.resource = .{ .image = texture };
 }
 
-fn drop(allocator: Allocator, decoded: DecodedPayload) void {
-    _ = allocator;
-    _ = decoded;
+fn drop(allocator: Allocator, decoded_payload: DecodedPayload) void {
+    switch (decoded_payload) {
+        .image => |img| allocator.free(img.pixels),
+        // Other variants never reach the image loader's drop hook —
+        // the catalog dispatches on the vtable carried by the
+        // `WorkResult`, not on `DecodedPayload`'s tag. Keep the arms
+        // exhaustive so this file compiles cleanly against future
+        // payload shapes.
+        else => {},
+    }
 }
 
 fn free(entry: *AssetEntry) void {
-    _ = entry;
+    const b = backend orelse return;
+    const resource = entry.resource orelse return;
+    switch (resource) {
+        .image => |tex| b.unload(tex),
+        else => {},
+    }
+    entry.resource = null;
 }
 
 pub const vtable: AssetLoaderVTable = .{
@@ -48,3 +192,202 @@ pub const vtable: AssetLoaderVTable = .{
     .drop = drop,
     .free = free,
 };
+
+// ---------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------
+
+const testing = std.testing;
+
+/// Tiny mock backend that records every call. `decode` allocates a
+/// fixed `width * height * 4`-byte RGBA buffer through the caller's
+/// allocator so we can exercise both the happy path (upload frees)
+/// and the discard path (drop frees) under `testing.allocator`,
+/// which catches leaks and double-frees.
+const MockBackend = struct {
+    var decode_calls: u32 = 0;
+    var upload_calls: u32 = 0;
+    var unload_calls: u32 = 0;
+    var last_uploaded: ?DecodedImage = null;
+    var last_unloaded: Texture = 0;
+    var next_texture: Texture = 1;
+    var decode_fails: bool = false;
+    var upload_fails: bool = false;
+    var decode_width: u32 = 2;
+    var decode_height: u32 = 2;
+
+    fn reset() void {
+        decode_calls = 0;
+        upload_calls = 0;
+        unload_calls = 0;
+        last_uploaded = null;
+        last_unloaded = 0;
+        next_texture = 1;
+        decode_fails = false;
+        upload_fails = false;
+        decode_width = 2;
+        decode_height = 2;
+    }
+
+    fn decodeFn(
+        file_type: [:0]const u8,
+        data: []const u8,
+        allocator: Allocator,
+    ) anyerror!DecodedImage {
+        _ = file_type;
+        _ = data;
+        decode_calls += 1;
+        if (decode_fails) return error.MockDecodeError;
+        const byte_count: usize = @as(usize, decode_width) * @as(usize, decode_height) * 4;
+        const pixels = try allocator.alloc(u8, byte_count);
+        // Fill with a recognisable byte so the upload mock can assert
+        // it was called with the same bytes the decode produced.
+        @memset(pixels, 0xAB);
+        return .{ .pixels = pixels, .width = decode_width, .height = decode_height };
+    }
+
+    fn uploadFn(decoded: DecodedImage) anyerror!Texture {
+        upload_calls += 1;
+        if (upload_fails) return error.MockUploadError;
+        last_uploaded = decoded;
+        const t = next_texture;
+        next_texture += 1;
+        return t;
+    }
+
+    fn unloadFn(texture: Texture) void {
+        unload_calls += 1;
+        last_unloaded = texture;
+    }
+
+    const backend_value: ImageBackend = .{
+        .decode = decodeFn,
+        .upload = uploadFn,
+        .unload = unloadFn,
+    };
+};
+
+test "image loader: decode without backend errors cleanly" {
+    clearBackend();
+    defer clearBackend();
+    try testing.expectError(
+        error.ImageBackendNotInitialized,
+        decode("png", "fake", testing.allocator),
+    );
+}
+
+test "image loader: mock backend decode→upload→free round-trip" {
+    MockBackend.reset();
+    setBackend(MockBackend.backend_value);
+    defer clearBackend();
+
+    // 1. decode on the worker thread (synchronously in the test).
+    const payload = try decode("png", "fake-png-bytes", testing.allocator);
+    try testing.expectEqual(@as(u32, 1), MockBackend.decode_calls);
+    try testing.expectEqual(@as(u32, 2), payload.image.width);
+    try testing.expectEqual(@as(u32, 2), payload.image.height);
+    try testing.expectEqual(@as(usize, 16), payload.image.pixels.len);
+    try testing.expectEqual(@as(u8, 0xAB), payload.image.pixels[0]);
+
+    // 2. upload on the main thread. The loader owns the free of the
+    //    CPU-side pixels after a successful upload.
+    var entry: AssetEntry = .{
+        .state = .decoding,
+        .refcount = 1,
+        .loader = &vtable,
+        .loader_kind = .image,
+        .raw_bytes = "fake-png-bytes",
+        .file_type = "png",
+        .decoded = payload,
+        .resource = null,
+        .last_error = null,
+    };
+    try upload(&entry, payload, testing.allocator);
+    try testing.expectEqual(@as(u32, 1), MockBackend.upload_calls);
+    try testing.expect(entry.resource != null);
+    try testing.expectEqual(@as(Texture, 1), entry.resource.?.image);
+    // The upload mock recorded the same pixel buffer the decode produced.
+    try testing.expect(MockBackend.last_uploaded != null);
+    try testing.expectEqual(@as(u32, 2), MockBackend.last_uploaded.?.width);
+
+    // 3. free on the main thread — refcount hit zero on a `.ready`
+    //    entry. Releases the texture through the backend.
+    free(&entry);
+    try testing.expectEqual(@as(u32, 1), MockBackend.unload_calls);
+    try testing.expectEqual(@as(Texture, 1), MockBackend.last_unloaded);
+    try testing.expectEqual(@as(?UploadedResource, null), entry.resource);
+    // `testing.allocator` would flag a leak of the pixel buffer here
+    // if upload had failed to free it. It is a GPA under the hood,
+    // so a double-free would also trip.
+}
+
+test "image loader: drop path frees pixels without touching GPU" {
+    MockBackend.reset();
+    setBackend(MockBackend.backend_value);
+    defer clearBackend();
+
+    // Simulate a decode landing on the result ring but the refcount
+    // dropping back to zero before pump() can finalise — the catalog
+    // routes the payload straight to `drop`.
+    const payload = try decode("png", "fake", testing.allocator);
+    drop(testing.allocator, payload);
+
+    try testing.expectEqual(@as(u32, 0), MockBackend.upload_calls);
+    try testing.expectEqual(@as(u32, 0), MockBackend.unload_calls);
+}
+
+test "image loader: upload error leaves pixels alive for drop cleanup" {
+    MockBackend.reset();
+    setBackend(MockBackend.backend_value);
+    MockBackend.upload_fails = true;
+    defer clearBackend();
+
+    const payload = try decode("png", "fake", testing.allocator);
+    var entry: AssetEntry = .{
+        .state = .decoding,
+        .refcount = 1,
+        .loader = &vtable,
+        .loader_kind = .image,
+        .raw_bytes = "fake",
+        .file_type = "png",
+        .decoded = payload,
+        .resource = null,
+        .last_error = null,
+    };
+    try testing.expectError(error.MockUploadError, upload(&entry, payload, testing.allocator));
+    try testing.expectEqual(@as(?UploadedResource, null), entry.resource);
+    // On the failure path, `upload` must NOT have freed the buffer —
+    // the catalog still needs to hand it to `drop`. Do that here to
+    // keep `testing.allocator` happy.
+    drop(testing.allocator, payload);
+}
+
+test "image loader: free without a backend or resource is a no-op" {
+    clearBackend();
+    var entry: AssetEntry = .{
+        .state = .registered,
+        .refcount = 0,
+        .loader = &vtable,
+        .loader_kind = .image,
+        .raw_bytes = "",
+        .file_type = "png",
+        .decoded = null,
+        .resource = null,
+        .last_error = null,
+    };
+    free(&entry);
+    try testing.expectEqual(@as(?UploadedResource, null), entry.resource);
+}
+
+test "image loader: decode propagates backend errors" {
+    MockBackend.reset();
+    setBackend(MockBackend.backend_value);
+    MockBackend.decode_fails = true;
+    defer clearBackend();
+
+    try testing.expectError(
+        error.MockDecodeError,
+        decode("png", "fake", testing.allocator),
+    );
+    try testing.expectEqual(@as(u32, 1), MockBackend.decode_calls);
+}

--- a/src/assets/loaders/image.zig
+++ b/src/assets/loaders/image.zig
@@ -177,12 +177,16 @@ fn drop(allocator: Allocator, decoded_payload: DecodedPayload) void {
 }
 
 fn free(entry: *AssetEntry) void {
-    const b = backend orelse return;
     const resource = entry.resource orelse return;
-    switch (resource) {
+    // Release the GPU handle if a backend is installed. If the backend
+    // was cleared (e.g. a test's `clearBackend`) after an asset uploaded,
+    // we can't reach the GPU — skip the `unload` call but STILL clear
+    // `entry.resource` so callers that check `entry.resource != null` as
+    // a cleanup-completed flag get the contract `loader.zig` documents.
+    if (backend) |b| switch (resource) {
         .image => |tex| b.unload(tex),
         else => {},
-    }
+    };
     entry.resource = null;
 }
 

--- a/src/assets/mod.zig
+++ b/src/assets/mod.zig
@@ -16,18 +16,32 @@ pub const AssetState = catalog_mod.AssetState;
 
 pub const LoaderKind = loader_mod.LoaderKind;
 pub const DecodedPayload = loader_mod.DecodedPayload;
+pub const UploadedResource = loader_mod.UploadedResource;
+pub const Texture = loader_mod.Texture;
 pub const AssetLoaderVTable = loader_mod.AssetLoaderVTable;
 
 pub const WorkRequest = worker_mod.WorkRequest;
 pub const WorkResult = worker_mod.WorkResult;
 
+/// Re-exported so games (via the assembler-generated `main.zig`) can
+/// call `setBackend` with adapters that forward to `labelle-gfx`'s
+/// `decodeImage` / `uploadTexture` / `unloadTexture`. Also exposed so
+/// integration tests in `test/asset_catalog_test.zig` can inject a
+/// mock backend via `engine.ImageLoader.setBackend`.
+pub const image_loader = @import("loaders/image.zig");
+
 test {
-    // Pull every file in the module tree into the test binary so
-    // `zig build test` exercises the catalog test blocks.
+    // Pull every file in the module tree into the test binary. The
+    // `zig build test` step rooted at this file (see `build.zig`'s
+    // `assets_tests` entry) is what actually runs these — a separate
+    // module root is needed because Zig only discovers in-source
+    // `test` blocks in files that belong to the same module as the
+    // test binary's root, and all of `test/*.zig` live in a module
+    // that only sees `engine` through a cross-module import.
     _ = catalog_mod;
     _ = loader_mod;
     _ = worker_mod;
-    _ = @import("loaders/image.zig");
+    _ = image_loader;
     _ = @import("loaders/audio.zig");
     _ = @import("loaders/font.zig");
 }

--- a/src/assets/worker.zig
+++ b/src/assets/worker.zig
@@ -312,6 +312,11 @@ test "SpscRing preserves order across producer/consumer threads" {
 }
 
 test "AssetWorker decodes a stub request and publishes a result" {
+    const image_loader = @import("loaders/image.zig");
+    // Leave the image backend unset so the real loader surfaces its
+    // "not initialised" error instead of actually decoding bytes.
+    image_loader.clearBackend();
+
     var requests = RequestRing.init();
     var results = ResultRing.init();
 
@@ -319,7 +324,6 @@ test "AssetWorker decodes a stub request and publishes a result" {
     try worker.start();
     defer worker.stop();
 
-    const image_loader = @import("loaders/image.zig");
     try requests.tryEnqueue(.{
         .entry_name = "stub",
         .vtable = &image_loader.vtable,
@@ -341,7 +345,7 @@ test "AssetWorker decodes a stub request and publishes a result" {
 
     try testing.expectEqualStrings("stub", result.entry_name);
     try testing.expectEqual(@as(?DecodedPayload, null), result.decoded);
-    try testing.expectEqual(@as(?anyerror, error.NotImplemented), result.err);
+    try testing.expectEqual(@as(?anyerror, error.ImageBackendNotInitialized), result.err);
 }
 
 test "AssetWorker shuts down cleanly with a request still in flight" {

--- a/src/root.zig
+++ b/src/root.zig
@@ -142,9 +142,19 @@ pub const AssetEntry = assets_mod.AssetEntry;
 pub const AssetState = assets_mod.AssetState;
 pub const LoaderKind = assets_mod.LoaderKind;
 pub const DecodedPayload = assets_mod.DecodedPayload;
+pub const UploadedResource = assets_mod.UploadedResource;
+pub const AssetTexture = assets_mod.Texture;
 pub const AssetLoaderVTable = assets_mod.AssetLoaderVTable;
 pub const AssetWorkRequest = assets_mod.WorkRequest;
 pub const AssetWorkResult = assets_mod.WorkResult;
+/// Runtime backend hook for the image asset loader. The assembler
+/// populates this at `Game.init` via `ImageLoader.setBackend(...)`
+/// with adapters that forward to labelle-gfx's `decodeImage` /
+/// `uploadTexture` / `unloadTexture`. See
+/// `src/assets/loaders/image.zig` for the full rationale.
+pub const ImageLoader = assets_mod.image_loader;
+pub const ImageBackend = assets_mod.image_loader.ImageBackend;
+pub const DecodedImage = assets_mod.image_loader.DecodedImage;
 
 // ── JSONC Scene Bridge ──
 pub const JsoncSceneBridge = @import("jsonc_scene_bridge.zig").JsoncSceneBridge;

--- a/test/asset_catalog_test.zig
+++ b/test/asset_catalog_test.zig
@@ -10,6 +10,7 @@ const std = @import("std");
 const testing = std.testing;
 
 const engine = @import("engine");
+const image_loader = engine.ImageLoader;
 
 test "engine re-exports AssetCatalog and friends" {
     // Catalog round-trip via the engine-level alias to make sure the
@@ -44,8 +45,170 @@ test "engine.AssetCatalog progress over an empty manifest is fully ready" {
     try testing.expectEqual(@as(f32, 1.0), catalog.progress(empty));
 }
 
-// Drag the in-source test blocks under `src/assets/` into this test
-// binary so they run together with the engine integration tests.
+// ---------------------------------------------------------------------
+// Image loader ↔ catalog integration
+// ---------------------------------------------------------------------
+//
+// These tests exercise the full register → acquire → worker-decode →
+// manual-upload → unload pipeline against a mock image backend. The
+// `pump()` body is still a no-op (lands in #442) so the tests dequeue
+// the worker result off the catalog's ring manually and call
+// `loader.upload` / `loader.free` directly — enough to prove the
+// vtable is wired end-to-end.
+
+const IntegrationMock = struct {
+    var decode_calls: u32 = 0;
+    var upload_calls: u32 = 0;
+    var unload_calls: u32 = 0;
+    var next_tex: engine.AssetTexture = 100;
+
+    fn reset() void {
+        decode_calls = 0;
+        upload_calls = 0;
+        unload_calls = 0;
+        next_tex = 100;
+    }
+
+    fn decodeFn(
+        file_type: [:0]const u8,
+        data: []const u8,
+        allocator: std.mem.Allocator,
+    ) anyerror!engine.DecodedImage {
+        _ = file_type;
+        _ = data;
+        decode_calls += 1;
+        // 1×1 RGBA — matches the mock-backend contract from
+        // labelle-gfx tests.
+        const pixels = try allocator.alloc(u8, 4);
+        @memset(pixels, 0x7F);
+        return .{ .pixels = pixels, .width = 1, .height = 1 };
+    }
+
+    fn uploadFn(decoded: engine.DecodedImage) anyerror!engine.AssetTexture {
+        _ = decoded;
+        upload_calls += 1;
+        const t = next_tex;
+        next_tex += 1;
+        return t;
+    }
+
+    fn unloadFn(texture: engine.AssetTexture) void {
+        _ = texture;
+        unload_calls += 1;
+    }
+
+    const backend: engine.ImageBackend = .{
+        .decode = decodeFn,
+        .upload = uploadFn,
+        .unload = unloadFn,
+    };
+};
+
+test "image loader: catalog → worker → upload → free end to end" {
+    IntegrationMock.reset();
+    image_loader.setBackend(IntegrationMock.backend);
+    defer image_loader.clearBackend();
+
+    var catalog = engine.AssetCatalog.init(testing.allocator);
+    defer catalog.deinit();
+
+    try catalog.register("ship", engine.LoaderKind.image, "png", "fake-png-bytes");
+    _ = try catalog.acquire("ship");
+
+    // Spin up to 200ms waiting for the worker to publish a decoded
+    // payload — `pump()` is still a no-op (#442) so we drain the
+    // result ring manually.
+    const deadline_ns: u64 = 200 * std.time.ns_per_ms;
+    var waited_ns: u64 = 0;
+    const step_ns: u64 = 1 * std.time.ns_per_ms;
+    const result = while (waited_ns < deadline_ns) {
+        if (catalog.results.tryDequeue()) |r| break r;
+        std.Thread.sleep(step_ns);
+        waited_ns += step_ns;
+    } else {
+        return error.WorkerDidNotRespond;
+    };
+
+    try testing.expectEqualStrings("ship", result.entry_name);
+    try testing.expect(result.err == null);
+    try testing.expect(result.decoded != null);
+    try testing.expectEqual(@as(u32, 1), IntegrationMock.decode_calls);
+
+    const payload = result.decoded.?;
+    try testing.expectEqual(@as(u32, 1), payload.image.width);
+    try testing.expectEqual(@as(u32, 1), payload.image.height);
+    try testing.expectEqual(@as(usize, 4), payload.image.pixels.len);
+
+    // Emulate what pump() (#442) will do: look the entry up, check
+    // refcount, call loader.upload, flip state to .ready.
+    const entry = catalog.entries.getPtr("ship").?;
+    try result.vtable.upload(entry, payload, testing.allocator);
+    entry.decoded = null;
+    entry.state = .ready;
+
+    try testing.expect(catalog.isReady("ship"));
+    try testing.expect(entry.resource != null);
+    try testing.expect(entry.resource.?.image >= 100);
+    try testing.expectEqual(@as(u32, 1), IntegrationMock.upload_calls);
+
+    // Release → emulate pump()'s eventual free hook dispatch.
+    catalog.release("ship");
+    try testing.expectEqual(@as(u32, 0), entry.refcount);
+    // The catalog's refcount-zero-on-ready path still defers the
+    // `loader.free` call to #446; invoke it manually here so the
+    // mock backend can record the unload.
+    result.vtable.free(entry);
+    try testing.expectEqual(@as(u32, 1), IntegrationMock.unload_calls);
+    try testing.expectEqual(@as(?engine.UploadedResource, null), entry.resource);
+}
+
+test "image loader: catalog discard path frees pixels when refcount hits zero before upload" {
+    IntegrationMock.reset();
+    image_loader.setBackend(IntegrationMock.backend);
+    defer image_loader.clearBackend();
+
+    var catalog = engine.AssetCatalog.init(testing.allocator);
+
+    try catalog.register("transient", engine.LoaderKind.image, "png", "fake-bytes");
+    _ = try catalog.acquire("transient");
+
+    // Wait for the worker to actually decode, so there is an
+    // allocator-owned pixel buffer in flight that `deinit` MUST free
+    // via `vtable.drop`. Without this we might race past decode and
+    // the test would pass trivially without exercising the path.
+    const deadline_ns: u64 = 200 * std.time.ns_per_ms;
+    var waited_ns: u64 = 0;
+    const step_ns: u64 = 1 * std.time.ns_per_ms;
+    while (waited_ns < deadline_ns) : (waited_ns += step_ns) {
+        if (IntegrationMock.decode_calls > 0) break;
+        std.Thread.sleep(step_ns);
+    }
+    try testing.expectEqual(@as(u32, 1), IntegrationMock.decode_calls);
+
+    // Drop the refcount to zero. The WorkResult with its
+    // allocator-owned pixels is still sitting on the ring.
+    catalog.release("transient");
+
+    // `deinit` drains the result ring and calls
+    // `vtable.drop(allocator, payload)` on everything it finds.
+    // `testing.allocator` (a GPA under the hood) will flag either a
+    // leak (drop forgot to free) or a double-free (drop freed twice).
+    catalog.deinit();
+
+    // Upload must NOT have been called — refcount hit zero before
+    // any main-thread pump() ever ran.
+    try testing.expectEqual(@as(u32, 0), IntegrationMock.upload_calls);
+    try testing.expectEqual(@as(u32, 0), IntegrationMock.unload_calls);
+}
+
+// Touch every decl on `engine.assets_mod` so the engine-side module
+// is semantically analyzed as part of this test binary — catches
+// misuses of the public surface from outside the engine. The
+// in-source test blocks under `src/assets/` run in a separate test
+// binary rooted at `src/assets/mod.zig` (see `build.zig`) because
+// Zig only discovers in-source tests in files that belong to the
+// same module as the test binary's root, and the `test/*.zig` files
+// reach the engine through a cross-module import.
 test {
     testing.refAllDecls(engine.assets_mod);
 }


### PR DESCRIPTION
Closes #440. Part of the Asset Streaming RFC (#437) — Phase 1.

## Summary

Replaces the `src/assets/loaders/image.zig` stub (scaffolded in #449) with a real vtable that CPU-decodes on the asset worker thread and GPU-uploads on the main thread, backed by a runtime-injected `ImageBackend` hook that the assembler populates at `Game.init` with adapters for `labelle-gfx`'s `decodeImage` / `uploadTexture` / `unloadTexture` (merged in labelle-gfx#245 and labelle-assembler#51).

After this lands, the ground is prepared for #442 (pump() body), #443 (legacy atlas shim), and #444–#446 (scene-transition acquire/release) — every one of them can now assume a loader that actually produces ready GPU handles.

## Backend wiring — why a runtime hook, not a direct gfx import

The engine crate does **not** depend on `labelle-gfx`. `build.zig` only wires `labelle-core`, `scene` and `jsonc` into the engine module, and that is deliberate: `labelle-gfx/build.zig.zon` still carries a path-relative dep on `../labelle-core` which breaks URL fetches (see the #440 ticket prologue), and we do not want the engine to inherit that fragility.

So instead of `@import(\"labelle-gfx\")`, `loaders/image.zig` exposes a tiny `ImageBackend` struct of function pointers:

\`\`\`zig
pub const ImageBackend = struct {
    decode: *const fn ([:0]const u8, []const u8, Allocator) anyerror!DecodedImage,
    upload: *const fn (DecodedImage) anyerror!Texture,
    unload: *const fn (Texture) void,
};
\`\`\`

The assembler (which already imports labelle-gfx) calls `engine.ImageLoader.setBackend(...)` at `Game.init` with adapters that forward to `gfx.decodeImage` / `gfx.uploadTexture` / `gfx.unloadTexture`. Until that call lands, `decode`/`upload` return `error.ImageBackendNotInitialized` — a clean error rather than a null deref. The assembler-side wiring is a separate follow-up; this PR ships only the engine side.

This approach also **side-steps the `DecodedImage` nominal-type collision** described in the ticket prologue entirely: because the engine never imports labelle-gfx's `DecodedImage`, there is no way for two structurally-identical types to collide through the generic `Backend(Impl)` wrapper. The backend adapter on the assembler side is the only place that has to know about both.

## Where does the uploaded Texture live? — option 1

Picks option 1 from the ticket — extends `AssetEntry` with a parallel \`resource: ?UploadedResource\` field alongside the existing \`decoded: ?DecodedPayload\`:

\`\`\`zig
pub const UploadedResource = union(LoaderKind) {
    image: Texture,   // u32 — matches src/atlas.zig's convention
    audio: struct {}, // placeholder for #441
    font:  struct {}, // placeholder for #441
};
\`\`\`

This mirrors the RFC §2 sketch (\`decoded: union { texture, audio, font }\`), survives #441 / #442 / #446 cleanly, and keeps the CPU-side and GPU-side slots independent. Option 2 (reusing \`decoded\` as a before-OR-after union) was rejected because Zig unions are comptime-tagged; option 3 (private loader state) adds another indirection nobody else needs.

The decision is documented in a top-of-file comment on \`src/assets/loader.zig\`.

## Ownership of \`DecodedImage.pixels\`

- \`decode\` allocates the pixel buffer through the worker's allocator.
- \`upload\` hands the pixels to the GPU and then \`allocator.free\`s them (the labelle-gfx contract explicitly says \`uploadTexture\` does NOT take ownership). On the error path \`upload\` leaves the buffer alive so the caller can route it to \`drop\`.
- \`drop\` (refcount-zero during decode) frees the CPU buffer, never touches the GPU.
- \`free\` (refcount-zero on \`.ready\`) releases the texture via \`backend.unload\` and clears \`entry.resource\`.

The vtable's \`upload\` signature gains an \`allocator: Allocator\` parameter so it can free on the success path; the audio / font stubs take the new parameter and \`_ = allocator\` it.

## Tests

Six in-source unit tests on \`loaders/image.zig\` via a recording mock backend:

- no-backend error
- full round-trip (decode → upload → free)
- drop path (refcount hit zero mid-decode)
- upload error leaves pixels alive for \`drop\` to clean up
- no-op \`free\` without a backend or resource
- decode error propagation

Two integration tests in \`test/asset_catalog_test.zig\` via a second mock:

- end-to-end \`register → acquire → worker-decode → manual upload → release → free\` round-trip
- catalog discard path — refcount hits zero between decode and upload, and \`deinit\` drains the orphaned payload through \`vtable.drop\`

Both run under \`testing.allocator\` (a GPA in test mode), which flags leaks **and** double-frees.

Updates the previously-passing \`catalog.zig\` + \`worker.zig\` tests to expect \`error.ImageBackendNotInitialized\` (new) instead of \`error.NotImplemented\` (stub) and to \`clearBackend()\` up front so a prior test cannot leak a mock.

## Build plumbing

\`zig build test\` gained a new test step rooted at \`src/assets/mod.zig\`. The existing \`test/asset_catalog_test.zig\` binary lives in its own module and reaches the engine through a cross-module import — Zig only discovers in-source \`test\` blocks in files that belong to the SAME module as the test binary's root, so every \`test\` under \`src/assets/\` (including the catalog / worker tests from #449 / #450 that were silently not running in CI) needs a dedicated root to execute.

**Net test count: 125 → 151.** That is +6 image loader unit tests, +2 image loader integration tests, and +18 latent catalog/worker tests from prior PRs that are now actually running.

## Verification

- \`zig build test\` — 151/151 passing
- \`zig test src/assets/mod.zig\` — 24/24 passing (catalog 12 + worker 5 + image 6 + test root 1)
- Direct compile of \`test/asset_catalog_test.zig\` — 5/5 passing

## Test plan

- [x] \`zig build test\` green on macOS arm64
- [ ] CI green on the PR
- [ ] Follow-up ticket (assembler / codegen template) wires \`gfx.decodeImage\` / \`gfx.uploadTexture\` / \`gfx.unloadTexture\` through \`engine.ImageLoader.setBackend\` at \`Game.init\`
- [ ] #442 picks up the new vtable and drives it from \`pump()\`

Refs: #437 (RFC), #449 (catalog scaffold), #450 (worker + rings)