### PR TITLE
feat(prefab): spawnFromPrefab runtime API with lineage tags (Slice 2a)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -47,6 +47,7 @@ pub fn build(b: *std.Build) void {
         "test/animation_def_test.zig",
         "test/scene_assets_hooks_test.zig",
         "test/pause_hook_test.zig",
+        "test/spawn_from_prefab_test.zig",
     };
 
     for (test_files) |test_file| {

--- a/src/game.zig
+++ b/src/game.zig
@@ -9,6 +9,8 @@ const ComponentPayload = hooks_types.ComponentPayload;
 const VisualType = core.VisualType;
 const ParentComponent = core.ParentComponent;
 const ChildrenComponent = core.ChildrenComponent;
+const PrefabInstance = core.PrefabInstance;
+const PrefabChild = core.PrefabChild;
 
 const atlas_mod = @import("atlas.zig");
 const assets_mod = @import("assets/mod.zig");
@@ -53,6 +55,7 @@ pub fn GameConfig(
     const Icon = if (@hasDecl(RenderImpl, "Icon")) RenderImpl.Icon else void;
     const Parent = ParentComponent(Entity);
     const Children = ChildrenComponent(Entity);
+    const PrefabChildT = PrefabChild(Entity);
     const EnginePayload = hooks_types.HookPayload(Entity);
     const has_events = GameEvents != void;
     const Payload = if (has_events) core.MergeHookPayloads(.{ EnginePayload, GameEvents }) else EnginePayload;
@@ -82,6 +85,8 @@ pub fn GameConfig(
         pub const IconComp = Icon;
         pub const ParentComp = Parent;
         pub const ChildrenComp = Children;
+        pub const PrefabInstanceComp = PrefabInstance;
+        pub const PrefabChildComp = PrefabChildT;
         pub const Input = @import("input.zig").InputInterface(InputImpl);
         pub const Audio = @import("audio.zig").AudioInterface(AudioImpl);
         pub const Gui = @import("gui.zig").GuiInterface(GuiImpl);

--- a/src/game.zig
+++ b/src/game.zig
@@ -559,12 +559,19 @@ pub fn GameConfig(
                     .root = root,
                     .local_path = child_path,
                 });
-                const next_base = try std.fmt.allocPrint(
-                    arena,
-                    "{s}.children",
-                    .{child_path},
-                );
-                try tagPrefabChildren(self, root, child, next_base, arena);
+                // Skip the `.children` suffix allocation when `child` is
+                // a leaf. Two-level prefab trees (hydroponics: root +
+                // room + plant overlay) are common; without this gate
+                // the leaf gets an unused `"children[i].children"`
+                // string arena-allocated every spawn.
+                if (self.hasChildren(child)) {
+                    const next_base = try std.fmt.allocPrint(
+                        arena,
+                        "{s}.children",
+                        .{child_path},
+                    );
+                    try tagPrefabChildren(self, root, child, next_base, arena);
+                }
             }
         }
 

