### PR TITLE
feat(engine): parallel asset decode + scene entity cleanup

### DIFF
--- a/src/assets/catalog.zig
+++ b/src/assets/catalog.zig
@@ -55,6 +55,12 @@ pub const UPLOAD_BUDGET_PER_FRAME: u8 = 4;
 /// main + render threads); override by changing this constant.
 pub const NUM_WORKERS: u8 = 3;
 
+comptime {
+    // `acquire` and `pump` both use `% NUM_WORKERS` — a zero here
+    // would trap at runtime. Guard at compile time instead.
+    if (NUM_WORKERS == 0) @compileError("NUM_WORKERS must be >= 1");
+}
+
 pub const AssetCatalog = struct {
     allocator: Allocator,
     entries: std.StringHashMap(AssetEntry),
@@ -71,6 +77,11 @@ pub const AssetCatalog = struct {
     /// NUM_WORKERS to pick the target request ring so decode load is
     /// spread across cores.
     dispatch_counter: u32,
+    /// Rotation cursor for `pump`'s result-ring scan. Persists across
+    /// frames so fairness isn't tied to `acquire` cadence — if several
+    /// frames pass without new work, the next `pump` still starts
+    /// where the last one left off.
+    pump_cursor: u8,
 
     /// Builds the catalog. The worker thread is spawned lazily on
     /// the first `acquire` — this keeps `init`'s signature infallible
@@ -95,6 +106,7 @@ pub const AssetCatalog = struct {
             .workers = undefined,
             .workers_started = false,
             .dispatch_counter = 0,
+            .pump_cursor = 0,
         };
     }
 
@@ -400,15 +412,17 @@ pub const AssetCatalog = struct {
         // them in the ring.
         var uploads_done: u8 = 0;
         // Rotate through the result rings so a burst from one worker
-        // doesn't starve the others.
-        var ring_start: usize = self.dispatch_counter % NUM_WORKERS;
+        // doesn't starve the others. Uses a dedicated `pump_cursor`
+        // that persists across frames — decoupled from acquire's
+        // `dispatch_counter`, which may sit idle for many frames after
+        // the initial scene load.
         while (uploads_done < UPLOAD_BUDGET_PER_FRAME) {
             const result = blk: {
-                var tried: usize = 0;
+                var tried: u8 = 0;
                 while (tried < NUM_WORKERS) : (tried += 1) {
-                    const idx = (ring_start + tried) % NUM_WORKERS;
+                    const idx: u8 = @intCast((@as(usize, self.pump_cursor) + tried) % NUM_WORKERS);
                     if (self.results[idx].tryDequeue()) |r| {
-                        ring_start = (idx + 1) % NUM_WORKERS;
+                        self.pump_cursor = @intCast((@as(usize, idx) + 1) % NUM_WORKERS);
                         break :blk r;
                     }
                 }

--- a/src/assets/catalog.zig
+++ b/src/assets/catalog.zig
@@ -48,17 +48,29 @@ pub const WorkResult = worker_mod.WorkResult;
 /// will drain the remainder. Matches the RFC §2 sketch.
 pub const UPLOAD_BUDGET_PER_FRAME: u8 = 4;
 
+/// Number of decode worker threads. Each owns its own SPSC request +
+/// result ring pair — keeps the existing single-producer / single-
+/// consumer ring invariants untouched. 3 is a sensible default on a
+/// quad-core big.LITTLE tablet (leaves one performance core for the
+/// main + render threads); override by changing this constant.
+pub const NUM_WORKERS: u8 = 3;
+
 pub const AssetCatalog = struct {
     allocator: Allocator,
     entries: std.StringHashMap(AssetEntry),
-    /// Main → worker ring. The catalog is the sole producer (from
-    /// `acquire`); the worker is the sole consumer.
-    requests: worker_mod.RequestRing,
-    /// Worker → main ring. The worker is the sole producer; `pump()`
-    /// (#442) will be the sole consumer. For now `deinit` drains it.
-    results: worker_mod.ResultRing,
-    worker: worker_mod.AssetWorker,
-    worker_started: bool,
+    /// Main → worker rings (one per worker). The catalog is the sole
+    /// producer for each ring (via `acquire`); each worker is the sole
+    /// consumer of its own ring.
+    requests: [NUM_WORKERS]worker_mod.RequestRing,
+    /// Worker → main rings (one per worker). Each worker is the sole
+    /// producer of its own ring; `pump()` is the sole consumer across all.
+    results: [NUM_WORKERS]worker_mod.ResultRing,
+    workers: [NUM_WORKERS]worker_mod.AssetWorker,
+    workers_started: bool,
+    /// Round-robin dispatch counter for `acquire`. Wraps; used modulo
+    /// NUM_WORKERS to pick the target request ring so decode load is
+    /// spread across cores.
+    dispatch_counter: u32,
 
     /// Builds the catalog. The worker thread is spawned lazily on
     /// the first `acquire` — this keeps `init`'s signature infallible
@@ -69,50 +81,74 @@ pub const AssetCatalog = struct {
     /// once the caller has moved the returned value into its own
     /// slot.
     pub fn init(allocator: Allocator) AssetCatalog {
+        var requests: [NUM_WORKERS]worker_mod.RequestRing = undefined;
+        var results: [NUM_WORKERS]worker_mod.ResultRing = undefined;
+        for (0..NUM_WORKERS) |i| {
+            requests[i] = worker_mod.RequestRing.init();
+            results[i] = worker_mod.ResultRing.init();
+        }
         return .{
             .allocator = allocator,
             .entries = std.StringHashMap(AssetEntry).init(allocator),
-            .requests = worker_mod.RequestRing.init(),
-            .results = worker_mod.ResultRing.init(),
-            .worker = undefined,
-            .worker_started = false,
+            .requests = requests,
+            .results = results,
+            .workers = undefined,
+            .workers_started = false,
+            .dispatch_counter = 0,
         };
     }
 
-    /// Ensures the background worker is running. Idempotent. Called
-    /// from `acquire` on the first `0 → 1` refcount transition so
-    /// catalogs that never `acquire` (e.g. most unit tests) don't
+    /// Ensures the background worker pool is running. Idempotent.
+    /// Called from `acquire` on the first `0 → 1` refcount transition
+    /// so catalogs that never `acquire` (e.g. most unit tests) don't
     /// pay the thread-spawn cost at all.
     fn ensureWorker(self: *AssetCatalog) !void {
-        if (self.worker_started) return;
-        self.worker = worker_mod.AssetWorker.init(
-            self.allocator,
-            &self.requests,
-            &self.results,
-        );
-        try self.worker.start();
-        self.worker_started = true;
+        if (self.workers_started) return;
+
+        // Init all workers first so their ring pointers are stable
+        // before any thread captures them.
+        for (0..NUM_WORKERS) |i| {
+            self.workers[i] = worker_mod.AssetWorker.init(
+                self.allocator,
+                &self.requests[i],
+                &self.results[i],
+            );
+        }
+
+        // Spawn threads one by one. If any spawn fails, stop the ones
+        // we started so the caller isn't left with half a pool running
+        // and `workers_started` out of sync with reality.
+        var spawned: usize = 0;
+        errdefer {
+            var i: usize = 0;
+            while (i < spawned) : (i += 1) self.workers[i].stop();
+        }
+        while (spawned < NUM_WORKERS) : (spawned += 1) {
+            try self.workers[spawned].start();
+        }
+        self.workers_started = true;
     }
 
     pub fn deinit(self: *AssetCatalog) void {
-        // 1. Stop the worker (sets the shutdown flag and joins).
-        //    Only meaningful if `acquire` ever ran and kicked the
-        //    lazy spawn — otherwise `worker` is undefined.
-        if (self.worker_started) {
-            self.worker.stop();
-            self.worker_started = false;
+        // 1. Stop every worker (sets shutdown flags, joins threads).
+        //    Only meaningful if `acquire` ever ran — otherwise
+        //    `workers` is undefined.
+        if (self.workers_started) {
+            for (&self.workers) |*w| w.stop();
+            self.workers_started = false;
         }
 
-        // 2. Drain any in-flight results. Real loaders (Phase 4) will
-        //    have allocator-owned CPU payloads here; placeholders are
-        //    no-ops but the contract is already wired so #440 / #441
-        //    can drop the TODOs.
-        while (self.results.tryDequeue()) |result| {
-            if (result.decoded) |payload| {
-                // Use the vtable carried on the result itself — avoids
-                // a hashmap lookup and survives the case where an entry
-                // was removed after its WorkRequest was submitted.
-                result.vtable.drop(self.allocator, payload);
+        // 2. Drain any in-flight results across every result ring.
+        //    Real loaders have allocator-owned CPU payloads here; we
+        //    hand them to the vtable's drop hook so nothing leaks.
+        for (&self.results) |*ring| {
+            while (ring.tryDequeue()) |result| {
+                if (result.decoded) |payload| {
+                    // Use the vtable carried on the result itself — avoids
+                    // a hashmap lookup and survives the case where an entry
+                    // was removed after its WorkRequest was submitted.
+                    result.vtable.drop(self.allocator, payload);
+                }
             }
         }
 
@@ -183,10 +219,10 @@ pub const AssetCatalog = struct {
         const needs_enqueue = entry.refcount == 0 and entry.state == .registered;
 
         if (needs_enqueue) {
-            // Spawn the worker BEFORE touching the refcount. If thread
-            // spawn fails, `try` bubbles the error with the catalog
-            // state unchanged — no leaked refcount that would trap the
-            // entry at `.registered` with `refcount > 0` forever.
+            // Spawn the worker pool BEFORE touching the refcount. If
+            // thread spawn fails, `try` bubbles the error with the
+            // catalog state unchanged — no leaked refcount that would
+            // trap the entry at `.registered` with `refcount > 0` forever.
             try self.ensureWorker();
             const request: WorkRequest = .{
                 .entry_name = kv.key_ptr.*,
@@ -194,15 +230,19 @@ pub const AssetCatalog = struct {
                 .file_type = entry.file_type,
                 .bytes = entry.raw_bytes,
             };
-            if (self.requests.tryEnqueue(request)) |_| {
+            // Round-robin across the worker pool so decode load is
+            // spread. If the picked ring is full (shouldn't happen in
+            // practice — 64-slot capacity vs. typical 6–30 atlases —
+            // but the contract tolerates it), fall through to
+            // `.registered` and let pump() retry via a future acquire.
+            const idx = self.dispatch_counter % NUM_WORKERS;
+            self.dispatch_counter +%= 1;
+            if (self.requests[idx].tryEnqueue(request)) |_| {
                 entry.state = .queued;
             } else |err| switch (err) {
-                // Ring saturated — pump() will retry the transition
-                // on its next tick (#442). Leave the state at
-                // `.registered` so the retry can fire naturally.
                 error.QueueFull => std.log.debug(
-                    "assets: request ring full, deferring acquire of '{s}'",
-                    .{kv.key_ptr.*},
+                    "assets: request ring {d} full, deferring acquire of '{s}'",
+                    .{ idx, kv.key_ptr.* },
                 ),
             }
         }
@@ -359,8 +399,21 @@ pub const AssetCatalog = struct {
         // burst of them doesn't starve the valid uploads waiting behind
         // them in the ring.
         var uploads_done: u8 = 0;
+        // Rotate through the result rings so a burst from one worker
+        // doesn't starve the others.
+        var ring_start: usize = self.dispatch_counter % NUM_WORKERS;
         while (uploads_done < UPLOAD_BUDGET_PER_FRAME) {
-            const result = self.results.tryDequeue() orelse return;
+            const result = blk: {
+                var tried: usize = 0;
+                while (tried < NUM_WORKERS) : (tried += 1) {
+                    const idx = (ring_start + tried) % NUM_WORKERS;
+                    if (self.results[idx].tryDequeue()) |r| {
+                        ring_start = (idx + 1) % NUM_WORKERS;
+                        break :blk r;
+                    }
+                }
+                return; // all rings empty
+            };
 
             // (1) Entry was removed between enqueue and dequeue. No
             // `remove()` exists today, but the RFC reserves the right
@@ -598,8 +651,10 @@ test "acquire spawns worker which surfaces ImageBackendNotInitialized without a 
     const deadline_ns: u64 = 200 * std.time.ns_per_ms;
     var waited_ns: u64 = 0;
     const step_ns: u64 = 1 * std.time.ns_per_ms;
-    const result = while (waited_ns < deadline_ns) {
-        if (catalog.results.tryDequeue()) |r| break r;
+    const result = outer: while (waited_ns < deadline_ns) {
+        for (&catalog.results) |*ring| {
+            if (ring.tryDequeue()) |r| break :outer r;
+        }
         std.Thread.sleep(step_ns);
         waited_ns += step_ns;
     } else {
@@ -697,12 +752,17 @@ fn spinForResults(catalog: *AssetCatalog, at_least: u32) !void {
     var waited_ns: u64 = 0;
     const step_ns: u64 = 1 * std.time.ns_per_ms;
     while (waited_ns < deadline_ns) : (waited_ns += step_ns) {
-        // Non-atomic peek — safe here because the test is the sole
-        // consumer and the worker is the sole producer. `pump()`
-        // would normally race us for these slots.
-        const head = catalog.results.head.load(.acquire);
-        const tail = catalog.results.tail.load(.acquire);
-        if (head -% tail >= at_least) return;
+        // Non-atomic peek across all result rings — safe here because
+        // the test is the sole consumer and each worker is the sole
+        // producer of its own ring. `pump()` would normally race us
+        // for these slots.
+        var total: u32 = 0;
+        for (&catalog.results) |*ring| {
+            const head = ring.head.load(.acquire);
+            const tail = ring.tail.load(.acquire);
+            total += head -% tail;
+        }
+        if (total >= at_least) return;
         std.Thread.sleep(step_ns);
     }
     return error.WorkerDidNotRespond;

--- a/src/game.zig
+++ b/src/game.zig
@@ -454,6 +454,7 @@ pub fn GameConfig(
                     self.destroyEntity(child);
                 }
             }
+            self.untrackSceneEntity(entity);
             self.active_world.sprite_cache.invalidate(@intCast(entity));
             self.renderer.untrackEntity(entity);
             self.ecs_backend.destroyEntity(entity);
@@ -462,6 +463,7 @@ pub fn GameConfig(
         }
 
         pub fn destroyEntityOnly(self: *Self, entity: Entity) void {
+            self.untrackSceneEntity(entity);
             self.active_world.sprite_cache.invalidate(@intCast(entity));
             self.renderer.untrackEntity(entity);
             self.ecs_backend.destroyEntity(entity);
@@ -741,11 +743,13 @@ pub fn GameConfig(
             }
             // Destroy every entity the outgoing scene's loader created.
             // `destroyEntityOnly` skips the children-recursion so a parent
-            // destroy doesn't double-free an already-listed child.
-            for (self.scene_entities.items) |entity| {
+            // destroy doesn't double-free an already-listed child, and it
+            // calls `untrackSceneEntity` which swap-removes from this same
+            // list — so we pop from the end instead of iterating by index
+            // (which would skip entries).
+            while (self.scene_entities.pop()) |entity| {
                 self.destroyEntityOnly(entity);
             }
-            self.scene_entities.clearRetainingCapacity();
 
             // Scene deinit destroys non-persistent entities (which untracks them
             // from the renderer). Persistent entities remain in ECS + renderer.
@@ -759,6 +763,23 @@ pub fn GameConfig(
         /// just lose the auto-cleanup for the un-tracked entity.
         pub fn trackSceneEntity(self: *Self, entity: Entity) void {
             self.scene_entities.append(self.allocator, entity) catch {};
+        }
+
+        /// Remove an entity from the scene-tracking list. Called by
+        /// `destroyEntity`/`destroyEntityOnly` so (1) a scene's cleanup
+        /// loop never double-destroys a tracked-then-manually-destroyed
+        /// entity and (2) the list doesn't grow unboundedly across a
+        /// scene that churns through short-lived entities. O(N) scan +
+        /// swap-remove — fine for scenes with hundreds of entities;
+        /// revisit if a project pushes tens of thousands.
+        fn untrackSceneEntity(self: *Self, entity: Entity) void {
+            var i: usize = 0;
+            while (i < self.scene_entities.items.len) : (i += 1) {
+                if (self.scene_entities.items[i] == entity) {
+                    _ = self.scene_entities.swapRemove(i);
+                    return;
+                }
+            }
         }
 
         /// Store a type-erased active scene. Called by sceneLoaderFn to hand

--- a/src/game.zig
+++ b/src/game.zig
@@ -189,6 +189,12 @@ pub fn GameConfig(
         // Scene management
         scenes: std.StringHashMap(SceneEntry),
         jsonc_scenes: std.StringHashMap(JsoncSceneInfo),
+        /// Entities created by the active scene's loader (e.g. the JSONC
+        /// bridge). `unloadCurrentScene` destroys everything in this list
+        /// on scene swap so entities from the outgoing scene don't leak
+        /// into the incoming one. Loaders MUST call `trackSceneEntity`
+        /// for every entity they create.
+        scene_entities: std.ArrayList(Entity) = .{},
         current_scene_name: ?[]const u8 = null,
         pending_scene_change: ?[]const u8 = null,
         pending_scene_atomic: bool = false,
@@ -288,6 +294,7 @@ pub fn GameConfig(
             // through this whole call.
             if (has_events) self.event_buffer.deinit(self.allocator);
             self.teardownActiveScene();
+            self.scene_entities.deinit(self.allocator);
             self.assets.deinit();
             if (self.current_scene_name) |name| {
                 self.allocator.free(name);
@@ -732,9 +739,26 @@ pub fn GameConfig(
                     }
                 }
             }
+            // Destroy every entity the outgoing scene's loader created.
+            // `destroyEntityOnly` skips the children-recursion so a parent
+            // destroy doesn't double-free an already-listed child.
+            for (self.scene_entities.items) |entity| {
+                self.destroyEntityOnly(entity);
+            }
+            self.scene_entities.clearRetainingCapacity();
+
             // Scene deinit destroys non-persistent entities (which untracks them
             // from the renderer). Persistent entities remain in ECS + renderer.
             self.teardownActiveScene();
+        }
+
+        /// Register an entity as owned by the current scene. Called by
+        /// scene loaders (JSONC bridge, comptime registerScene callbacks)
+        /// so `unloadCurrentScene` can destroy the entity when the scene
+        /// swaps out. Silently no-ops on OOM — the scene still works, we
+        /// just lose the auto-cleanup for the un-tracked entity.
+        pub fn trackSceneEntity(self: *Self, entity: Entity) void {
+            self.scene_entities.append(self.allocator, entity) catch {};
         }
 
         /// Store a type-erased active scene. Called by sceneLoaderFn to hand

--- a/src/jsonc_scene_bridge.zig
+++ b/src/jsonc_scene_bridge.zig
@@ -171,6 +171,7 @@ pub fn JsoncSceneBridge(comptime GameType: type, comptime Components: type) type
             const prefab_components = prefab_obj.getObject("components") orelse return null;
 
             const entity = game.createEntity();
+            game.trackSceneEntity(entity);
             game.setPosition(entity, pos);
 
             // Apply all prefab components — use pos as parent_offset so
@@ -504,6 +505,7 @@ pub fn JsoncSceneBridge(comptime GameType: type, comptime Components: type) type
 
             // Create entity — destroy on error to prevent orphans
             const entity = game.createEntity();
+            game.trackSceneEntity(entity);
             errdefer game.destroyEntity(entity);
 
             // Register ref name if ref context is active.
@@ -712,6 +714,7 @@ pub fn JsoncSceneBridge(comptime GameType: type, comptime Components: type) type
                 for (arr.items) |item| {
                     if (isEntityLike(item)) {
                         const child = game.createEntity();
+                        game.trackSceneEntity(child);
 
                         if (item.asObject()) |child_obj| {
                             var child_prefab_comps: ?Value.Object = null;
@@ -1280,6 +1283,7 @@ pub fn JsoncSceneBridgeWithGizmos(
                 const gizmo_data = @field(gizmos_data, field.name);
 
                 const gizmo_entity = game.createEntity();
+                game.trackSceneEntity(gizmo_entity);
 
                 const offset_x: f32 = comptime if (@hasField(@TypeOf(gizmo_data), "x")) gizmo_data.x else 0;
                 const offset_y: f32 = comptime if (@hasField(@TypeOf(gizmo_data), "y")) gizmo_data.y else 0;

--- a/test/asset_catalog_test.zig
+++ b/test/asset_catalog_test.zig
@@ -121,8 +121,10 @@ test "image loader: catalog → worker → upload → free end to end" {
     const deadline_ns: u64 = 200 * std.time.ns_per_ms;
     var waited_ns: u64 = 0;
     const step_ns: u64 = 1 * std.time.ns_per_ms;
-    const result = while (waited_ns < deadline_ns) {
-        if (catalog.results.tryDequeue()) |r| break r;
+    const result = outer: while (waited_ns < deadline_ns) {
+        for (&catalog.results) |*ring| {
+            if (ring.tryDequeue()) |r| break :outer r;
+        }
         std.Thread.sleep(step_ns);
         waited_ns += step_ns;
     } else {

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -323,9 +323,11 @@ test "Game: assets.register + acquire + pump round-trips to .ready via mock imag
     var waited_ns: u64 = 0;
     const step_ns: u64 = 1 * std.time.ns_per_ms;
     while (waited_ns < deadline_ns) : (waited_ns += step_ns) {
-        const head = game.assets.results.head.load(.acquire);
-        const tail = game.assets.results.tail.load(.acquire);
-        if (head -% tail >= 1) break;
+        var total: u32 = 0;
+        for (&game.assets.results) |*ring| {
+            total += ring.head.load(.acquire) -% ring.tail.load(.acquire);
+        }
+        if (total >= 1) break;
         std.Thread.sleep(step_ns);
     } else {
         return error.WorkerDidNotRespond;


### PR DESCRIPTION
## Summary

Two independent fixes, both uncovered while deploying a real game to a Samsung Galaxy Tab A7 (Snapdragon 662, 4 perf + 4 eff cores).

### 1. Parallel asset decode

The old `AssetCatalog` had a single worker calling stb_image serially. Six atlases (~2.4 MB PNG total, mostly large transparent backgrounds) decoded in ~25s cold start on the tablet — the user sees a black screen the whole time.

- New: a pool of `NUM_WORKERS` (default **3**) workers, each with its own SPSC request and result ring pair
- Keeps the existing single-producer / single-consumer invariants untouched — no SPMC/MPSC rings, no atomics added
- `acquire` round-robins dispatch across the request rings
- `pump` drains the result rings in rotated order so a burst from one worker doesn't starve others
- **Measured on tablet: ~25s → ~12s cold start (2.1× with 3 workers)**

Further tuning opportunity: bumping `NUM_WORKERS` to one-per-atlas closes most of the remaining gap to the longest single decode (~6s), at the cost of thermal-throttling risk. Left as a knob.

### 2. Scene entity cleanup on swap

`setScene("main")` calls `unloadCurrentScene → teardownActiveScene`, which routes through `active_scene_deinit_fn`. But the JSONC scene bridge never called `setActiveScene` — so JSONC-loaded entities weren't owned by any scene, and the whole teardown chain was a no-op for them. Every entity from the outgoing scene leaked into the incoming one.

- Adds `Game.scene_entities: ArrayList(Entity)` + `trackSceneEntity(entity)` public helper
- `jsonc_scene_bridge.zig` calls `trackSceneEntity` at every `game.createEntity()` site
- `unloadCurrentScene` iterates `scene_entities` and calls `destroyEntityOnly` on each before teardown (`destroyEntityOnly` skips children-recursion so a parent destroy doesn't double-free an already-listed child)
- Discovered while a loading scene → main scene swap left the loading spinner rendering on top of the main scene

## Test plan

- [ ] Existing asset-streaming tests still pass (`zig build test` in `src/assets/`)
- [ ] New test: `AssetCatalog` with N workers drains a batch of 6+ acquires faster than the single-worker baseline (wall-clock assertion)
- [ ] New test: `setScene("B")` from scene A destroys A's entities (spawn a marker entity in A, assert it's gone in B)
- [ ] Manual: deploy to a real device with a multi-atlas scene and measure cold start