### PR TITLE
fix(jsonc): fire onReady + postLoad for nested scene entities

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -40,6 +40,7 @@ pub fn build(b: *std.Build) void {
         "test/save_policy_test.zig",
         "test/save_load_mixin_test.zig",
         "test/jsonc_bridge_leak_test.zig",
+        "test/jsonc_nested_lifecycle_test.zig",
         "test/scene_ref_test.zig",
         "test/asset_catalog_test.zig",
         "test/asset_streaming_shim_test.zig",

--- a/src/jsonc_scene_bridge.zig
+++ b/src/jsonc_scene_bridge.zig
@@ -856,6 +856,17 @@ pub fn JsoncSceneBridge(comptime GameType: type, comptime Components: type) type
                             for (local_ref_ctx.deferred.items) |deferred| {
                                 patchRefField(game, deferred, &local_ref_ctx);
                             }
+
+                            // Fire onReady + postLoad for this nested child
+                            // now that its components, nested entities, and
+                            // refs are all in place. Parity with the
+                            // top-level `fireOnReadyAll` in `loadEntityInternal`
+                            // — without this, components declared on nested
+                            // entities (e.g. `Workstation.postLoad` inside a
+                            // Room's `workstations` array) never run.
+                            var nested_applied = std.StringHashMap(void).init(game.allocator);
+                            defer nested_applied.deinit();
+                            fireOnReadyAll(game, child, child_scene_comps, child_prefab_comps, &nested_applied);
                         }
 
                         ids[idx] = @intCast(child);

--- a/src/jsonc_scene_bridge.zig
+++ b/src/jsonc_scene_bridge.zig
@@ -864,8 +864,21 @@ pub fn JsoncSceneBridge(comptime GameType: type, comptime Components: type) type
                             // — without this, components declared on nested
                             // entities (e.g. `Workstation.postLoad` inside a
                             // Room's `workstations` array) never run.
+                            //
+                            // Pre-populate `applied` with scene component
+                            // names so `fireOnReadyAll`'s prefab-loop
+                            // `contains` check skips prefab entries that
+                            // the scene already overrode. Otherwise any
+                            // component present in BOTH maps would fire
+                            // its hooks twice (once from the scene loop,
+                            // once from the prefab loop).
                             var nested_applied = std.StringHashMap(void).init(game.allocator);
                             defer nested_applied.deinit();
+                            if (child_scene_comps) |sc| {
+                                for (sc.entries) |e| {
+                                    nested_applied.put(e.key, {}) catch {};
+                                }
+                            }
                             fireOnReadyAll(game, child, child_scene_comps, child_prefab_comps, &nested_applied);
                         }
 

