### PR TITLE
feat(scene-bridge): auto-tag prefab entities on scene load (Slice 2b)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -48,6 +48,7 @@ pub fn build(b: *std.Build) void {
         "test/scene_assets_hooks_test.zig",
         "test/pause_hook_test.zig",
         "test/spawn_from_prefab_test.zig",
+        "test/jsonc_bridge_prefab_tags_test.zig",
     };
 
     for (test_files) |test_file| {

--- a/src/jsonc_scene_bridge.zig
+++ b/src/jsonc_scene_bridge.zig
@@ -590,6 +590,34 @@ pub fn JsoncSceneBridge(comptime GameType: type, comptime Components: type) type
                 }
             }
 
+            // Save/load Slice 2b: tag prefab-sourced entities with
+            // PrefabInstance so the save mixin's built-in handler
+            // records their prefab origin. This is the scene-load
+            // counterpart to the runtime `game.spawnFromPrefab` API.
+            //
+            // Scope: tags the ROOT only (entities whose scene jsonc
+            // declared a `"prefab"` field). PrefabChild tagging of
+            // nested prefab children lands in a follow-up — the
+            // children loop above doesn't know which children came
+            // from the prefab's `children` array vs the scene's
+            // (they interleave), so structured path generation needs
+            // its own pass. For now, runtime `spawnFromPrefab` handles
+            // the full root+children tagging; scene-load covers just
+            // the root, which is what the save mixin needs to
+            // reinstantiate the prefab on load.
+            if (entity_obj.getString("prefab")) |prefab_name| {
+                const PrefabInstance = GameType.PrefabInstanceComp;
+                const arena = game.active_world.nested_entity_arena.allocator();
+                if (arena.dupe(u8, prefab_name)) |path_dup| {
+                    game.active_world.ecs_backend.addComponent(entity, PrefabInstance{
+                        .path = path_dup,
+                        .overrides = "",
+                    });
+                } else |_| {
+                    game.log.err("[JsoncSceneBridge] failed to allocate PrefabInstance.path for '{s}'", .{prefab_name});
+                }
+            }
+
             return entity;
         }
 

--- a/src/jsonc_scene_bridge.zig
+++ b/src/jsonc_scene_bridge.zig
@@ -608,14 +608,19 @@ pub fn JsoncSceneBridge(comptime GameType: type, comptime Components: type) type
             if (entity_obj.getString("prefab")) |prefab_name| {
                 const PrefabInstance = GameType.PrefabInstanceComp;
                 const arena = game.active_world.nested_entity_arena.allocator();
-                if (arena.dupe(u8, prefab_name)) |path_dup| {
-                    game.active_world.ecs_backend.addComponent(entity, PrefabInstance{
-                        .path = path_dup,
-                        .overrides = "",
-                    });
-                } else |_| {
-                    game.log.err("[JsoncSceneBridge] failed to allocate PrefabInstance.path for '{s}'", .{prefab_name});
-                }
+                // Propagate arena OOM up through `LoadEntityError` (which
+                // already carries `OutOfMemory`). Swallowing the error
+                // here and continuing would load the entity without its
+                // `PrefabInstance` tag — invisible to the save mixin's
+                // Phase 1, breaking F5 → F9 silently. Same atomicity
+                // contract `spawnFromPrefab` adopted in #482: any
+                // tagging failure tears the load down instead of
+                // leaving a half-tagged world behind.
+                const path_dup = try arena.dupe(u8, prefab_name);
+                game.active_world.ecs_backend.addComponent(entity, PrefabInstance{
+                    .path = path_dup,
+                    .overrides = "",
+                });
             }
 
             return entity;

