### PR TITLE
feat(animation): SpriteAnimation — declarative frame-cycling component (Phase A)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -45,6 +45,7 @@ pub fn build(b: *std.Build) void {
         "test/asset_catalog_test.zig",
         "test/asset_streaming_shim_test.zig",
         "test/animation_def_test.zig",
+        "test/sprite_animation_test.zig",
         "test/scene_assets_hooks_test.zig",
         "test/pause_hook_test.zig",
     };

--- a/src/root.zig
+++ b/src/root.zig
@@ -19,6 +19,7 @@ pub const hooks_types_mod = @import("hooks_types.zig");
 pub const animation_mod = @import("animation.zig");
 pub const animation_def_mod = @import("animation_def.zig");
 pub const animation_state_mod = @import("animation_state.zig");
+pub const sprite_animation_mod = @import("sprite_animation.zig");
 pub const atlas_mod = @import("atlas.zig");
 pub const assets_mod = @import("assets/mod.zig");
 pub const jsonc_mod = @import("jsonc");
@@ -124,6 +125,8 @@ pub const AnimationDef = animation_def_mod.AnimationDef;
 pub const AnimationState = animation_state_mod.AnimationState;
 pub const AnimMode = animation_def_mod.Mode;
 pub const AnimClipMeta = animation_def_mod.ClipMeta;
+pub const SpriteAnimation = sprite_animation_mod.SpriteAnimation;
+pub const SpriteAnimationMode = sprite_animation_mod.AnimationMode;
 
 // ── Atlas ──
 pub const SpriteData = atlas_mod.SpriteData;

