### PR TITLE
docs(rfc): prefab foundations — save/load + declarative animation

### DIFF
--- a/RFC-PREFAB-ANIMATION.md
+++ b/RFC-PREFAB-ANIMATION.md
@@ -91,10 +91,18 @@ pub const SpriteAnimation = struct {
     // runtime state — excluded from save; re-instantiation from prefab
     // resets to frame 0 which is fine for cycling animations.
     timer: f32 = 0,
-    frame: u8 = 0,
+    frame: u8 = 0,  // max 255 frames per clip; see ceiling note below
     forward: bool = true,  // for ping_pong
 };
 ```
+
+**Frame-count ceiling.** `frame` is `u8`, capping a clip at 255 frames.
+Intentional: this component is the "simple cycle" primitive (pipe
+puffs, smoke, growth overlays — all well under a dozen frames). Rigs
+that need more go through `AnimationDef` / `AnimationState`, which
+carry clip+variant tables and were designed for that scale. The
+`advance` implementation asserts `frames.len <= 255` so misuse traps
+immediately rather than silently wrapping.
 
 **Tick semantics:**
 
@@ -139,7 +147,7 @@ pub const SpriteByFieldSource = enum { self, parent };
 
 pub const SpriteByField = struct {
     pub const save = Saveable(.saveable, @This(), .{
-        .skip = &.{"last_sprite_ptr"},
+        .skip = &.{ "last_key", "last_key_set" },
     });
 
     component: []const u8,    // component name on target entity
@@ -149,9 +157,16 @@ pub const SpriteByField = struct {
     // null sprite_name means "hide" (set Sprite.visible = false).
     entries: []const Entry,
 
-    // runtime state (skipped from save): last sprite_name.ptr written, used
-    // to skip markVisualDirty when nothing changed.
-    last_sprite_ptr: ?[*]const u8 = null,
+    // Runtime cache: last key value we wrote through. Skips the
+    // lookup + Sprite mutation + markVisualDirty when the field
+    // hasn't moved since last tick. Keyed on the i32 value rather
+    // than a raw pointer to the last sprite name — pointer equality
+    // across allocations isn't reliable (two different names could
+    // share the same pointer, or the same name could come from two
+    // arenas), whereas the i32 key is a stable identity for "same
+    // lookup result as before."
+    last_key: i32 = 0,
+    last_key_set: bool = false,
 
     pub const Entry = struct {
         key: i32,  // signed so `-1 = unset` and other sentinel values work
@@ -192,7 +207,7 @@ pub const SpriteByField = struct {
 
 `HydroponicsPlant` reduces to a pure role marker (`.transient` save policy) — it's still useful for scripts that want to find plant entities, but no longer carries the re-hydration burden. The entire `hydroponics_animation.zig` file deletes.
 
-**Component lookup.** `component` is resolved via the game's `ComponentRegistry.getType(name)` (same pattern plugin controllers already use — e.g., `libs/production/src/controller.zig:284` and `libs/command_buffer/src/controller.zig:397`). Missing component at the given source → tick skips silently.
+**Component lookup.** `component` is resolved via the game's `ComponentRegistry.getType(name)` — the same runtime name → comptime type pattern already used by `src/jsonc_scene_bridge.zig` (entity-component deserialisation) and `src/game/save_load_mixin.zig` (saveable component iteration). Both walk `Reg.names()` with `inline for` and match the runtime name against each comptime-known type. Missing component at the given source → tick skips silently.
 
 **Field extraction.** `std.meta.fieldIndex` + `@field` via comptime-generated switch. Values coerce to `i32`: signed + unsigned integers direct (widening / bounds-checked), enums via `@intFromEnum`. Unsupported field types fail at `spawnFromPrefab` time with a clear error.
 

--- a/RFC-PREFAB-ANIMATION.md
+++ b/RFC-PREFAB-ANIMATION.md
@@ -98,7 +98,7 @@ pub const SpriteAnimation = struct {
 
 **Tick semantics:**
 
-- `.loop` — `frame = @intFromFloat(@mod(timer * fps, frames.len))`. Classic cycle.
+- `.loop` — `frame = @intFromFloat(@mod(timer * fps, @as(f32, @floatFromInt(frames.len))))`. Classic cycle. (Both `@mod` operands must be the same type; `frames.len` is `usize` and needs the explicit float cast.)
 - `.once` — plays through `frames` once; stays on the last frame after. Game can remove the component to replay.
 - `.ping_pong` — plays forward to `frames.len - 1`, then backward to 0, flipping `forward` each end.
 
@@ -154,7 +154,7 @@ pub const SpriteByField = struct {
     last_sprite_ptr: ?[*]const u8 = null,
 
     pub const Entry = struct {
-        key: u32,
+        key: i32,  // signed so `-1 = unset` and other sentinel values work
         sprite_name: ?[]const u8,
     };
 };
@@ -194,7 +194,7 @@ pub const SpriteByField = struct {
 
 **Component lookup.** `component` is resolved via the game's `ComponentRegistry.getType(name)` (same pattern plugin controllers already use — e.g., `libs/production/src/controller.zig:284` and `libs/command_buffer/src/controller.zig:397`). Missing component at the given source → tick skips silently.
 
-**Field extraction.** `std.meta.fieldIndex` + `@field` via comptime-generated switch. Values coerce to `u32`: integers direct, enums via `@intFromEnum`. Unsupported field types fail at `spawnFromPrefab` time with a clear error.
+**Field extraction.** `std.meta.fieldIndex` + `@field` via comptime-generated switch. Values coerce to `i32`: signed + unsigned integers direct (widening / bounds-checked), enums via `@intFromEnum`. Unsupported field types fail at `spawnFromPrefab` time with a clear error.
 
 ## Gating
 

--- a/RFC-PREFAB-ANIMATION.md
+++ b/RFC-PREFAB-ANIMATION.md
@@ -1,0 +1,270 @@
+# RFC: Prefab-Driven Sprite Animation
+
+**Status:** Draft
+**Author:** Alexandre
+**Date:** 2026-04-23
+
+## Problem
+
+Every simple sprite animation in flying-platform-labelle is hand-rolled as its own tick script. They all do the same handful of things — cycle a frame array at a fixed rate, swap a sprite based on a component field, hide the sprite between states — but each gets a bespoke implementation, its own state struct, and its own post-load recovery path.
+
+Concrete headcount in the game today:
+
+- **`scripts/condenser_animation.zig`** — 6-frame pipe cycle + 2-frame shake cycle, gated on a worker processing the workstation. ~250 lines including state management + `needsReinit` dance.
+- **`scripts/kitchen_animation.zig`** — 7-frame smoke + 5-frame sink, same shape as condenser. Another ~250 lines, near-copy.
+- **`scripts/hydroponics_animation.zig`** — not really animation: picks one of 4 sprites based on `TendableWorkstation.level`, hides below level 2. Plus a Sprite re-add block for save/load recovery. ~140 lines.
+- **Condenser/kitchen `initOverlays`** — runtime `createEntity + setParent + addSprite` per workstation, complete with cached-state management that's broken in subtle ways after save/load (we spent six iterations of flying-platform-labelle #286 hardening `needsReinit`).
+
+None of these does anything interesting per-file. They're all the same three shapes:
+
+1. **Frame cycle** — walk an array of sprite names at N fps, optionally gated by a predicate.
+2. **Field-driven selection** — read a field on another component (TendableWorkstation.level, Worker.job_state, …) and pick a sprite from a map.
+3. **Visibility toggle** — hide the sprite outside certain states (hydroponics plant at level 0/1).
+
+The engine has a sophisticated animation system (`animation_def.zig` → `AnimationDef(zon)`) tuned for characters: multiple clips × multiple variants × many frames, precomputed sprite tables, enum-typed clip/variant. It's great for workers (`walk` / `idle` / `carry` × `m_bald` / `w_brown` / …). It's overkill for "cycle 6 pipe frames." The gap between "one-clip frame cycle" and `AnimationDef` is where every hand-rolled animation script lives.
+
+## Proposal
+
+Add two engine-side components that drive sprite mutation declaratively:
+
+- **`SpriteAnimation`** — cycles `Sprite.sprite_name` through a frame array at a fixed rate.
+- **`SpriteByField`** — picks `Sprite.sprite_name` from a map keyed by the runtime value of a named field on another component on the same entity (or its parent).
+
+Games declare them in prefabs like any other component. The engine runs one tick system per component type and mutates `Sprite` as needed. Entities without either component don't pay any cost.
+
+Combined with the save/load-for-prefabs RFC, runtime overlays live in prefabs, save/load just re-instantiates them, and the hand-rolled animation scripts delete.
+
+## Goals
+
+1. **Declarative animations authored in prefabs** — no script per animation.
+2. **Composable** — attach/detach at runtime like any other ECS component; multiple animation components on one entity coexist without interference.
+3. **Zero allocation at tick time.** Frame arrays are comptime or loaded once; tick just advances an integer.
+4. **Consistent with existing engine.** `AnimationState` stays for character-style animation; these components cover the simple case that was previously hand-rolled.
+5. **Clean save/load story.** In-flight `timer` / `frame` skipped from save via `Saveable.skip`. Re-instantiation from a prefab re-adds the component; the animation starts at frame 0. (Acceptable — the one-frame visual glitch is invisible at 60fps, and a shipping game cares more about the save being small and deterministic than exact animation continuity across F9.)
+
+## Non-goals
+
+- **Characters.** `AnimationDef` + `AnimationState` stay for clip/variant character animation. This RFC is for everything else.
+- **Tweening / easing.** Not a frame animator; no interpolation between keyframes, no bezier curves. If you need tweening, the component is the wrong tool — write a script.
+- **Audio sync.** Frame-to-sound triggering is its own concern; out of scope here.
+- **Animation graphs / state machines.** No transitions, no blend. If the animation needs states, attach and detach components from a script.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  Prefab (jsonc) or runtime attach                                │
+│    Sprite + SpriteAnimation { frames, fps, mode }                │
+│    Sprite + SpriteByField { component, field, map }              │
+└──────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  Engine tick (once per component type)                           │
+│    For SpriteAnimation:                                          │
+│      view(.{ SpriteAnimation, Sprite }, .{})                     │
+│        advance timer; on frame flip, write Sprite.sprite_name    │
+│        + source_rect + texture; markVisualDirty                  │
+│    For SpriteByField:                                            │
+│      view(.{ SpriteByField, Sprite }, .{})                       │
+│        read field value on target component; look up in map;     │
+│        on change, write Sprite fields; markVisualDirty           │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+Both live in labelle-engine (or labelle-gfx — see open questions). No changes to `Sprite` itself.
+
+## `SpriteAnimation`
+
+```zig
+pub const AnimationMode = enum { loop, once, ping_pong };
+
+pub const SpriteAnimation = struct {
+    pub const save = Saveable(.saveable, @This(), .{
+        .skip = &.{ "timer", "frame", "forward" },
+    });
+
+    frames: []const []const u8,
+    fps: f32,
+    mode: AnimationMode = .loop,
+
+    // runtime state — excluded from save; re-instantiation from prefab
+    // resets to frame 0 which is fine for cycling animations.
+    timer: f32 = 0,
+    frame: u8 = 0,
+    forward: bool = true,  // for ping_pong
+};
+```
+
+**Tick semantics:**
+
+- `.loop` — `frame = @intFromFloat(@mod(timer * fps, frames.len))`. Classic cycle.
+- `.once` — plays through `frames` once; stays on the last frame after. Game can remove the component to replay.
+- `.ping_pong` — plays forward to `frames.len - 1`, then backward to 0, flipping `forward` each end.
+
+**Frame flip triggers** `markVisualDirty(entity)`. Idle entities (same frame as last tick) write nothing.
+
+**Example prefab** — condenser pipe overlay:
+
+```jsonc
+{
+    "components": {
+        "Position": { "x": -30, "y": -47 },
+        "Sprite": {
+            "sprite_name": "condenser/condenser_pipe/condenser_pipe_0001.png",
+            "pivot": "bottom_left",
+            "layer": "world",
+            "z_index": -4
+        },
+        "SpriteAnimation": {
+            "frames": [
+                "condenser/condenser_pipe/condenser_pipe_0001.png",
+                "condenser/condenser_pipe/condenser_pipe_0002.png",
+                "condenser/condenser_pipe/condenser_pipe_0003.png",
+                "condenser/condenser_pipe/condenser_pipe_0004.png",
+                "condenser/condenser_pipe/condenser_pipe_0005.png",
+                "condenser/condenser_pipe/condenser_pipe_0006.png"
+            ],
+            "fps": 6,
+            "mode": "loop"
+        }
+    }
+}
+```
+
+## `SpriteByField`
+
+```zig
+pub const SpriteByFieldSource = enum { self, parent };
+
+pub const SpriteByField = struct {
+    pub const save = Saveable(.saveable, @This(), .{
+        .skip = &.{"last_sprite_ptr"},
+    });
+
+    component: []const u8,    // component name on target entity
+    field: []const u8,        // field name on that component, integer or enum
+    source: SpriteByFieldSource = .self,
+    // Parallel arrays: entries[i].key matches field value => entries[i].sprite_name.
+    // null sprite_name means "hide" (set Sprite.visible = false).
+    entries: []const Entry,
+
+    // runtime state (skipped from save): last sprite_name.ptr written, used
+    // to skip markVisualDirty when nothing changed.
+    last_sprite_ptr: ?[*]const u8 = null,
+
+    pub const Entry = struct {
+        key: u32,
+        sprite_name: ?[]const u8,
+    };
+};
+```
+
+**Example** — hydroponics plant overlay (currently `hydroponics_animation.zig`, ~140 lines → 0 lines):
+
+```jsonc
+{
+    "components": {
+        "Position": { "x": 0, "y": -41 },
+        "Sprite": {
+            "sprite_name": "nursery/nursery_sapling/nursery_sapling_room1_lvl1.png",
+            "pivot": "bottom_center",
+            "layer": "world",
+            "z_index": -3
+        },
+        "SpriteByField": {
+            "component": "TendableWorkstation",
+            "field": "level",
+            "source": "parent",
+            "entries": [
+                { "key": 0, "sprite_name": null },
+                { "key": 1, "sprite_name": null },
+                { "key": 2, "sprite_name": "nursery/nursery_sapling/nursery_sapling_room1_lvl1.png" },
+                { "key": 3, "sprite_name": "nursery/nursery_sapling/nursery_sapling_room1_lvl2.png" },
+                { "key": 4, "sprite_name": "nursery/nursery_green/nursery_green_room1_lvl1.png" },
+                { "key": 5, "sprite_name": "nursery/nursery_green/nursery_green_room1_lvl2.png" }
+            ]
+        },
+        "HydroponicsPlant": {}
+    }
+}
+```
+
+`HydroponicsPlant` reduces to a pure role marker (`.transient` save policy) — it's still useful for scripts that want to find plant entities, but no longer carries the re-hydration burden. The entire `hydroponics_animation.zig` file deletes.
+
+**Component lookup.** `component` is resolved via the game's `ComponentRegistry.getType(name)` (same pattern plugin controllers already use — e.g., `libs/production/src/controller.zig:284` and `libs/command_buffer/src/controller.zig:397`). Missing component at the given source → tick skips silently.
+
+**Field extraction.** `std.meta.fieldIndex` + `@field` via comptime-generated switch. Values coerce to `u32`: integers direct, enums via `@intFromEnum`. Unsupported field types fail at `spawnFromPrefab` time with a clear error.
+
+## Gating
+
+Some animations should only run in certain states. Condenser pipe + shake only cycle while a worker is processing the workstation.
+
+Two options considered:
+
+**(a) Gate field on `SpriteAnimation`** — `gate_component: ?string`, engine skips ticks when the named component is absent. Simple, but bakes a game-logic predicate into engine component schema. Only handles presence/absence — not field values.
+
+**(b) Runtime add/remove** — game controls presence of `SpriteAnimation` itself. Script adds the component when the condition becomes true, removes it when false.
+
+Leaning **(b)** — strictly more flexible, engine stays ignorant of game-side predicates, and it fits the ECS model where presence *is* the state. The condenser animation becomes a ~20-line script that watches worker processing state and adds/removes `SpriteAnimation` — infinitely simpler than the current implementation, and safe across save/load because the script tick will re-attach on the first frame after F9.
+
+If experience shows that (b) is too verbose for common gating patterns (worker-processing, locked, powered-on), a narrow `SpriteAnimationGated { gate_component }` companion can add later.
+
+## Migration examples
+
+### `condenser_animation.zig` → prefab + ~20 line controller
+
+**Today:** ~250 lines across the script (`initOverlays`, `needsReinit`, tick with per-workstation pipe/shake frame computation, ID caching, save/load reinit dance, `isPipeFrame` / `isShakeFrame` sprite frame validators).
+
+**After:**
+- `prefabs/condenser_pipe_overlay.jsonc` + `prefabs/condenser_shake_overlay.jsonc`, each with `Sprite` + `SpriteAnimation`.
+- `scripts/condenser_controller.zig` — watches worker processing per condenser; on transition to processing, `addComponent(pipe_entity, SpriteAnimation{…})`; on transition off, `removeComponent(pipe_entity, SpriteAnimation)`. ~20 lines.
+- Scene-init spawns pipe + shake overlays once per condenser (via `spawnFromPrefab` from the save/load-prefabs RFC). Save/load Phase 1 re-spawns them.
+
+### `kitchen_animation.zig` — same shape, same delta.
+
+### `hydroponics_animation.zig` → deleted
+
+`SpriteByField` on the plant overlay does the whole job. The plant prefab re-instantiates via the save/load-prefabs RFC; `SpriteByField` runs every tick; level changes update the sprite. `HydroponicsPlant` marker becomes `.transient`.
+
+## Open questions
+
+1. **labelle-engine vs labelle-gfx location.** Both components manipulate `Sprite`, which is gfx-owned. But the tick system is per-frame logic — engine territory. Lean: components live in labelle-gfx (same module as `SpriteComponent`), tick system lives in engine. Same split as today for `AnimationState`.
+
+2. **Atlas lookup on frame swap.** Frame flip overwrites `sprite_name`, `source_rect`, `texture`. `source_rect` + `texture` need an atlas lookup (`game.findSprite(name)`). Cache the resolved values at `spawnFromPrefab` time to avoid re-lookup each frame? Or resolve on every flip? Probably cache — frame arrays are known at spawn time.
+
+3. **Deterministic tick ordering.** If a script mutates `SpriteByField.entries` at runtime (seems unlikely but possible), and the animation tick runs in the same frame, does the script see the before or after? Convention across the existing engine: animation ticks after gameplay scripts, before render. Document explicitly.
+
+4. **Ping-pong edge cases.** Single-frame array + `.ping_pong` = infinite loop on frame 0; validate at spawn time.
+
+5. **Sprite lifetime.** If the underlying sprite name refers to a sprite that isn't in the atlas (typo, stale reference), `findSprite` returns null. Log a warning once per entity, not per tick.
+
+## Phased rollout
+
+- **Phase A — `SpriteAnimation`.** Component + tick system + integration test (loop, once, ping_pong). Migrate condenser overlays as the pilot. Delete `condenser_animation.zig::initOverlays` / `needsReinit` / frame math (still requires the save/load-prefabs RFC for the spawn path).
+- **Phase B — `SpriteByField`.** Component + tick system + integration test. Migrate hydroponics plant overlay. Delete `hydroponics_animation.zig`.
+- **Phase C — Kitchen.** Migrate `kitchen_animation.zig` overlays. Delete the script.
+- **Phase D — Cleanup.** Remove the `isPipeFrame` / `isShakeFrame` sprite validators and `needsReinit` functions from all animation scripts. The RoomDecor-shaped re-hydration story goes away entirely (save/load RFC does the heavy lifting; animation RFC picks up the per-tick mutation).
+
+Each phase is independently shippable and testable.
+
+## Prior art
+
+- **Godot `AnimatedSprite2D`** — a node with a `SpriteFrames` resource that lists animations; the engine plays them by name. Closest match — the component split here is the ECS-idiomatic translation.
+- **Unity `SpriteRenderer` + `Animator`** — `Animator` is a state-machine graph, overkill for the use case. Unity's simpler `SpriteAnimation` (deprecated) did what `SpriteAnimation` here does.
+- **Bevy `TextureAtlasSprite` + `AnimationPlugin` crates** — community plugins tend to implement exactly `SpriteAnimation { frames, fps }` as their first primitive. Converges on the same shape.
+
+## Relationship to other work
+
+- **Depends on** the save/load-for-prefabs RFC for Phase 1 (without prefab re-instantiation, migrated overlays can't survive F9).
+- **Enables deletion of** `condenser_animation.zig`, `kitchen_animation.zig`, `hydroponics_animation.zig`, and the `initOverlays` / `needsReinit` patterns in each. Net: ~600 lines of game code deleted, replaced by two engine components + one engine tick system.
+- **Complements** `AnimationDef` / `AnimationState` — character animation stays as-is; this is for the much simpler single-clip case.
+
+## Acceptance criteria
+
+1. Integration test: entity with `Sprite` + `SpriteAnimation { mode: .loop, frames: [a, b, c], fps: 3 }`; advance 1 second; assert frame cycled to expected index and `sprite_name`/`source_rect` updated.
+2. Integration test: `.once` mode holds on the last frame after the cycle completes.
+3. Integration test: `.ping_pong` reverses at the endpoints.
+4. Integration test: entity with `Sprite` + `SpriteByField { component: "Foo", field: "bar" }`; mutate `Foo.bar` to each key; assert `sprite_name` updates to the mapped value; assert `null` sprite_name sets `Sprite.visible = false`.
+5. Integration test: `source: "parent"` reads the field from the parent entity, not self.
+6. Downstream smoke in flying-platform-labelle: pilot condenser overlay migration, `labelle run --timeout=20s`, save + load, verify pipe + shake animate correctly post-load.

--- a/RFC-SAVE-LOAD-PREFABS.md
+++ b/RFC-SAVE-LOAD-PREFABS.md
@@ -1,0 +1,253 @@
+# RFC: Save/Load for Prefabs
+
+**Status:** Draft
+**Author:** Alexandre
+**Date:** 2026-04-23
+
+## Problem
+
+Today the engine's save mixin serialises **registered components**. Everything else — non-saveable render components, runtime-created overlays, prefab-defined children whose components aren't all saveable — is gone after `loadGameState`. Games are left to hand-roll re-hydration scripts, one per kind of "thing that disappeared," and the scripts are all slight variations of the same two patterns:
+
+**Pattern A (marker + re-add render component):**
+```zig
+// scripts/save_load.zig::restoreSprites, and hydroponics_animation.zig,
+// and every future room's decor script…
+var view = game.active_world.ecs_backend.view(.{RoomDecor}, .{Sprite});
+while (view.next()) |entity| {
+    const decor = game.active_world.ecs_backend.getComponent(entity, RoomDecor).?;
+    const desc = decorSprite(decor.kind);
+    addSprite(game, entity, desc.name, .bottom_left, .world, desc.z);
+}
+```
+
+**Pattern B (runtime overlay reinit):**
+```zig
+// condenser_animation.zig — overlays created at runtime, not in any prefab.
+// needsReinit has to detect "my cached entity IDs are stale after load" by
+// probing for specific component shapes + sprite frame names. Easy to get
+// wrong; we just spent five rounds hardening it.
+if (needsReinit(game, state)) {
+    for (0..state.count) |idx| {
+        if (game.active_world.ecs_backend.entityExists(state.pipe_entities[idx])) {
+            game.destroyEntity(state.pipe_entities[idx]);
+        }
+        if (game.active_world.ecs_backend.entityExists(state.shake_entities[idx])) {
+            game.destroyEntity(state.shake_entities[idx]);
+        }
+    }
+    initOverlays(game, state);
+}
+```
+
+Recent history shows the cost:
+
+- flying-platform-labelle **#286** — PRs #283 / #285 moved each room's background onto a `Position`-offset child. `restoreSprites` only touched `Room` entities, so the decor children rendered blank after F9. Fix: new `RoomDecor` marker + switch-table re-add + prefab tags across 4 prefabs. 9 kinds now, more coming.
+- labelle-engine **#467** — nested scene entities didn't fire `postLoad`, silently breaking `Workstation.postLoad`'s slot-table rebuild.
+- labelle-engine **#470** — `Parent` wasn't persisted. Children of parented prefab nodes lost their parent and rendered at raw local position, drifting to scene origin.
+- flying-platform-labelle **#286 (continued)** — even with Parent persistence, `condenser_animation.zig`'s overlay reinit had a latent ID-reuse bug: `entityExists` on a stale workstation ID returned true because zig-ecs reassigns low IDs on `resetEcsBackend`. Needed three rounds of narrowing `needsReinit`.
+
+Every one of these was the game paying for something the engine should have done: **remember what was there and put it back**.
+
+## Proposal
+
+Add **prefab-aware** save/load. On save, record each entity's **prefab source** (path + instance overrides). On load, **two-phase restore**:
+
+1. **Phase 1 — Structure.** Re-instantiate every prefab-sourced entity from its recorded prefab. All children, all components (including non-saveable ones like `Sprite`), come back for free.
+2. **Phase 2 — State.** Apply the saved component data on top. Runtime-mutated fields (worker FSM, storage contents, needs decay, etc.) restore normally.
+
+Entities not sourced from a prefab (raw `createEntity` + `addComponent`) continue to use the current flat save/load path unchanged.
+
+Once adopted, the re-hydration scripts above **delete**:
+
+- `components/room_decor.zig` — not needed; prefabs define `Sprite` on the decor child and instantiation puts it back.
+- `scripts/save_load.zig::restoreSprites` — Rooms / Ships / Items / Workers all instantiate from prefabs that carry their own `Sprite`.
+- `condenser_animation.zig::needsReinit` / `initOverlays` — if overlays live in a prefab (or an auto-spawned prefab hook), they come back with the workstation.
+- `hydroponics_animation.zig`'s Sprite re-add block — `HydroponicsPlant` doesn't need to be saveable.
+- `worker_animation.zig`'s Sprite re-add block.
+- Same story for the kitchen animation and every future animation overlay.
+
+## Goals
+
+1. **Zero game-side re-hydration for prefab-authored structure.** If the prefab puts it there, the engine puts it back.
+2. **Preserve runtime state.** Saved component values still apply on top of re-instantiation. Worker job states, storage contents, needs values, pathfinder caches — unchanged.
+3. **Gradual adoption.** Games can opt in per-prefab. The flat save format stays valid; the new format is an additive entity schema.
+4. **Handles prefab overrides.** Scene-level and runtime overrides to prefab-sourced entities (e.g., a specific `Position` set via `game.setPosition` post-spawn) round-trip.
+5. **Handles entity-ref remapping.** Prefab re-instantiation mints new IDs. Saved `entity_refs` / `ref_arrays` remap through the load `id_map`, same as today.
+
+## Non-goals
+
+- **Prefab hot reload.** If the prefab file changes between save and load, the loaded world reflects the *new* prefab — with saved overrides replayed where fields still exist. Defining a semver + migration story for prefabs is out of scope here.
+- **Prefab diffing at save time.** Every prefab-sourced entity records *some* overrides even if none; we don't diff against the prefab to minimise bytes. Saves get bigger by a small amount; the complexity of exact diffing isn't worth it for v1.
+- **Non-prefab entity tracking.** Entities created with `createEntity` and no prefab continue to save/load as today. They don't get Phase 1; they get the current flat component-list path. This keeps the RFC small.
+- **Partial prefab instantiation.** If a prefab was modified at runtime to remove a child, we still re-instantiate the full prefab on load, then the Phase 2 pass would need to destroy the removed child. Actually we handle this — see Open Questions.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  spawnFromPrefab(path, overrides) → entity                       │
+│    resolves prefab, instantiates components + children,          │
+│    tags the root with PrefabInstance { path, overrides_blob }    │
+│    tags each child with PrefabChild { root, local_path }         │
+└──────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+   Entity now has:  PrefabInstance (saveable)  +  all component data
+   Children have:   PrefabChild (saveable)     +  all component data
+
+┌──────────────────────────────────────────────────────────────────┐
+│  saveGameState                                                   │
+│    For each entity:                                              │
+│      if PrefabInstance: emit {"prefab": path, "overrides": {…},  │
+│                                "components": {…}}                │
+│      else if PrefabChild: emit {"prefab_child": {root, path},    │
+│                                 "components": {…}}               │
+│      else:              emit {"components": {…}}  (as today)     │
+└──────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  loadGameState (two phases)                                      │
+│    Phase 1 — Structure:                                          │
+│      For each {"prefab": path} record:                           │
+│        new_root = spawnFromPrefab(path, saved_overrides)         │
+│        id_map[old_id] = new_root                                 │
+│        For each child emitted by spawn, record id_map mapping    │
+│          via matching "prefab_child" records (by local_path).    │
+│    Phase 2 — State:                                              │
+│      For every entity in save (prefab-sourced or not):           │
+│        apply "components" data, remap entity refs, fire postLoad │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### New built-in components
+
+- `PrefabInstance { path: []const u8, overrides: []const u8 }` — marker on prefab-root entities. `overrides` is an opaque JSON blob (the engine produces it at spawn time and replays it on load).
+- `PrefabChild { root: u64, local_path: []const u8 }` — marker on each child entity created by the prefab. `local_path` is the dotted path within the prefab (e.g., `"children[0]"`, `"children[2].children[0]"`). Survives save/load so Phase 1 can map old child IDs to newly-spawned child IDs.
+
+Both are engine built-ins, not registered by the game. Same treatment as `Position` and (after #470) `Parent`.
+
+### Spawn API change
+
+Today games typically use scene jsonc → engine parses → creates entities. The jsonc path **already** knows each entity's source prefab when one is declared. Adding `PrefabInstance` / `PrefabChild` tagging happens in `src/jsonc_scene_bridge.zig::spawnAndLinkNestedEntities` and friends.
+
+For games that spawn prefabs programmatically (runtime overlays), the engine exposes:
+```zig
+pub fn spawnFromPrefab(self: *Game, path: []const u8, overrides: anytype) !Entity
+```
+
+`overrides` is a comptime-known struct whose fields are component instances; the engine serialises them into the `overrides` blob and applies them at spawn time. `condenser_animation.zig` migrates to this, replacing the `createEntity + setParent + setPosition + addSprite` sequence with a single `spawnFromPrefab("condenser_pipe_overlay", .{ .Position = .{…} })`.
+
+### Skipping runtime-mutated fields
+
+Two existing layers already cover this and the RFC doesn't need a third:
+
+- `Saveable(.saveable, @This(), .{ .skip = &.{"field"} })` — declared by the **component author**, applies to every instance everywhere. Use this for fields that should never be persisted (e.g., `Workstation.eis_slots`, rebuilt in `postLoad`).
+- The sibling RFC on **prefab-driven animation** (`@animate`, see `RFC-PREFAB-ANIMATION.md` — pending) — a prefab-author annotation that delegates field mutation to the engine *and* implicitly tells the save layer that those fields are engine-owned, so they stay out of the overrides blob.
+
+An earlier revision of this RFC proposed a third attribute (`@no_override`) for per-prefab field skipping. We dropped it: all the real examples turned out to be either (a) already-covered by `Saveable.skip`, or (b) animation-driven and therefore covered by the animation RFC's `@animate`. If a case appears that neither layer fits, we'll add `@no_override` then — with a concrete use case driving the design instead of a speculative one.
+
+### Save file format v3
+
+Additive over v2. The `entities` array grows three new per-entity shapes:
+
+```jsonc
+{ "version": 3, "entities": [
+  // v2-compatible (for non-prefab entities)
+  { "id": 42, "components": { "Position": {…}, "Worker": {…} } },
+
+  // Prefab root
+  { "id": 50,
+    "prefab": "hydroponics",
+    "overrides": "{\"components\":{\"Position\":{\"x\":156,\"y\":0}}}",
+    "components": { "Room": {…}, … }
+  },
+
+  // Prefab child
+  { "id": 51,
+    "prefab_child": { "root": 50, "local_path": "children[0]" },
+    "components": { "Position": {…}, "RoomDecor": {…} }
+  }
+] }
+```
+
+`version: 2` saves load unchanged (every entity hits the v2 path, nothing is spawned from a prefab). `version: 3` saves can still carry v2-shaped entities for anything `createEntity`-sourced.
+
+### Order of operations on load
+
+1. `resetEcsBackend` — same as today.
+2. **Phase 1:** scan saved entities for `prefab` records. For each, `spawnFromPrefab(path, overrides)`. Build `id_map`:
+   - `id_map[saved_root_id] = new_root_id`.
+   - For every entity the spawn created (children, grandchildren), match by `(root, local_path)` against the saved `prefab_child` records and map them too.
+3. **Phase 2 (existing path, slightly adapted):** for each saved entity, look up its new entity via `id_map` (creating one fresh if it's a v2-shape non-prefab entity), apply `components` data on top, remap entity refs.
+4. `postLoad` fires as today (engine #467 already covers nested entities).
+
+### Handling child deletions
+
+If the game destroyed a prefab-spawned child at runtime, save-time won't emit a `prefab_child` record for it. Phase 1 still re-instantiates the full prefab. Phase 2 sweeps: any child created in Phase 1 whose `(root, local_path)` didn't appear in the save is **destroyed** before Phase 2 applies component data. Clean.
+
+## Migration of existing pain points
+
+Each of these becomes a deletion in its own PR once the infra lands.
+
+### RoomDecor (flying-platform-labelle #286)
+- **Today:** `components/room_decor.zig` + tag in 4 prefab jsonc files + switch table in `save_load.zig`.
+- **After:** Delete the component, delete the switch table, delete the `RoomDecor` tags. Prefabs already declare `Sprite` on the decor children — instantiation puts them back.
+
+### HydroponicsPlant
+- **Today:** `.saveable` marker + plant animation script has a "walk markers missing Sprite, re-add" block.
+- **After:** Delete the `.saveable` policy; mark as `.transient`. The plant overlay child prefab re-instantiates with its Sprite at Phase 1; the next tick sets the correct level-driven sprite. The sprite-swap-per-level goes away once the prefab animation RFC lands (declarative `@sprite_by_field` or similar); until then it stays as a short tick-driven script.
+
+### condenser_animation / kitchen_animation overlays
+- **Today:** Runtime `createEntity + setParent + addSprite` in `initOverlays`; `needsReinit` dance to detect stale state after save/load.
+- **After:** Move overlay creation into a `condenser_overlay.jsonc` prefab. At scene-init the animation script calls `spawnFromPrefab("condenser_overlay", .{…})` per workstation. On save/load Phase 1 brings them back. `needsReinit` deletes. Once the prefab animation RFC lands, the frame-cycling goes away too — the prefab declares `@animate` and the engine drives it.
+
+### restoreSprites in `save_load.zig`
+- **Today:** 80 lines walking Rooms, Ships, Items, Workers, decor, and filling in sprites.
+- **After:** Gone. Every one of those entities is prefab-sourced; Phase 1 restores their Sprites.
+
+## Open questions
+
+1. **Overrides schema.** Storing the `overrides` blob as an opaque JSON string is simplest, but it leaks inside the save file and bloats it. Alternative: track overrides as a structured `componentDiff` keyed by component name, emitted via the same serde the rest of the save uses. Leaning structured — easier to diff, easier to inspect, easier to extend when a future attribute (animation, etc.) needs to filter specific fields.
+
+2. **Prefab evolution.** If a prefab grew a new component between save and load, the loaded entity gets it (good). If the prefab dropped a component, the saved data for that component is silently discarded in Phase 2 (acceptable — warn in debug). If a component's field changed type, Phase 2's serde fails as it does today.
+
+3. **Non-prefab runtime children.** Any entity created at runtime with `createEntity + setParent` without going through `spawnFromPrefab` is a v2 entity. It saves/loads flat — so its non-saveable render components are still lost. For now games opt in by migrating to `spawnFromPrefab`. A future extension: let games register a **rehydrator hook** on a marker component that the engine calls during Phase 1.
+
+4. **Transient vs saveable on the PrefabChild marker.** `PrefabChild` needs to survive save/load (so Phase 1 can map old IDs to new IDs). But once a prefab-child's mapping is applied, the `local_path` string never gets looked at again at runtime. Fine to keep it saveable; it's ~30 bytes per child. The question is whether we also need to store it in memory at runtime (yes — to re-emit it on a subsequent save).
+
+5. **Cycles in prefab references.** Out of scope v1. Prefab A containing prefab B containing prefab A would recurse infinitely; the loader rejects cycles at jsonc-parse time, same rule applies at spawn.
+
+6. **Ordering of Phase 1.** A prefab-root entity whose `overrides` reference other entities via `@ref` needs those others spawned first. Sort by topological order (no-refs first). If there's a cycle in inter-entity refs, load fails with an explicit error rather than silent corruption.
+
+## Phased rollout
+
+- **Phase A — infrastructure.** `PrefabInstance`, `PrefabChild`, `spawnFromPrefab`, save format v3, two-phase load. Lands in a single labelle-engine PR with integration tests and doc updates. v2 saves continue to load through the v2 path; v3 saves carry both shapes.
+- **Phase B — jsonc bridge.** `src/jsonc_scene_bridge.zig` tags prefab-spawned entities automatically. No game changes needed; games immediately see smaller save files and cleaner loads because every scene-jsonc-sourced entity now goes through Phase 1.
+- **Phase C — flying-platform-labelle pilot.** Delete `RoomDecor`, delete most of `restoreSprites`, migrate `HydroponicsPlant` to `.transient`. Smoke on F5 → F9. Close out #286.
+- **Phase D — animation overlays.** Move `condenser_overlay` / `kitchen_overlay` creation into prefabs + `spawnFromPrefab` calls. Delete `needsReinit` / `initOverlays` reinit dances.
+- **Phase E — rehydrator hooks for runtime children.** Optional escape hatch for games that genuinely need runtime-created children outside the prefab system.
+
+Each phase is independently shippable and independently testable.
+
+## Prior art
+
+- **Unity Prefabs** — scene files record each GameObject's prefab source + property overrides; on play, the editor instantiates the prefab and overlays the overrides.
+- **Unreal Engine Actor spawning** — `Actor` instances in a Level record the archetype (the `UClass`) and per-instance property deltas. Save slots round-trip these deltas, not full Actor state.
+- **Godot Scene instancing** — scenes reference child scenes by path; instance-specific overrides live on the parent scene. Same two-phase concept as proposed here.
+
+All three engines converged on "record the source + overrides, instantiate + apply" as the simplest durable shape. This RFC applies the same pattern to labelle.
+
+## Relationship to recent work
+
+- **Built on** engine #467 (postLoad on nested entities) — Phase 2 needs nested postLoad to fire.
+- **Built on** engine #470 (Parent persistence) — prefab-sourced children need their Parent remapped to the new root ID; Parent carrying through the save is a prerequisite.
+- **Enables deletion of** flying-platform-labelle #286's game-side work (`RoomDecor`), `HydroponicsPlant.saveable`, and most of `restoreSprites`.
+- **Enables deletion of** the `needsReinit` hardening we've been iterating on in `condenser_animation.zig` / `kitchen_animation.zig`.
+
+## Acceptance criteria for Phase A
+
+1. Integration test: save a world with a prefab-sourced entity + children, `resetEcsBackend`, load, assert all children exist with their prefab-authored components (including a non-saveable render-like component) and Phase 2 overrides applied.
+2. Integration test: destroy a prefab-spawned child at runtime, save, load, assert that child is NOT present after load.
+3. Integration test: v2 save file loads unchanged through the v2 path (no Phase 1 entered).
+4. `labelle run --scene=save_load_prefab_smoke --timeout=10s` on a downstream game confirms visual round-trip without any game-side re-hydration.

--- a/RFC-SAVE-LOAD-PREFABS.md
+++ b/RFC-SAVE-LOAD-PREFABS.md
@@ -123,7 +123,7 @@ Once adopted, the re-hydration scripts above **delete**:
 ### New built-in components
 
 - `PrefabInstance { path: []const u8, overrides: []const u8 }` — marker on prefab-root entities. `overrides` is an opaque JSON blob (the engine produces it at spawn time and replays it on load).
-- `PrefabChild { root: u64, local_path: []const u8 }` — marker on each child entity created by the prefab. `local_path` is the dotted path within the prefab (e.g., `"children[0]"`, `"children[2].children[0]"`). Survives save/load so Phase 1 can map old child IDs to newly-spawned child IDs.
+- `PrefabChild { root: Entity, local_path: []const u8 }` — marker on each child entity created by the prefab. `local_path` is the dotted path within the prefab (e.g., `"children[0]"`, `"children[2].children[0]"`). Survives save/load so Phase 1 can map old child IDs to newly-spawned child IDs. In-memory `root` is the native `Entity` handle (matching `Parent`'s convention); the save format serialises it as `u64` and remaps through the load `id_map`.
 
 Both are engine built-ins, not registered by the game. Same treatment as `Position` and (after #470) `Parent`.
 

--- a/RFC-SAVE-LOAD-PREFABS.md
+++ b/RFC-SAVE-LOAD-PREFABS.md
@@ -98,7 +98,7 @@ Once adopted, the re-hydration scripts above **delete**:
 ┌──────────────────────────────────────────────────────────────────┐
 │  saveGameState                                                   │
 │    For each entity:                                              │
-│      if PrefabInstance: emit {"prefab": path, "overrides": {…},  │
+│      if PrefabInstance: emit {"prefab": path, "overrides": "…",  │
 │                                "components": {…}}                │
 │      else if PrefabChild: emit {"prefab_child": {root, path},    │
 │                                 "components": {…}}               │
@@ -122,7 +122,7 @@ Once adopted, the re-hydration scripts above **delete**:
 
 ### New built-in components
 
-- `PrefabInstance { path: []const u8, overrides: []const u8 }` — marker on prefab-root entities. `overrides` is an opaque JSON blob (the engine produces it at spawn time and replays it on load).
+- `PrefabInstance { path: []const u8, overrides: []const u8 }` — marker on prefab-root entities. `overrides` is an opaque JSON blob (the engine produces it at spawn time and replays it on load). Because it's a `[]const u8` in the component, the save format stores it as an **escaped JSON string** rather than a nested object — the save layer treats it as opaque content it doesn't need to re-parse. The architecture diagram above and the v3 format example below both use the string form; any prior snippets showing a nested object are pre-revision residue.
 - `PrefabChild { root: Entity, local_path: []const u8 }` — marker on each child entity created by the prefab. `local_path` is the dotted path within the prefab (e.g., `"children[0]"`, `"children[2].children[0]"`). Survives save/load so Phase 1 can map old child IDs to newly-spawned child IDs. In-memory `root` is the native `Entity` handle (matching `Parent`'s convention); the save format serialises it as `u64` and remaps through the load `id_map`.
 
 Both are engine built-ins, not registered by the game. Same treatment as `Position` and (after #470) `Parent`.
@@ -216,7 +216,7 @@ Each of these becomes a deletion in its own PR once the infra lands.
 
 4. **Transient vs saveable on the PrefabChild marker.** `PrefabChild` needs to survive save/load (so Phase 1 can map old IDs to new IDs). But once a prefab-child's mapping is applied, the `local_path` string never gets looked at again at runtime. Fine to keep it saveable; it's ~30 bytes per child. The question is whether we also need to store it in memory at runtime (yes — to re-emit it on a subsequent save).
 
-5. **Cycles in prefab references.** Out of scope v1. Prefab A containing prefab B containing prefab A would recurse infinitely; the loader rejects cycles at jsonc-parse time, same rule applies at spawn.
+5. **Cycles in prefab references.** Out of scope v1. Prefab A containing prefab B containing prefab A would recurse infinitely. Today the JSONC scene bridge doesn't do explicit cycle detection — it bounds recursion with a generic `MAX_DEPTH` counter and fails with `IncludeDepthExceeded` once the stack gets too deep. That's a depth limit, not a cycle check, so a shallow cycle could in principle go unreported. A dedicated graph-walk with an explicit "already-visited" set is left for a follow-up; the `MAX_DEPTH` guard is sufficient to prevent runaway recursion in the meantime.
 
 6. **Ordering of Phase 1.** A prefab-root entity whose `overrides` reference other entities via `@ref` needs those others spawned first. Sort by topological order (no-refs first). If there's a cycle in inter-entity refs, load fails with an explicit error rather than silent corruption.
 


### PR DESCRIPTION
## Summary

Two paired RFCs covering the "author in prefabs, let the engine handle round-trip and animation" story. Each builds on the other.

### [RFC-SAVE-LOAD-PREFABS.md](RFC-SAVE-LOAD-PREFABS.md)
Prefab-aware save/load. Record each entity's prefab source + instance overrides on save; on load re-instantiate the prefab (Phase 1 — structure) then apply saved overrides (Phase 2 — state). Non-prefab entities stay on the current flat save/load path.

Deletes the per-entity re-hydration scripts games hand-roll today:
- flying-platform-labelle's `RoomDecor` marker + switch table (born yesterday from #286)
- `HydroponicsPlant.saveable` + the Sprite re-add block in its animation
- `restoreSprites` in the game's save_load.zig
- The `needsReinit` / `initOverlays` dances in the condenser + kitchen animation scripts (six iterations of hardening on #286 traces back to stale-ID recovery that this RFC eliminates)

Built on #467 (postLoad on nested entities) and #470 (Parent persistence).

### [RFC-PREFAB-ANIMATION.md](RFC-PREFAB-ANIMATION.md)
Two engine components authored declaratively in prefabs:
- `SpriteAnimation { frames, fps, mode }` — frame cycling (loop / once / ping_pong).
- `SpriteByField { component, field, source, entries }` — pick sprite from a map keyed by a runtime field value (level → sprite for hydroponics plants, etc.).

Engine tick systems walk `view(.{SpriteAnimation, Sprite}, .{})` / `view(.{SpriteByField, Sprite}, .{})` and mutate `Sprite`. Runtime add/remove is the gate — engine stays ignorant of game predicates.

Net after adoption: ~600 lines of game-side animation code deleted, replaced by two engine components + two tick systems.

Complements the existing `AnimationDef` / `AnimationState` character animation; this is for the single-clip simple case that was previously hand-rolled.

## Why together

The two RFCs are conceptually paired:
- Save/load-for-prefabs gives us "non-saveable components come back on load."
- Prefab-animation gives us "declarative per-tick mutation with in-flight state excluded from save."

Together they eliminate the re-hydration + manual ticking that every room's decor, every workstation's overlay, and every character animation's Sprite restoration has been reinventing.

## Status

**Draft.** Seeking review on:
- Two-phase load structure + `PrefabInstance` / `PrefabChild` built-in markers (save/load RFC §Architecture).
- Structured vs opaque overrides blob (save/load RFC §Open questions).
- Component-based animation design vs a jsonc pseudo-attribute (`@animate`) — the RFC lands on components, decision justified in animation RFC §Proposal.
- Whether `SpriteAnimation` needs a built-in gate field or whether runtime add/remove is enough (animation RFC §Gating — currently leans add/remove).

## Not in scope

- Implementation. Both RFCs are design-phase; if accepted, Phase A of each lands as separate follow-up PRs with integration tests.
- Character animation refactor — `AnimationDef` / `AnimationState` stay as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)