--- a/src/game.zig
+++ b/src/game.zig
@@ -492,15 +492,28 @@ pub fn GameConfig(
         ///    Phase 1 on load can map saved child IDs back to newly-
         ///    spawned children via `(root, local_path)`.
         ///
-        /// String fields are allocated in `active_world.nested_entity_arena`
-        /// — lifetime matches the prefab children (world-scoped), freed
-        /// on scene change. Same ownership contract as the save mixin's
-        /// load-side allocation.
+        /// `PrefabInstance.path` and every `PrefabChild.local_path` are
+        /// duped into `active_world.nested_entity_arena` — lifetime
+        /// matches the prefab children (world-scoped), freed on scene
+        /// change. Same ownership contract as the save mixin's load-
+        /// side allocation. `PrefabInstance.overrides` is the string
+        /// literal `""` in this first-cut slice (program lifetime, no
+        /// arena allocation needed for a zero-length literal); the
+        /// structured-overrides pipeline lands in a follow-up and will
+        /// dupe `overrides` into the same arena then.
         ///
-        /// `overrides` is passed through as an empty blob in this
-        /// first-cut implementation — the full structured-overrides
-        /// pipeline (apply caller-supplied component values on top of
-        /// prefab defaults) lands in a follow-up.
+        /// **Interaction with the save mixin:** `spawnFromPrefab` tags
+        /// the entity so Phase 1 on load can respawn it from its
+        /// prefab. But the save mixin only *collects* entities that
+        /// carry at least one component with `.saveable` or `.marker`
+        /// save policy (see `saveGameState` in
+        /// `src/game/save_load_mixin.zig`). A prefab-spawned entity
+        /// that carries only engine built-ins (PrefabInstance/
+        /// PrefabChild) + non-saveable components (e.g. Sprite) will
+        /// NOT appear in the save file and therefore won't be respawned
+        /// on load. Authors relying on save/load round-trip need at
+        /// least one saveable or marker component on the prefab root —
+        /// typically game-owned (e.g. `Workstation`, `RoomDecor`).
         pub fn spawnFromPrefab(self: *Self, path: []const u8, pos: Position) ?Entity {
             const entity = self.spawnPrefab(path, pos) orelse return null;
             // Any tagging failure (arena OOM on path dupe, or inside
@@ -510,7 +523,13 @@ pub fn GameConfig(
             // the save mixin's Phase 1. Destroy the whole tree on
             // failure so `spawnFromPrefab`'s null return really
             // means "the world is unchanged."
-            tagAndSpawnChildren(self, entity, path) catch {
+            //
+            // Log the error name before tearing down: `null` return
+            // collides with the "unknown prefab" signal from
+            // `spawnPrefab`, so without the log an OOM during tagging
+            // is indistinguishable from a typo in the prefab path.
+            tagAndSpawnChildren(self, entity, path) catch |err| {
+                self.log.err("[Game] spawnFromPrefab: tagging failed for '{s}': {s}", .{ path, @errorName(err) });
                 self.destroyEntity(entity);
                 return null;
             };

--- a/src/game.zig
+++ b/src/game.zig
@@ -503,20 +503,30 @@ pub fn GameConfig(
         /// prefab defaults) lands in a follow-up.
         pub fn spawnFromPrefab(self: *Self, path: []const u8, pos: Position) ?Entity {
             const entity = self.spawnPrefab(path, pos) orelse return null;
-
-            const arena = self.active_world.nested_entity_arena.allocator();
-            const path_dup = arena.dupe(u8, path) catch {
-                self.log.err("[Game] spawnFromPrefab: arena dupe failed for path", .{});
+            // Any tagging failure (arena OOM on path dupe, or inside
+            // the recursive child walk) leaves the world with an
+            // orphan entity tree that has no `PrefabInstance` tag —
+            // scene-tracked, component-populated, but invisible to
+            // the save mixin's Phase 1. Destroy the whole tree on
+            // failure so `spawnFromPrefab`'s null return really
+            // means "the world is unchanged."
+            tagAndSpawnChildren(self, entity, path) catch {
+                self.destroyEntity(entity);
                 return null;
             };
+            return entity;
+        }
+
+        fn tagAndSpawnChildren(self: *Self, entity: Entity, path: []const u8) !void {
+            const arena = self.active_world.nested_entity_arena.allocator();
+            const path_dup = try arena.dupe(u8, path);
 
             self.ecs_backend.addComponent(entity, PrefabInstance{
                 .path = path_dup,
                 .overrides = "",
             });
 
-            tagPrefabChildren(self, entity, entity, "children", arena);
-            return entity;
+            try tagPrefabChildren(self, entity, entity, "children", arena);
         }
 
         /// Recursively tag every descendant of `root` with `PrefabChild`.
@@ -524,33 +534,37 @@ pub fn GameConfig(
         /// `"children"` at the top level; `"children[0].children"` one
         /// level in). Each child appends `[i]` to form its unique path
         /// within the prefab tree.
+        ///
+        /// Propagates allocation errors up instead of silently
+        /// `continue`-ing — a partially-tagged tree would have
+        /// `PrefabChild` on some descendants and not others, breaking
+        /// the `(root, local_path)` lookup the two-phase load relies
+        /// on. Atomic: if anything fails, `spawnFromPrefab` destroys
+        /// the tree and returns null.
         fn tagPrefabChildren(
             self: *Self,
             root: Entity,
             parent: Entity,
             base_path: []const u8,
             arena: std.mem.Allocator,
-        ) void {
+        ) !void {
             const children = self.getChildren(parent);
             for (children, 0..) |child, i| {
-                const child_path = std.fmt.allocPrint(
+                const child_path = try std.fmt.allocPrint(
                     arena,
                     "{s}[{d}]",
                     .{ base_path, i },
-                ) catch {
-                    self.log.err("[Game] spawnFromPrefab: arena allocPrint failed for child path", .{});
-                    continue;
-                };
+                );
                 self.ecs_backend.addComponent(child, PrefabChildT{
                     .root = root,
                     .local_path = child_path,
                 });
-                const next_base = std.fmt.allocPrint(
+                const next_base = try std.fmt.allocPrint(
                     arena,
                     "{s}.children",
                     .{child_path},
-                ) catch continue;
-                tagPrefabChildren(self, root, child, next_base, arena);
+                );
+                try tagPrefabChildren(self, root, child, next_base, arena);
             }
         }
 

--- a/src/game.zig
+++ b/src/game.zig
@@ -479,6 +479,81 @@ pub fn GameConfig(
             return null;
         }
 
+        /// Spawn a prefab *and* tag it for save/load Phase 1 reinstantiation.
+        ///
+        /// Wraps `spawnPrefab` with two additions from
+        /// `RFC-SAVE-LOAD-PREFABS.md`:
+        ///
+        /// 1. The **root** entity gets `PrefabInstance { path, overrides = "" }`
+        ///    so the save mixin's built-in handler (added in #474)
+        ///    records its prefab origin.
+        /// 2. Each **child** entity (recursively) gets
+        ///    `PrefabChild { root, local_path = "children[i]..." }` so
+        ///    Phase 1 on load can map saved child IDs back to newly-
+        ///    spawned children via `(root, local_path)`.
+        ///
+        /// String fields are allocated in `active_world.nested_entity_arena`
+        /// — lifetime matches the prefab children (world-scoped), freed
+        /// on scene change. Same ownership contract as the save mixin's
+        /// load-side allocation.
+        ///
+        /// `overrides` is passed through as an empty blob in this
+        /// first-cut implementation — the full structured-overrides
+        /// pipeline (apply caller-supplied component values on top of
+        /// prefab defaults) lands in a follow-up.
+        pub fn spawnFromPrefab(self: *Self, path: []const u8, pos: Position) ?Entity {
+            const entity = self.spawnPrefab(path, pos) orelse return null;
+
+            const arena = self.active_world.nested_entity_arena.allocator();
+            const path_dup = arena.dupe(u8, path) catch {
+                self.log.err("[Game] spawnFromPrefab: arena dupe failed for path", .{});
+                return null;
+            };
+
+            self.ecs_backend.addComponent(entity, PrefabInstance{
+                .path = path_dup,
+                .overrides = "",
+            });
+
+            tagPrefabChildren(self, entity, entity, "children", arena);
+            return entity;
+        }
+
+        /// Recursively tag every descendant of `root` with `PrefabChild`.
+        /// `base_path` is the dotted path accumulated so far (e.g.
+        /// `"children"` at the top level; `"children[0].children"` one
+        /// level in). Each child appends `[i]` to form its unique path
+        /// within the prefab tree.
+        fn tagPrefabChildren(
+            self: *Self,
+            root: Entity,
+            parent: Entity,
+            base_path: []const u8,
+            arena: std.mem.Allocator,
+        ) void {
+            const children = self.getChildren(parent);
+            for (children, 0..) |child, i| {
+                const child_path = std.fmt.allocPrint(
+                    arena,
+                    "{s}[{d}]",
+                    .{ base_path, i },
+                ) catch {
+                    self.log.err("[Game] spawnFromPrefab: arena allocPrint failed for child path", .{});
+                    continue;
+                };
+                self.ecs_backend.addComponent(child, PrefabChildT{
+                    .root = root,
+                    .local_path = child_path,
+                });
+                const next_base = std.fmt.allocPrint(
+                    arena,
+                    "{s}.children",
+                    .{child_path},
+                ) catch continue;
+                tagPrefabChildren(self, root, child, next_base, arena);
+            }
+        }
+
         pub fn destroyEntity(self: *Self, entity: Entity) void {
             if (self.ecs_backend.getComponent(entity, Children)) |children_comp| {
                 for (children_comp.getChildren()) |child| {

--- a/src/game/save_load_mixin.zig
+++ b/src/game/save_load_mixin.zig
@@ -134,13 +134,7 @@ pub fn Mixin(comptime Game: type) type {
 
                 // Save Position (built-in) — only if not already in the component registry
                 const Position = core.Position;
-                const has_position_in_registry = comptime blk: {
-                    for (names) |name| {
-                        if (Reg.getType(name) == Position) break :blk true;
-                    }
-                    break :blk false;
-                };
-                if (!has_position_in_registry) {
+                if (comptime !isRegistered(Position)) {
                     const pos = self.getPosition(entity);
                     if (!first_comp) try writer.writeAll(",");
                     try writer.writeAll("\n        \"Position\": {\"x\": ");
@@ -170,13 +164,7 @@ pub fn Mixin(comptime Game: type) type {
                 // be "Parent" — that would still collide. Deliberately
                 // scoped to the common case (same type) for now.
                 const Parent = Game.ParentComp;
-                const has_parent_in_registry = comptime blk: {
-                    for (names) |name| {
-                        if (Reg.getType(name) == Parent) break :blk true;
-                    }
-                    break :blk false;
-                };
-                if (!has_parent_in_registry) {
+                if (comptime !isRegistered(Parent)) {
                     if (self.active_world.ecs_backend.getComponent(entity, Parent)) |parent| {
                         if (!first_comp) try writer.writeAll(",");
                         try writer.writeAll("\n        \"Parent\": {\"entity\": ");
@@ -332,13 +320,7 @@ pub fn Mixin(comptime Game: type) type {
 
                 // Restore Position (built-in) — only if not in component registry
                 const Position_load = core.Position;
-                const has_position_in_registry_load = comptime blk: {
-                    for (names) |name| {
-                        if (Reg.getType(name) == Position_load) break :blk true;
-                    }
-                    break :blk false;
-                };
-                if (!has_position_in_registry_load) {
+                if (comptime !isRegistered(Position_load)) {
                     if (components.get("Position")) |pos_val| {
                         const pos_obj = pos_val.object;
                         var px: f32 = 0;
@@ -394,13 +376,7 @@ pub fn Mixin(comptime Game: type) type {
                 // `assertEntityAlive` in debug or corrupt hierarchy
                 // state in release builds.
                 const Parent_load = Game.ParentComp;
-                const has_parent_in_registry_load = comptime blk: {
-                    for (names) |name| {
-                        if (Reg.getType(name) == Parent_load) break :blk true;
-                    }
-                    break :blk false;
-                };
-                if (!has_parent_in_registry_load) {
+                if (comptime !isRegistered(Parent_load)) {
                     if (components.get("Parent")) |parent_val| blk: {
                         // A malformed save carrying `"Parent": 123` or
                         // `"Parent": null` would otherwise trip the

--- a/src/game/save_load_mixin.zig
+++ b/src/game/save_load_mixin.zig
@@ -33,6 +33,31 @@ pub fn Mixin(comptime Game: type) type {
             };
         }
 
+        /// Write a JSON-escaped string literal (including surrounding
+        /// quotes) to `writer`. Used by the built-in save pathway for
+        /// components with `[]const u8` fields (PrefabInstance.path,
+        /// PrefabInstance.overrides, PrefabChild.local_path) — serde's
+        /// `writeComponent` doesn't support string slices, so the save
+        /// mixin handles these components as built-ins and needs its
+        /// own escape helper.
+        fn writeJsonString(writer: anytype, s: []const u8) !void {
+            try writer.writeByte('"');
+            for (s) |c| {
+                switch (c) {
+                    '"' => try writer.writeAll("\\\""),
+                    '\\' => try writer.writeAll("\\\\"),
+                    '\n' => try writer.writeAll("\\n"),
+                    '\r' => try writer.writeAll("\\r"),
+                    '\t' => try writer.writeAll("\\t"),
+                    0x08 => try writer.writeAll("\\b"),
+                    0x0c => try writer.writeAll("\\f"),
+                    0...0x07, 0x0b, 0x0e...0x1f => try std.fmt.format(writer, "\\u{x:0>4}", .{c}),
+                    else => try writer.writeByte(c),
+                }
+            }
+            try writer.writeByte('"');
+        }
+
         /// Collect entities from a view into an ArrayList, closing the view after.
         fn collectEntities(comptime T: type, ecs: anytype, allocator: std.mem.Allocator) !std.ArrayList(Entity) {
             var buf: std.ArrayList(Entity) = .{};
@@ -145,6 +170,61 @@ pub fn Mixin(comptime Game: type) type {
                         try writer.writeAll(if (parent.inherit_rotation) "true" else "false");
                         try writer.writeAll(", \"inherit_scale\": ");
                         try writer.writeAll(if (parent.inherit_scale) "true" else "false");
+                        try writer.writeAll("}");
+                        first_comp = false;
+                    }
+                }
+
+                // Save PrefabInstance (built-in) — attached by
+                // `spawnFromPrefab` to prefab-root entities so save/load
+                // Phase 1 can re-instantiate the prefab and bring back
+                // non-saveable components (Sprite, animation overlays)
+                // on load. Path + overrides-blob are both `[]const u8`,
+                // which serde.writeComponent can't round-trip, so
+                // PrefabInstance lives in the built-in channel alongside
+                // Position and Parent. Same registry-identity guard so
+                // a game registering the type in its ComponentRegistry
+                // doesn't produce duplicate JSON keys.
+                const PrefabInstance = Game.PrefabInstanceComp;
+                const has_prefab_instance_in_registry = comptime blk: {
+                    for (names) |name| {
+                        if (Reg.getType(name) == PrefabInstance) break :blk true;
+                    }
+                    break :blk false;
+                };
+                if (!has_prefab_instance_in_registry) {
+                    if (self.active_world.ecs_backend.getComponent(entity, PrefabInstance)) |pi| {
+                        if (!first_comp) try writer.writeAll(",");
+                        try writer.writeAll("\n        \"PrefabInstance\": {\"path\": ");
+                        try writeJsonString(writer, pi.path);
+                        try writer.writeAll(", \"overrides\": ");
+                        try writeJsonString(writer, pi.overrides);
+                        try writer.writeAll("}");
+                        first_comp = false;
+                    }
+                }
+
+                // Save PrefabChild (built-in) — attached by
+                // `spawnFromPrefab` to every child entity created as
+                // part of a prefab instantiation. `root` points back
+                // at the PrefabInstance entity; serialised as u64 and
+                // remapped through the load `id_map` so lineage
+                // survives entity-ID reassignment (same pattern
+                // Parent.entity uses).
+                const PrefabChildT = Game.PrefabChildComp;
+                const has_prefab_child_in_registry = comptime blk: {
+                    for (names) |name| {
+                        if (Reg.getType(name) == PrefabChildT) break :blk true;
+                    }
+                    break :blk false;
+                };
+                if (!has_prefab_child_in_registry) {
+                    if (self.active_world.ecs_backend.getComponent(entity, PrefabChildT)) |pc| {
+                        if (!first_comp) try writer.writeAll(",");
+                        try writer.writeAll("\n        \"PrefabChild\": {\"root\": ");
+                        try std.fmt.format(writer, "{d}", .{entityToU64(pc.root)});
+                        try writer.writeAll(", \"local_path\": ");
+                        try writeJsonString(writer, pc.local_path);
                         try writer.writeAll("}");
                         first_comp = false;
                     }
@@ -340,6 +420,78 @@ pub fn Mixin(comptime Game: type) type {
                         self.setParent(entity, parent_entity, .{
                             .inherit_rotation = inherit_rotation,
                             .inherit_scale = inherit_scale,
+                        });
+                    }
+                }
+
+                // Restore PrefabInstance (built-in) — counterpart to
+                // the save block above. String fields are duped into
+                // the world's nested-entity arena so they outlive the
+                // parsed JSON deinit.
+                const PrefabInstance_load = Game.PrefabInstanceComp;
+                const has_prefab_instance_in_registry_load = comptime blk: {
+                    for (names) |name| {
+                        if (Reg.getType(name) == PrefabInstance_load) break :blk true;
+                    }
+                    break :blk false;
+                };
+                if (!has_prefab_instance_in_registry_load) {
+                    if (components.get("PrefabInstance")) |pi_val| blk: {
+                        const pi_obj = switch (pi_val) {
+                            .object => |o| o,
+                            else => break :blk,
+                        };
+                        const path_str = switch (pi_obj.get("path") orelse break :blk) {
+                            .string => |s| s,
+                            else => break :blk,
+                        };
+                        const overrides_str = switch (pi_obj.get("overrides") orelse break :blk) {
+                            .string => |s| s,
+                            else => break :blk,
+                        };
+                        const pi_arena = self.active_world.nested_entity_arena.allocator();
+                        const path_dup = try pi_arena.dupe(u8, path_str);
+                        const overrides_dup = try pi_arena.dupe(u8, overrides_str);
+                        self.active_world.ecs_backend.addComponent(entity, PrefabInstance_load{
+                            .path = path_dup,
+                            .overrides = overrides_dup,
+                        });
+                    }
+                }
+
+                // Restore PrefabChild (built-in) — counterpart to the
+                // save block above. `root` is an entity ref, remapped
+                // through `id_map`; `local_path` is duped into the
+                // world arena to outlive the parsed JSON.
+                const PrefabChild_load = Game.PrefabChildComp;
+                const has_prefab_child_in_registry_load = comptime blk: {
+                    for (names) |name| {
+                        if (Reg.getType(name) == PrefabChild_load) break :blk true;
+                    }
+                    break :blk false;
+                };
+                if (!has_prefab_child_in_registry_load) {
+                    if (components.get("PrefabChild")) |pc_val| blk: {
+                        const pc_obj = switch (pc_val) {
+                            .object => |o| o,
+                            else => break :blk,
+                        };
+                        const root_val = pc_obj.get("root") orelse break :blk;
+                        const saved_root_id: u64 = switch (root_val) {
+                            .integer => |i| if (i >= 0) @intCast(i) else break :blk,
+                            else => break :blk,
+                        };
+                        const current_root_id = id_map.get(saved_root_id) orelse break :blk;
+                        const root_entity: Entity = @intCast(current_root_id);
+                        const local_path_str = switch (pc_obj.get("local_path") orelse break :blk) {
+                            .string => |s| s,
+                            else => break :blk,
+                        };
+                        const pc_arena = self.active_world.nested_entity_arena.allocator();
+                        const local_path_dup = try pc_arena.dupe(u8, local_path_str);
+                        self.active_world.ecs_backend.addComponent(entity, PrefabChild_load{
+                            .root = root_entity,
+                            .local_path = local_path_dup,
                         });
                     }
                 }

--- a/src/game/save_load_mixin.zig
+++ b/src/game/save_load_mixin.zig
@@ -20,6 +20,21 @@ pub fn Mixin(comptime Game: type) type {
             return @intCast(entity);
         }
 
+        /// `true` when `T` is registered in the game's
+        /// `ComponentRegistry`. The built-in save/load channel for
+        /// engine-defined components (`Position`, `Parent`,
+        /// `PrefabInstance`, `PrefabChild`) guards on the negation
+        /// of this so a game that decides to register one of them
+        /// directly doesn't end up with duplicate JSON keys (the
+        /// registry-driven path would also emit that component).
+        fn isRegistered(comptime T: type) bool {
+            const names = comptime Reg.names();
+            inline for (names) |name| {
+                if (Reg.getType(name) == T) return true;
+            }
+            return false;
+        }
+
         /// Read a boolean field out of a serialised Parent object,
         /// defaulting to `false` for missing / non-bool values. Kept
         /// local so the save and load sides of the built-in Parent
@@ -186,13 +201,7 @@ pub fn Mixin(comptime Game: type) type {
                 // a game registering the type in its ComponentRegistry
                 // doesn't produce duplicate JSON keys.
                 const PrefabInstance = Game.PrefabInstanceComp;
-                const has_prefab_instance_in_registry = comptime blk: {
-                    for (names) |name| {
-                        if (Reg.getType(name) == PrefabInstance) break :blk true;
-                    }
-                    break :blk false;
-                };
-                if (!has_prefab_instance_in_registry) {
+                if (comptime !isRegistered(PrefabInstance)) {
                     if (self.active_world.ecs_backend.getComponent(entity, PrefabInstance)) |pi| {
                         if (!first_comp) try writer.writeAll(",");
                         try writer.writeAll("\n        \"PrefabInstance\": {\"path\": ");
@@ -212,13 +221,7 @@ pub fn Mixin(comptime Game: type) type {
                 // survives entity-ID reassignment (same pattern
                 // Parent.entity uses).
                 const PrefabChildT = Game.PrefabChildComp;
-                const has_prefab_child_in_registry = comptime blk: {
-                    for (names) |name| {
-                        if (Reg.getType(name) == PrefabChildT) break :blk true;
-                    }
-                    break :blk false;
-                };
-                if (!has_prefab_child_in_registry) {
+                if (comptime !isRegistered(PrefabChildT)) {
                     if (self.active_world.ecs_backend.getComponent(entity, PrefabChildT)) |pc| {
                         if (!first_comp) try writer.writeAll(",");
                         try writer.writeAll("\n        \"PrefabChild\": {\"root\": ");
@@ -429,13 +432,7 @@ pub fn Mixin(comptime Game: type) type {
                 // the world's nested-entity arena so they outlive the
                 // parsed JSON deinit.
                 const PrefabInstance_load = Game.PrefabInstanceComp;
-                const has_prefab_instance_in_registry_load = comptime blk: {
-                    for (names) |name| {
-                        if (Reg.getType(name) == PrefabInstance_load) break :blk true;
-                    }
-                    break :blk false;
-                };
-                if (!has_prefab_instance_in_registry_load) {
+                if (comptime !isRegistered(PrefabInstance_load)) {
                     if (components.get("PrefabInstance")) |pi_val| blk: {
                         const pi_obj = switch (pi_val) {
                             .object => |o| o,
@@ -464,13 +461,7 @@ pub fn Mixin(comptime Game: type) type {
                 // through `id_map`; `local_path` is duped into the
                 // world arena to outlive the parsed JSON.
                 const PrefabChild_load = Game.PrefabChildComp;
-                const has_prefab_child_in_registry_load = comptime blk: {
-                    for (names) |name| {
-                        if (Reg.getType(name) == PrefabChild_load) break :blk true;
-                    }
-                    break :blk false;
-                };
-                if (!has_prefab_child_in_registry_load) {
+                if (comptime !isRegistered(PrefabChild_load)) {
                     if (components.get("PrefabChild")) |pc_val| blk: {
                         const pc_obj = switch (pc_val) {
                             .object => |o| o,

--- a/test/save_load_mixin_test.zig
+++ b/test/save_load_mixin_test.zig
@@ -671,3 +671,142 @@ test "save/load mixin: PrefabInstance + PrefabChild round-trip with id_map remap
     }
     try testing.expectEqual(@as(usize, 1), child_count);
 }
+
+// Regression guard: a save file carrying a malformed PrefabInstance
+// value (e.g. a bare integer or null where the loader expects an
+// object) must NOT panic in debug builds. The defensive
+// `switch (pi_val) { .object => ..., else => break :blk }` on the
+// load side exists specifically for this; if someone ever simplifies
+// it to `pi_val.object` (tag-cast), this test will panic.
+test "save/load mixin: malformed PrefabInstance JSON value is skipped, not panicked" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const filename = "test_save_malformed_pi.json";
+    const malformed =
+        \\{
+        \\  "version": 2,
+        \\  "entities": [
+        \\    {
+        \\      "id": 99,
+        \\      "components": {
+        \\        "Position": {"x": 0, "y": 0},
+        \\        "Worker": {},
+        \\        "PrefabInstance": 123
+        \\      }
+        \\    }
+        \\  ]
+        \\}
+    ;
+    try std.fs.cwd().writeFile(.{ .sub_path = filename, .data = malformed });
+    defer std.fs.cwd().deleteFile(filename) catch {};
+
+    // Load must succeed — the malformed PrefabInstance is silently
+    // skipped, the rest of the entity loads normally.
+    try game.loadGameState(filename);
+
+    const PrefabInstanceT = @TypeOf(game).PrefabInstanceComp;
+    var worker_count: usize = 0;
+    var pi_count: usize = 0;
+    {
+        var view = game.active_world.ecs_backend.view(.{Worker}, .{});
+        while (view.next()) |ent| {
+            worker_count += 1;
+            // Entity exists + Worker was restored; PrefabInstance is
+            // NOT attached because its JSON payload was unusable.
+            try testing.expect(!game.active_world.ecs_backend.hasComponent(ent, PrefabInstanceT));
+        }
+        view.deinit();
+    }
+    try testing.expectEqual(@as(usize, 1), worker_count);
+    {
+        var view = game.active_world.ecs_backend.view(.{PrefabInstanceT}, .{});
+        while (view.next()) |_| pi_count += 1;
+        view.deinit();
+    }
+    try testing.expectEqual(@as(usize, 0), pi_count);
+}
+
+// Regression guard: when a save file's PrefabChild.root points at a
+// saved entity ID that isn't present in the save, the `id_map.get
+// orelse break :blk` guard must skip the restore — otherwise the
+// child would be attached to entity 0 (or whatever integer the JSON
+// carries, stale) and corrupt the lineage.
+test "save/load mixin: PrefabChild with unresolvable root is skipped, not attached to stale id" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const filename = "test_save_unresolvable_root.json";
+    // Entity 77 references a non-existent root 9999 via PrefabChild;
+    // the only registered saveable on entity 77 is Worker so it gets
+    // collected, and Position is emitted as a built-in.
+    const malformed =
+        \\{
+        \\  "version": 2,
+        \\  "entities": [
+        \\    {
+        \\      "id": 77,
+        \\      "components": {
+        \\        "Position": {"x": 0, "y": 0},
+        \\        "Worker": {},
+        \\        "PrefabChild": {"root": 9999, "local_path": "children[0]"}
+        \\      }
+        \\    }
+        \\  ]
+        \\}
+    ;
+    try std.fs.cwd().writeFile(.{ .sub_path = filename, .data = malformed });
+    defer std.fs.cwd().deleteFile(filename) catch {};
+
+    try game.loadGameState(filename);
+
+    const PrefabChildT = @TypeOf(game).PrefabChildComp;
+    var count: usize = 0;
+    {
+        var view = game.active_world.ecs_backend.view(.{PrefabChildT}, .{});
+        while (view.next()) |_| count += 1;
+        view.deinit();
+    }
+    try testing.expectEqual(@as(usize, 0), count);
+}
+
+// Regression guard for `writeJsonString` control-char handling.
+// `overrides` is a JSON blob; in practice it might carry escape
+// sequences like `\n` (newline), `\t` (tab), or `\b` (backspace)
+// when scene-level overrides span multiple lines. This test pins the
+// round-trip: a string containing every short escape case survives
+// save + load byte-for-byte.
+test "save/load mixin: PrefabInstance overrides round-trips with control-char escapes" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const PrefabInstanceT = @TypeOf(game).PrefabInstanceComp;
+    const tricky: []const u8 = "line1\nline2\ttabbed\\back\"quote\rcr\x08bs\x0cff\x01ctl";
+
+    const entity = game.createEntity();
+    game.active_world.ecs_backend.addComponent(entity, Position{ .x = 0, .y = 0 });
+    game.active_world.ecs_backend.addComponent(entity, Worker{});
+    game.active_world.ecs_backend.addComponent(entity, PrefabInstanceT{
+        .path = "test",
+        .overrides = tricky,
+    });
+
+    const filename = "test_save_escapes.json";
+    try game.saveGameState(filename);
+    defer std.fs.cwd().deleteFile(filename) catch {};
+
+    game.resetEcsBackend();
+    try game.loadGameState(filename);
+
+    var count: usize = 0;
+    {
+        var view = game.active_world.ecs_backend.view(.{PrefabInstanceT}, .{});
+        while (view.next()) |ent| {
+            count += 1;
+            const pi = game.active_world.ecs_backend.getComponent(ent, PrefabInstanceT).?;
+            try testing.expectEqualStrings(tricky, pi.overrides);
+        }
+        view.deinit();
+    }
+    try testing.expectEqual(@as(usize, 1), count);
+}

--- a/test/save_load_mixin_test.zig
+++ b/test/save_load_mixin_test.zig
@@ -572,3 +572,102 @@ test "save/load mixin: marker-driven re-hydration of non-saveable render compone
         try testing.expectEqual(expected.z_index, visual.z_index);
     }
 }
+
+// Slice 1b of the save/load-for-prefabs RFC (labelle-engine #472):
+// PrefabInstance + PrefabChild get serialised as built-ins alongside
+// Position and Parent. This test locks that round-trip:
+//
+// 1. Create a "prefab root" entity with `PrefabInstance { path,
+//    overrides }` plus a registered saveable component (Worker) so it
+//    gets picked up by the entity-collection pass.
+// 2. Create a "prefab child" entity with `PrefabChild { root,
+//    local_path }` pointing at the root, plus Position and another
+//    registered component.
+// 3. Save → reset → load.
+// 4. Assert: PrefabInstance survives with its exact string fields;
+//    PrefabChild.root is remapped via `id_map` to the new root entity
+//    ID; local_path round-trips; the save file contains escaped JSON
+//    strings (not a pointer address or raw byte dump).
+//
+// The save file's entity order isn't stable across implementations,
+// so the test looks up the new root entity by walking entities with
+// PrefabInstance, then asserts PrefabChild.root matches that entity.
+test "save/load mixin: PrefabInstance + PrefabChild round-trip with id_map remap" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const PrefabInstanceT = @TypeOf(game).PrefabInstanceComp;
+    const PrefabChildT = @TypeOf(game).PrefabChildComp;
+
+    // Root entity: registered Worker + built-in Position + PrefabInstance.
+    const root_entity = game.createEntity();
+    game.active_world.ecs_backend.addComponent(root_entity, Position{ .x = 156, .y = 0 });
+    game.active_world.ecs_backend.addComponent(root_entity, Worker{});
+    game.active_world.ecs_backend.addComponent(root_entity, PrefabInstanceT{
+        .path = "hydroponics",
+        // Overrides blob — a JSON string embedded as a string field,
+        // exercising the writeJsonString escape path for `"` and `\`.
+        .overrides = "{\"components\":{\"Position\":{\"x\":156,\"y\":0}}}",
+    });
+
+    // Child entity: registered Health + Position + PrefabChild.
+    const child_entity = game.createEntity();
+    game.active_world.ecs_backend.addComponent(child_entity, Position{ .x = 15, .y = 0 });
+    game.active_world.ecs_backend.addComponent(child_entity, Health{ .current = 100, .max = 100 });
+    game.active_world.ecs_backend.addComponent(child_entity, PrefabChildT{
+        .root = @intCast(root_entity),
+        .local_path = "children[0]",
+    });
+
+    // Save.
+    const filename = "test_save_prefab.json";
+    try game.saveGameState(filename);
+    defer std.fs.cwd().deleteFile(filename) catch {};
+
+    // Inspect the save file: the path + escaped overrides + local_path
+    // should be present as JSON strings. Guards against a regression
+    // where writeJsonString stops escaping quotes / backslashes.
+    const json = try std.fs.cwd().readFileAlloc(testing.allocator, filename, 1024 * 1024);
+    defer testing.allocator.free(json);
+    try testing.expect(std.mem.indexOf(u8, json, "\"path\": \"hydroponics\"") != null);
+    try testing.expect(std.mem.indexOf(u8, json, "\\\"components\\\"") != null); // escaped quote
+    try testing.expect(std.mem.indexOf(u8, json, "\"local_path\": \"children[0]\"") != null);
+
+    // Reset + load.
+    game.resetEcsBackend();
+    try game.loadGameState(filename);
+
+    // Find the new root entity (the one carrying PrefabInstance).
+    var new_root_id: ?u64 = null;
+    var root_count: usize = 0;
+    {
+        var view = game.active_world.ecs_backend.view(.{PrefabInstanceT}, .{});
+        while (view.next()) |ent| {
+            root_count += 1;
+            new_root_id = @intCast(ent);
+            const pi = game.active_world.ecs_backend.getComponent(ent, PrefabInstanceT).?;
+            try testing.expectEqualStrings("hydroponics", pi.path);
+            try testing.expectEqualStrings(
+                "{\"components\":{\"Position\":{\"x\":156,\"y\":0}}}",
+                pi.overrides,
+            );
+        }
+        view.deinit();
+    }
+    try testing.expectEqual(@as(usize, 1), root_count);
+
+    // Assert PrefabChild.root was remapped through id_map to point at
+    // the new root entity (not the saved 1 or 2 or whatever ID).
+    var child_count: usize = 0;
+    {
+        var view = game.active_world.ecs_backend.view(.{PrefabChildT}, .{});
+        while (view.next()) |ent| {
+            child_count += 1;
+            const pc = game.active_world.ecs_backend.getComponent(ent, PrefabChildT).?;
+            try testing.expectEqual(new_root_id.?, @as(u64, @intCast(pc.root)));
+            try testing.expectEqualStrings("children[0]", pc.local_path);
+        }
+        view.deinit();
+    }
+    try testing.expectEqual(@as(usize, 1), child_count);
+}

--- a/test/spawn_from_prefab_test.zig
+++ b/test/spawn_from_prefab_test.zig
@@ -1,0 +1,197 @@
+//! `spawnFromPrefab` integration tests.
+//!
+//! Exercises the prefab-instantiation → PrefabInstance/PrefabChild
+//! tagging pipeline added in Slice 2 of the save/load-for-prefabs
+//! RFC. Uses `engine.Game` + `JsoncSceneBridge` + a tmp-dir scene
+//! jsonc to get a realistic prefab-cache setup.
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+
+const Health = struct {
+    current: f32 = 100,
+    max: f32 = 100,
+};
+
+const Components = engine.ComponentRegistry(.{
+    .Health = Health,
+});
+
+const Bridge = engine.JsoncSceneBridge(engine.Game, Components);
+const PrefabInstance = engine.Game.PrefabInstanceComp;
+const PrefabChild = engine.Game.PrefabChildComp;
+
+/// Fixture bundles the Game with the heap-allocated `prefab_dir`
+/// path that its prefab cache borrows. Freeing the path while the
+/// game is still alive dangles the cache's borrow, so both die
+/// together in `deinit`.
+const TestFixture = struct {
+    game: engine.Game,
+    prefab_dir: []const u8,
+
+    fn deinit(self: *TestFixture) void {
+        self.game.deinit();
+        testing.allocator.free(self.prefab_dir);
+    }
+};
+
+fn bootGameWithPrefab(
+    tmp_dir: *std.testing.TmpDir,
+    prefab_name: []const u8,
+    prefab_source: []const u8,
+) !TestFixture {
+    try tmp_dir.dir.makeDir("prefabs");
+
+    const prefab_sub = try std.fmt.allocPrint(testing.allocator, "prefabs/{s}.jsonc", .{prefab_name});
+    defer testing.allocator.free(prefab_sub);
+    try tmp_dir.dir.writeFile(.{ .sub_path = prefab_sub, .data = prefab_source });
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = try tmp_dir.dir.realpath(".", &buf);
+    const prefab_dir = try std.fmt.allocPrint(testing.allocator, "{s}/prefabs", .{dir_path});
+    errdefer testing.allocator.free(prefab_dir);
+
+    var game = engine.Game.init(testing.allocator);
+    errdefer game.deinit();
+
+    try Bridge.loadSceneFromSource(&game,
+        \\{ "entities": [] }
+    , prefab_dir);
+
+    return .{ .game = game, .prefab_dir = prefab_dir };
+}
+
+test "spawnFromPrefab: tags root with PrefabInstance { path }" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var fixture = try bootGameWithPrefab(&tmp_dir, "bare",
+        \\{
+        \\  "components": { "Health": { "current": 75, "max": 100 } }
+        \\}
+    );
+    defer fixture.deinit();
+
+    const entity = fixture.game.spawnFromPrefab("bare", .{ .x = 10, .y = 20 }).?;
+
+    const h = fixture.game.ecs_backend.getComponent(entity, Health).?;
+    try testing.expectApproxEqAbs(@as(f32, 75), h.current, 0.01);
+
+    const pi = fixture.game.ecs_backend.getComponent(entity, PrefabInstance).?;
+    try testing.expectEqualStrings("bare", pi.path);
+    try testing.expectEqualStrings("", pi.overrides);
+}
+
+test "spawnFromPrefab: returns null for unknown prefab name" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var fixture = try bootGameWithPrefab(&tmp_dir, "bare",
+        \\{
+        \\  "components": { "Health": {} }
+        \\}
+    );
+    defer fixture.deinit();
+
+    const result = fixture.game.spawnFromPrefab("not_a_prefab", .{ .x = 0, .y = 0 });
+    try testing.expect(result == null);
+}
+
+test "spawnFromPrefab: tags children with PrefabChild { root, local_path }" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    // Prefab with two children; the second has a grand-child.
+    // Expected local_paths:
+    //   child 0:                       children[0]
+    //   child 1:                       children[1]
+    //   child 1 → grand-child 0:       children[1].children[0]
+    var fixture = try bootGameWithPrefab(&tmp_dir, "tree",
+        \\{
+        \\  "components": { "Health": { "current": 100, "max": 100 } },
+        \\  "children": [
+        \\    { "components": { "Health": { "current": 10, "max": 10 } } },
+        \\    {
+        \\      "components": { "Health": { "current": 20, "max": 20 } },
+        \\      "children": [
+        \\        { "components": { "Health": { "current": 30, "max": 30 } } }
+        \\      ]
+        \\    }
+        \\  ]
+        \\}
+    );
+    defer fixture.deinit();
+
+    const root = fixture.game.spawnFromPrefab("tree", .{ .x = 0, .y = 0 }).?;
+    const root_id: u32 = @intCast(root);
+
+    var found_c0 = false;
+    var found_c1 = false;
+    var found_c1_gc0 = false;
+    var tagged_count: usize = 0;
+
+    var view = fixture.game.ecs_backend.view(.{PrefabChild}, .{});
+    defer view.deinit();
+    while (view.next()) |ent| {
+        tagged_count += 1;
+        const pc = fixture.game.ecs_backend.getComponent(ent, PrefabChild).?;
+        try testing.expectEqual(root_id, @as(u32, @intCast(pc.root)));
+        if (std.mem.eql(u8, pc.local_path, "children[0]")) {
+            found_c0 = true;
+        } else if (std.mem.eql(u8, pc.local_path, "children[1]")) {
+            found_c1 = true;
+        } else if (std.mem.eql(u8, pc.local_path, "children[1].children[0]")) {
+            found_c1_gc0 = true;
+        }
+    }
+
+    try testing.expectEqual(@as(usize, 3), tagged_count);
+    try testing.expect(found_c0);
+    try testing.expect(found_c1);
+    try testing.expect(found_c1_gc0);
+
+    // The root itself has PrefabInstance (not PrefabChild).
+    const pi = fixture.game.ecs_backend.getComponent(root, PrefabInstance).?;
+    try testing.expectEqualStrings("tree", pi.path);
+    try testing.expect(!fixture.game.ecs_backend.hasComponent(root, PrefabChild));
+}
+
+test "spawnFromPrefab: multiple spawns get independent roots" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var fixture = try bootGameWithPrefab(&tmp_dir, "unit",
+        \\{
+        \\  "components": { "Health": { "current": 50, "max": 50 } },
+        \\  "children": [
+        \\    { "components": { "Health": { "current": 5, "max": 5 } } }
+        \\  ]
+        \\}
+    );
+    defer fixture.deinit();
+
+    const a = fixture.game.spawnFromPrefab("unit", .{ .x = 0, .y = 0 }).?;
+    const b = fixture.game.spawnFromPrefab("unit", .{ .x = 50, .y = 50 }).?;
+    try testing.expect(a != b);
+
+    try testing.expect(fixture.game.ecs_backend.hasComponent(a, PrefabInstance));
+    try testing.expect(fixture.game.ecs_backend.hasComponent(b, PrefabInstance));
+
+    const a_id: u32 = @intCast(a);
+    const b_id: u32 = @intCast(b);
+    var a_children: usize = 0;
+    var b_children: usize = 0;
+
+    var view = fixture.game.ecs_backend.view(.{PrefabChild}, .{});
+    defer view.deinit();
+    while (view.next()) |ent| {
+        const pc = fixture.game.ecs_backend.getComponent(ent, PrefabChild).?;
+        const root_id: u32 = @intCast(pc.root);
+        if (root_id == a_id) a_children += 1;
+        if (root_id == b_id) b_children += 1;
+    }
+
+    try testing.expectEqual(@as(usize, 1), a_children);
+    try testing.expectEqual(@as(usize, 1), b_children);
+}


### PR DESCRIPTION
## Summary

Slice 2 of [RFC-SAVE-LOAD-PREFABS.md](https://github.com/labelle-toolkit/labelle-engine/pull/472). Stacked on [#474](https://github.com/labelle-toolkit/labelle-engine/pull/474) (Slice 1b built-in handlers).

New `game.spawnFromPrefab(path, pos) ?Entity` — wraps the existing `game.spawnPrefab` with automatic `PrefabInstance` / `PrefabChild` tagging so the save mixin's built-in handlers can round-trip the prefab lineage through F5 → F9.

Closes the `spawnFromPrefab` half of [#479](https://github.com/labelle-toolkit/labelle-engine/issues/479). The jsonc-bridge auto-tagging half is the natural follow-up.

## What's in it

1. **`Game.spawnFromPrefab(path, pos)`** — delegates to the existing `spawnPrefab` hook (already wired via `JsoncSceneBridge::loadSceneFromSource`), then tags:
   - Root → `PrefabInstance { path: <arena-duped>, overrides: "" }`.
   - Each descendant → `PrefabChild { root, local_path }` where `local_path` is a dotted-index path (`children[0]`, `children[1].children[0]`, etc.).
   - String storage in `active_world.nested_entity_arena` — same ownership contract [labelle-core v1.12](https://github.com/labelle-toolkit/labelle-core/pull/13) documented for the tracking types (arena-owned, freed on scene change, no per-entity free needed).

2. **Recursive child tagger** — `tagPrefabChildren(root, parent, base_path, arena)` walks `game.getChildren(parent)` and emits `children[i]` → `children[i].children[j]` paths as it descends.

## What this does NOT do yet

Explicitly scoped. Follow-ups:

- **Structured overrides** — `overrides = ""` on every spawn. The full "apply caller-supplied component overrides on top of prefab defaults" pipeline needs design work for `serde.writeComponent` round-trip + application semantics.
- **jsonc-bridge auto-tagging** (the other half of #479) — scene-sourced prefab entities don't get tagged yet. Lands as a separate PR once the runtime API shape settles here.
- **Two-phase load** (Slice 3) — Phase 1 reinstantiating from saved `PrefabInstance` + matching saved `PrefabChild` records to newly-spawned children via `(root, local_path)`. This slice establishes the `local_path` format Slice 3 will match against.

## Tests (4 new in `test/spawn_from_prefab_test.zig`)

1. Root entity carries `PrefabInstance { path, overrides: "" }` with Health from the prefab preserved.
2. Unknown prefab name returns `null`.
3. Multi-level children get correctly-indexed `PrefabChild.local_path` — `children[0]`, `children[1]`, `children[1].children[0]` — and the root entity itself has NO `PrefabChild` (only `PrefabInstance`).
4. Multiple spawns produce independent roots with non-crossing `PrefabChild.root` references.

### Lifetime gotcha caught during test development

First pass crashed in `std.fmt.allocPrint` — `PrefabCache.prefab_dir` borrows into a string the test allocated, and my helper was freeing it before the Game deinit. Fixture struct now bundles `Game + prefab_dir` so both die together. Documented inline.

Full engine suite: **211/211 green** (+4 new).

## Dependencies

- [#474](https://github.com/labelle-toolkit/labelle-engine/pull/474) (Slice 1b handlers) — stacked on. Tags don't round-trip without those handlers.
- [labelle-core v1.12](https://github.com/labelle-toolkit/labelle-core/pull/13) — already released.

## Chain state after this PR

| Phase | PR | State |
|---|---|---|
| Save/load Slice 1 — types | core #13 | ✅ Merged |
| Save/load Slice 1b — handlers | #474 | Draft |
| **Save/load Slice 2a — spawnFromPrefab** | **this PR** | **Draft (stacked on #474)** |
| Save/load Slice 2b — jsonc-bridge auto-tag | — | Not started |
| Save/load Slice 3 — two-phase load | — | Blocked on 2a + 2b |
| Animation A/A+/B/B+ | #475/#480/#476/#481 | All drafts |

🤖 Generated with [Claude Code](https://claude.com/claude-code)