### PR TITLE
feat(save_load): persist Parent component alongside Position

### DIFF
--- a/src/game/save_load_mixin.zig
+++ b/src/game/save_load_mixin.zig
@@ -292,26 +292,42 @@ pub fn Mixin(comptime Game: type) type {
                 // save block above. Uses `setParent` so the engine's
                 // Children back-link is rebuilt alongside.
                 //
+                // Mirrors the save-side `has_parent_in_registry` guard
+                // and Position's load-side guard: if a game ever
+                // registers `Game.ParentComp`, the registry-driven
+                // restore already handles Parent via `addComponent`, so
+                // this built-in block would double-restore and trigger
+                // `setParent` with stale state (review #470).
+                //
                 // Skip the restore unless we can both parse a valid
                 // saved entity ID and map it to a post-load entity —
                 // passing a stale or raw ID to `setParent` would trip
                 // `assertEntityAlive` in debug or corrupt hierarchy
-                // state in release builds (cursor / Copilot review).
-                if (components.get("Parent")) |parent_val| blk: {
-                    const parent_obj = parent_val.object;
-                    const ent_val = parent_obj.get("entity") orelse break :blk;
-                    const saved_parent_id: u64 = switch (ent_val) {
-                        .integer => |i| if (i >= 0) @intCast(i) else break :blk,
-                        else => break :blk,
-                    };
-                    const current_parent_id = id_map.get(saved_parent_id) orelse break :blk;
-                    const parent_entity: Entity = @intCast(current_parent_id);
-                    const inherit_rotation = parentFlag(parent_obj, "inherit_rotation");
-                    const inherit_scale = parentFlag(parent_obj, "inherit_scale");
-                    self.setParent(entity, parent_entity, .{
-                        .inherit_rotation = inherit_rotation,
-                        .inherit_scale = inherit_scale,
-                    });
+                // state in release builds.
+                const Parent_load = Game.ParentComp;
+                const has_parent_in_registry_load = comptime blk: {
+                    for (names) |name| {
+                        if (Reg.getType(name) == Parent_load) break :blk true;
+                    }
+                    break :blk false;
+                };
+                if (!has_parent_in_registry_load) {
+                    if (components.get("Parent")) |parent_val| blk: {
+                        const parent_obj = parent_val.object;
+                        const ent_val = parent_obj.get("entity") orelse break :blk;
+                        const saved_parent_id: u64 = switch (ent_val) {
+                            .integer => |i| if (i >= 0) @intCast(i) else break :blk,
+                            else => break :blk,
+                        };
+                        const current_parent_id = id_map.get(saved_parent_id) orelse break :blk;
+                        const parent_entity: Entity = @intCast(current_parent_id);
+                        const inherit_rotation = parentFlag(parent_obj, "inherit_rotation");
+                        const inherit_scale = parentFlag(parent_obj, "inherit_scale");
+                        self.setParent(entity, parent_entity, .{
+                            .inherit_rotation = inherit_rotation,
+                            .inherit_scale = inherit_scale,
+                        });
+                    }
                 }
             }
 

--- a/src/game/save_load_mixin.zig
+++ b/src/game/save_load_mixin.zig
@@ -119,10 +119,16 @@ pub fn Mixin(comptime Game: type) type {
                 // every child-with-Position drifts to scene origin
                 // after load (see labelle-core #11).
                 //
-                // Guarded by a registry-type check so a game that does
-                // register a component serialised as `"Parent"` in the
-                // future doesn't produce duplicate JSON keys (mirrors
-                // Position's `has_position_in_registry`).
+                // Guarded by a type-identity check: if a game does
+                // register the engine's `ParentComponent` directly in
+                // its ComponentRegistry, the registry-driven save/load
+                // path already handles it and writing the built-in
+                // block on top would produce duplicate JSON keys.
+                // Mirrors Position's `has_position_in_registry`.
+                // Note: this does NOT protect against a game defining
+                // a *different* component whose serde name happens to
+                // be "Parent" — that would still collide. Deliberately
+                // scoped to the common case (same type) for now.
                 const Parent = Game.ParentComp;
                 const has_parent_in_registry = comptime blk: {
                     for (names) |name| {
@@ -313,7 +319,15 @@ pub fn Mixin(comptime Game: type) type {
                 };
                 if (!has_parent_in_registry_load) {
                     if (components.get("Parent")) |parent_val| blk: {
-                        const parent_obj = parent_val.object;
+                        // A malformed save carrying `"Parent": 123` or
+                        // `"Parent": null` would otherwise trip the
+                        // `.object` tag-cast safety check and panic in
+                        // debug before the field-level guards below
+                        // had a chance to skip the restore.
+                        const parent_obj = switch (parent_val) {
+                            .object => |o| o,
+                            else => break :blk,
+                        };
                         const ent_val = parent_obj.get("entity") orelse break :blk;
                         const saved_parent_id: u64 = switch (ent_val) {
                             .integer => |i| if (i >= 0) @intCast(i) else break :blk,

--- a/src/game/save_load_mixin.zig
+++ b/src/game/save_load_mixin.zig
@@ -98,6 +98,26 @@ pub fn Mixin(comptime Game: type) type {
                     first_comp = false;
                 }
 
+                // Save Parent (built-in). Games don't register the
+                // engine's `ParentComponent` in their ComponentRegistry
+                // (it's generic over Entity + used internally by
+                // `setParent`), but the save mixin needs to persist it
+                // so prefab hierarchies survive save/load — otherwise
+                // every child-with-Position drifts to scene origin
+                // after load (see labelle-core #11).
+                const Parent = Game.ParentComp;
+                if (self.active_world.ecs_backend.getComponent(entity, Parent)) |parent| {
+                    if (!first_comp) try writer.writeAll(",");
+                    try writer.writeAll("\n        \"Parent\": {\"entity\": ");
+                    try std.fmt.format(writer, "{d}", .{entityToU64(parent.entity)});
+                    try writer.writeAll(", \"inherit_rotation\": ");
+                    try writer.writeAll(if (parent.inherit_rotation) "true" else "false");
+                    try writer.writeAll(", \"inherit_scale\": ");
+                    try writer.writeAll(if (parent.inherit_scale) "true" else "false");
+                    try writer.writeAll("}");
+                    first_comp = false;
+                }
+
                 inline for (names) |name| {
                     const T = Reg.getType(name);
                     if (comptime core.getSavePolicy(T)) |policy| {
@@ -239,6 +259,34 @@ pub fn Mixin(comptime Game: type) type {
                                 } else |_| {}
                             }
                         }
+                    }
+                }
+
+                // Restore Parent (built-in) — counterpart to the Parent
+                // save block above. Uses `setParent` so the engine's
+                // Children back-link is rebuilt alongside.
+                if (components.get("Parent")) |parent_val| {
+                    const parent_obj = parent_val.object;
+                    if (parent_obj.get("entity")) |ent_val| {
+                        const saved_parent_id: u64 = switch (ent_val) {
+                            .integer => |i| @intCast(i),
+                            .float => |f| @intFromFloat(f),
+                            else => 0,
+                        };
+                        const current_parent_id = id_map.get(saved_parent_id) orelse saved_parent_id;
+                        const parent_entity: Entity = @intCast(current_parent_id);
+                        const inherit_rotation = if (parent_obj.get("inherit_rotation")) |v| switch (v) {
+                            .bool => |b| b,
+                            else => false,
+                        } else false;
+                        const inherit_scale = if (parent_obj.get("inherit_scale")) |v| switch (v) {
+                            .bool => |b| b,
+                            else => false,
+                        } else false;
+                        self.setParent(entity, parent_entity, .{
+                            .inherit_rotation = inherit_rotation,
+                            .inherit_scale = inherit_scale,
+                        });
                     }
                 }
             }

--- a/src/game/save_load_mixin.zig
+++ b/src/game/save_load_mixin.zig
@@ -20,6 +20,19 @@ pub fn Mixin(comptime Game: type) type {
             return @intCast(entity);
         }
 
+        /// Read a boolean field out of a serialised Parent object,
+        /// defaulting to `false` for missing / non-bool values. Kept
+        /// local so the save and load sides of the built-in Parent
+        /// pathway stay symmetric and the call sites don't repeat the
+        /// `switch (v) { .bool => ... }` boilerplate.
+        fn parentFlag(parent_obj: std.json.ObjectMap, field: []const u8) bool {
+            const v = parent_obj.get(field) orelse return false;
+            return switch (v) {
+                .bool => |b| b,
+                else => false,
+            };
+        }
+
         /// Collect entities from a view into an ArrayList, closing the view after.
         fn collectEntities(comptime T: type, ecs: anytype, allocator: std.mem.Allocator) !std.ArrayList(Entity) {
             var buf: std.ArrayList(Entity) = .{};
@@ -105,17 +118,30 @@ pub fn Mixin(comptime Game: type) type {
                 // so prefab hierarchies survive save/load — otherwise
                 // every child-with-Position drifts to scene origin
                 // after load (see labelle-core #11).
+                //
+                // Guarded by a registry-type check so a game that does
+                // register a component serialised as `"Parent"` in the
+                // future doesn't produce duplicate JSON keys (mirrors
+                // Position's `has_position_in_registry`).
                 const Parent = Game.ParentComp;
-                if (self.active_world.ecs_backend.getComponent(entity, Parent)) |parent| {
-                    if (!first_comp) try writer.writeAll(",");
-                    try writer.writeAll("\n        \"Parent\": {\"entity\": ");
-                    try std.fmt.format(writer, "{d}", .{entityToU64(parent.entity)});
-                    try writer.writeAll(", \"inherit_rotation\": ");
-                    try writer.writeAll(if (parent.inherit_rotation) "true" else "false");
-                    try writer.writeAll(", \"inherit_scale\": ");
-                    try writer.writeAll(if (parent.inherit_scale) "true" else "false");
-                    try writer.writeAll("}");
-                    first_comp = false;
+                const has_parent_in_registry = comptime blk: {
+                    for (names) |name| {
+                        if (Reg.getType(name) == Parent) break :blk true;
+                    }
+                    break :blk false;
+                };
+                if (!has_parent_in_registry) {
+                    if (self.active_world.ecs_backend.getComponent(entity, Parent)) |parent| {
+                        if (!first_comp) try writer.writeAll(",");
+                        try writer.writeAll("\n        \"Parent\": {\"entity\": ");
+                        try std.fmt.format(writer, "{d}", .{entityToU64(parent.entity)});
+                        try writer.writeAll(", \"inherit_rotation\": ");
+                        try writer.writeAll(if (parent.inherit_rotation) "true" else "false");
+                        try writer.writeAll(", \"inherit_scale\": ");
+                        try writer.writeAll(if (parent.inherit_scale) "true" else "false");
+                        try writer.writeAll("}");
+                        first_comp = false;
+                    }
                 }
 
                 inline for (names) |name| {
@@ -265,29 +291,27 @@ pub fn Mixin(comptime Game: type) type {
                 // Restore Parent (built-in) — counterpart to the Parent
                 // save block above. Uses `setParent` so the engine's
                 // Children back-link is rebuilt alongside.
-                if (components.get("Parent")) |parent_val| {
+                //
+                // Skip the restore unless we can both parse a valid
+                // saved entity ID and map it to a post-load entity —
+                // passing a stale or raw ID to `setParent` would trip
+                // `assertEntityAlive` in debug or corrupt hierarchy
+                // state in release builds (cursor / Copilot review).
+                if (components.get("Parent")) |parent_val| blk: {
                     const parent_obj = parent_val.object;
-                    if (parent_obj.get("entity")) |ent_val| {
-                        const saved_parent_id: u64 = switch (ent_val) {
-                            .integer => |i| @intCast(i),
-                            .float => |f| @intFromFloat(f),
-                            else => 0,
-                        };
-                        const current_parent_id = id_map.get(saved_parent_id) orelse saved_parent_id;
-                        const parent_entity: Entity = @intCast(current_parent_id);
-                        const inherit_rotation = if (parent_obj.get("inherit_rotation")) |v| switch (v) {
-                            .bool => |b| b,
-                            else => false,
-                        } else false;
-                        const inherit_scale = if (parent_obj.get("inherit_scale")) |v| switch (v) {
-                            .bool => |b| b,
-                            else => false,
-                        } else false;
-                        self.setParent(entity, parent_entity, .{
-                            .inherit_rotation = inherit_rotation,
-                            .inherit_scale = inherit_scale,
-                        });
-                    }
+                    const ent_val = parent_obj.get("entity") orelse break :blk;
+                    const saved_parent_id: u64 = switch (ent_val) {
+                        .integer => |i| if (i >= 0) @intCast(i) else break :blk,
+                        else => break :blk,
+                    };
+                    const current_parent_id = id_map.get(saved_parent_id) orelse break :blk;
+                    const parent_entity: Entity = @intCast(current_parent_id);
+                    const inherit_rotation = parentFlag(parent_obj, "inherit_rotation");
+                    const inherit_scale = parentFlag(parent_obj, "inherit_scale");
+                    self.setParent(entity, parent_entity, .{
+                        .inherit_rotation = inherit_rotation,
+                        .inherit_scale = inherit_scale,
+                    });
                 }
             }
 

--- a/test/save_load_mixin_test.zig
+++ b/test/save_load_mixin_test.zig
@@ -304,6 +304,81 @@ test "save/load mixin: transient ref arrays are not saved" {
     try testing.expectEqual(@as(usize, 0), transient_count);
 }
 
+test "save/load mixin: Parent component round-trips and remaps entity ID" {
+    // Guards the fix for labelle-core #11 / flying-platform-labelle #286.
+    // Parent is engine-internal (parameterised over Entity inside
+    // `GameConfig`) so it never appears in the game's ComponentRegistry.
+    // The save mixin therefore needs to emit it as a built-in (like
+    // Position) and rebuild the hierarchy on load via `setParent`.
+    // Without that, every child-with-Position drifts to scene origin
+    // on load because the Parent edge is silently dropped.
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const parent_entity = game.createEntity();
+    game.active_world.ecs_backend.addComponent(parent_entity, Position{ .x = 100.0, .y = 50.0 });
+    game.active_world.ecs_backend.addComponent(parent_entity, Worker{});
+
+    const child_entity = game.createEntity();
+    game.active_world.ecs_backend.addComponent(child_entity, Position{ .x = 15.0, .y = 0.0 });
+    game.active_world.ecs_backend.addComponent(child_entity, Health{ .current = 42.0, .max = 100.0 });
+    game.setParent(child_entity, parent_entity, .{});
+
+    // Sanity: parent link exists pre-save.
+    const Parent = TestGame.ParentComp;
+    try testing.expect(game.active_world.ecs_backend.hasComponent(child_entity, Parent));
+
+    const filename = "test_save_parent.json";
+    try game.saveGameState(filename);
+    defer std.fs.cwd().deleteFile(filename) catch {};
+
+    // Save output should carry a Parent block (built-in, alongside Position).
+    {
+        const json = try std.fs.cwd().readFileAlloc(testing.allocator, filename, 1024 * 1024);
+        defer testing.allocator.free(json);
+        try testing.expect(std.mem.indexOf(u8, json, "\"Parent\"") != null);
+    }
+
+    game.resetEcsBackend();
+    try game.loadGameState(filename);
+
+    // Find the post-load parent (Worker marker) and child (Health + Parent).
+    var new_parent_id: u64 = 0;
+    {
+        var view = game.active_world.ecs_backend.view(.{Worker}, .{});
+        if (view.next()) |ent| new_parent_id = @intCast(ent);
+        view.deinit();
+    }
+    try testing.expect(new_parent_id != 0);
+
+    var child_seen: usize = 0;
+    {
+        var view = game.active_world.ecs_backend.view(.{ Health, Parent }, .{});
+        while (view.next()) |ent| {
+            child_seen += 1;
+            const parent_comp = game.active_world.ecs_backend.getComponent(ent, Parent).?;
+            // Parent.entity must be remapped through the load id_map —
+            // the saved runtime ID wouldn't match after `resetEcsBackend`.
+            try testing.expectEqual(new_parent_id, @as(u64, @intCast(parent_comp.entity)));
+
+            // Child's local Position survives save/load (saveable via
+            // labelle-core), and rendering should now anchor under the
+            // restored parent.
+            const pos = game.active_world.ecs_backend.getComponent(ent, Position).?;
+            try testing.expectApproxEqAbs(@as(f32, 15.0), pos.x, 0.01);
+            try testing.expectApproxEqAbs(@as(f32, 0.0), pos.y, 0.01);
+        }
+        view.deinit();
+    }
+    try testing.expectEqual(@as(usize, 1), child_seen);
+
+    // setParent rebuilds the Children back-link — the parent entity should
+    // now list the child among its children.
+    const Children = TestGame.ChildrenComp;
+    const children_comp = game.active_world.ecs_backend.getComponent(@as(MockEcs.Entity, @intCast(new_parent_id)), Children).?;
+    try testing.expectEqual(@as(usize, 1), children_comp.count());
+}
+
 test "save/load mixin: load nonexistent file returns error" {
     var game = TestGame.init(testing.allocator);
     defer game.deinit();

--- a/test/save_load_mixin_test.zig
+++ b/test/save_load_mixin_test.zig
@@ -379,6 +379,62 @@ test "save/load mixin: Parent component round-trips and remaps entity ID" {
     try testing.expectEqual(@as(usize, 1), children_comp.count());
 }
 
+test "save/load mixin: Parent restore skips when id_map lookup misses" {
+    // Guards the Copilot / cursor review on #470 — if the saved parent
+    // entity isn't in the load id_map (missing from the file, malformed,
+    // or negative integer), the restore path must SKIP the Parent rather
+    // than hand a pre-reset raw ID to `setParent` (which would assert in
+    // debug or corrupt hierarchy state in release).
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    // Hand-craft a save file with a Parent pointing at an entity that
+    // doesn't appear in the "entities" list.
+    const crafted_json =
+        \\{
+        \\  "version": 2,
+        \\  "entities": [
+        \\    {
+        \\      "id": 5,
+        \\      "components": {
+        \\        "Position": {"x": 1, "y": 2},
+        \\        "Health": {"current": 42, "max": 100},
+        \\        "Parent": {"entity": 999, "inherit_rotation": false, "inherit_scale": false}
+        \\      }
+        \\    }
+        \\  ]
+        \\}
+    ;
+    const filename = "test_save_parent_miss.json";
+    {
+        const file = try std.fs.cwd().createFile(filename, .{});
+        defer file.close();
+        try file.writeAll(crafted_json);
+    }
+    defer std.fs.cwd().deleteFile(filename) catch {};
+
+    try game.loadGameState(filename);
+
+    const Parent = TestGame.ParentComp;
+    var orphan_seen: usize = 0;
+    {
+        var view = game.active_world.ecs_backend.view(.{Health}, .{});
+        while (view.next()) |ent| {
+            orphan_seen += 1;
+            // The child entity exists and its non-hierarchy state
+            // restored fine. The Parent entry in the JSON referenced
+            // an entity that was never created — so the restore must
+            // have skipped setParent rather than attaching to a stale
+            // ID.
+            try testing.expect(!game.active_world.ecs_backend.hasComponent(ent, Parent));
+            const pos = game.active_world.ecs_backend.getComponent(ent, Position).?;
+            try testing.expectApproxEqAbs(@as(f32, 1.0), pos.x, 0.01);
+        }
+        view.deinit();
+    }
+    try testing.expectEqual(@as(usize, 1), orphan_seen);
+}
+
 test "save/load mixin: load nonexistent file returns error" {
     var game = TestGame.init(testing.allocator);
     defer game.deinit();


### PR DESCRIPTION
## Summary
The save mixin only writes / reads components that appear in the game's `ComponentRegistry`. `Parent` (i.e. `core.ParentComponent(Entity)`) isn't registered there — it's instantiated inside `GameConfig` and written by `setParent`. So even with [labelle-core 1.11.0](https://github.com/labelle-toolkit/labelle-core/releases/tag/v1.11.0) marking `ParentComponent` `.saveable`, the engine still never emitted Parent to the save file; children of parented prefab nodes (room decor, fridge shelves, canteen tables, hunger-carry items, …) lost their parent on load and their saved local Position rendered as world-space, drifting to scene origin.

Mirror the built-in Position pathway for Parent:
- **Save**: if the entity has a `Parent` component, emit a `"Parent": {\"entity\": ..., \"inherit_rotation\": ..., \"inherit_scale\": ...}` object.
- **Load**: after the registry-driven component restore, if the entity's JSON carries a Parent block, look the `entity` up in the load `id_map` and call `setParent` so the engine's `Children` back-link is rebuilt alongside.

## Why not register Parent in the game's ComponentRegistry?
`ParentComponent(Entity)` is parameterised by the ECS backend's `Entity` type, so the concrete Parent type only exists inside `GameConfig`. The registry is assembler-generated from game-authored files; it can't reach the engine-internal specialisation. Treating Parent as a built-in (like Position) is the right layer for this.

## Surfaces
- [labelle-core #11 / #12](https://github.com/labelle-toolkit/labelle-core/pull/12) – declared Parent saveable + extended `remapEntityRefs` to narrower unsigned-integer Entity types (zig-ecs uses `u32`).
- [flying-platform-labelle #286](https://github.com/Flying-Platform/flying-platform-labelle/issues/286) – the game-side save/load decor work that surfaced all of this.

## Test plan
- [x] `zig build test` — existing suite passes
- [ ] Downstream smoke in flying-platform-labelle on a build that bumps `engine_version` — F5 → F9 keeps the hydroponics / condenser backgrounds / pots / shelves at their centered positions instead of snapping to scene origin.