--- a/test/jsonc_bridge_prefab_tags_test.zig
+++ b/test/jsonc_bridge_prefab_tags_test.zig
@@ -1,0 +1,215 @@
+//! Slice 2b tests: `JsoncSceneBridge` auto-tags scene-loaded prefab
+//! entities with `PrefabInstance` so the save mixin can reinstantiate
+//! them on load without the game having to call `spawnFromPrefab`
+//! manually.
+//!
+//! Scope covered here (root-only tagging; PrefabChild for scene-load
+//! nested children is a follow-up — see the comment in
+//! `loadEntityInternal` near the tagging call).
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+const core = @import("labelle-core");
+
+const Health = struct {
+    pub const save = core.Saveable(.saveable, @This(), .{});
+    current: f32 = 100,
+    max: f32 = 100,
+};
+
+const TestComponents = engine.ComponentRegistry(.{
+    .Health = Health,
+});
+
+// A Game configured with our `Health` in the component registry so
+// the save mixin actually collects entities carrying it. The default
+// `engine.Game` uses `EmptyComponents`, which means `saveGameState`
+// would see zero entities — fine for jsonc-parse tests but not for
+// save/load round-trip.
+const MockEcs = core.MockEcsBackend(u32);
+const TestGame = engine.game_mod.GameConfig(
+    core.StubRender(MockEcs.Entity),
+    MockEcs,
+    engine.input_mod.StubInput,
+    engine.audio_mod.StubAudio,
+    engine.gui_mod.StubGui,
+    void,
+    core.StubLogSink,
+    TestComponents,
+    &.{},
+    void,
+);
+
+const Bridge = engine.JsoncSceneBridge(TestGame, TestComponents);
+const PrefabInstance = TestGame.PrefabInstanceComp;
+
+const TestFixture = struct {
+    game: TestGame,
+    prefab_dir: []const u8,
+
+    fn deinit(self: *TestFixture) void {
+        self.game.deinit();
+        testing.allocator.free(self.prefab_dir);
+    }
+};
+
+fn setupFixture(
+    tmp_dir: *std.testing.TmpDir,
+    prefab_files: anytype,
+    scene_source: []const u8,
+) !TestFixture {
+    try tmp_dir.dir.makeDir("prefabs");
+
+    inline for (std.meta.fields(@TypeOf(prefab_files))) |field| {
+        const path = try std.fmt.allocPrint(testing.allocator, "prefabs/{s}.jsonc", .{field.name});
+        defer testing.allocator.free(path);
+        try tmp_dir.dir.writeFile(.{ .sub_path = path, .data = @field(prefab_files, field.name) });
+    }
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = try tmp_dir.dir.realpath(".", &buf);
+    const prefab_dir = try std.fmt.allocPrint(testing.allocator, "{s}/prefabs", .{dir_path});
+    errdefer testing.allocator.free(prefab_dir);
+
+    var game = TestGame.init(testing.allocator);
+    errdefer game.deinit();
+
+    try Bridge.loadSceneFromSource(&game, scene_source, prefab_dir);
+
+    return .{ .game = game, .prefab_dir = prefab_dir };
+}
+
+test "jsonc_scene_bridge: prefab-sourced entity gets PrefabInstance tag" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var fixture = try setupFixture(&tmp_dir, .{
+        .enemy =
+        \\{
+        \\  "components": { "Health": { "current": 75, "max": 100 } }
+        \\}
+        ,
+    },
+        \\{
+        \\  "entities": [
+        \\    { "prefab": "enemy", "components": { "Position": { "x": 10, "y": 20 } } }
+        \\  ]
+        \\}
+    );
+    defer fixture.deinit();
+
+    var count: usize = 0;
+    var view = fixture.game.active_world.ecs_backend.view(.{Health}, .{});
+    defer view.deinit();
+    while (view.next()) |ent| {
+        count += 1;
+        const pi = fixture.game.active_world.ecs_backend.getComponent(ent, PrefabInstance).?;
+        try testing.expectEqualStrings("enemy", pi.path);
+        try testing.expectEqualStrings("", pi.overrides);
+    }
+    try testing.expectEqual(@as(usize, 1), count);
+}
+
+test "jsonc_scene_bridge: non-prefab entity does NOT get PrefabInstance" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var fixture = try setupFixture(&tmp_dir, .{},
+        \\{
+        \\  "entities": [
+        \\    { "components": { "Health": { "current": 50, "max": 50 } } }
+        \\  ]
+        \\}
+    );
+    defer fixture.deinit();
+
+    var view = fixture.game.active_world.ecs_backend.view(.{Health}, .{});
+    defer view.deinit();
+    var count: usize = 0;
+    while (view.next()) |ent| {
+        count += 1;
+        try testing.expect(!fixture.game.active_world.ecs_backend.hasComponent(ent, PrefabInstance));
+    }
+    try testing.expectEqual(@as(usize, 1), count);
+}
+
+test "jsonc_scene_bridge: multiple prefab instances each get their own PrefabInstance tag" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var fixture = try setupFixture(&tmp_dir, .{
+        .warrior =
+        \\{ "components": { "Health": { "current": 100, "max": 100 } } }
+        ,
+        .archer =
+        \\{ "components": { "Health": { "current": 50, "max": 50 } } }
+        ,
+    },
+        \\{
+        \\  "entities": [
+        \\    { "prefab": "warrior" },
+        \\    { "prefab": "warrior", "components": { "Position": { "x": 5, "y": 5 } } },
+        \\    { "prefab": "archer" }
+        \\  ]
+        \\}
+    );
+    defer fixture.deinit();
+
+    var warrior_count: usize = 0;
+    var archer_count: usize = 0;
+
+    var view = fixture.game.active_world.ecs_backend.view(.{PrefabInstance}, .{});
+    defer view.deinit();
+    while (view.next()) |ent| {
+        const pi = fixture.game.active_world.ecs_backend.getComponent(ent, PrefabInstance).?;
+        if (std.mem.eql(u8, pi.path, "warrior")) warrior_count += 1;
+        if (std.mem.eql(u8, pi.path, "archer")) archer_count += 1;
+    }
+
+    try testing.expectEqual(@as(usize, 2), warrior_count);
+    try testing.expectEqual(@as(usize, 1), archer_count);
+}
+
+test "jsonc_scene_bridge: PrefabInstance.path survives save/load round-trip" {
+    // End-to-end: scene-load tags → save → reset → load → tag restored.
+    // This is the contract the save mixin's Slice 1b handlers build on,
+    // and the reason the auto-tagging matters for downstream games.
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var fixture = try setupFixture(&tmp_dir, .{
+        .unit =
+        \\{ "components": { "Health": { "current": 30, "max": 30 } } }
+        ,
+    },
+        \\{
+        \\  "entities": [
+        \\    { "prefab": "unit" }
+        \\  ]
+        \\}
+    );
+    defer fixture.deinit();
+
+    const save_path = "test_save_bridge_prefab.json";
+    try fixture.game.saveGameState(save_path);
+    defer std.fs.cwd().deleteFile(save_path) catch {};
+
+    const json = try std.fs.cwd().readFileAlloc(testing.allocator, save_path, 1024 * 1024);
+    defer testing.allocator.free(json);
+    try testing.expect(std.mem.indexOf(u8, json, "\"PrefabInstance\"") != null);
+    try testing.expect(std.mem.indexOf(u8, json, "\"path\": \"unit\"") != null);
+
+    fixture.game.resetEcsBackend();
+    try fixture.game.loadGameState(save_path);
+
+    var view = fixture.game.active_world.ecs_backend.view(.{PrefabInstance}, .{});
+    defer view.deinit();
+    var count: usize = 0;
+    while (view.next()) |ent| {
+        count += 1;
+        const pi = fixture.game.active_world.ecs_backend.getComponent(ent, PrefabInstance).?;
+        try testing.expectEqualStrings("unit", pi.path);
+    }
+    try testing.expectEqual(@as(usize, 1), count);
+}


