### PR TITLE
feat(scene): auto-pump in Game.tick + bridge catalog image handles to atlas_manager

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -953,6 +953,14 @@ pub fn GameConfig(
         pub fn tick(self: *Self, dt: f32) void {
             const scaled_dt = dt * self.time_scale;
 
+            // Drain any worker-decoded asset uploads onto the GPU.
+            // Without this no acquired asset ever reaches `.ready`,
+            // and the Phase 2 setScene gate (#458) spins forever in
+            // its `not_ready` branch. Pump runs every frame even
+            // when paused so loading screens keep filling the bar
+            // through pause states.
+            self.assets.pump();
+
             // Always run: logging, audio, input, renderer sync, gizmo reconciliation.
             // These must run even when paused so the game remains responsive.
             self.log.update(dt);

--- a/src/game/scene_mixin.zig
+++ b/src/game/scene_mixin.zig
@@ -66,6 +66,36 @@ fn rollbackPendingAssets(game: anytype) void {
     game.pending_scene_assets = null;
 }
 
+/// Bridge catalog-uploaded image assets into `atlas_manager` so
+/// the renderer's `findSprite` lookup returns the right texture
+/// id. Without this the catalog owns the texture (and the renderer
+/// has it via labelle-gfx#248's `registerCatalogTexture`), but
+/// `atlas.texture_id` stays at 0 — `findSprite` returns 0,
+/// `resolveAtlasSprites` writes 0 into every sprite, and all
+/// non-first atlases render with the wrong UVs (the jumper sprite
+/// would sample from sprites.png because its atlas's texture_id
+/// is the same default 0 as sprites.png's).
+///
+/// Idempotent — `markPendingLoaded` errors with `AtlasNotPending`
+/// for already-bridged atlases; we silently ignore.
+fn bridgeImageAssetsToAtlasManager(game: anytype, assets: []const []const u8) void {
+    for (assets) |asset_name| {
+        const entry = game.assets.entries.getPtr(asset_name) orelse continue;
+        if (entry.loader_kind != .image) continue;
+        const resource = entry.resource orelse continue;
+        const handle = switch (resource) {
+            .image => |t| t,
+            else => continue,
+        };
+        // Bridge is best-effort — already-loaded atlases return
+        // AtlasNotPending, missing atlases return AtlasNotFound.
+        // Both are normal: the first means we already bridged on
+        // an earlier setScene; the second means the asset name
+        // doesn't correspond to a registered atlas (e.g. audio).
+        game.atlas_manager.markPendingLoaded(asset_name, handle, null) catch {};
+    }
+}
+
 /// Returns the scene management mixin for a given Game type.
 pub fn Mixin(comptime Game: type) type {
     return struct {
@@ -160,6 +190,12 @@ pub fn Mixin(comptime Game: type) type {
                 },
             }
 
+            // Bridge catalog-uploaded image handles into
+            // atlas_manager so findSprite can return the right
+            // texture id. See `bridgeImageAssetsToAtlasManager`
+            // for the full failure mode this prevents.
+            bridgeImageAssetsToAtlasManager(self, target_assets);
+
             // Capture the previous scene name BEFORE we wipe
             // `current_scene_name` — we need it to release the
             // outgoing manifest after the swap completes.
@@ -226,6 +262,8 @@ pub fn Mixin(comptime Game: type) type {
                     return err;
                 },
             }
+
+            bridgeImageAssetsToAtlasManager(self, entry.assets);
 
             const previous_name = if (self.current_scene_name) |n| self.allocator.dupe(u8, n) catch null else null;
             defer if (previous_name) |p| self.allocator.free(p);


### PR DESCRIPTION
## Summary

Two missing pieces between Phase 2 (#458) and an actually-working RFC end-state. Both are tiny but together unblock the smoke's two-line loading_controller form.

## 1. Auto-pump on every tick

Catalog worker decodes off-thread; the upload runs from `pump()`, which was the caller's responsibility. Without a per-frame pump, acquired assets never reach `.ready` and the Phase 2 setScene gate spins forever in `not_ready`. Add `self.assets.pump()` to `Game.tick` so any game whose script calls `setScene(target_with_manifest)` Just Works.

## 2. Bridge catalog → atlas_manager in setScene

The catalog owns the texture (and the renderer has it via gfx#248's `registerCatalogTexture`), but `atlas.texture_id` stays at 0 if `markPendingLoaded` is never called. `findSprite` then returns 0 → every sprite's `texture` field becomes 0 → non-first atlases sample the wrong texture. The jumper sprite would render garbage from sprites.png because both atlases share the default `texture_id == 0`.

Add `bridgeImageAssetsToAtlasManager` called after each successful manifest gate. Idempotent — best-effort `markPendingLoaded` swallows AtlasNotPending (already bridged) and AtlasNotFound (asset not an atlas).

## Test plan

- [x] `zig build test` — green
- [x] Asset-streaming smoke verified end-to-end with the new Phase-2-shaped loading_controller (companion change in labelle-assembler#62 currently in flight): both sprites render with correct textures, animation cycles, no manual `loadAtlasIfNeeded` calls