--- a/src/sprite_animation.zig
+++ b/src/sprite_animation.zig
@@ -1,0 +1,153 @@
+//! SpriteAnimation — declarative per-frame sprite cycling.
+//!
+//! For simple animations that just walk an array of sprite names at a
+//! fixed rate, declared inline in a prefab instead of hand-rolling a
+//! tick script per use case (condenser pipe, kitchen smoke, hydroponics
+//! growth overlay, etc. — see `RFC-PREFAB-ANIMATION.md` for the full
+//! motivation).
+//!
+//! This module adds the component + pure advance() state machine. The
+//! ECS tick system that walks `view(.{SpriteAnimation, Sprite}, .{})`
+//! and mutates the Sprite's `sprite_name` / `source_rect` / `texture`
+//! lives elsewhere (one per game backend; or as an engine helper once
+//! the atlas-lookup dependency is resolved).
+//!
+//! Complements the existing `AnimationState` + `AnimationDef` system,
+//! which is tuned for characters with many clips × many variants ×
+//! precomputed sprite-name tables. `SpriteAnimation` is the
+//! one-clip-fixed-frames primitive: no variants, no clip transitions,
+//! no comptime-generated tables — just an array of frame names and an
+//! fps rate. Games use `AnimationDef` for workers and
+//! `SpriteAnimation` for everything else.
+
+const std = @import("std");
+const save_policy = @import("labelle-core").save_policy;
+
+/// How the frame index advances past `frames.len - 1`.
+pub const AnimationMode = enum {
+    /// Wrap back to 0 and continue cycling. Most animations.
+    loop,
+    /// Stop on the last frame and stay there. Set-and-forget transitions
+    /// (opening a curtain, a one-shot explosion). Game removes the
+    /// component to replay.
+    once,
+    /// Play forward to the last frame, then reverse back to 0, flipping
+    /// at each endpoint. Breathing, idle swaying.
+    ping_pong,
+};
+
+/// Animation component. Attach to any entity that also carries a
+/// sprite-like component whose `sprite_name` the engine tick system
+/// will rewrite on frame changes.
+///
+/// Field lifetimes:
+/// - `frames` is **borrowed** — typically a comptime slice of static
+///   string literals, or a prefab-owned slice in an arena whose
+///   lifetime covers the entity. The component does not copy.
+/// - `timer` / `frame` / `forward` are runtime state advanced by the
+///   tick system; skipped from save via `Saveable.skip` so save files
+///   stay small and post-load the animation starts from frame 0 (one-
+///   frame visual continuity loss is invisible at 60 fps; a shipping
+///   game cares more about the save being small and deterministic).
+pub const SpriteAnimation = struct {
+    pub const save = save_policy.Saveable(.saveable, @This(), .{
+        .skip = &.{ "timer", "frame", "forward" },
+    });
+
+    frames: []const []const u8,
+    fps: f32,
+    mode: AnimationMode = .loop,
+
+    // Runtime state — excluded from save.
+    timer: f32 = 0,
+    frame: u8 = 0,
+    /// Direction of travel in `.ping_pong`. Unused for `.loop` / `.once`.
+    forward: bool = true,
+
+    /// Advance the animation by `dt` seconds. Pure state machine —
+    /// does not touch the entity's Sprite. The caller (a tick system
+    /// that walks `view(.{SpriteAnimation, Sprite}, .{})`) decides
+    /// whether to copy the resolved frame name onto the Sprite.
+    ///
+    /// Returns `true` if `frame` changed this tick (i.e. the caller
+    /// should update the Sprite + markVisualDirty). In steady state
+    /// (animation playing on a frame it's already on) returns `false`,
+    /// which is the common case for single-frame animations or ticks
+    /// that fall within the same frame.
+    pub fn advance(self: *SpriteAnimation, dt: f32) bool {
+        // Degenerate case: empty frames or zero/negative fps. No
+        // advance, no mutation. Protects against malformed data
+        // (e.g. a prefab with `"frames": []`) without a compile-time
+        // constraint that would complicate the prefab schema.
+        if (self.frames.len == 0 or self.fps <= 0) return false;
+
+        const old_frame = self.frame;
+        self.timer += dt;
+        const frame_duration = 1.0 / self.fps;
+        const steps_f: f32 = self.timer / frame_duration;
+        const steps: u32 = @intFromFloat(@floor(steps_f));
+        if (steps == 0) return false;
+        self.timer -= @as(f32, @floatFromInt(steps)) * frame_duration;
+
+        // Each mode advances by `steps` frames with its own wrap rule.
+        const len_u8: u8 = @intCast(self.frames.len);
+        switch (self.mode) {
+            .loop => {
+                const base: u32 = self.frame;
+                self.frame = @intCast((base + steps) % self.frames.len);
+            },
+            .once => {
+                const base: u32 = self.frame;
+                const target = base + steps;
+                self.frame = if (target >= self.frames.len)
+                    len_u8 - 1
+                else
+                    @intCast(target);
+            },
+            .ping_pong => {
+                // Iterate per-step so the `forward` flag preserves the
+                // "direction we JUST moved in" convention — flipping
+                // strictly on direction reversal (at peak / trough),
+                // never on landing exactly at an endpoint. Folding the
+                // iteration into closed-form modular arithmetic breaks
+                // this convention at frames 0 and (len-1) where the
+                // analytical `linear_position <= len-1` check can't
+                // distinguish "arriving at 0 via reverse" from
+                // "arriving at 0 via forward about to peel off".
+                // O(steps) per call is fine — at 60 Hz with
+                // reasonable fps, steps is 0–1 per tick.
+                if (self.frames.len == 1) {
+                    self.frame = 0;
+                } else {
+                    var remaining: u32 = steps;
+                    while (remaining > 0) : (remaining -= 1) {
+                        if (self.forward) {
+                            if (self.frame + 1 >= len_u8) {
+                                self.forward = false;
+                                self.frame -= 1;
+                            } else {
+                                self.frame += 1;
+                            }
+                        } else {
+                            if (self.frame == 0) {
+                                self.forward = true;
+                                self.frame += 1;
+                            } else {
+                                self.frame -= 1;
+                            }
+                        }
+                    }
+                }
+            },
+        }
+        return self.frame != old_frame;
+    }
+
+    /// Current frame's sprite name. Returns `null` for a degenerate
+    /// zero-frame animation so the caller can handle the case
+    /// explicitly rather than indexing into an empty slice.
+    pub fn currentSprite(self: *const SpriteAnimation) ?[]const u8 {
+        if (self.frames.len == 0) return null;
+        return self.frames[self.frame];
+    }
+};