### PR DESCRIPTION
## Summary

Slice 2b of [RFC-SAVE-LOAD-PREFABS.md](https://github.com/labelle-toolkit/labelle-engine/pull/472). Scene-load counterpart to [#482](https://github.com/labelle-toolkit/labelle-engine/pull/482) (Slice 2a runtime `spawnFromPrefab`) — entities whose scene jsonc declared a `"prefab"` field now get tagged with `PrefabInstance` on load. Games don't have to call `spawnFromPrefab` manually for scene-declared prefab instances.

## Change

One insertion in `src/jsonc_scene_bridge.zig::loadEntityInternal` at the end of entity assembly (after components applied, children spawned, `onReady` fired): if the scene jsonc had `"prefab": "..."`, dupe the path into `active_world.nested_entity_arena` and `addComponent` `PrefabInstance { path, overrides: "" }`.

## Scope — root only

Explicitly tagging the root entity only, NOT nested children. The children loop in `loadEntityInternal` interleaves prefab-defined children and scene-declared children and recurses through `loadChildEntity`; picking out which children came from the prefab and generating `children[i]...` paths matching the runtime `spawnFromPrefab` format ([#482](https://github.com/labelle-toolkit/labelle-engine/pull/482)) is a separate design problem worth its own PR.

- Runtime `spawnFromPrefab` ([#482](https://github.com/labelle-toolkit/labelle-engine/pull/482)) tags root + all descendants with `children[i]...`.
- Scene-load (this PR) tags root only — sufficient for the save mixin to recognise prefab-sourced entities; not yet sufficient for full Slice 3 two-phase load of nested-prefab scenes.

## Tests (4 new in `test/jsonc_bridge_prefab_tags_test.zig`)

1. Prefab-sourced scene entity → `PrefabInstance { path: "enemy" }`.
2. Non-prefab scene entity → no `PrefabInstance`.
3. Multiple prefab instances — 2× warrior + 1× archer each get their own tag with the correct path.
4. **Save/load round-trip** — scene-load tags → `saveGameState` → `resetEcsBackend` → `loadGameState` → tags restored. Pins the contract with Slice 1b's built-in save handler via a byte-level check on the save file (`"PrefabInstance": ...` + `"path": "unit"`).

### Gotcha caught during test development

First pass of the round-trip test failed — the save file contained no `PrefabInstance`. Cause: `engine.Game` uses `EmptyComponents`, so the save mixin iterates an empty registry and collects zero entities. Fine for jsonc-parse tests but wrong for save/load. Test now builds a proper `TestGame` with a registered `Health` component so the collection pass picks up entities.

Full engine suite: **215/215 green** (+4 new).

## Dependencies

- Slice 1b ([#474](https://github.com/labelle-toolkit/labelle-engine/pull/474)) — built-in `PrefabInstance` save handler.
- Slice 2a ([#482](https://github.com/labelle-toolkit/labelle-engine/pull/482)) — shares the tagging pattern.

Stacked: `#474 → #482 → this`.

## Chain state after this PR

| Phase | PR | State |
|---|---|---|
| Save/load Slice 1 (types) | core #13 | ✅ Merged v1.12 |
| Save/load Slice 1b (handlers) | #474 | Draft |
| Save/load Slice 2a (spawnFromPrefab) | #482 | Draft (stacked on #474) |
| **Save/load Slice 2b (scene auto-tag)** | **this PR** | **Draft (stacked on #482)** |
| Save/load Slice 3 (two-phase load) | — | Next |
| Animation A/A+/B/B+ | #475/#480/#476/#481 | All drafts |

🤖 Generated with [Claude Code](https://claude.com/claude-code)