--- a/test/jsonc_nested_lifecycle_test.zig
+++ b/test/jsonc_nested_lifecycle_test.zig
@@ -1,0 +1,303 @@
+/// Tests for nested-entity lifecycle hooks (onReady, postLoad) in the
+/// JSONC scene bridge.
+///
+/// Regression coverage for the fix that made `spawnAndLinkNestedEntities`
+/// fire `fireOnReadyAll` for nested children. Before the fix, only
+/// top-level scene entities ran their `onReady`/`postLoad` hooks — any
+/// component declared on a nested entity (e.g. inside a Room's
+/// `workstations` array) silently skipped them.
+///
+/// A second regression covered here: the `applied` map passed into
+/// `fireOnReadyAll` must be pre-populated with scene-component names,
+/// or any component present in BOTH scene overrides and the prefab
+/// would have its hooks fire twice (flagged by reviewers on the
+/// original PR).
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+const core = @import("labelle-core");
+
+// ── Test components ────────────────────────────────────────────────
+//
+// `PostLoadBump` counts its own `postLoad` invocations via an instance
+// field. Asserting on `bump.calls` per-entity keeps the test state
+// entity-local and avoids global counters.
+
+const PostLoadBump = struct {
+    pub const save = core.Saveable(.saveable, @This(), .{});
+    calls: u32 = 0,
+
+    pub fn postLoad(self: *@This(), game: anytype, entity: anytype) void {
+        _ = game;
+        _ = entity;
+        self.calls += 1;
+    }
+};
+
+/// `OnReadyBump`'s hook is a static method — no instance to mutate. A
+/// module-scope counter is reset at the start of each relevant test.
+var on_ready_calls: u32 = 0;
+
+const OnReadyBump = struct {
+    _tag: u8 = 0,
+
+    pub fn onReady(payload: engine.ComponentPayload) void {
+        _ = payload;
+        on_ready_calls += 1;
+    }
+};
+
+/// Container that holds nested entities via a `slots` ref-array — the
+/// same shape Workstation uses for `storages` in flying-platform.
+const Container = struct {
+    slots: []const u64 = &.{},
+};
+
+const Components = engine.ComponentRegistry(.{
+    .PostLoadBump = PostLoadBump,
+    .OnReadyBump = OnReadyBump,
+    .Container = Container,
+});
+
+const Game = engine.Game;
+const Bridge = engine.JsoncSceneBridge(Game, Components);
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+fn tmpPath(tmp_dir: *std.testing.TmpDir, sub: []const u8) ![]const u8 {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = try tmp_dir.dir.realpath(".", &buf);
+    return std.fmt.allocPrint(testing.allocator, "{s}/{s}", .{ dir_path, sub });
+}
+
+fn loadSource(game: *Game, source: []const u8) !void {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    try tmp_dir.dir.makeDir("prefabs");
+    const prefab_path = try tmpPath(&tmp_dir, "prefabs");
+    defer testing.allocator.free(prefab_path);
+    try Bridge.loadSceneFromSource(game, source, prefab_path);
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+test "nested postLoad fires exactly once" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    try loadSource(&game,
+        \\{
+        \\  "entities": [
+        \\    {
+        \\      "components": {
+        \\        "Container": {
+        \\          "slots": [
+        \\            { "components": { "PostLoadBump": {} } },
+        \\            { "components": { "PostLoadBump": {} } }
+        \\          ]
+        \\        }
+        \\      }
+        \\    }
+        \\  ]
+        \\}
+    );
+
+    // Every nested entity with PostLoadBump should have calls == 1.
+    // Pre-fix value would be 0 (postLoad never invoked on nested entities).
+    var seen: u32 = 0;
+    var view = game.ecs_backend.view(.{PostLoadBump}, .{});
+    defer view.deinit();
+    while (view.next()) |e| {
+        const bump = game.ecs_backend.getComponent(e, PostLoadBump).?;
+        try testing.expectEqual(@as(u32, 1), bump.calls);
+        seen += 1;
+    }
+    try testing.expectEqual(@as(u32, 2), seen);
+}
+
+test "nested onReady fires exactly once per nested entity" {
+    on_ready_calls = 0;
+
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    try loadSource(&game,
+        \\{
+        \\  "entities": [
+        \\    {
+        \\      "components": {
+        \\        "Container": {
+        \\          "slots": [
+        \\            { "components": { "OnReadyBump": {} } },
+        \\            { "components": { "OnReadyBump": {} } },
+        \\            { "components": { "OnReadyBump": {} } }
+        \\          ]
+        \\        }
+        \\      }
+        \\    }
+        \\  ]
+        \\}
+    );
+
+    try testing.expectEqual(@as(u32, 3), on_ready_calls);
+}
+
+test "top-level postLoad still fires (regression guard)" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    try loadSource(&game,
+        \\{
+        \\  "entities": [
+        \\    { "components": { "PostLoadBump": {} } }
+        \\  ]
+        \\}
+    );
+
+    var view = game.ecs_backend.view(.{PostLoadBump}, .{});
+    defer view.deinit();
+    const e = view.next() orelse return error.TestExpectedEntity;
+    const bump = game.ecs_backend.getComponent(e, PostLoadBump).?;
+    try testing.expectEqual(@as(u32, 1), bump.calls);
+    try testing.expect(view.next() == null);
+}
+
+test "nested prefab-only postLoad fires exactly once" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    try tmp_dir.dir.makeDir("prefabs");
+
+    try tmp_dir.dir.writeFile(.{
+        .sub_path = "prefabs/slot.jsonc",
+        .data =
+        \\{
+        \\  "components": {
+        \\    "PostLoadBump": {}
+        \\  }
+        \\}
+        ,
+    });
+    const scene_src =
+        \\{
+        \\  "entities": [
+        \\    {
+        \\      "components": {
+        \\        "Container": {
+        \\          "slots": [ { "prefab": "slot" } ]
+        \\        }
+        \\      }
+        \\    }
+        \\  ]
+        \\}
+    ;
+    const prefab_path = try tmpPath(&tmp_dir, "prefabs");
+    defer testing.allocator.free(prefab_path);
+
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    try Bridge.loadSceneFromSource(&game, scene_src, prefab_path);
+
+    var view = game.ecs_backend.view(.{PostLoadBump}, .{});
+    defer view.deinit();
+    const e = view.next() orelse return error.TestExpectedEntity;
+    const bump = game.ecs_backend.getComponent(e, PostLoadBump).?;
+    try testing.expectEqual(@as(u32, 1), bump.calls);
+}
+
+test "nested scene override + prefab definition fires postLoad exactly once (no double-fire)" {
+    // Regression for the bot-flagged second bug: if the `applied`
+    // StringHashMap isn't seeded with scene-component names, the
+    // prefab loop in `fireOnReadyAll` doesn't know a component was
+    // already processed, so its hooks fire a second time.
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    try tmp_dir.dir.makeDir("prefabs");
+
+    try tmp_dir.dir.writeFile(.{
+        .sub_path = "prefabs/overridable.jsonc",
+        .data =
+        \\{
+        \\  "components": {
+        \\    "PostLoadBump": { "calls": 0 }
+        \\  }
+        \\}
+        ,
+    });
+    const scene_src =
+        \\{
+        \\  "entities": [
+        \\    {
+        \\      "components": {
+        \\        "Container": {
+        \\          "slots": [
+        \\            {
+        \\              "prefab": "overridable",
+        \\              "components": { "PostLoadBump": { "calls": 0 } }
+        \\            }
+        \\          ]
+        \\        }
+        \\      }
+        \\    }
+        \\  ]
+        \\}
+    ;
+    const prefab_path = try tmpPath(&tmp_dir, "prefabs");
+    defer testing.allocator.free(prefab_path);
+
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    try Bridge.loadSceneFromSource(&game, scene_src, prefab_path);
+
+    var view = game.ecs_backend.view(.{PostLoadBump}, .{});
+    defer view.deinit();
+    const e = view.next() orelse return error.TestExpectedEntity;
+    const bump = game.ecs_backend.getComponent(e, PostLoadBump).?;
+    // Pre-seed-fix value would be 2 (scene loop + prefab loop).
+    try testing.expectEqual(@as(u32, 1), bump.calls);
+}
+
+test "nested scene override + prefab definition fires onReady exactly once" {
+    on_ready_calls = 0;
+
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    try tmp_dir.dir.makeDir("prefabs");
+
+    try tmp_dir.dir.writeFile(.{
+        .sub_path = "prefabs/overridable_ready.jsonc",
+        .data =
+        \\{
+        \\  "components": {
+        \\    "OnReadyBump": {}
+        \\  }
+        \\}
+        ,
+    });
+    const scene_src =
+        \\{
+        \\  "entities": [
+        \\    {
+        \\      "components": {
+        \\        "Container": {
+        \\          "slots": [
+        \\            {
+        \\              "prefab": "overridable_ready",
+        \\              "components": { "OnReadyBump": {} }
+        \\            }
+        \\          ]
+        \\        }
+        \\      }
+        \\    }
+        \\  ]
+        \\}
+    ;
+    const prefab_path = try tmpPath(&tmp_dir, "prefabs");
+    defer testing.allocator.free(prefab_path);
+
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    try Bridge.loadSceneFromSource(&game, scene_src, prefab_path);
+
+    try testing.expectEqual(@as(u32, 1), on_ready_calls);
+}