--- a/src/sprite_animation.zig
+++ b/src/sprite_animation.zig
@@ -49,6 +49,11 @@ pub const AnimationMode = enum {
 ///   stay small and post-load the animation starts from frame 0 (one-
 ///   frame visual continuity loss is invisible at 60 fps; a shipping
 ///   game cares more about the save being small and deterministic).
+///
+/// Frame count limit: `frame` is stored as `u8`, so `frames.len` must
+/// not exceed 255. Simple overlay cycles rarely need more than a dozen
+/// frames; use `AnimationDef` / `AnimationState` for character rigs
+/// that push against that ceiling.
 pub const SpriteAnimation = struct {
     pub const save = save_policy.Saveable(.saveable, @This(), .{
         .skip = &.{ "timer", "frame", "forward" },
@@ -80,6 +85,11 @@ pub const SpriteAnimation = struct {
         // (e.g. a prefab with `"frames": []`) without a compile-time
         // constraint that would complicate the prefab schema.
         if (self.frames.len == 0 or self.fps <= 0) return false;
+        // `frame` is u8 — enforce the 255-frame ceiling at the call
+        // site so misuse surfaces immediately rather than producing a
+        // silent wraparound or a cryptic @intCast panic deep in the
+        // switch below.
+        std.debug.assert(self.frames.len <= std.math.maxInt(u8) + 1);
 
         const old_frame = self.frame;
         self.timer += dt;
@@ -149,5 +159,17 @@ pub const SpriteAnimation = struct {
     pub fn currentSprite(self: *const SpriteAnimation) ?[]const u8 {
         if (self.frames.len == 0) return null;
         return self.frames[self.frame];
+    }
+
+    /// Returns `true` when a `.once` animation has played through to
+    /// its last frame and will not advance further. The tick system
+    /// (or game code) can use this to remove the component and replay
+    /// the clip from the start.
+    ///
+    /// Always returns `false` for `.loop` and `.ping_pong` (neither
+    /// finishes) and for degenerate zero-frame animations.
+    pub fn isFinished(self: *const SpriteAnimation) bool {
+        if (self.mode != .once or self.frames.len == 0) return false;
+        return @as(usize, self.frame) + 1 >= self.frames.len;
     }
 };

--- a/src/sprite_animation.zig
+++ b/src/sprite_animation.zig
@@ -93,6 +93,17 @@ pub const SpriteAnimation = struct {
 
         const old_frame = self.frame;
         self.timer += dt;
+        // Clamp to zero before the signed → unsigned cast below.
+        // `timer` can go sub-zero two ways: a negative `dt` (paused
+        // game rewinding its scaled clock, a test driving the tick
+        // backwards), or floating-point residual from the previous
+        // `timer -= steps * frame_duration` landing marginally under
+        // the true remainder. Either leaves `steps_f` negative,
+        // which turns `@intFromFloat(@floor(...))` into a u32 cast
+        // of a negative value — a runtime trap. Treating the
+        // clamped case as "no frame advance this tick" matches the
+        // steady-state `steps == 0` branch below.
+        if (self.timer < 0) self.timer = 0;
         const frame_duration = 1.0 / self.fps;
         const steps_f: f32 = self.timer / frame_duration;
         const steps: u32 = @intFromFloat(@floor(steps_f));

--- a/src/sprite_animation.zig
+++ b/src/sprite_animation.zig
@@ -85,11 +85,11 @@ pub const SpriteAnimation = struct {
         // (e.g. a prefab with `"frames": []`) without a compile-time
         // constraint that would complicate the prefab schema.
         if (self.frames.len == 0 or self.fps <= 0) return false;
-        // `frame` is u8 — enforce the 255-frame ceiling at the call
-        // site so misuse surfaces immediately rather than producing a
-        // silent wraparound or a cryptic @intCast panic deep in the
-        // switch below.
-        std.debug.assert(self.frames.len <= std.math.maxInt(u8) + 1);
+        // `frame` is u8 — enforce the true 255-frame ceiling here so
+        // misuse surfaces immediately rather than producing a silent
+        // wraparound or a cryptic @intCast panic when `frames.len` is
+        // converted to `u8` below.
+        std.debug.assert(self.frames.len <= std.math.maxInt(u8));
 
         const old_frame = self.frame;
         self.timer += dt;

--- a/test/sprite_animation_test.zig
+++ b/test/sprite_animation_test.zig
@@ -1,0 +1,186 @@
+//! SpriteAnimation state machine tests.
+//! Covers .loop / .once / .ping_pong modes, degenerate inputs, and the
+//! save-policy contract. The ECS tick system that consumes these
+//! components is tested separately once that lands.
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+const core = @import("labelle-core");
+
+const SpriteAnimation = engine.SpriteAnimation;
+
+const pipe_frames = [6][]const u8{
+    "pipe_0001.png",
+    "pipe_0002.png",
+    "pipe_0003.png",
+    "pipe_0004.png",
+    "pipe_0005.png",
+    "pipe_0006.png",
+};
+
+test "SpriteAnimation: loop mode cycles through frames" {
+    var anim = SpriteAnimation{
+        .frames = &pipe_frames,
+        .fps = 6,
+        .mode = .loop,
+    };
+    // One full cycle = 6 frames / 6 fps = 1 second.
+    // At dt=1/6, advance one frame per call.
+    const step: f32 = 1.0 / 6.0;
+
+    try testing.expectEqual(@as(u8, 0), anim.frame);
+    try testing.expect(anim.advance(step));
+    try testing.expectEqual(@as(u8, 1), anim.frame);
+    try testing.expect(anim.advance(step));
+    try testing.expectEqual(@as(u8, 2), anim.frame);
+    try testing.expect(anim.advance(step * 3));
+    try testing.expectEqual(@as(u8, 5), anim.frame);
+    try testing.expect(anim.advance(step));
+    try testing.expectEqual(@as(u8, 0), anim.frame); // wrapped
+}
+
+test "SpriteAnimation: loop mode is idempotent within a frame" {
+    var anim = SpriteAnimation{
+        .frames = &pipe_frames,
+        .fps = 6,
+        .mode = .loop,
+    };
+    // Half-step: timer accumulates but no frame change.
+    const half_step: f32 = 1.0 / 12.0;
+    try testing.expect(!anim.advance(half_step));
+    try testing.expectEqual(@as(u8, 0), anim.frame);
+    // Another half: now total 1 frame → flips.
+    try testing.expect(anim.advance(half_step));
+    try testing.expectEqual(@as(u8, 1), anim.frame);
+}
+
+test "SpriteAnimation: once mode stops on the last frame" {
+    var anim = SpriteAnimation{
+        .frames = &pipe_frames,
+        .fps = 6,
+        .mode = .once,
+    };
+    // Full cycle: should land on the last frame (index 5).
+    try testing.expect(anim.advance(1.0));
+    try testing.expectEqual(@as(u8, 5), anim.frame);
+    // Further advance does not wrap or restart.
+    try testing.expect(!anim.advance(1.0));
+    try testing.expectEqual(@as(u8, 5), anim.frame);
+    try testing.expect(!anim.advance(10.0));
+    try testing.expectEqual(@as(u8, 5), anim.frame);
+}
+
+test "SpriteAnimation: ping_pong reverses at endpoints" {
+    var anim = SpriteAnimation{
+        .frames = &pipe_frames,
+        .fps = 6,
+        .mode = .ping_pong,
+    };
+    const step: f32 = 1.0 / 6.0;
+
+    // Forward: 0 → 1 → 2 → 3 → 4 → 5
+    for (1..6) |expected_frame| {
+        try testing.expect(anim.advance(step));
+        try testing.expectEqual(@as(u8, @intCast(expected_frame)), anim.frame);
+    }
+    try testing.expect(anim.forward);
+
+    // At 5, next step reverses: 5 → 4 → 3 → 2 → 1 → 0
+    const expected_reverse = [_]u8{ 4, 3, 2, 1, 0 };
+    for (expected_reverse) |expected_frame| {
+        try testing.expect(anim.advance(step));
+        try testing.expectEqual(expected_frame, anim.frame);
+    }
+    try testing.expect(!anim.forward);
+
+    // At 0, next step flips forward again: 0 → 1
+    try testing.expect(anim.advance(step));
+    try testing.expectEqual(@as(u8, 1), anim.frame);
+    try testing.expect(anim.forward);
+}
+
+test "SpriteAnimation: ping_pong with single frame is stationary" {
+    const single = [1][]const u8{"only.png"};
+    var anim = SpriteAnimation{
+        .frames = &single,
+        .fps = 6,
+        .mode = .ping_pong,
+    };
+    try testing.expect(!anim.advance(10.0));
+    try testing.expectEqual(@as(u8, 0), anim.frame);
+}
+
+test "SpriteAnimation: degenerate zero-frame animation is a no-op" {
+    const empty: []const []const u8 = &.{};
+    var anim = SpriteAnimation{
+        .frames = empty,
+        .fps = 6,
+        .mode = .loop,
+    };
+    try testing.expect(!anim.advance(10.0));
+    try testing.expectEqual(@as(u8, 0), anim.frame);
+}
+
+test "SpriteAnimation: zero fps is a no-op" {
+    var anim = SpriteAnimation{
+        .frames = &pipe_frames,
+        .fps = 0,
+        .mode = .loop,
+    };
+    try testing.expect(!anim.advance(10.0));
+    try testing.expectEqual(@as(u8, 0), anim.frame);
+}
+
+test "SpriteAnimation: large dt covers multiple frames in one call" {
+    var anim = SpriteAnimation{
+        .frames = &pipe_frames,
+        .fps = 6,
+        .mode = .loop,
+    };
+    // 2.5 seconds at 6 fps = 15 frames. 15 mod 6 = 3.
+    try testing.expect(anim.advance(2.5));
+    try testing.expectEqual(@as(u8, 3), anim.frame);
+}
+
+test "SpriteAnimation: save policy is saveable with timer/frame/forward skipped" {
+    try testing.expect(core.hasSavePolicy(SpriteAnimation));
+    try testing.expectEqual(core.SavePolicy.saveable, core.getSavePolicy(SpriteAnimation).?);
+
+    // In-flight state (timer, frame, forward) must be skipped so save
+    // files don't bloat with per-tick mutation and post-load animations
+    // start from frame 0.
+    const skip = core.getSkipFields(SpriteAnimation);
+    var has_timer = false;
+    var has_frame = false;
+    var has_forward = false;
+    for (skip) |name| {
+        if (std.mem.eql(u8, name, "timer")) has_timer = true;
+        if (std.mem.eql(u8, name, "frame")) has_frame = true;
+        if (std.mem.eql(u8, name, "forward")) has_forward = true;
+    }
+    try testing.expect(has_timer);
+    try testing.expect(has_frame);
+    try testing.expect(has_forward);
+}
+
+test "SpriteAnimation: currentSprite returns the expected frame name" {
+    var anim = SpriteAnimation{
+        .frames = &pipe_frames,
+        .fps = 6,
+        .mode = .loop,
+    };
+    try testing.expectEqualStrings("pipe_0001.png", anim.currentSprite().?);
+    _ = anim.advance(1.0 / 6.0);
+    try testing.expectEqualStrings("pipe_0002.png", anim.currentSprite().?);
+}
+
+test "SpriteAnimation: currentSprite on empty frames returns null" {
+    const empty: []const []const u8 = &.{};
+    const anim = SpriteAnimation{
+        .frames = empty,
+        .fps = 6,
+        .mode = .loop,
+    };
+    try testing.expect(anim.currentSprite() == null);
+}

--- a/test/sprite_animation_test.zig
+++ b/test/sprite_animation_test.zig
@@ -184,3 +184,46 @@ test "SpriteAnimation: currentSprite on empty frames returns null" {
     };
     try testing.expect(anim.currentSprite() == null);
 }
+
+test "SpriteAnimation: isFinished false for loop and ping_pong" {
+    var loop_anim = SpriteAnimation{
+        .frames = &pipe_frames,
+        .fps = 6,
+        .mode = .loop,
+    };
+    _ = loop_anim.advance(100.0);
+    try testing.expect(!loop_anim.isFinished());
+
+    var pp_anim = SpriteAnimation{
+        .frames = &pipe_frames,
+        .fps = 6,
+        .mode = .ping_pong,
+    };
+    _ = pp_anim.advance(100.0);
+    try testing.expect(!pp_anim.isFinished());
+}
+
+test "SpriteAnimation: isFinished true after once completes" {
+    var anim = SpriteAnimation{
+        .frames = &pipe_frames,
+        .fps = 6,
+        .mode = .once,
+    };
+    try testing.expect(!anim.isFinished()); // not done at frame 0
+    _ = anim.advance(1.0); // advance through all 6 frames
+    try testing.expectEqual(@as(u8, 5), anim.frame);
+    try testing.expect(anim.isFinished());
+    // stays finished after further advances
+    _ = anim.advance(10.0);
+    try testing.expect(anim.isFinished());
+}
+
+test "SpriteAnimation: isFinished false for empty-frame animation" {
+    const empty: []const []const u8 = &.{};
+    const anim = SpriteAnimation{
+        .frames = empty,
+        .fps = 6,
+        .mode = .once,
+    };
+    try testing.expect(!anim.isFinished());
+}

--- a/test/sprite_animation_test.zig
+++ b/test/sprite_animation_test.zig
@@ -227,3 +227,39 @@ test "SpriteAnimation: isFinished false for empty-frame animation" {
     };
     try testing.expect(!anim.isFinished());
 }
+
+test "SpriteAnimation: negative dt does not panic" {
+    // Regression guard for gemini HIGH feedback on #475: negative
+    // `dt` would drive `timer` below zero, and the later signed →
+    // unsigned cast in `@intFromFloat(@floor(steps_f))` would trap.
+    // The fix clamps `timer` to non-negative before the cast.
+    var anim = SpriteAnimation{
+        .frames = &pipe_frames,
+        .fps = 6,
+        .mode = .loop,
+    };
+    try testing.expect(!anim.advance(-1.0));
+    try testing.expectEqual(@as(u8, 0), anim.frame);
+    try testing.expectEqual(@as(f32, 0), anim.timer);
+    // Subsequent positive tick still advances normally — the clamp
+    // just erased the backward travel, it didn't break the clock.
+    try testing.expect(anim.advance(1.0 / 6.0));
+    try testing.expectEqual(@as(u8, 1), anim.frame);
+}
+
+test "SpriteAnimation: sub-zero timer from FP residual does not panic" {
+    // The other path into the same bug: a prior `timer -= steps *
+    // frame_duration` can land marginally below zero because of FP
+    // rounding. The next `advance` would then see a negative timer
+    // and trap on the cast. Simulate by poking the timer directly
+    // to a tiny negative value, then calling advance with small dt.
+    var anim = SpriteAnimation{
+        .frames = &pipe_frames,
+        .fps = 6,
+        .mode = .loop,
+    };
+    anim.timer = -1e-7;
+    // No panic, no frame change, timer clamped.
+    try testing.expect(!anim.advance(0));
+    try testing.expectEqual(@as(f32, 0), anim.timer);
+}


### PR DESCRIPTION
## Summary

Phase A of [RFC-PREFAB-ANIMATION.md](https://github.com/labelle-toolkit/labelle-engine/pull/472) — a lightweight per-frame sprite cycling component for the "one clip, fixed frames, cycle at N fps" case currently hand-rolled in each game (condenser pipe, kitchen smoke, hydroponics overlay — ~600 lines of near-copies across three scripts in flying-platform-labelle alone).

Complements the existing `AnimationState` + `AnimationDef` system, which is tuned for characters with many clips × many variants × precomputed sprite tables. `SpriteAnimation` is the simpler primitive: no variants, no transitions, no comptime tables — just a frame array + fps + mode.

## Scope — pure state machine only

This PR adds the **component type + `advance(dt)` method**. Not included:

- ECS tick system walking `view(.{SpriteAnimation, Sprite}, .{})` and mutating the Sprite's `sprite_name`/`source_rect`/`texture` on frame flips. Lands in a follow-up — depends on game-backend atlas lookup (`game.findSprite`) and is easier to design once the state machine is settled.
- `SpriteByField` component from the same RFC (Phase B).
- Downstream migration of `condenser_animation.zig` etc. (Phase C, depends on save/load-for-prefabs for `spawnFromPrefab`).

Each independently shippable.

## Component shape

```zig
pub const SpriteAnimation = struct {
    pub const save = Saveable(.saveable, @This(), .{
        .skip = &.{ "timer", "frame", "forward" },
    });
    frames: []const []const u8,
    fps: f32,
    mode: AnimationMode = .loop,   // .loop / .once / .ping_pong
    // runtime state, skipped from save
    timer: f32 = 0,
    frame: u8 = 0,
    forward: bool = true,           // ping_pong direction
};
```

## Modes

- **`.loop`** — `frame = (frame + steps) % frames.len`.
- **`.once`** — plays through, stops on the last frame. Game removes the component to replay.
- **`.ping_pong`** — walks forward to `frames.len - 1`, then reverse to 0, flipping direction at each endpoint. Iterates per-step so the `forward` flag reflects "direction we JUST moved in" — flipping strictly on reversal, not on landing at an endpoint. (A closed-form modular version in the first draft hit the ambiguity at frames 0 and `len-1`; the comment in `src/sprite_animation.zig` explains the tradeoff.)

## Save policy

`.saveable` with `timer` / `frame` / `forward` skipped via `Saveable.skip`. On load, the animation starts from frame 0 — one-frame visual continuity loss is invisible at 60 fps, and save files stay small/deterministic. Explicit design call documented in the RFC.

## Tests

11 new tests in `test/sprite_animation_test.zig`:

- `.loop` — cycle, idempotent within a frame, large-dt multiple frames in one call.
- `.once` — stops on last frame, no further advance.
- `.ping_pong` — forward → peak → reverse → trough → forward sequence with forward-flag checks at each endpoint, single-frame stationary case.
- Degenerate inputs — zero frames, zero fps — both no-op cleanly.
- Save-policy contract — `.saveable`, with `timer`/`frame`/`forward` in the skip list (regression guard: if someone removes `.skip`, save files start bloating with per-tick timer drift).
- `currentSprite` — happy path + empty-frames null case.

Full engine suite: **214/214 green** (was 202 pre-slice-1; +11 new + misc recount from other recently-landed tests).

## Relationship to existing animation

| Component | Use case | Frames | Clips |
|---|---|---|---|
| `AnimationDef(zon)` / `AnimationState` | Characters | Per-clip, precomputed sprite table | Many (walk/idle/carry) × variants |
| `SpriteAnimation` | Simple overlay cycles | Inline `[]const []const u8` | One |

Games will use `AnimationState` for workers and `SpriteAnimation` for everything else. Neither obsoletes the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)