### PR TITLE
feat(save_load): PrefabInstance + PrefabChild built-in handlers (Slice 1b)

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -9,6 +9,8 @@ const ComponentPayload = hooks_types.ComponentPayload;
 const VisualType = core.VisualType;
 const ParentComponent = core.ParentComponent;
 const ChildrenComponent = core.ChildrenComponent;
+const PrefabInstance = core.PrefabInstance;
+const PrefabChild = core.PrefabChild;
 
 const atlas_mod = @import("atlas.zig");
 const assets_mod = @import("assets/mod.zig");
@@ -53,6 +55,7 @@ pub fn GameConfig(
     const Icon = if (@hasDecl(RenderImpl, "Icon")) RenderImpl.Icon else void;
     const Parent = ParentComponent(Entity);
     const Children = ChildrenComponent(Entity);
+    const PrefabChildT = PrefabChild(Entity);
     const EnginePayload = hooks_types.HookPayload(Entity);
     const has_events = GameEvents != void;
     const Payload = if (has_events) core.MergeHookPayloads(.{ EnginePayload, GameEvents }) else EnginePayload;
@@ -82,6 +85,8 @@ pub fn GameConfig(
         pub const IconComp = Icon;
         pub const ParentComp = Parent;
         pub const ChildrenComp = Children;
+        pub const PrefabInstanceComp = PrefabInstance;
+        pub const PrefabChildComp = PrefabChildT;
         pub const Input = @import("input.zig").InputInterface(InputImpl);
         pub const Audio = @import("audio.zig").AudioInterface(AudioImpl);
         pub const Gui = @import("gui.zig").GuiInterface(GuiImpl);

--- a/src/game/save_load_mixin.zig
+++ b/src/game/save_load_mixin.zig
@@ -33,6 +33,31 @@ pub fn Mixin(comptime Game: type) type {
             };
         }
 
+        /// Write a JSON-escaped string literal (including surrounding
+        /// quotes) to `writer`. Used by the built-in save pathway for
+        /// components with `[]const u8` fields (PrefabInstance.path,
+        /// PrefabInstance.overrides, PrefabChild.local_path) — serde's
+        /// `writeComponent` doesn't support string slices, so the save
+        /// mixin handles these components as built-ins and needs its
+        /// own escape helper.
+        fn writeJsonString(writer: anytype, s: []const u8) !void {
+            try writer.writeByte('"');
+            for (s) |c| {
+                switch (c) {
+                    '"' => try writer.writeAll("\\\""),
+                    '\\' => try writer.writeAll("\\\\"),
+                    '\n' => try writer.writeAll("\\n"),
+                    '\r' => try writer.writeAll("\\r"),
+                    '\t' => try writer.writeAll("\\t"),
+                    0x08 => try writer.writeAll("\\b"),
+                    0x0c => try writer.writeAll("\\f"),
+                    0...0x07, 0x0b, 0x0e...0x1f => try std.fmt.format(writer, "\\u{x:0>4}", .{c}),
+                    else => try writer.writeByte(c),
+                }
+            }
+            try writer.writeByte('"');
+        }
+
         /// Collect entities from a view into an ArrayList, closing the view after.
         fn collectEntities(comptime T: type, ecs: anytype, allocator: std.mem.Allocator) !std.ArrayList(Entity) {
             var buf: std.ArrayList(Entity) = .{};
@@ -145,6 +170,61 @@ pub fn Mixin(comptime Game: type) type {
                         try writer.writeAll(if (parent.inherit_rotation) "true" else "false");
                         try writer.writeAll(", \"inherit_scale\": ");
                         try writer.writeAll(if (parent.inherit_scale) "true" else "false");
+                        try writer.writeAll("}");
+                        first_comp = false;
+                    }
+                }
+
+                // Save PrefabInstance (built-in) — attached by
+                // `spawnFromPrefab` to prefab-root entities so save/load
+                // Phase 1 can re-instantiate the prefab and bring back
+                // non-saveable components (Sprite, animation overlays)
+                // on load. Path + overrides-blob are both `[]const u8`,
+                // which serde.writeComponent can't round-trip, so
+                // PrefabInstance lives in the built-in channel alongside
+                // Position and Parent. Same registry-identity guard so
+                // a game registering the type in its ComponentRegistry
+                // doesn't produce duplicate JSON keys.
+                const PrefabInstance = Game.PrefabInstanceComp;
+                const has_prefab_instance_in_registry = comptime blk: {
+                    for (names) |name| {
+                        if (Reg.getType(name) == PrefabInstance) break :blk true;
+                    }
+                    break :blk false;
+                };
+                if (!has_prefab_instance_in_registry) {
+                    if (self.active_world.ecs_backend.getComponent(entity, PrefabInstance)) |pi| {
+                        if (!first_comp) try writer.writeAll(",");
+                        try writer.writeAll("\n        \"PrefabInstance\": {\"path\": ");
+                        try writeJsonString(writer, pi.path);
+                        try writer.writeAll(", \"overrides\": ");
+                        try writeJsonString(writer, pi.overrides);
+                        try writer.writeAll("}");
+                        first_comp = false;
+                    }
+                }
+
+                // Save PrefabChild (built-in) — attached by
+                // `spawnFromPrefab` to every child entity created as
+                // part of a prefab instantiation. `root` points back
+                // at the PrefabInstance entity; serialised as u64 and
+                // remapped through the load `id_map` so lineage
+                // survives entity-ID reassignment (same pattern
+                // Parent.entity uses).
+                const PrefabChildT = Game.PrefabChildComp;
+                const has_prefab_child_in_registry = comptime blk: {
+                    for (names) |name| {
+                        if (Reg.getType(name) == PrefabChildT) break :blk true;
+                    }
+                    break :blk false;
+                };
+                if (!has_prefab_child_in_registry) {
+                    if (self.active_world.ecs_backend.getComponent(entity, PrefabChildT)) |pc| {
+                        if (!first_comp) try writer.writeAll(",");
+                        try writer.writeAll("\n        \"PrefabChild\": {\"root\": ");
+                        try std.fmt.format(writer, "{d}", .{entityToU64(pc.root)});
+                        try writer.writeAll(", \"local_path\": ");
+                        try writeJsonString(writer, pc.local_path);
                         try writer.writeAll("}");
                         first_comp = false;
                     }
@@ -340,6 +420,78 @@ pub fn Mixin(comptime Game: type) type {
                         self.setParent(entity, parent_entity, .{
                             .inherit_rotation = inherit_rotation,
                             .inherit_scale = inherit_scale,
+                        });
+                    }
+                }
+
+                // Restore PrefabInstance (built-in) — counterpart to
+                // the save block above. String fields are duped into
+                // the world's nested-entity arena so they outlive the
+                // parsed JSON deinit.
+                const PrefabInstance_load = Game.PrefabInstanceComp;
+                const has_prefab_instance_in_registry_load = comptime blk: {
+                    for (names) |name| {
+                        if (Reg.getType(name) == PrefabInstance_load) break :blk true;
+                    }
+                    break :blk false;
+                };
+                if (!has_prefab_instance_in_registry_load) {
+                    if (components.get("PrefabInstance")) |pi_val| blk: {
+                        const pi_obj = switch (pi_val) {
+                            .object => |o| o,
+                            else => break :blk,
+                        };
+                        const path_str = switch (pi_obj.get("path") orelse break :blk) {
+                            .string => |s| s,
+                            else => break :blk,
+                        };
+                        const overrides_str = switch (pi_obj.get("overrides") orelse break :blk) {
+                            .string => |s| s,
+                            else => break :blk,
+                        };
+                        const pi_arena = self.active_world.nested_entity_arena.allocator();
+                        const path_dup = try pi_arena.dupe(u8, path_str);
+                        const overrides_dup = try pi_arena.dupe(u8, overrides_str);
+                        self.active_world.ecs_backend.addComponent(entity, PrefabInstance_load{
+                            .path = path_dup,
+                            .overrides = overrides_dup,
+                        });
+                    }
+                }
+
+                // Restore PrefabChild (built-in) — counterpart to the
+                // save block above. `root` is an entity ref, remapped
+                // through `id_map`; `local_path` is duped into the
+                // world arena to outlive the parsed JSON.
+                const PrefabChild_load = Game.PrefabChildComp;
+                const has_prefab_child_in_registry_load = comptime blk: {
+                    for (names) |name| {
+                        if (Reg.getType(name) == PrefabChild_load) break :blk true;
+                    }
+                    break :blk false;
+                };
+                if (!has_prefab_child_in_registry_load) {
+                    if (components.get("PrefabChild")) |pc_val| blk: {
+                        const pc_obj = switch (pc_val) {
+                            .object => |o| o,
+                            else => break :blk,
+                        };
+                        const root_val = pc_obj.get("root") orelse break :blk;
+                        const saved_root_id: u64 = switch (root_val) {
+                            .integer => |i| if (i >= 0) @intCast(i) else break :blk,
+                            else => break :blk,
+                        };
+                        const current_root_id = id_map.get(saved_root_id) orelse break :blk;
+                        const root_entity: Entity = @intCast(current_root_id);
+                        const local_path_str = switch (pc_obj.get("local_path") orelse break :blk) {
+                            .string => |s| s,
+                            else => break :blk,
+                        };
+                        const pc_arena = self.active_world.nested_entity_arena.allocator();
+                        const local_path_dup = try pc_arena.dupe(u8, local_path_str);
+                        self.active_world.ecs_backend.addComponent(entity, PrefabChild_load{
+                            .root = root_entity,
+                            .local_path = local_path_dup,
                         });
                     }
                 }

--- a/src/game/save_load_mixin.zig
+++ b/src/game/save_load_mixin.zig
@@ -20,6 +20,21 @@ pub fn Mixin(comptime Game: type) type {
             return @intCast(entity);
         }
 
+        /// `true` when `T` is registered in the game's
+        /// `ComponentRegistry`. The built-in save/load channel for
+        /// engine-defined components (`Position`, `Parent`,
+        /// `PrefabInstance`, `PrefabChild`) guards on the negation
+        /// of this so a game that decides to register one of them
+        /// directly doesn't end up with duplicate JSON keys (the
+        /// registry-driven path would also emit that component).
+        fn isRegistered(comptime T: type) bool {
+            const names = comptime Reg.names();
+            inline for (names) |name| {
+                if (Reg.getType(name) == T) return true;
+            }
+            return false;
+        }
+
         /// Read a boolean field out of a serialised Parent object,
         /// defaulting to `false` for missing / non-bool values. Kept
         /// local so the save and load sides of the built-in Parent
@@ -186,13 +201,7 @@ pub fn Mixin(comptime Game: type) type {
                 // a game registering the type in its ComponentRegistry
                 // doesn't produce duplicate JSON keys.
                 const PrefabInstance = Game.PrefabInstanceComp;
-                const has_prefab_instance_in_registry = comptime blk: {
-                    for (names) |name| {
-                        if (Reg.getType(name) == PrefabInstance) break :blk true;
-                    }
-                    break :blk false;
-                };
-                if (!has_prefab_instance_in_registry) {
+                if (comptime !isRegistered(PrefabInstance)) {
                     if (self.active_world.ecs_backend.getComponent(entity, PrefabInstance)) |pi| {
                         if (!first_comp) try writer.writeAll(",");
                         try writer.writeAll("\n        \"PrefabInstance\": {\"path\": ");
@@ -212,13 +221,7 @@ pub fn Mixin(comptime Game: type) type {
                 // survives entity-ID reassignment (same pattern
                 // Parent.entity uses).
                 const PrefabChildT = Game.PrefabChildComp;
-                const has_prefab_child_in_registry = comptime blk: {
-                    for (names) |name| {
-                        if (Reg.getType(name) == PrefabChildT) break :blk true;
-                    }
-                    break :blk false;
-                };
-                if (!has_prefab_child_in_registry) {
+                if (comptime !isRegistered(PrefabChildT)) {
                     if (self.active_world.ecs_backend.getComponent(entity, PrefabChildT)) |pc| {
                         if (!first_comp) try writer.writeAll(",");
                         try writer.writeAll("\n        \"PrefabChild\": {\"root\": ");
@@ -429,13 +432,7 @@ pub fn Mixin(comptime Game: type) type {
                 // the world's nested-entity arena so they outlive the
                 // parsed JSON deinit.
                 const PrefabInstance_load = Game.PrefabInstanceComp;
-                const has_prefab_instance_in_registry_load = comptime blk: {
-                    for (names) |name| {
-                        if (Reg.getType(name) == PrefabInstance_load) break :blk true;
-                    }
-                    break :blk false;
-                };
-                if (!has_prefab_instance_in_registry_load) {
+                if (comptime !isRegistered(PrefabInstance_load)) {
                     if (components.get("PrefabInstance")) |pi_val| blk: {
                         const pi_obj = switch (pi_val) {
                             .object => |o| o,
@@ -464,13 +461,7 @@ pub fn Mixin(comptime Game: type) type {
                 // through `id_map`; `local_path` is duped into the
                 // world arena to outlive the parsed JSON.
                 const PrefabChild_load = Game.PrefabChildComp;
-                const has_prefab_child_in_registry_load = comptime blk: {
-                    for (names) |name| {
-                        if (Reg.getType(name) == PrefabChild_load) break :blk true;
-                    }
-                    break :blk false;
-                };
-                if (!has_prefab_child_in_registry_load) {
+                if (comptime !isRegistered(PrefabChild_load)) {
                     if (components.get("PrefabChild")) |pc_val| blk: {
                         const pc_obj = switch (pc_val) {
                             .object => |o| o,

--- a/test/save_load_mixin_test.zig
+++ b/test/save_load_mixin_test.zig
@@ -671,3 +671,142 @@ test "save/load mixin: PrefabInstance + PrefabChild round-trip with id_map remap
     }
     try testing.expectEqual(@as(usize, 1), child_count);
 }
+
+// Regression guard: a save file carrying a malformed PrefabInstance
+// value (e.g. a bare integer or null where the loader expects an
+// object) must NOT panic in debug builds. The defensive
+// `switch (pi_val) { .object => ..., else => break :blk }` on the
+// load side exists specifically for this; if someone ever simplifies
+// it to `pi_val.object` (tag-cast), this test will panic.
+test "save/load mixin: malformed PrefabInstance JSON value is skipped, not panicked" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const filename = "test_save_malformed_pi.json";
+    const malformed =
+        \\{
+        \\  "version": 2,
+        \\  "entities": [
+        \\    {
+        \\      "id": 99,
+        \\      "components": {
+        \\        "Position": {"x": 0, "y": 0},
+        \\        "Worker": {},
+        \\        "PrefabInstance": 123
+        \\      }
+        \\    }
+        \\  ]
+        \\}
+    ;
+    try std.fs.cwd().writeFile(.{ .sub_path = filename, .data = malformed });
+    defer std.fs.cwd().deleteFile(filename) catch {};
+
+    // Load must succeed — the malformed PrefabInstance is silently
+    // skipped, the rest of the entity loads normally.
+    try game.loadGameState(filename);
+
+    const PrefabInstanceT = @TypeOf(game).PrefabInstanceComp;
+    var worker_count: usize = 0;
+    var pi_count: usize = 0;
+    {
+        var view = game.active_world.ecs_backend.view(.{Worker}, .{});
+        while (view.next()) |ent| {
+            worker_count += 1;
+            // Entity exists + Worker was restored; PrefabInstance is
+            // NOT attached because its JSON payload was unusable.
+            try testing.expect(!game.active_world.ecs_backend.hasComponent(ent, PrefabInstanceT));
+        }
+        view.deinit();
+    }
+    try testing.expectEqual(@as(usize, 1), worker_count);
+    {
+        var view = game.active_world.ecs_backend.view(.{PrefabInstanceT}, .{});
+        while (view.next()) |_| pi_count += 1;
+        view.deinit();
+    }
+    try testing.expectEqual(@as(usize, 0), pi_count);
+}
+
+// Regression guard: when a save file's PrefabChild.root points at a
+// saved entity ID that isn't present in the save, the `id_map.get
+// orelse break :blk` guard must skip the restore — otherwise the
+// child would be attached to entity 0 (or whatever integer the JSON
+// carries, stale) and corrupt the lineage.
+test "save/load mixin: PrefabChild with unresolvable root is skipped, not attached to stale id" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const filename = "test_save_unresolvable_root.json";
+    // Entity 77 references a non-existent root 9999 via PrefabChild;
+    // the only registered saveable on entity 77 is Worker so it gets
+    // collected, and Position is emitted as a built-in.
+    const malformed =
+        \\{
+        \\  "version": 2,
+        \\  "entities": [
+        \\    {
+        \\      "id": 77,
+        \\      "components": {
+        \\        "Position": {"x": 0, "y": 0},
+        \\        "Worker": {},
+        \\        "PrefabChild": {"root": 9999, "local_path": "children[0]"}
+        \\      }
+        \\    }
+        \\  ]
+        \\}
+    ;
+    try std.fs.cwd().writeFile(.{ .sub_path = filename, .data = malformed });
+    defer std.fs.cwd().deleteFile(filename) catch {};
+
+    try game.loadGameState(filename);
+
+    const PrefabChildT = @TypeOf(game).PrefabChildComp;
+    var count: usize = 0;
+    {
+        var view = game.active_world.ecs_backend.view(.{PrefabChildT}, .{});
+        while (view.next()) |_| count += 1;
+        view.deinit();
+    }
+    try testing.expectEqual(@as(usize, 0), count);
+}
+
+// Regression guard for `writeJsonString` control-char handling.
+// `overrides` is a JSON blob; in practice it might carry escape
+// sequences like `\n` (newline), `\t` (tab), or `\b` (backspace)
+// when scene-level overrides span multiple lines. This test pins the
+// round-trip: a string containing every short escape case survives
+// save + load byte-for-byte.
+test "save/load mixin: PrefabInstance overrides round-trips with control-char escapes" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const PrefabInstanceT = @TypeOf(game).PrefabInstanceComp;
+    const tricky: []const u8 = "line1\nline2\ttabbed\\back\"quote\rcr\x08bs\x0cff\x01ctl";
+
+    const entity = game.createEntity();
+    game.active_world.ecs_backend.addComponent(entity, Position{ .x = 0, .y = 0 });
+    game.active_world.ecs_backend.addComponent(entity, Worker{});
+    game.active_world.ecs_backend.addComponent(entity, PrefabInstanceT{
+        .path = "test",
+        .overrides = tricky,
+    });
+
+    const filename = "test_save_escapes.json";
+    try game.saveGameState(filename);
+    defer std.fs.cwd().deleteFile(filename) catch {};
+
+    game.resetEcsBackend();
+    try game.loadGameState(filename);
+
+    var count: usize = 0;
+    {
+        var view = game.active_world.ecs_backend.view(.{PrefabInstanceT}, .{});
+        while (view.next()) |ent| {
+            count += 1;
+            const pi = game.active_world.ecs_backend.getComponent(ent, PrefabInstanceT).?;
+            try testing.expectEqualStrings(tricky, pi.overrides);
+        }
+        view.deinit();
+    }
+    try testing.expectEqual(@as(usize, 1), count);
+}

--- a/test/save_load_mixin_test.zig
+++ b/test/save_load_mixin_test.zig
@@ -572,3 +572,102 @@ test "save/load mixin: marker-driven re-hydration of non-saveable render compone
         try testing.expectEqual(expected.z_index, visual.z_index);
     }
 }
+
+// Slice 1b of the save/load-for-prefabs RFC (labelle-engine #472):
+// PrefabInstance + PrefabChild get serialised as built-ins alongside
+// Position and Parent. This test locks that round-trip:
+//
+// 1. Create a "prefab root" entity with `PrefabInstance { path,
+//    overrides }` plus a registered saveable component (Worker) so it
+//    gets picked up by the entity-collection pass.
+// 2. Create a "prefab child" entity with `PrefabChild { root,
+//    local_path }` pointing at the root, plus Position and another
+//    registered component.
+// 3. Save → reset → load.
+// 4. Assert: PrefabInstance survives with its exact string fields;
+//    PrefabChild.root is remapped via `id_map` to the new root entity
+//    ID; local_path round-trips; the save file contains escaped JSON
+//    strings (not a pointer address or raw byte dump).
+//
+// The save file's entity order isn't stable across implementations,
+// so the test looks up the new root entity by walking entities with
+// PrefabInstance, then asserts PrefabChild.root matches that entity.
+test "save/load mixin: PrefabInstance + PrefabChild round-trip with id_map remap" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const PrefabInstanceT = @TypeOf(game).PrefabInstanceComp;
+    const PrefabChildT = @TypeOf(game).PrefabChildComp;
+
+    // Root entity: registered Worker + built-in Position + PrefabInstance.
+    const root_entity = game.createEntity();
+    game.active_world.ecs_backend.addComponent(root_entity, Position{ .x = 156, .y = 0 });
+    game.active_world.ecs_backend.addComponent(root_entity, Worker{});
+    game.active_world.ecs_backend.addComponent(root_entity, PrefabInstanceT{
+        .path = "hydroponics",
+        // Overrides blob — a JSON string embedded as a string field,
+        // exercising the writeJsonString escape path for `"` and `\`.
+        .overrides = "{\"components\":{\"Position\":{\"x\":156,\"y\":0}}}",
+    });
+
+    // Child entity: registered Health + Position + PrefabChild.
+    const child_entity = game.createEntity();
+    game.active_world.ecs_backend.addComponent(child_entity, Position{ .x = 15, .y = 0 });
+    game.active_world.ecs_backend.addComponent(child_entity, Health{ .current = 100, .max = 100 });
+    game.active_world.ecs_backend.addComponent(child_entity, PrefabChildT{
+        .root = @intCast(root_entity),
+        .local_path = "children[0]",
+    });
+
+    // Save.
+    const filename = "test_save_prefab.json";
+    try game.saveGameState(filename);
+    defer std.fs.cwd().deleteFile(filename) catch {};
+
+    // Inspect the save file: the path + escaped overrides + local_path
+    // should be present as JSON strings. Guards against a regression
+    // where writeJsonString stops escaping quotes / backslashes.
+    const json = try std.fs.cwd().readFileAlloc(testing.allocator, filename, 1024 * 1024);
+    defer testing.allocator.free(json);
+    try testing.expect(std.mem.indexOf(u8, json, "\"path\": \"hydroponics\"") != null);
+    try testing.expect(std.mem.indexOf(u8, json, "\\\"components\\\"") != null); // escaped quote
+    try testing.expect(std.mem.indexOf(u8, json, "\"local_path\": \"children[0]\"") != null);
+
+    // Reset + load.
+    game.resetEcsBackend();
+    try game.loadGameState(filename);
+
+    // Find the new root entity (the one carrying PrefabInstance).
+    var new_root_id: ?u64 = null;
+    var root_count: usize = 0;
+    {
+        var view = game.active_world.ecs_backend.view(.{PrefabInstanceT}, .{});
+        while (view.next()) |ent| {
+            root_count += 1;
+            new_root_id = @intCast(ent);
+            const pi = game.active_world.ecs_backend.getComponent(ent, PrefabInstanceT).?;
+            try testing.expectEqualStrings("hydroponics", pi.path);
+            try testing.expectEqualStrings(
+                "{\"components\":{\"Position\":{\"x\":156,\"y\":0}}}",
+                pi.overrides,
+            );
+        }
+        view.deinit();
+    }
+    try testing.expectEqual(@as(usize, 1), root_count);
+
+    // Assert PrefabChild.root was remapped through id_map to point at
+    // the new root entity (not the saved 1 or 2 or whatever ID).
+    var child_count: usize = 0;
+    {
+        var view = game.active_world.ecs_backend.view(.{PrefabChildT}, .{});
+        while (view.next()) |ent| {
+            child_count += 1;
+            const pc = game.active_world.ecs_backend.getComponent(ent, PrefabChildT).?;
+            try testing.expectEqual(new_root_id.?, @as(u64, @intCast(pc.root)));
+            try testing.expectEqualStrings("children[0]", pc.local_path);
+        }
+        view.deinit();
+    }
+    try testing.expectEqual(@as(usize, 1), child_count);
+}

--- a/test/save_load_mixin_test.zig
+++ b/test/save_load_mixin_test.zig
@@ -77,6 +77,25 @@ const Container = struct {
     }
 };
 
+/// Models the "saveable marker with enum tag" pattern used by downstream
+/// games (e.g. flying-platform-labelle's `RoomDecor` / `HydroponicsPlant`)
+/// to re-hydrate a non-saveable render component after load.
+const DecorKind = enum { background, shelf };
+
+const Decor = struct {
+    pub const save = Saveable(.saveable, @This(), .{});
+    kind: DecorKind = .background,
+};
+
+/// Models a non-saveable render component (e.g. labelle-gfx's Sprite).
+/// NOT registered in `TestComponents` below — that's what makes it
+/// "transient" from the save mixin's perspective: instances live in the
+/// world at runtime but are never serialised or restored.
+const VisualMock = struct {
+    sprite_name: []const u8 = "",
+    z_index: i16 = 0,
+};
+
 const TestComponents = ComponentRegistry(.{
     .Position = Position,
     .Worker = Worker,
@@ -86,6 +105,9 @@ const TestComponents = ComponentRegistry(.{
     .NeedsRecalc = NeedsRecalc,
     .RebuildMarker = RebuildMarker,
     .TransientRefs = TransientRefs,
+    .Decor = Decor,
+    // Note: VisualMock is intentionally absent — modelling a render
+    // component that isn't owned by the ECS save path.
 });
 
 // ── Test Game Type ──────────────────────────────────────────────────────
@@ -441,4 +463,112 @@ test "save/load mixin: load nonexistent file returns error" {
 
     const result = game.loadGameState("nonexistent_file.json");
     try testing.expectError(error.FileNotFound, result);
+}
+
+// Regression guard for flying-platform-labelle #286 ("save/load:
+// restoreSprites ignores child-entity room backgrounds").
+//
+// PRs #283 and #285 moved the hydroponics/condenser room backgrounds
+// from the Room entity onto a child entity with a `Position` offset
+// (so the art centers in its slot). After save/load, the child's
+// Sprite was gone — Sprite isn't owned by the ECS save path — and
+// the game's `restoreSprites` only re-added sprites on Room entities,
+// so the decor child rendered blank.
+//
+// The fix is a saveable `RoomDecor { kind }` marker on the child
+// plus a restore-pass that walks `view(.{RoomDecor}, .{Sprite})`
+// and re-adds Sprite from a `kind → (sprite_name, z_index)` switch
+// table. This test exercises that pattern end-to-end at the engine
+// layer: save → reset → load → assert marker persists and render
+// component is missing → run mock walker → assert render component
+// is restored with the right fields.
+test "save/load mixin: marker-driven re-hydration of non-saveable render component" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    // Two decor entities — a background and a shelf — each with a
+    // transient VisualMock (models Sprite).
+    const bg = game.createEntity();
+    game.active_world.ecs_backend.addComponent(bg, Position{ .x = 15, .y = 0 });
+    game.active_world.ecs_backend.addComponent(bg, Decor{ .kind = .background });
+    game.active_world.ecs_backend.addComponent(bg, VisualMock{
+        .sprite_name = "room_background.png",
+        .z_index = -5,
+    });
+
+    const shelf = game.createEntity();
+    game.active_world.ecs_backend.addComponent(shelf, Position{ .x = 15, .y = 0 });
+    game.active_world.ecs_backend.addComponent(shelf, Decor{ .kind = .shelf });
+    game.active_world.ecs_backend.addComponent(shelf, VisualMock{
+        .sprite_name = "wooden_shelf.png",
+        .z_index = -3,
+    });
+
+    const filename = "test_save_decor.json";
+    try game.saveGameState(filename);
+    defer std.fs.cwd().deleteFile(filename) catch {};
+
+    // Verify VisualMock did NOT end up in the save file — it isn't
+    // registered in ComponentRegistry, so the save mixin shouldn't see it.
+    const json = try std.fs.cwd().readFileAlloc(testing.allocator, filename, 1024 * 1024);
+    defer testing.allocator.free(json);
+    try testing.expect(std.mem.indexOf(u8, json, "VisualMock") == null);
+    try testing.expect(std.mem.indexOf(u8, json, "sprite_name") == null);
+
+    // Reset + load — same shape as the F9 handler.
+    game.resetEcsBackend();
+    try game.loadGameState(filename);
+
+    // Collect decor entities, assert marker persisted + visual is gone.
+    var decor_entities: [4]MockEcs.Entity = undefined;
+    var decor_count: usize = 0;
+    {
+        var view = game.active_world.ecs_backend.view(.{Decor}, .{});
+        while (view.next()) |ent| {
+            try testing.expect(decor_count < decor_entities.len);
+            decor_entities[decor_count] = ent;
+            decor_count += 1;
+            try testing.expect(!game.active_world.ecs_backend.hasComponent(ent, VisualMock));
+        }
+        view.deinit();
+    }
+    try testing.expectEqual(@as(usize, 2), decor_count);
+
+    // Mock `restoreSprites` — exactly the shape of
+    // `flying-platform-labelle/scripts/save_load.zig::restoreSprites`
+    // for the RoomDecor branch.
+    const resolve = struct {
+        fn call(kind: DecorKind) VisualMock {
+            return switch (kind) {
+                .background => .{ .sprite_name = "room_background.png", .z_index = -5 },
+                .shelf => .{ .sprite_name = "wooden_shelf.png", .z_index = -3 },
+            };
+        }
+    }.call;
+
+    {
+        var view = game.active_world.ecs_backend.view(.{Decor}, .{VisualMock});
+        var buf: [4]MockEcs.Entity = undefined;
+        var count: usize = 0;
+        while (view.next()) |ent| {
+            try testing.expect(count < buf.len);
+            buf[count] = ent;
+            count += 1;
+        }
+        view.deinit();
+        try testing.expectEqual(@as(usize, 2), count);
+        for (buf[0..count]) |ent| {
+            const decor = game.active_world.ecs_backend.getComponent(ent, Decor).?;
+            game.active_world.ecs_backend.addComponent(ent, resolve(decor.kind));
+        }
+    }
+
+    // Assert every decor entity now carries the expected VisualMock.
+    for (decor_entities[0..decor_count]) |ent| {
+        const decor = game.active_world.ecs_backend.getComponent(ent, Decor).?;
+        const visual = game.active_world.ecs_backend.getComponent(ent, VisualMock).?;
+        const expected = resolve(decor.kind);
+        try testing.expectEqualStrings(expected.sprite_name, visual.sprite_name);
+        try testing.expectEqual(expected.z_index, visual.z_index);
+    }
 }


### PR DESCRIPTION
## Summary

Slice 1b of the save/load-for-prefabs design in RFC #472. Serialises the two prefab-lineage components added in [labelle-core #13](https://github.com/labelle-toolkit/labelle-core/pull/13) — `PrefabInstance { path, overrides }` and `PrefabChild(Entity) { root, local_path }` — as built-ins in the save mixin, same channel `Position` and `Parent` use.

`[]const u8` fields aren't round-trippable through `serde.writeComponent`, so handling them as built-ins with a small `writeJsonString` escape helper keeps the serde layer decoupled from the new types.

Entity-ID remapping works the same as `Parent.entity` — `PrefabChild.root` goes through `id_map` on load.

## Dependencies

- **labelle-core [#13](https://github.com/labelle-toolkit/labelle-core/pull/13)** — adds `PrefabInstance` + `PrefabChild` types. This PR's CI won't pass until that merges and labelle-core ≥ 1.12.0 is available. Built + tested locally against `../labelle-core` on `feat/prefab-components`.
- **This repo #470** (`feat(save_load): persist Parent component`) — rebased on top of `feat/save-parent-component`. `PrefabInstance` / `PrefabChild` handlers slot in next to the `Parent` handler and share the same built-in-channel machinery. Merge after #470 lands.

## What's in it

- `src/game.zig` — expose `PrefabInstanceComp` + `PrefabChildComp` on `GameConfig` (mirrors `ParentComp` / `ChildrenComp`).
- `src/game/save_load_mixin.zig`:
  - `writeJsonString` helper — RFC 8259-compliant string escape for `"`, `\`, and control chars (short escapes for `\b \t \n \f \r`, `\uXXXX` for the rest).
  - Save-side blocks after the Parent block. Both guarded by the same `has_X_in_registry` type-identity check so a game that registers either type directly doesn't produce duplicate JSON keys.
  - Load-side blocks after the Parent restore. Defensive `.object` + field-type switches. String fields duped into `active_world.nested_entity_arena` to outlive the parsed JSON's `deinit`. `PrefabChild.root` remapped via `id_map`.
- `test/save_load_mixin_test.zig` — new round-trip test ensuring: path + overrides survive as exact strings (including escaped quotes/backslashes in the JSON), `PrefabChild.root` is remapped to the new root ID post-load.

## What this does NOT do yet

Explicitly scoped to the data-plumbing. Later slices:

- **Slice 2** — `spawnFromPrefab` API on `Game` + jsonc bridge auto-tagging of prefab-sourced entities.
- **Slice 3** — two-phase load (Phase 1 reinstantiates prefabs before Phase 2 applies overrides). This is where the real user-visible value shows up.
- **Slice 4** — downstream migration (delete `RoomDecor` etc. in flying-platform-labelle).

Also note: entity collection on save still iterates registered components only, so an entity carrying ONLY built-in components (no registered ones) won't appear in the save file. Same limitation as `Parent` today. Fix belongs in a follow-up if the RFC lands that way.

## Test plan

- [x] `zig build test` — 8/8 in `save_load_mixin_test.zig` (was 7 before this PR), full engine suite green.
- [x] Round-trip: PrefabInstance path + overrides survive byte-for-byte; PrefabChild.local_path survives; PrefabChild.root is remapped via `id_map` to the new root entity ID.
- [x] JSON-escape regression guard: save file contains `\"components\"` (escaped quote from the overrides blob) and `"path": "hydroponics"` as inspected strings — catches regressions in `writeJsonString`.
- [ ] Downstream smoke in flying-platform-labelle — can't run until labelle-core 1.12.0 is out and the engine pin bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)