### PR DESCRIPTION
## Summary
- Nested entities created by `spawnAndLinkNestedEntities` (workstations inside a Room's `workstations` array, storages inside a Workstation's `storages` array, etc.) never fired `onReady` hooks or component-level `postLoad` methods. Only top-level scene entities did, via `loadEntityInternal`'s `fireOnReadyAll` call.
- Any `postLoad` that derived runtime state from entity-ID ref arrays was silently skipped on scene load, forcing downstream games to re-implement the same init inside per-frame tick systems — with wrong frame-1 timing that caused incorrect scheduling.
- This patch fires `fireOnReadyAll` at the end of each nested-child construction in `spawnAndLinkNestedEntities`, after components, sub-nested entities, and ref patches are all in place, matching the top-level contract.

## Impact
Downstream games can now delete their per-frame slot-population workarounds and rely on `postLoad` seeing a fully constructed world. Example: flying-platform-labelle's `07_production_system` init loop existed solely to work around this; with the fix, it becomes a no-op on scene load.

## Test plan
- [ ] Run an existing game that uses nested scene entities with `postLoad` (e.g. flying-platform-labelle) and confirm slot-derived state is populated before frame-1 scheduling.
- [ ] Verify no regression in top-level `postLoad` firing.
- [ ] Add unit coverage for nested `postLoad` in the engine's scene-bridge tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)