### PR TITLE
feat(scene): auto-acquire/release scene asset manifest on setScene (RFC #437 Phase 2)

### DIFF
--- a/src/assets/catalog.zig
+++ b/src/assets/catalog.zig
@@ -290,6 +290,17 @@ pub const AssetCatalog = struct {
         return entry.last_error;
     }
 
+    /// First `.failed` entry's error from `names`, or null when no
+    /// entry is `.failed`. Used by the scene-manifest gate (Phase 2
+    /// of RFC #437) to abort `setScene` with a meaningful error
+    /// rather than spinning forever in the not-ready branch.
+    pub fn anyFailed(self: *AssetCatalog, names: []const []const u8) ?anyerror {
+        for (names) |name| {
+            if (self.lastError(name)) |err| return err;
+        }
+        return null;
+    }
+
     /// Rewind a `.failed` entry back to `.registered` so the next
     /// `acquire` re-enqueues the decode. Without this, a transient
     /// decode/upload failure becomes permanent: `acquire` only

--- a/src/game.zig
+++ b/src/game.zig
@@ -193,6 +193,19 @@ pub fn GameConfig(
         pending_scene_change: ?[]const u8 = null,
         pending_scene_atomic: bool = false,
 
+        /// Phase 2 of the Asset Streaming RFC (#437). Tracks the
+        /// scene name we have already called `assets.acquire()` for
+        /// from inside `setScene` / `setSceneAtomic`. The transition
+        /// is poll-driven: if the manifest is not yet `allReady`,
+        /// `setScene` returns early and the script keeps calling it
+        /// every frame. `pending_scene_assets` is the idempotency
+        /// guard — without it we would re-acquire on every frame
+        /// and the refcount would never come back to zero.
+        ///
+        /// Cleared after the swap completes (success path) or after
+        /// an explicit abort (`scene_assets_release_pending`).
+        pending_scene_assets: ?[]const u8 = null,
+
         // Active scene (type-erased) — managed by sceneLoaderFn / setActiveScene
         active_scene_ptr: ?*anyopaque = null,
         active_scene_update_fn: ?*const fn (*anyopaque, f32) void = null,
@@ -280,6 +293,9 @@ pub fn GameConfig(
                 self.allocator.free(name);
             }
             if (self.pending_scene_change) |name| {
+                self.allocator.free(name);
+            }
+            if (self.pending_scene_assets) |name| {
                 self.allocator.free(name);
             }
             // Clean up inactive worlds

--- a/src/game/scene_mixin.zig
+++ b/src/game/scene_mixin.zig
@@ -1,6 +1,71 @@
 /// Scene mixin — scene registration, loading, transitions, and lifecycle.
 const std = @import("std");
 
+/// Possible outcomes of the asset-manifest gate fired at the start
+/// of `setScene`/`setSceneAtomic` (Phase 2 of the Asset Streaming
+/// RFC #437). `proceed` lets the swap continue; `not_ready` defers
+/// the swap until the next call (the script is expected to poll
+/// `setScene` every frame); `failed` aborts the swap with the
+/// underlying load error.
+const ManifestGate = union(enum) {
+    proceed,
+    not_ready,
+    failed: anyerror,
+};
+
+/// Acquire any not-yet-acquired assets in `target_assets`, then
+/// classify the current state. Idempotent across frames via
+/// `game.pending_scene_assets` — same scene name = same acquire
+/// call once, no matter how many frames the caller polls.
+fn gateOnManifest(game: anytype, target_name: []const u8, target_assets: []const []const u8) ManifestGate {
+    if (target_assets.len == 0) return .proceed;
+
+    const already_acquired = if (game.pending_scene_assets) |p|
+        std.mem.eql(u8, p, target_name)
+    else
+        false;
+
+    if (!already_acquired) {
+        for (target_assets) |asset_name| {
+            _ = game.assets.acquire(asset_name) catch |err| {
+                // Roll back any prior acquires in this batch.
+                for (target_assets) |rb| {
+                    if (game.assets.entries.getPtr(rb)) |e| {
+                        if (e.refcount > 0) game.assets.release(rb);
+                    }
+                }
+                return .{ .failed = err };
+            };
+        }
+        if (game.pending_scene_assets) |old| game.allocator.free(old);
+        game.pending_scene_assets = game.allocator.dupe(u8, target_name) catch null;
+    }
+
+    if (game.assets.anyFailed(target_assets)) |err| return .{ .failed = err };
+    if (!game.assets.allReady(target_assets)) return .not_ready;
+    return .proceed;
+}
+
+/// Release the previous scene's asset manifest after a successful
+/// swap. Called from the success path of both setScene variants.
+fn releasePreviousAssets(game: anytype, prev_name: []const u8) void {
+    if (game.scenes.get(prev_name)) |entry| {
+        for (entry.assets) |asset_name| game.assets.release(asset_name);
+    }
+}
+
+/// Roll back the acquire batch on failure / abort. Frees the
+/// `pending_scene_assets` marker so the next setScene call starts
+/// from scratch.
+fn rollbackPendingAssets(game: anytype) void {
+    const target_name = game.pending_scene_assets orelse return;
+    if (game.scenes.get(target_name)) |entry| {
+        for (entry.assets) |asset_name| game.assets.release(asset_name);
+    }
+    game.allocator.free(target_name);
+    game.pending_scene_assets = null;
+}
+
 /// Returns the scene management mixin for a given Game type.
 pub fn Mixin(comptime Game: type) type {
     return struct {
@@ -74,6 +139,33 @@ pub fn Mixin(comptime Game: type) type {
         }
 
         pub fn setScene(self: *Game, name: []const u8) !void {
+            // Phase 2 of the Asset Streaming RFC (#437) — gate the
+            // swap on the new scene's `assets:` manifest. Acquires
+            // (idempotently across frames) any not-yet-loaded assets,
+            // then either proceeds (allReady), defers (still
+            // decoding), or aborts (failed). Empty manifests skip
+            // the gate entirely. Scenes registered via the legacy
+            // `registerSceneSimple` (no manifest) have `assets ==
+            // &.{}` and behave identically to before this change.
+            const target_assets: []const []const u8 = if (self.scenes.get(name)) |e|
+                e.assets
+            else
+                &.{};
+            switch (gateOnManifest(self, name, target_assets)) {
+                .proceed => {},
+                .not_ready => return,
+                .failed => |err| {
+                    rollbackPendingAssets(self);
+                    return err;
+                },
+            }
+
+            // Capture the previous scene name BEFORE we wipe
+            // `current_scene_name` — we need it to release the
+            // outgoing manifest after the swap completes.
+            const previous_name = if (self.current_scene_name) |n| self.allocator.dupe(u8, n) catch null else null;
+            defer if (previous_name) |p| self.allocator.free(p);
+
             self.unloadCurrentScene();
 
             if (self.current_scene_name) |old_name| {
@@ -98,7 +190,19 @@ pub fn Mixin(comptime Game: type) type {
                 self.current_scene_name = self.allocator.dupe(u8, name) catch null;
                 self.emitHook(.{ .scene_load = .{ .name = name } });
             } else {
+                rollbackPendingAssets(self);
                 return error.SceneNotFound;
+            }
+
+            // Swap committed — release the OUTGOING manifest and
+            // clear the pending marker. Order is acquire-new-then-
+            // release-old (RFC §scene transition wiring) so shared
+            // assets keep refcount ≥ 1 across the swap and never
+            // get freed-then-reloaded.
+            if (previous_name) |p| releasePreviousAssets(self, p);
+            if (self.pending_scene_assets) |p| {
+                self.allocator.free(p);
+                self.pending_scene_assets = null;
             }
         }
 
@@ -108,6 +212,23 @@ pub fn Mixin(comptime Game: type) type {
         /// then resets the ECS atomically, then loads the new scene.
         pub fn setSceneAtomic(self: *Game, name: []const u8) !void {
             const entry = self.scenes.get(name) orelse return error.SceneNotFound;
+
+            // Manifest gate — see `setScene` for the full
+            // explanation. Both entry points participate in the
+            // same idempotent acquire/release cycle so callers can
+            // mix `setScene` and `setSceneAtomic` without confusing
+            // the gate.
+            switch (gateOnManifest(self, name, entry.assets)) {
+                .proceed => {},
+                .not_ready => return,
+                .failed => |err| {
+                    rollbackPendingAssets(self);
+                    return err;
+                },
+            }
+
+            const previous_name = if (self.current_scene_name) |n| self.allocator.dupe(u8, n) catch null else null;
+            defer if (previous_name) |p| self.allocator.free(p);
 
             // Clear scene entity list BEFORE deinit so Scene.deinit's entity
             // destruction loop has nothing to iterate (entities will be destroyed
@@ -133,6 +254,12 @@ pub fn Mixin(comptime Game: type) type {
 
             if (entry.hooks.onLoad) |onLoad| {
                 onLoad(self);
+            }
+
+            if (previous_name) |p| releasePreviousAssets(self, p);
+            if (self.pending_scene_assets) |p| {
+                self.allocator.free(p);
+                self.pending_scene_assets = null;
             }
         }
 


### PR DESCRIPTION
## Summary

Phase 2 of the Asset Streaming RFC #437. `setScene` and `setSceneAtomic` now act as a poll-driven gate on the new scene's `assets:` manifest:

1. **Acquire-new-then-release-old** ordering so shared assets keep refcount ≥ 1 across the swap and never get freed-then-reloaded.
2. **Idempotent re-entry** via `pending_scene_assets` — the script keeps calling setScene every frame; the first call acquires, subsequent calls skip the acquire and just re-check allReady.
3. **Three outcomes**: `proceed` (allReady → swap commits, releases previous manifest), `not_ready` (still decoding → returns early silently, caller polls), `failed` (rolls back acquired refcounts and returns the underlying error).

Adds `AssetCatalog.anyFailed(names)` so the gate can surface load errors instead of spinning forever in the not-ready branch.

Empty manifests / legacy `registerSceneSimple` scenes get `assets == &.{}` and skip the gate entirely — no caller break.

## RFC mapping

The cold-start UX win (loading-controller collapsing to two lines per the RFC) needs:
- This PR (Phase 2 acquire/release machinery in setScene)
- labelle-toolkit/labelle-gfx#248 (fixes a white-quad regression in the catalog render path)
- A companion labelle-assembler PR that wires the codegen for the gfx fix

All three together = the smoke can swap its loading_controller from the manual `loadAtlasIfNeeded` loop to `progress(target.assets) + setScene(when allReady)`.

## Test plan

- [x] \`zig build test\` — green (full suite)
- [ ] End-to-end smoke verification once gfx#248 + the assembler companion land