### PR TITLE
feat(scene): scene_assets_acquire/release hooks + asset_failure_policy

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -44,6 +44,7 @@ pub fn build(b: *std.Build) void {
         "test/asset_catalog_test.zig",
         "test/asset_streaming_shim_test.zig",
         "test/animation_def_test.zig",
+        "test/scene_assets_hooks_test.zig",
     };
 
     for (test_files) |test_file| {

--- a/src/game.zig
+++ b/src/game.zig
@@ -108,6 +108,11 @@ pub fn GameConfig(
             onUnload: ?*const fn (*Self) void = null,
         };
 
+        /// Controls how `setScene` reacts when the new scene's asset
+        /// manifest contains a `.failed` entry. See
+        /// `Self.asset_failure_policy`.
+        pub const AssetFailurePolicy = enum { fatal, warn, silent };
+
         pub const SceneEntry = struct {
             loader_fn: *const fn (*Self) anyerror!void,
             hooks: SceneHooks,
@@ -205,6 +210,18 @@ pub fn GameConfig(
         /// Cleared after the swap completes (success path) or after
         /// an explicit abort (`scene_assets_release_pending`).
         pending_scene_assets: ?[]const u8 = null,
+
+        /// Controls how `setScene` / `setSceneAtomic` react when
+        /// `catalog.anyFailed(target.assets)` returns non-null during
+        /// the manifest gate. `.fatal` (default) preserves today's
+        /// behaviour — the swap is rolled back and the load error is
+        /// returned. `.warn` logs via `game.log.warn` and proceeds
+        /// (broken assets stay in `.failed` state; lookups return
+        /// whatever fallback the loader installed). `.silent` proceeds
+        /// without logging. Games that ship with optional assets
+        /// (e.g. missing background music) can set this to `.warn`
+        /// at startup.
+        asset_failure_policy: AssetFailurePolicy = .fatal,
 
         // Active scene (type-erased) — managed by sceneLoaderFn / setActiveScene
         active_scene_ptr: ?*anyopaque = null,

--- a/src/game/scene_mixin.zig
+++ b/src/game/scene_mixin.zig
@@ -5,12 +5,20 @@ const std = @import("std");
 /// of `setScene`/`setSceneAtomic` (Phase 2 of the Asset Streaming
 /// RFC #437). `proceed` lets the swap continue; `not_ready` defers
 /// the swap until the next call (the script is expected to poll
-/// `setScene` every frame); `failed` aborts the swap with the
-/// underlying load error.
+/// `setScene` every frame). The two failure variants are kept
+/// separate because they carry different severity:
+///   - `acquire_error` — `catalog.acquire` itself failed (e.g. the
+///     asset wasn't registered, or the worker couldn't be spawned).
+///     Always a bug in the caller or platform layer; bypasses
+///     `asset_failure_policy` and is always fatal.
+///   - `asset_error` — `catalog.anyFailed` reports a manifest entry
+///     in `.failed` state. Subject to `asset_failure_policy`
+///     (fatal / warn / silent).
 const ManifestGate = union(enum) {
     proceed,
     not_ready,
-    failed: anyerror,
+    acquire_error: anyerror,
+    asset_error: anyerror,
 };
 
 /// Acquire any not-yet-acquired assets in `target_assets`, then
@@ -34,33 +42,72 @@ fn gateOnManifest(game: anytype, target_name: []const u8, target_assets: []const
                         if (e.refcount > 0) game.assets.release(rb);
                     }
                 }
-                return .{ .failed = err };
+                return .{ .acquire_error = err };
             };
         }
         if (game.pending_scene_assets) |old| game.allocator.free(old);
         game.pending_scene_assets = game.allocator.dupe(u8, target_name) catch null;
     }
 
-    if (game.assets.anyFailed(target_assets)) |err| return .{ .failed = err };
+    if (game.assets.anyFailed(target_assets)) |err| return .{ .asset_error = err };
     if (!game.assets.allReady(target_assets)) return .not_ready;
     return .proceed;
 }
 
