### PR TITLE
feat(engine): plugin-accessible pause flag + pause_changed hook

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -45,6 +45,7 @@ pub fn build(b: *std.Build) void {
         "test/asset_streaming_shim_test.zig",
         "test/animation_def_test.zig",
         "test/scene_assets_hooks_test.zig",
+        "test/pause_hook_test.zig",
     };
 
     for (test_files) |test_file| {

--- a/src/game.zig
+++ b/src/game.zig
@@ -259,6 +259,15 @@ pub fn GameConfig(
         /// Time scale factor: 0 = paused, 0.5 = slow-mo, 1.0 = normal, 2.0 = fast.
         /// When paused (0), rendering and GUI continue but tick logic stops.
         time_scale: f32 = 1.0,
+        /// Plugin-accessible pause flag (#465). Plugin-shipped scripts
+        /// (pathfinder's `Controller.advance`, asset-catalog's `pump`,
+        /// etc.) gate on `game.isPaused()` instead of importing a
+        /// game-side `GamePaused` component, which would cross the Zig
+        /// module-path boundary. The game owns the source of truth —
+        /// typically a tiny always-on script syncing its own
+        /// `GamePaused` component into `setPaused` — and the engine
+        /// just stores + dispatches the bool.
+        paused: bool = false,
 
         // Profiling (debug builds only)
         /// Opaque pointer to ScriptRunner's profile array. Set by generated code.
@@ -748,6 +757,34 @@ pub fn GameConfig(
         pub const queueStateChange = StateMixin.queueStateChange;
         pub const getState = StateMixin.getState;
 
+        // ── Pause flag (#465) ───────────────────────────────────────
+
+        /// Set the engine-level pause flag. Emits `pause_changed` when
+        /// the value transitions; idempotent if already at `paused`.
+        ///
+        /// Intended to be called from a game-side sync script that
+        /// mirrors a game-owned `GamePaused` component (or equivalent)
+        /// into the engine, so plugin-shipped scripts can gate via
+        /// `game.isPaused()` without importing game components.
+        pub fn setPaused(self: *Self, paused: bool) void {
+            if (self.paused == paused) return;
+            self.paused = paused;
+            self.emitHook(.{ .pause_changed = .{ .paused = paused } });
+        }
+
+        /// Read the engine-level pause predicate. Returns true if
+        /// *either* the explicit `paused` flag is set OR `time_scale`
+        /// is zero — both are valid pause mechanisms and tick gating
+        /// should honour both uniformly.
+        ///
+        /// Plugin scripts should use this instead of reaching for a
+        /// game-side `GamePaused` component — the latter would couple
+        /// plugin code to the game's component types across module
+        /// boundaries.
+        pub fn isPaused(self: *const Self) bool {
+            return self.paused or self.time_scale == 0;
+        }
+
         pub fn unloadCurrentScene(self: *Self) void {
             if (has_events) self.event_buffer.clearRetainingCapacity();
             if (self.current_scene_name) |name| {
@@ -1000,16 +1037,14 @@ pub fn GameConfig(
             return self.time_scale;
         }
 
-        pub fn isPaused(self: *const Self) bool {
-            return self.time_scale == 0;
-        }
-
         pub fn pause(self: *Self) void {
             self.time_scale = 0;
+            self.setPaused(true);
         }
 
         pub fn resume_(self: *Self) void {
             self.time_scale = 1.0;
+            self.setPaused(false);
         }
 
         pub fn tick(self: *Self, dt: f32) void {
@@ -1071,8 +1106,11 @@ pub fn GameConfig(
                 }
             }
 
-            // Paused: skip game logic but keep frame counter advancing
-            if (scaled_dt == 0) {
+            // Paused: skip game logic but keep frame counter advancing.
+            // Gates on the unified `isPaused()` so an explicit
+            // `setPaused(true)` halts the tick even when time_scale is
+            // still 1.0 — not just the `scaled_dt == 0` variant below.
+            if (self.isPaused()) {
                 self.frame_number += 1;
                 return;
             }

--- a/src/hooks_types.zig
+++ b/src/hooks_types.zig
@@ -28,6 +28,9 @@ pub fn HookPayload(comptime Entity: type) type {
         state_before_change: StateChangeInfo,
         state_after_change: StateChangeInfo,
 
+        // Pause lifecycle
+        pause_changed: PauseChangedInfo,
+
         // Entity lifecycle
         entity_created: EntityInfo(Entity),
         entity_destroyed: EntityInfo(Entity),
@@ -65,6 +68,14 @@ pub const SceneAssetsInfo = struct {
 pub const StateChangeInfo = struct {
     old_state: []const u8,
     new_state: []const u8,
+};
+
+/// Payload for `pause_changed` — emitted by `Game.setPaused` when the
+/// pause flag actually changes value. Plugin-shipped scripts gate on
+/// `game.isPaused()` directly; this hook is for game/system code that
+/// wants to react to the transition (e.g. fade audio, pulse a UI badge).
+pub const PauseChangedInfo = struct {
+    paused: bool,
 };
 
 pub fn EntityInfo(comptime Entity: type) type {

--- a/src/root.zig
+++ b/src/root.zig
@@ -93,6 +93,7 @@ pub const FrameInfo = hooks_types_mod.FrameInfo;
 pub const SceneBeforeLoadInfo = hooks_types_mod.SceneBeforeLoadInfo;
 pub const SceneInfo = hooks_types_mod.SceneInfo;
 pub const StateChangeInfo = hooks_types_mod.StateChangeInfo;
+pub const PauseChangedInfo = hooks_types_mod.PauseChangedInfo;
 pub const EntityInfo = hooks_types_mod.EntityInfo;
 pub const ComponentPayload = hooks_types_mod.ComponentPayload;
 

--- a/test/pause_hook_test.zig
+++ b/test/pause_hook_test.zig
@@ -1,0 +1,107 @@
+/// Tests for the engine-level pause flag (#465).
+///
+/// `Game.setPaused` / `Game.isPaused` give plugin-shipped scripts a
+/// game-component-free way to gate per-frame work on pause. The
+/// transition emits a `pause_changed` hook so game/system code can
+/// react (audio fade, UI badge, etc.).
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+
+const game_mod = engine.game_mod;
+
+// ── Hook recorder ───────────────────────────────────────────────────────
+
+const PauseRecorder = struct {
+    changes: std.ArrayListUnmanaged(bool) = .{},
+    allocator: std.mem.Allocator,
+
+    pub fn pause_changed(self: *PauseRecorder, info: anytype) void {
+        self.changes.append(self.allocator, info.paused) catch unreachable;
+    }
+
+    pub fn deinit(self: *PauseRecorder) void {
+        self.changes.deinit(self.allocator);
+    }
+};
+
+const TestGame = game_mod.GameWith(*PauseRecorder);
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+test "isPaused defaults to false" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    try testing.expect(!game.isPaused());
+}
+
+test "setPaused(true) flips the flag" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    game.setPaused(true);
+    try testing.expect(game.isPaused());
+}
+
+test "setPaused emits pause_changed hook on transition" {
+    var recorder = PauseRecorder{ .allocator = testing.allocator };
+    defer recorder.deinit();
+
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&recorder);
+
+    game.setPaused(true);
+
+    try testing.expectEqual(@as(usize, 1), recorder.changes.items.len);
+    try testing.expect(recorder.changes.items[0]);
+}
+
+test "setPaused is idempotent — same value emits no second hook" {
+    var recorder = PauseRecorder{ .allocator = testing.allocator };
+    defer recorder.deinit();
+
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&recorder);
+
+    game.setPaused(true);
+    game.setPaused(true);
+    game.setPaused(true);
+
+    try testing.expectEqual(@as(usize, 1), recorder.changes.items.len);
+    try testing.expect(game.isPaused());
+}
+
+test "setPaused(false) after setPaused(true) emits change hook" {
+    var recorder = PauseRecorder{ .allocator = testing.allocator };
+    defer recorder.deinit();
+
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&recorder);
+
+    game.setPaused(true);
+    game.setPaused(false);
+
+    try testing.expectEqual(@as(usize, 2), recorder.changes.items.len);
+    try testing.expect(recorder.changes.items[0]);
+    try testing.expect(!recorder.changes.items[1]);
+    try testing.expect(!game.isPaused());
+}
+
+test "setPaused(false) when already false is a no-op" {
+    var recorder = PauseRecorder{ .allocator = testing.allocator };
+    defer recorder.deinit();
+
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&recorder);
+
+    game.setPaused(false);
+
+    try testing.expectEqual(@as(usize, 0), recorder.changes.items.len);
+    try testing.expect(!game.isPaused());
+}


### PR DESCRIPTION
## Summary

- Adds `Game.paused: bool` (default `false`), `setPaused(bool)`, and `isPaused()` so plugin-shipped scripts (pathfinder `Controller.advance`, asset catalog `pump`, etc.) can gate per-frame work on pause without importing a game-side `GamePaused` component across Zig module boundaries.
- Adds a `pause_changed: { paused: bool }` variant to the engine `HookPayload` union; `setPaused` emits it only on transition and is idempotent when the value is unchanged.
- Wires the legacy `pause()` / `resume_()` helpers through `setPaused` so the existing `time_scale`-driven path stays consistent with the new flag (and the duplicate `time_scale == 0` flavour of `isPaused` goes away).

This is item 1 of the four-item scope in the issue. Items 2-4 (RFC docs update, game-side `GamePaused` -> engine sync script, restoring the plugin-shipped `01_advance.zig`) live in the consumer / docs repos and follow up after a release that picks this commit up.

## Test plan

- [x] `zig build test` in `labelle-engine` (184/184 tests pass; 6 new tests in `test/pause_hook_test.zig`)
- [ ] Once consumed: pathfinder plugin's restored `Controller.advance` script gates correctly on `game.isPaused()` in flying-platform-labelle

Closes labelle-toolkit/labelle-engine#465