### PR TITLE
feat(game): emitSync for synchronous event dispatch

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -398,8 +398,32 @@ pub fn GameConfig(
         /// caller needs the handler to have run before the next
         /// statement (cross-plugin state machines that can't tolerate
         /// the buffered-dispatch window).
+        ///
+        /// ## Caveats
+        ///
+        /// The event-buffer design in the custom-game-events RFC exists
+        /// precisely to avoid these, so reach for `emitSync` only when
+        /// the buffered path is provably wrong for the call site:
+        ///
+        /// - **Re-entrancy.** Handlers run mid-tick, inside whatever
+        ///   script or plugin called `emitSync`. A handler that itself
+        ///   mutates entity state, emits more events, or calls back
+        ///   into the caller's own code can interleave with partially-
+        ///   completed work on the stack above. Favour buffered `emit`
+        ///   unless the caller is a leaf operation.
+        ///
+        /// - **Ordering vs buffered events.** `emitSync` does NOT drain
+        ///   the end-of-frame buffer first. A hook fired synchronously
+        ///   mid-tick runs *before* all the events `emit` queued
+        ///   earlier in the same frame, even though those were queued
+        ///   first. Mixing the two on a single event kind produces
+        ///   out-of-order handler calls — usually not what you want.
         pub fn emitSync(self: *Self, event: GameEvents) void {
-            if (!has_events) return;
+            // Skip the switch + @unionInit payload construction when
+            // the game has no hooks to dispatch to — same comptime
+            // shortcut `emitHook` relies on. Folds the entire call
+            // away in zero-hook builds.
+            if (!has_events or !has_hooks) return;
             switch (event) {
                 inline else => |data, tag| {
                     self.emitHook(@unionInit(Payload, @tagName(tag), data));

--- a/src/game.zig
+++ b/src/game.zig
@@ -393,6 +393,20 @@ pub fn GameConfig(
             }
         }
 
+        /// Emit a game event synchronously — dispatch to registered hooks
+        /// immediately, bypassing the end-of-frame buffer. Use when the
+        /// caller needs the handler to have run before the next
+        /// statement (cross-plugin state machines that can't tolerate
+        /// the buffered-dispatch window).
+        pub fn emitSync(self: *Self, event: GameEvents) void {
+            if (!has_events) return;
+            switch (event) {
+                inline else => |data, tag| {
+                    self.emitHook(@unionInit(Payload, @tagName(tag), data));
+                },
+            }
+        }
+
         /// Deliver buffered game events to hooks. Called at end of frame.
         pub fn dispatchEvents(self: *Self) void {
             if (!has_events) return;


### PR DESCRIPTION
## Summary
- Adds `Game.emitSync(event)` — same shape as `emit`, but dispatches the buffered Payload immediately to registered hooks instead of queuing it for end-of-frame `dispatchEvents`.
- Uses the exact same `@unionInit(Payload, @tagName(tag), data)` conversion as `dispatchEvents`, so hook signatures and tags stay identical.

## Why
Motivated by a cross-plugin race in [flying-platform-labelle #280](https://github.com/Flying-Platform/flying-platform-labelle/issues/280): `needs_machine` emits `need_fulfillment_requested` during its controller tick, but the buffered dispatch leaves a window where a sibling plugin (`production`) running later in the same tick sees the worker as idle with no pending fulfillment and double-assigns a delivery. Switching the hunger-dispatch site from `emit` → `emitSync` closes that window without changing the handler signature or breaking the game-script hook contract.

The game-side fix for #280 uses a reservation flag to mitigate the race without this method, but `emitSync` makes the underlying fix available to any plugin that needs synchronous event semantics.

## Test plan
- [x] `zig build test` — existing suite passes
- [x] `emitSync` is `pub fn`; no change to `emit`/`dispatchEvents` semantics
- [ ] Once this ships, flying-platform-labelle will switch the hunger dispatch to `emitSync` and the reservation can be narrowed