-/// Release the previous scene's asset manifest after a successful
-/// swap. Called from the success path of both setScene variants.
-fn releasePreviousAssets(game: anytype, prev_name: []const u8) void {
-    if (game.scenes.get(prev_name)) |entry| {
-        for (entry.assets) |asset_name| game.assets.release(asset_name);
+/// Run the gate and interpret the result. Returns `true` iff the
+/// caller should proceed with the swap. Returns `false` when the
+/// swap must be deferred (manifest still decoding, or a `.warn` /
+/// `.silent` policy swallowed an asset failure but other assets
+/// in the manifest are not yet `.ready`). `acquire_error` always
+/// bubbles — it signals a bug upstream, not an expected load
+/// failure, so `asset_failure_policy` does not apply.
+fn gateOrDefer(
+    game: anytype,
+    caller_tag: []const u8,
+    target_name: []const u8,
+    target_assets: []const []const u8,
+) !bool {
+    switch (gateOnManifest(game, target_name, target_assets)) {
+        .proceed => return true,
+        .not_ready => return false,
+        .acquire_error => |err| {
+            rollbackPendingAssets(game);
+            return err;
+        },
+        .asset_error => |err| {
+            try handleAssetFailure(game, caller_tag, target_name, err);
+            // Policy was `.warn` or `.silent` — the failed asset is
+            // OK to ship with, but other entries in the manifest
+            // might still be in flight (`.queued` / `.decoding`).
+            // Proceeding now would pop the scene up with half-loaded
+            // assets. Defer until every manifest entry reaches a
+            // terminal state — `.ready` (usable) or `.failed`
+            // (policy already said this is OK).
+            for (target_assets) |n| {
+                if (game.assets.entries.getPtr(n)) |e| {
+                    if (e.state != .ready and e.state != .failed) return false;
+                }
+            }
+            return true;
+        },
     }
 }
 
+/// Release every asset in `assets`. Called from the success path
+/// of both `setScene` variants with the outgoing scene's manifest
+/// slice (looked up once by the caller — no second `scenes.get`).
+fn releasePreviousAssets(game: anytype, assets: []const []const u8) void {
+    for (assets) |asset_name| game.assets.release(asset_name);
+}
+
 /// Consults `game.asset_failure_policy` when the manifest gate
-/// reports a `.failed` asset. `.fatal` rolls back and bubbles the
-/// error; `.warn` logs and swallows; `.silent` swallows without
-/// logging. Under `.warn`/`.silent` the caller proceeds with the
-/// swap despite the failure — lookups on the broken asset fall
-/// through to whatever fallback the loader installed.
-fn handleAssetFailure(game: anytype, target_name: []const u8, err: anyerror) !void {
+/// reports an asset in `.failed` state (the `anyFailed` path —
+/// `acquire` errors are routed separately and bypass this helper).
+/// `.fatal` rolls back and bubbles the error; `.warn` logs and
+/// swallows; `.silent` swallows without logging. `caller_tag`
+/// distinguishes the log message between `setScene` and
+/// `setSceneAtomic` entry points.
+fn handleAssetFailure(game: anytype, caller_tag: []const u8, target_name: []const u8, err: anyerror) !void {
     switch (game.asset_failure_policy) {
         .fatal => {
             rollbackPendingAssets(game);
@@ -68,8 +115,8 @@ fn handleAssetFailure(game: anytype, target_name: []const u8, err: anyerror) !vo
         },
         .warn => {
             game.log.warn(
-                "setScene('{s}'): asset load failure ({s}) — proceeding under .warn policy",
-                .{ target_name, @errorName(err) },
+                "{s}('{s}'): asset load failure ({s}) — proceeding under .warn policy",
+                .{ caller_tag, target_name, @errorName(err) },
             );
         },
         .silent => {},
@@ -203,11 +250,7 @@ pub fn Mixin(comptime Game: type) type {
                 e.assets
             else
                 &.{};
-            switch (gateOnManifest(self, name, target_assets)) {
-                .proceed => {},
-                .not_ready => return,
-                .failed => |err| try handleAssetFailure(self, name, err),
-            }
+            if (!try gateOrDefer(self, "setScene", name, target_assets)) return;
 
             // Bridge catalog-uploaded image handles into
             // atlas_manager so findSprite can return the right
@@ -260,13 +303,14 @@ pub fn Mixin(comptime Game: type) type {
             // clear the pending marker. Order is acquire-new-then-
             // release-old (RFC §scene transition wiring) so shared
             // assets keep refcount ≥ 1 across the swap and never
-            // get freed-then-reloaded.
+            // get freed-then-reloaded. The scene-entry lookup
+            // happens once here and the resulting slice is shared
+            // between the release hook (which lets listeners read
+            // the final refcount state) and the release loop.
             if (previous_name) |p| {
                 const prev_assets: []const []const u8 = if (self.scenes.get(p)) |e| e.assets else &.{};
-                // Fire BEFORE the release so listeners observe the
-                // final refcount state while the assets still exist.
                 self.emitHook(.{ .scene_assets_release = .{ .name = p, .assets = prev_assets } });
-                releasePreviousAssets(self, p);
+                releasePreviousAssets(self, prev_assets);
             }
             if (self.pending_scene_assets) |p| {
                 self.allocator.free(p);
@@ -286,11 +330,7 @@ pub fn Mixin(comptime Game: type) type {
             // same idempotent acquire/release cycle so callers can
             // mix `setScene` and `setSceneAtomic` without confusing
             // the gate.
-            switch (gateOnManifest(self, name, entry.assets)) {
-                .proceed => {},
-                .not_ready => return,
-                .failed => |err| try handleAssetFailure(self, name, err),
-            }
+            if (!try gateOrDefer(self, "setSceneAtomic", name, entry.assets)) return;
 
             bridgeImageAssetsToAtlasManager(self, entry.assets);
 
@@ -328,7 +368,7 @@ pub fn Mixin(comptime Game: type) type {
             if (previous_name) |p| {
                 const prev_assets: []const []const u8 = if (self.scenes.get(p)) |e| e.assets else &.{};
                 self.emitHook(.{ .scene_assets_release = .{ .name = p, .assets = prev_assets } });
-                releasePreviousAssets(self, p);
+                releasePreviousAssets(self, prev_assets);
             }
             if (self.pending_scene_assets) |p| {
                 self.allocator.free(p);

--- a/src/game/scene_mixin.zig
+++ b/src/game/scene_mixin.zig
@@ -54,6 +54,28 @@ fn releasePreviousAssets(game: anytype, prev_name: []const u8) void {
     }
 }
 
+/// Consults `game.asset_failure_policy` when the manifest gate
+/// reports a `.failed` asset. `.fatal` rolls back and bubbles the
+/// error; `.warn` logs and swallows; `.silent` swallows without
+/// logging. Under `.warn`/`.silent` the caller proceeds with the
+/// swap despite the failure — lookups on the broken asset fall
+/// through to whatever fallback the loader installed.
+fn handleAssetFailure(game: anytype, target_name: []const u8, err: anyerror) !void {
+    switch (game.asset_failure_policy) {
+        .fatal => {
+            rollbackPendingAssets(game);
+            return err;
+        },
+        .warn => {
+            game.log.warn(
+                "setScene('{s}'): asset load failure ({s}) — proceeding under .warn policy",
+                .{ target_name, @errorName(err) },
+            );
+        },
+        .silent => {},
+    }
+}
+
 /// Roll back the acquire batch on failure / abort. Frees the
 /// `pending_scene_assets` marker so the next setScene call starts
 /// from scratch.
@@ -184,10 +206,7 @@ pub fn Mixin(comptime Game: type) type {
             switch (gateOnManifest(self, name, target_assets)) {
                 .proceed => {},
                 .not_ready => return,
-                .failed => |err| {
-                    rollbackPendingAssets(self);
-                    return err;
-                },
+                .failed => |err| try handleAssetFailure(self, name, err),
             }
 
             // Bridge catalog-uploaded image handles into
@@ -201,6 +220,13 @@ pub fn Mixin(comptime Game: type) type {
             // outgoing manifest after the swap completes.
             const previous_name = if (self.current_scene_name) |n| self.allocator.dupe(u8, n) catch null else null;
             defer if (previous_name) |p| self.allocator.free(p);
+
+            // Fire `scene_assets_acquire` at the "we own the new
+            // manifest and are about to swap" moment — after the
+            // gate proved allReady, before any scene teardown. This
+            // gives listeners a chance to cache the manifest and
+            // react before `scene_before_load` fires.
+            self.emitHook(.{ .scene_assets_acquire = .{ .name = name, .assets = target_assets } });
 
             self.unloadCurrentScene();
 
@@ -235,7 +261,13 @@ pub fn Mixin(comptime Game: type) type {
             // release-old (RFC §scene transition wiring) so shared
             // assets keep refcount ≥ 1 across the swap and never
             // get freed-then-reloaded.
-            if (previous_name) |p| releasePreviousAssets(self, p);
+            if (previous_name) |p| {
+                const prev_assets: []const []const u8 = if (self.scenes.get(p)) |e| e.assets else &.{};
+                // Fire BEFORE the release so listeners observe the
+                // final refcount state while the assets still exist.
+                self.emitHook(.{ .scene_assets_release = .{ .name = p, .assets = prev_assets } });
+                releasePreviousAssets(self, p);
+            }
             if (self.pending_scene_assets) |p| {
                 self.allocator.free(p);
                 self.pending_scene_assets = null;
@@ -257,16 +289,15 @@ pub fn Mixin(comptime Game: type) type {
             switch (gateOnManifest(self, name, entry.assets)) {
                 .proceed => {},
                 .not_ready => return,
-                .failed => |err| {
-                    rollbackPendingAssets(self);
-                    return err;
-                },
+                .failed => |err| try handleAssetFailure(self, name, err),
             }
 
             bridgeImageAssetsToAtlasManager(self, entry.assets);
 
             const previous_name = if (self.current_scene_name) |n| self.allocator.dupe(u8, n) catch null else null;
             defer if (previous_name) |p| self.allocator.free(p);
+
+            self.emitHook(.{ .scene_assets_acquire = .{ .name = name, .assets = entry.assets } });
 
             // Clear scene entity list BEFORE deinit so Scene.deinit's entity
             // destruction loop has nothing to iterate (entities will be destroyed
@@ -294,7 +325,11 @@ pub fn Mixin(comptime Game: type) type {
                 onLoad(self);
             }
 
-            if (previous_name) |p| releasePreviousAssets(self, p);
+            if (previous_name) |p| {
+                const prev_assets: []const []const u8 = if (self.scenes.get(p)) |e| e.assets else &.{};
+                self.emitHook(.{ .scene_assets_release = .{ .name = p, .assets = prev_assets } });
+                releasePreviousAssets(self, p);
+            }
             if (self.pending_scene_assets) |p| {
                 self.allocator.free(p);
                 self.pending_scene_assets = null;

--- a/src/hooks_types.zig
+++ b/src/hooks_types.zig
@@ -21,6 +21,8 @@ pub fn HookPayload(comptime Entity: type) type {
         scene_before_load: SceneBeforeLoadInfo,
         scene_load: SceneInfo,
         scene_unload: SceneInfo,
+        scene_assets_acquire: SceneAssetsInfo,
+        scene_assets_release: SceneAssetsInfo,
 
         // State lifecycle
         state_before_change: StateChangeInfo,
@@ -48,6 +50,16 @@ pub const SceneBeforeLoadInfo = struct {
 
 pub const SceneInfo = struct {
     name: []const u8,
+};
+
+/// Payload for `scene_assets_acquire` / `scene_assets_release`. `assets`
+/// is the manifest attached to the scene entry — listeners can read it
+/// without a `scenes.get(name)` lookup. Slice lifetime matches the
+/// `SceneEntry.assets` slice (program-lifetime when populated by the
+/// assembler).
+pub const SceneAssetsInfo = struct {
+    name: []const u8,
+    assets: []const []const u8,
 };
 
 pub const StateChangeInfo = struct {

--- a/test/scene_assets_hooks_test.zig
+++ b/test/scene_assets_hooks_test.zig
@@ -1,0 +1,179 @@
+//! Scene asset hooks + `asset_failure_policy` (issue #444).
+//!
+//! Exercises:
+//!   1. `scene_assets_acquire` and `scene_assets_release` fire with the
+//!      right name/manifest payloads and in the right relative order.
+//!   2. `Game.asset_failure_policy` — `.fatal` rolls back + bubbles the
+//!      error, `.warn` / `.silent` swallow and let `setScene` proceed.
+//!
+//! Asset worker state is manipulated directly via `catalog.entries`
+//! rather than driven through the real loader — these tests target
+//! the hook wiring in `scene_mixin.zig`, not the catalog pump.
+
+const std = @import("std");
+const testing = std.testing;
+
+const engine = @import("engine");
+const Game = engine.Game;
+const GameWith = engine.GameWith;
+const AssetState = engine.AssetState;
+const LoaderKind = engine.LoaderKind;
+
+fn emptyLoader(_: *Game) anyerror!void {}
+fn emptyLoaderRec(_: *GameWith(*RecordingHooks)) anyerror!void {}
+
+// ── Hook wiring tests ────────────────────────────────────────────────
+
+const HookEvent = struct {
+    kind: enum { acquire, release, before_load, load },
+    name: []u8,
+    assets_len: usize,
+};
+
+const RecordingHooks = struct {
+    events: std.ArrayList(HookEvent) = .{},
+    allocator: std.mem.Allocator,
+
+    fn deinit(self: *RecordingHooks) void {
+        for (self.events.items) |ev| self.allocator.free(ev.name);
+        self.events.deinit(self.allocator);
+    }
+
+    fn push(self: *RecordingHooks, kind: anytype, name: []const u8, assets_len: usize) void {
+        const dup = self.allocator.dupe(u8, name) catch return;
+        self.events.append(self.allocator, .{ .kind = kind, .name = dup, .assets_len = assets_len }) catch {};
+    }
+
+    pub fn scene_assets_acquire(self: *@This(), info: anytype) void {
+        self.push(.acquire, info.name, info.assets.len);
+    }
+    pub fn scene_assets_release(self: *@This(), info: anytype) void {
+        self.push(.release, info.name, info.assets.len);
+    }
+    pub fn scene_before_load(self: *@This(), info: anytype) void {
+        self.push(.before_load, info.name, 0);
+    }
+    pub fn scene_load(self: *@This(), info: anytype) void {
+        self.push(.load, info.name, 0);
+    }
+};
+
+test "scene_assets_acquire/release: fire with name + manifest payload" {
+    var hooks = RecordingHooks{ .allocator = testing.allocator };
+    defer hooks.deinit();
+
+    var game = GameWith(*RecordingHooks).init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&hooks);
+
+    // Empty manifests — the gate proceeds immediately. We only
+    // want to prove the acquire hook fires with the target's
+    // manifest (even if empty) at the right point in the flow.
+    game.registerSceneSimple("first", emptyLoaderRec);
+    game.registerSceneSimple("second", emptyLoaderRec);
+
+    try game.setScene("first");
+    try game.setScene("second");
+
+    // Expected sequence across both swaps:
+    //   first:  acquire(first) → before_load(first) → load(first)
+    //   second: acquire(second) → before_load(second) → load(second) → release(first)
+    const events = hooks.events.items;
+    try testing.expectEqual(@as(usize, 7), events.len);
+
+    try testing.expectEqual(.acquire, events[0].kind);
+    try testing.expectEqualStrings("first", events[0].name);
+    try testing.expectEqual(.before_load, events[1].kind);
+    try testing.expectEqual(.load, events[2].kind);
+
+    try testing.expectEqual(.acquire, events[3].kind);
+    try testing.expectEqualStrings("second", events[3].name);
+    try testing.expectEqual(.before_load, events[4].kind);
+    try testing.expectEqual(.load, events[5].kind);
+
+    try testing.expectEqual(.release, events[6].kind);
+    try testing.expectEqualStrings("first", events[6].name);
+}
+
+test "scene_assets_acquire: payload carries the manifest slice" {
+    var hooks = RecordingHooks{ .allocator = testing.allocator };
+    defer hooks.deinit();
+
+    var game = GameWith(*RecordingHooks).init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&hooks);
+
+    // Register with a manifest and force its entries to `.ready`
+    // so the gate proceeds without running the real worker.
+    const manifest: []const []const u8 = &.{ "ship", "background" };
+    game.registerSceneWithAssets("level", emptyLoaderRec, manifest);
+
+    for (manifest) |name| {
+        try game.assets.register(name, .image, "png", "stub-bytes");
+        const entry = game.assets.entries.getPtr(name).?;
+        entry.state = .ready;
+        entry.refcount = 0;
+    }
+
+    try game.setScene("level");
+
+    // First event must be acquire with both asset names.
+    try testing.expectEqual(.acquire, hooks.events.items[0].kind);
+    try testing.expectEqualStrings("level", hooks.events.items[0].name);
+    try testing.expectEqual(@as(usize, 2), hooks.events.items[0].assets_len);
+}
+
+// ── Failure-policy tests ─────────────────────────────────────────────
+
+fn registerFailedAsset(game: *Game, name: []const u8) !void {
+    try game.assets.register(name, .image, "png", "stub");
+    const entry = game.assets.entries.getPtr(name).?;
+    entry.state = .failed;
+    entry.last_error = error.TestInjectedFailure;
+}
+
+test "asset_failure_policy.fatal: setScene returns the load error" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const manifest: []const []const u8 = &.{"broken"};
+    game.registerSceneWithAssets("level", emptyLoader, manifest);
+    try registerFailedAsset(&game, "broken");
+
+    // Default is `.fatal`.
+    try testing.expectEqual(Game.AssetFailurePolicy.fatal, game.asset_failure_policy);
+    try testing.expectError(error.TestInjectedFailure, game.setScene("level"));
+
+    // Rollback happened — no pending marker leaked, refcount not
+    // left incremented on the broken asset (it never was, but
+    // anyone else acquired during the batch must have been released).
+    try testing.expectEqual(@as(?[]const u8, null), game.pending_scene_assets);
+}
+
+test "asset_failure_policy.warn: setScene swallows the failure and proceeds" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    game.asset_failure_policy = .warn;
+
+    const manifest: []const []const u8 = &.{"broken"};
+    game.registerSceneWithAssets("level", emptyLoader, manifest);
+    try registerFailedAsset(&game, "broken");
+
+    try game.setScene("level");
+
+    // Swap committed despite the broken asset.
+    try testing.expectEqualStrings("level", game.getCurrentSceneName().?);
+}
+
+test "asset_failure_policy.silent: setScene swallows without logging" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    game.asset_failure_policy = .silent;
+
+    const manifest: []const []const u8 = &.{"broken"};
+    game.registerSceneWithAssets("level", emptyLoader, manifest);
+    try registerFailedAsset(&game, "broken");
+
+    try game.setScene("level");
+    try testing.expectEqualStrings("level", game.getCurrentSceneName().?);
+}

--- a/test/scene_assets_hooks_test.zig
+++ b/test/scene_assets_hooks_test.zig
@@ -177,3 +177,45 @@ test "asset_failure_policy.silent: setScene swallows without logging" {
     try game.setScene("level");
     try testing.expectEqualStrings("level", game.getCurrentSceneName().?);
 }
+
+test "asset_failure_policy.warn: defers swap while other manifest assets are still in-flight" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    game.asset_failure_policy = .warn;
+
+    const manifest: []const []const u8 = &.{ "broken", "still_loading" };
+    game.registerSceneWithAssets("level", emptyLoader, manifest);
+    try registerFailedAsset(&game, "broken");
+
+    // `still_loading` is registered but stuck in an in-flight
+    // state — simulates an asset the real worker hasn't finished.
+    try game.assets.register("still_loading", .image, "png", "stub");
+    const loading = game.assets.entries.getPtr("still_loading").?;
+    loading.state = .queued;
+
+    try game.setScene("level");
+    // Swap deferred — `broken` is .failed (OK under .warn) but
+    // `still_loading` hasn't reached .ready or .failed yet.
+    try testing.expectEqual(@as(?[]const u8, null), game.getCurrentSceneName());
+
+    // Move `still_loading` to a terminal state — swap unblocks.
+    loading.state = .ready;
+    try game.setScene("level");
+    try testing.expectEqualStrings("level", game.getCurrentSceneName().?);
+}
+
+test "acquire error bypasses asset_failure_policy (always fatal)" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    game.asset_failure_policy = .silent; // even under .silent…
+
+    // Reference an asset name that was never registered with the
+    // catalog. `acquire` fails with `error.AssetNotRegistered`
+    // (or similar) — that's an acquire_error path, not an
+    // asset_error, and must bubble regardless of policy.
+    const manifest: []const []const u8 = &.{"unregistered_asset"};
+    game.registerSceneWithAssets("level", emptyLoader, manifest);
+
+    try testing.expectError(error.AssetNotRegistered, game.setScene("level"));
+    try testing.expectEqual(@as(?[]const u8, null), game.pending_scene_assets);
+}


### PR DESCRIPTION
Closes #444.

## Summary
- Adds two new hook variants to `HookPayload`: `scene_assets_acquire` and `scene_assets_release`, carrying a `SceneAssetsInfo { name, assets }` payload.
- Fires `scene_assets_acquire(target)` after the manifest gate proves `allReady` and before `scene_before_load`. Fires `scene_assets_release(previous)` in the post-swap success path, before the actual release loop so listeners see the final refcount state while assets still exist. Wired in both `setScene` and `setSceneAtomic`.
- Adds `Game.asset_failure_policy: AssetFailurePolicy` (`fatal | warn | silent`). Default `.fatal` preserves today's rollback-and-bubble. `.warn` logs via `game.log.warn` and proceeds. `.silent` proceeds without logging. Games that ship with optional assets can set this at startup.

## Out of scope (intentional)
The ticket's "auto-fallback to loading scene via `setSceneAtomic(loading_scene)`" bullet is **not** implemented here. The existing state/scene pattern (loading state → loading scene via the state machine, see flying-platform-labelle's `scripts/loading/loading_controller.zig`) already covers it, and adding `Game.loading_scene_name` would duplicate that coordination. Hooks are the enabling primitive; fallback is a game-level concern. If we revisit this, it should be an opt-in field rather than a hard-coded engine behaviour.

## Tests
`test/scene_assets_hooks_test.zig` (new, 5 tests):
- Hook ordering across two consecutive swaps (acquire → before_load → load, then release fires on the *next* transition).
- `scene_assets_acquire` payload carries the manifest slice.
- `.fatal` returns the load error and clears `pending_scene_assets`.
- `.warn` swallows the failure and commits the swap.
- `.silent` same behaviour, no log.

Failed-asset states are set up by directly poking `catalog.entries.getPtr(name).?.{state, last_error}` — isolates the hook wiring from the real loader/worker pump.

Full test run: **183/183 passing** (up from 178).

## Test plan
- [x] `zig build` succeeds
- [x] `zig build test` green
- [ ] Consumer smoke test in flying-platform-labelle once this merges — the existing `loading_controller.zig` polling stays unchanged; optional follow-up: register a handler for `scene_assets_acquire` to drive the progress bar.