### PR TITLE
feat(animation): SpriteByField — field-driven sprite selection (Phase B)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -46,6 +46,7 @@ pub fn build(b: *std.Build) void {
         "test/asset_streaming_shim_test.zig",
         "test/animation_def_test.zig",
         "test/sprite_animation_test.zig",
+        "test/sprite_by_field_test.zig",
         "test/scene_assets_hooks_test.zig",
         "test/pause_hook_test.zig",
         "test/spawn_from_prefab_test.zig",

--- a/src/root.zig
+++ b/src/root.zig
@@ -20,6 +20,7 @@ pub const animation_mod = @import("animation.zig");
 pub const animation_def_mod = @import("animation_def.zig");
 pub const animation_state_mod = @import("animation_state.zig");
 pub const sprite_animation_mod = @import("sprite_animation.zig");
+pub const sprite_by_field_mod = @import("sprite_by_field.zig");
 pub const atlas_mod = @import("atlas.zig");
 pub const assets_mod = @import("assets/mod.zig");
 pub const jsonc_mod = @import("jsonc");
@@ -127,6 +128,8 @@ pub const AnimMode = animation_def_mod.Mode;
 pub const AnimClipMeta = animation_def_mod.ClipMeta;
 pub const SpriteAnimation = sprite_animation_mod.SpriteAnimation;
 pub const SpriteAnimationMode = sprite_animation_mod.AnimationMode;
+pub const SpriteByField = sprite_by_field_mod.SpriteByField;
+pub const SpriteByFieldSource = sprite_by_field_mod.SpriteByFieldSource;
 
 // ── Atlas ──
 pub const SpriteData = atlas_mod.SpriteData;

--- a/src/sprite_by_field.zig
+++ b/src/sprite_by_field.zig
@@ -19,7 +19,9 @@
 //! reads a field from a named component on each entity, coerces its
 //! value to `i32`, looks up via `lookup`, and mutates the entity's
 //! Sprite on match lands in a follow-up. Same staging as Phase A
-//! (`sprite_animation.zig`).
+//! (the sibling `SpriteAnimation` component) — that module introduces
+//! `sprite_animation.zig` when its PR lands; the two components ship
+//! together and cross-reference each other by intent.
 
 const std = @import("std");
 const save_policy = @import("labelle-core").save_policy;
@@ -48,10 +50,10 @@ pub const SpriteByFieldSource = enum {
 /// (signed or unsigned) and `enum` fields (via `@intFromEnum`) all
 /// feed the same `lookup` table.
 ///
-/// `entries` is parallel arrays — each `Entry.key` is matched against
-/// the coerced field value; the first match wins and its
-/// `sprite_name` is written onto the Sprite. A `null` `sprite_name`
-/// means "hide the sprite" (the tick system toggles
+/// `entries` is a slice of `Entry` structs — each `Entry.key` is
+/// matched against the coerced field value; the first match wins and
+/// its `sprite_name` is written onto the Sprite. A `null`
+/// `sprite_name` means "hide the sprite" (the tick system toggles
 /// `Sprite.visible = false` rather than setting a name) — used for
 /// the hydroponics level 0/1 case.
 ///
@@ -65,8 +67,8 @@ pub const SpriteByFieldSource = enum {
 ///
 /// ## Save policy
 ///
-/// `.saveable` with the runtime `last_key_set` / `last_sprite_ptr`
-/// cache skipped. On load, both reset and the next tick re-resolves
+/// `.saveable` with the runtime `last_key_set` / `last_key` cache
+/// skipped. On load, both reset and the next tick re-resolves
 /// through the whole pipeline — a one-tick recheck is negligible
 /// compared to saving the cache. Ensures save files stay small and
 /// deterministic.

--- a/src/sprite_by_field.zig
+++ b/src/sprite_by_field.zig
@@ -1,0 +1,121 @@
+//! SpriteByField — declarative field-driven sprite selection.
+//!
+//! Complements `SpriteAnimation` (time-driven frame cycling) for the
+//! other half of the prefab-animation RFC: cases where the sprite
+//! follows the runtime value of a field on another component rather
+//! than a frame timer. Canonical example: the hydroponics plant
+//! overlay that swaps sprite based on `TendableWorkstation.level`
+//! (0/1 → hidden, 2 → sapling_lvl1, 3 → sapling_lvl2, 4/5 → green).
+//! Today that logic lives in a ~140-line tick script per use case
+//! (`hydroponics_animation.zig`); this component collapses it to the
+//! prefab data.
+//!
+//! See `labelle-engine/RFC-PREFAB-ANIMATION.md` for the full design.
+//!
+//! ## What this file ships
+//!
+//! Phase B slice of the animation RFC: the **pure state machine** —
+//! component shape + `lookup(key)` method. The ECS tick system that
+//! reads a field from a named component on each entity, coerces its
+//! value to `i32`, looks up via `lookup`, and mutates the entity's
+//! Sprite on match lands in a follow-up. Same staging as Phase A
+//! (`sprite_animation.zig`).
+
+const std = @import("std");
+const save_policy = @import("labelle-core").save_policy;
+
+/// Which entity carries the driving field.
+///
+/// - `.self` — read the field off this entity's own component of the
+///   named type. Use when the sprite-bearing entity also holds the
+///   state (rare for decoration).
+/// - `.parent` — walk to the entity's parent first, then read. The
+///   hydroponics case: the plant overlay is a child of the
+///   workstation, and the driving `TendableWorkstation` lives on the
+///   parent.
+pub const SpriteByFieldSource = enum {
+    self,
+    parent,
+};
+
+/// Drive `Sprite.sprite_name` from a runtime field value.
+///
+/// `component` is the serde name of the source component (e.g.
+/// `"TendableWorkstation"`), `field` is the field on that component
+/// to read (e.g. `"level"`). The engine tick system resolves both at
+/// runtime through `ComponentRegistry.getType` + `std.meta.fieldIndex`
+/// and coerces the resulting value to `i32` so integer fields
+/// (signed or unsigned) and `enum` fields (via `@intFromEnum`) all
+/// feed the same `lookup` table.
+///
+/// `entries` is parallel arrays — each `Entry.key` is matched against
+/// the coerced field value; the first match wins and its
+/// `sprite_name` is written onto the Sprite. A `null` `sprite_name`
+/// means "hide the sprite" (the tick system toggles
+/// `Sprite.visible = false` rather than setting a name) — used for
+/// the hydroponics level 0/1 case.
+///
+/// ## Field lifetimes
+///
+/// `component`, `field`, and each entry's `sprite_name` are
+/// **borrowed** — typically comptime string literals in the prefab,
+/// or prefab-arena-owned slices. The component does not copy. Same
+/// ownership contract as `PrefabInstance` / `PrefabChild` — see
+/// `labelle-core/src/prefab.zig` for the full memory note.
+///
+/// ## Save policy
+///
+/// `.saveable` with the runtime `last_key_set` / `last_sprite_ptr`
+/// cache skipped. On load, both reset and the next tick re-resolves
+/// through the whole pipeline — a one-tick recheck is negligible
+/// compared to saving the cache. Ensures save files stay small and
+/// deterministic.
+pub const SpriteByField = struct {
+    pub const save = save_policy.Saveable(.saveable, @This(), .{
+        .skip = &.{ "last_key_set", "last_key" },
+    });
+
+    pub const Entry = struct {
+        /// Signed (per gemini review on RFC #472) so components using
+        /// `-1` as a sentinel `Unset` value can participate.
+        key: i32,
+        /// `null` means "hide the sprite" (tick sets `visible = false`).
+        sprite_name: ?[]const u8,
+    };
+
+    component: []const u8,
+    field: []const u8,
+    source: SpriteByFieldSource = .self,
+    entries: []const Entry,
+
+    // Runtime cache — skipped from save. Used by the tick system to
+    // short-circuit `markVisualDirty` when the resolved sprite name
+    // hasn't changed tick-over-tick (steady-state entities writing
+    // nothing).
+    last_key_set: bool = false,
+    last_key: i32 = 0,
+
+    /// Find the entry matching `key` and return its `sprite_name`.
+    /// Returns:
+    /// - `.match` with the entry's sprite (possibly `null` → "hide")
+    ///   when an entry matched.
+    /// - `.no_match` when `key` isn't in the table.
+    ///
+    /// First-match-wins on duplicate keys; duplicates are a prefab-
+    /// authoring bug, not an engine invariant, so we don't assert.
+    pub fn lookup(self: *const SpriteByField, key: i32) LookupResult {
+        for (self.entries) |entry| {
+            if (entry.key == key) return .{ .match = entry.sprite_name };
+        }
+        return .no_match;
+    }
+
+    pub const LookupResult = union(enum) {
+        /// An entry matched. `sprite_name` is `null` when the entry
+        /// says "hide" (empty slot in the table).
+        match: ?[]const u8,
+        /// No entry matched — tick system should leave the sprite
+        /// alone (no mutation, no hide) rather than guessing.
+        no_match,
+    };
+};

--- a/test/sprite_by_field_test.zig
+++ b/test/sprite_by_field_test.zig
@@ -1,0 +1,144 @@
+//! SpriteByField state machine tests. Covers the lookup table +
+//! save-policy contract. The ECS tick system that reads the runtime
+//! field value and mutates the Sprite lands in a follow-up.
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+const core = @import("labelle-core");
+
+const SpriteByField = engine.SpriteByField;
+
+// Hydroponics plant as the canonical example: level 0/1 hide the
+// overlay, levels 2–5 select increasingly advanced growth sprites.
+const plant_entries = [_]SpriteByField.Entry{
+    .{ .key = 0, .sprite_name = null },
+    .{ .key = 1, .sprite_name = null },
+    .{ .key = 2, .sprite_name = "nursery_sapling_lvl1.png" },
+    .{ .key = 3, .sprite_name = "nursery_sapling_lvl2.png" },
+    .{ .key = 4, .sprite_name = "nursery_green_lvl1.png" },
+    .{ .key = 5, .sprite_name = "nursery_green_lvl2.png" },
+};
+
+fn plantTable() SpriteByField {
+    return .{
+        .component = "TendableWorkstation",
+        .field = "level",
+        .source = .parent,
+        .entries = &plant_entries,
+    };
+}
+
+test "SpriteByField: lookup resolves each configured key" {
+    const table = plantTable();
+
+    try testing.expectEqualStrings("nursery_sapling_lvl1.png", table.lookup(2).match.?);
+    try testing.expectEqualStrings("nursery_sapling_lvl2.png", table.lookup(3).match.?);
+    try testing.expectEqualStrings("nursery_green_lvl1.png", table.lookup(4).match.?);
+    try testing.expectEqualStrings("nursery_green_lvl2.png", table.lookup(5).match.?);
+}
+
+test "SpriteByField: null sprite_name means hide" {
+    const table = plantTable();
+
+    // Levels 0 and 1 match the table but have null sprite_name —
+    // tick system should interpret as "hide the sprite."
+    const r0 = table.lookup(0);
+    try testing.expect(r0 == .match);
+    try testing.expect(r0.match == null);
+
+    const r1 = table.lookup(1);
+    try testing.expect(r1 == .match);
+    try testing.expect(r1.match == null);
+}
+
+test "SpriteByField: unmapped key returns .no_match" {
+    const table = plantTable();
+
+    try testing.expect(table.lookup(-1) == .no_match);
+    try testing.expect(table.lookup(6) == .no_match);
+    try testing.expect(table.lookup(100) == .no_match);
+}
+
+test "SpriteByField: signed keys supported (sentinel values)" {
+    // Games using `-1` as "Unset" / "None" sentinels (per gemini
+    // review on RFC #472) should round-trip negative keys unchanged.
+    const entries = [_]SpriteByField.Entry{
+        .{ .key = -1, .sprite_name = "unset.png" },
+        .{ .key = 0, .sprite_name = "zero.png" },
+        .{ .key = 1, .sprite_name = "one.png" },
+    };
+    const table = SpriteByField{
+        .component = "Foo",
+        .field = "bar",
+        .entries = &entries,
+    };
+
+    try testing.expectEqualStrings("unset.png", table.lookup(-1).match.?);
+    try testing.expectEqualStrings("zero.png", table.lookup(0).match.?);
+    try testing.expectEqualStrings("one.png", table.lookup(1).match.?);
+    try testing.expect(table.lookup(-2) == .no_match);
+}
+
+test "SpriteByField: empty entries table is all .no_match" {
+    const empty: []const SpriteByField.Entry = &.{};
+    const table = SpriteByField{
+        .component = "Foo",
+        .field = "bar",
+        .entries = empty,
+    };
+
+    try testing.expect(table.lookup(0) == .no_match);
+    try testing.expect(table.lookup(-1) == .no_match);
+}
+
+test "SpriteByField: first-match-wins on duplicate keys" {
+    // Duplicate keys are a prefab-authoring bug, not an engine
+    // invariant — but the resolution rule is worth pinning so a
+    // future micro-optimisation doesn't accidentally change it.
+    const entries = [_]SpriteByField.Entry{
+        .{ .key = 42, .sprite_name = "first.png" },
+        .{ .key = 42, .sprite_name = "second.png" },
+    };
+    const table = SpriteByField{
+        .component = "Foo",
+        .field = "bar",
+        .entries = &entries,
+    };
+
+    try testing.expectEqualStrings("first.png", table.lookup(42).match.?);
+}
+
+test "SpriteByField: save policy is saveable with runtime cache skipped" {
+    try testing.expect(core.hasSavePolicy(SpriteByField));
+    try testing.expectEqual(core.SavePolicy.saveable, core.getSavePolicy(SpriteByField).?);
+
+    // `last_key_set` and `last_key` form the steady-state cache the
+    // tick system uses to skip `markVisualDirty` when nothing
+    // changed. They must stay out of the save file — restoring a
+    // stale cache would mask a legitimate sprite update on the
+    // first post-load tick.
+    const skip = core.getSkipFields(SpriteByField);
+    var has_last_key_set = false;
+    var has_last_key = false;
+    for (skip) |name| {
+        if (std.mem.eql(u8, name, "last_key_set")) has_last_key_set = true;
+        if (std.mem.eql(u8, name, "last_key")) has_last_key = true;
+    }
+    try testing.expect(has_last_key_set);
+    try testing.expect(has_last_key);
+}
+
+test "SpriteByField: default source is .self" {
+    const table = SpriteByField{
+        .component = "Foo",
+        .field = "bar",
+        .entries = &.{},
+    };
+    // Explicit-default regression guard: the hydroponics migration
+    // relies on `.parent` being set explicitly in the prefab, so
+    // silently defaulting existing `.self` usage to `.parent` would
+    // break downstream games that have started tagging their own
+    // components.
+    try testing.expectEqual(engine.SpriteByFieldSource.self, table.source);
+}


### PR DESCRIPTION
## Summary

Phase B of [RFC-PREFAB-ANIMATION.md](https://github.com/labelle-toolkit/labelle-engine/pull/472), sibling to [#475](https://github.com/labelle-toolkit/labelle-engine/pull/475) (Phase A — `SpriteAnimation`). Where `SpriteAnimation` handles the time-driven frame cycle case, `SpriteByField` handles the field-driven case: the sprite follows the runtime value of a named field on another component.

Canonical example: the hydroponics plant overlay swaps sprite based on `TendableWorkstation.level` — 0/1 hidden, 2 → sapling_lvl1, 3 → sapling_lvl2, 4/5 → green. Today that's ~140 lines in `hydroponics_animation.zig`; once the tick system lands (Phase B+), this component collapses the logic to prefab data.

## Component shape

```zig
pub const SpriteByField = struct {
    pub const save = Saveable(.saveable, @This(), .{
        .skip = &.{ "last_key_set", "last_key" },
    });

    pub const Entry = struct {
        key: i32,                    // signed (gemini review on #472)
        sprite_name: ?[]const u8,    // null → hide
    };

    component: []const u8,
    field: []const u8,
    source: SpriteByFieldSource = .self,  // .self or .parent
    entries: []const Entry,

    last_key_set: bool = false,      // tick cache, skipped from save
    last_key: i32 = 0,
};
```

## Scope — pure state machine

This PR adds the component type + `lookup(key: i32)` method that returns `.match(?[]const u8)` or `.no_match`. The ECS tick system that reads the runtime field value, coerces to `i32`, calls `lookup`, and mutates the Sprite on match lands in a follow-up — depends on `ComponentRegistry.getType` + `std.meta.fieldIndex` reflection + `.parent` traversal, all easier to design once the data shape is settled.

Same staging pattern as [#475](https://github.com/labelle-toolkit/labelle-engine/pull/475) (Phase A state machine).

## `lookup` result

Union for three distinguished cases:
- **`.match`** with non-null sprite — normal swap.
- **`.match`** with null sprite — "hide" (tick system sets `visible = false`).
- **`.no_match`** — no entry matched, tick system leaves Sprite alone rather than guessing.

The `match` / `no_match` distinction matters because a table can legitimately contain a null entry (e.g. level 0 hides the overlay), and the tick system needs to distinguish "no entry for this value" from "entry says hide."

## Save policy

`.saveable` with `last_key_set` / `last_key` runtime cache skipped via `Saveable.skip`. On load, the cache resets and the next tick re-resolves the whole pipeline — negligible cost, and avoids the failure mode where a stale cache masks a legitimate sprite update on the first post-load tick.

## Tests (8 new in `test/sprite_by_field_test.zig`)

- Lookup resolves each configured key in the canonical 6-row hydroponics table.
- Null `sprite_name` means "hide" (distinct from `.no_match`).
- Unmapped keys return `.no_match`.
- Signed keys supported (sentinel `-1` works — the gemini-reviewed change from `u32` to `i32`).
- Empty entries table returns `.no_match` for every key.
- First-match-wins on duplicate keys (prefab-authoring bug, but the rule is pinned).
- Save-policy regression guard: `last_key_set` / `last_key` are in the skip list.
- Default `source` is `.self` — silent flip to `.parent` would break downstream games.

Full engine suite: **211/211 green** (+8 new).

## Relationship to Phase A (#475)

Both PRs are pure state-machine slices of the same RFC; independent of each other and independent of everything else. Merging order doesn't matter — both land their tick systems as separate follow-up PRs.

## Parallel thread

RFC progress on engine side:

| Phase | PR | State |
|---|---|---|
| A — SpriteAnimation | #475 | Draft, under review |
| B — SpriteByField | **this PR** | **Draft, new** |
| A+ — SpriteAnimation tick | — | Not started |
| B+ — SpriteByField tick | — | Not started |
| C — flying-platform migration | — | Blocked on tick systems + save/load Slice 2 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)