### PR TITLE
feat(save_load): two-phase load — prefab re-instantiation on F9 (Slice 3)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -49,6 +49,7 @@ pub fn build(b: *std.Build) void {
         "test/pause_hook_test.zig",
         "test/spawn_from_prefab_test.zig",
         "test/jsonc_bridge_prefab_tags_test.zig",
+        "test/save_load_two_phase_test.zig",
     };
 
     for (test_files) |test_file| {

--- a/src/game/save_load_mixin.zig
+++ b/src/game/save_load_mixin.zig
@@ -48,6 +48,32 @@ pub fn Mixin(comptime Game: type) type {
             };
         }
 
+        /// Walk a dotted `children[i]...` path from `root` through
+        /// `game.getChildren`, returning the entity at the end or
+        /// `null` when the path doesn't resolve (missing index,
+        /// malformed syntax, root has no children, etc.). Matches the
+        /// path format `spawnFromPrefab` (and the scene-bridge
+        /// auto-tagger) emit, so save/load Phase 1 can find the
+        /// re-spawned child that corresponds to each saved PrefabChild.
+        fn findChildByLocalPath(self: *Game, root: Entity, local_path: []const u8) ?Entity {
+            var current: Entity = root;
+            var rest = local_path;
+            while (rest.len > 0) {
+                if (rest[0] == '.') rest = rest[1..];
+                const prefix = "children[";
+                if (!std.mem.startsWith(u8, rest, prefix)) return null;
+                rest = rest[prefix.len..];
+                const close = std.mem.indexOfScalar(u8, rest, ']') orelse return null;
+                const idx = std.fmt.parseInt(usize, rest[0..close], 10) catch return null;
+                rest = rest[close + 1 ..];
+
+                const children = self.getChildren(current);
+                if (idx >= children.len) return null;
+                current = children[idx];
+            }
+            return current;
+        }
+
         /// Write a JSON-escaped string literal (including surrounding
         /// quotes) to `writer`. Used by the built-in save pathway for
         /// components with `[]const u8` fields (PrefabInstance.path,
@@ -298,13 +324,119 @@ pub fn Mixin(comptime Game: type) type {
             self.clearActiveSceneEntities();
             self.resetEcsBackend();
 
-            // Step 2: Create new entities and build ID map
+            // Step 2: Create new entities and build ID map.
+            //
+            // Two-phase structure (RFC-SAVE-LOAD-PREFABS §Architecture,
+            // Slice 3):
+            //
+            //   Phase 1 — PrefabInstance-tagged entities are re-spawned
+            //   via `game.spawnFromPrefab`. The prefab reinstantiation
+            //   brings back non-saveable components (Sprite, animation
+            //   overlays, etc.) and the full child structure for free.
+            //   For each saved PrefabChild, we walk the spawned tree by
+            //   its `local_path` and map the saved child ID to the
+            //   newly-spawned child entity.
+            //
+            //   Phase 1b — any saved entity NOT covered by Phase 1 (no
+            //   PrefabInstance tag, and its ID wasn't mapped via a
+            //   PrefabChild lookup) is created fresh with `createEntity`.
+            //   Same as the v2 behaviour; preserves the non-prefab path.
+            //
+            //   Phase 2 (Step 3 below) applies saved component data on
+            //   every entity — prefab-spawned or fresh — as overrides.
             var id_map = std.AutoHashMap(u64, u64).init(allocator);
             defer id_map.deinit();
 
+            // Phase 1a: spawn prefab roots. We need Position for the
+            // spawn point; read it from the saved `Position` component.
+            for (entities_json.items) |entry| {
+                const obj = entry.object;
+                const components = (obj.get("components") orelse continue).object;
+                const pi_val = components.get("PrefabInstance") orelse continue;
+                const pi_obj = switch (pi_val) {
+                    .object => |o| o,
+                    else => continue,
+                };
+                const path_str = switch (pi_obj.get("path") orelse continue) {
+                    .string => |s| s,
+                    else => continue,
+                };
+
+                // Extract spawn Position from saved components, defaulting
+                // to (0,0) when absent (the prefab's own Position wins in
+                // that case via `spawnPrefab`'s `parent_offset` path).
+                var spawn_pos: core.Position = .{ .x = 0, .y = 0 };
+                if (components.get("Position")) |pos_val| {
+                    if (pos_val == .object) {
+                        if (pos_val.object.get("x")) |xv| {
+                            spawn_pos.x = switch (xv) {
+                                .float => |f| @floatCast(f),
+                                .integer => |i| @floatFromInt(i),
+                                else => 0,
+                            };
+                        }
+                        if (pos_val.object.get("y")) |yv| {
+                            spawn_pos.y = switch (yv) {
+                                .float => |f| @floatCast(f),
+                                .integer => |i| @floatFromInt(i),
+                                else => 0,
+                            };
+                        }
+                    }
+                }
+
+                const new_root = self.spawnFromPrefab(path_str, spawn_pos) orelse {
+                    self.log.warn("[SaveLoad] Phase 1: spawnFromPrefab('{s}') failed; falling back to fresh entity", .{path_str});
+                    continue;
+                };
+
+                const saved_id: u64 = @intCast((obj.get("id") orelse continue).integer);
+                try id_map.put(saved_id, entityToU64(new_root));
+            }
+
+            // Phase 1b: for each saved PrefabChild, walk the spawned
+            // tree by `local_path` and map the saved child ID to the
+            // already-spawned child entity. Requires Phase 1a to have
+            // populated `id_map` with the root mappings first.
+            for (entities_json.items) |entry| {
+                const obj = entry.object;
+                const components = (obj.get("components") orelse continue).object;
+                const pc_val = components.get("PrefabChild") orelse continue;
+                const pc_obj = switch (pc_val) {
+                    .object => |o| o,
+                    else => continue,
+                };
+                const saved_child_id: u64 = @intCast((obj.get("id") orelse continue).integer);
+                const saved_root_id: u64 = switch (pc_obj.get("root") orelse continue) {
+                    .integer => |i| if (i >= 0) @intCast(i) else continue,
+                    else => continue,
+                };
+                const local_path: []const u8 = switch (pc_obj.get("local_path") orelse continue) {
+                    .string => |s| s,
+                    else => continue,
+                };
+
+                const current_root_id = id_map.get(saved_root_id) orelse {
+                    self.log.warn("[SaveLoad] Phase 1b: PrefabChild root {d} not in id_map — root spawn failed or save is inconsistent", .{saved_root_id});
+                    continue;
+                };
+                const root_entity: Entity = @intCast(current_root_id);
+
+                const child_entity = findChildByLocalPath(self, root_entity, local_path) orelse {
+                    self.log.warn("[SaveLoad] Phase 1b: failed to walk local_path '{s}' from root entity {d}", .{ local_path, current_root_id });
+                    continue;
+                };
+                try id_map.put(saved_child_id, entityToU64(child_entity));
+            }
+
+            // Phase 1c (the v2 path): any saved entity whose ID isn't
+            // already in the id_map — non-prefab entities, or entities
+            // whose prefab resolve failed — gets a fresh `createEntity`
+            // so Phase 2 has something to apply components to.
             for (entities_json.items) |entry| {
                 const obj = entry.object;
                 const saved_id: u64 = @intCast((obj.get("id") orelse continue).integer);
+                if (id_map.contains(saved_id)) continue;
                 const new_entity = self.createEntity();
                 try id_map.put(saved_id, entityToU64(new_entity));
             }

--- a/src/game/save_load_mixin.zig
+++ b/src/game/save_load_mixin.zig
@@ -119,6 +119,15 @@ pub fn Mixin(comptime Game: type) type {
         /// auto-tagger) emit, so save/load Phase 1 can find the
         /// re-spawned child that corresponds to each saved PrefabChild.
         fn findChildByLocalPath(self: *Game, root: Entity, local_path: []const u8) ?Entity {
+            // Empty path is not valid — `PrefabChild.local_path` is always
+            // at least `"children[0]"` when a child was legitimately
+            // emitted. An empty string on the saved side indicates a
+            // corrupted save, and resolving it to `root` would alias the
+            // child's ID onto the root entity in `id_map`, causing Phase 2
+            // to apply the child's components on top of the root. Return
+            // null so the caller's `orelse` path logs + skips instead.
+            if (local_path.len == 0) return null;
+
             var current: Entity = root;
             var rest = local_path;
             while (rest.len > 0) {
@@ -383,7 +392,21 @@ pub fn Mixin(comptime Game: type) type {
 
             const entities_json = (root.get("entities") orelse return error.MissingField).array;
 
-            // Step 1: Clear scene tracking and destroy all entities atomically
+            // Step 1: Clear scene tracking and destroy all entities atomically.
+            //
+            // Both scene-entity lists have to be cleared here:
+            //   * `clearActiveSceneEntities()` — clears the active scene's
+            //     *own* list (the one `active_scene_clear_entities_fn`
+            //     wraps).
+            //   * `self.scene_entities` — the Game-level list, populated
+            //     by `trackSceneEntity` via the JSONC bridge's
+            //     `spawnPrefabImpl`. `resetEcsBackend` doesn't touch it,
+            //     so without this clear the list retains pre-load entity
+            //     IDs that are dangling after the ECS reset. Phase 1a's
+            //     `spawnFromPrefab` then appends new IDs on top, and a
+            //     later `unloadCurrentScene` would iterate the stale ones
+            //     and hit `destroyEntityOnly` with invalid handles.
+            self.scene_entities.clearRetainingCapacity();
             self.clearActiveSceneEntities();
             self.resetEcsBackend();
 
@@ -425,6 +448,12 @@ pub fn Mixin(comptime Game: type) type {
                 const pi_obj = getObjectField(components, "PrefabInstance") orelse continue;
                 if (components.get("PrefabChild") != null) continue;
                 const path_str = getStringField(pi_obj, "path") orelse continue;
+                // Validate `saved_id` BEFORE spawning. If the entry is
+                // missing a valid id, the spawned tree would have no
+                // id_map entry — Phase 2 couldn't reconcile it and it
+                // would remain as an orphan prefab tree in the world.
+                // Reading first turns a silent leak into a skip.
+                const saved_id = getSavedId(entry) orelse continue;
 
                 // Extract spawn Position from saved components, defaulting
                 // to (0,0) when absent (the prefab's own Position wins in
@@ -440,7 +469,6 @@ pub fn Mixin(comptime Game: type) type {
                     continue;
                 };
 
-                const saved_id = getSavedId(entry) orelse continue;
                 try id_map.put(saved_id, entityToU64(new_root));
             }
 
@@ -481,35 +509,27 @@ pub fn Mixin(comptime Game: type) type {
 
             // Step 3: Restore components (includes Position)
             for (entities_json.items) |entry| {
-                const obj = entry.object;
-                const saved_id: u64 = @intCast((obj.get("id") orelse continue).integer);
+                // Defensive accessors — a malformed entry whose `id` isn't
+                // an integer, or whose `components` field is the wrong
+                // shape, must not crash the load; skip the entry so the
+                // rest of the save still applies. Same treatment
+                // Phase 1a/1b/1c went through; mirror here so no
+                // direct `.integer` / `.object` tag casts remain in the
+                // load path.
+                const saved_id = getSavedId(entry) orelse continue;
                 const current_id = id_map.get(saved_id) orelse continue;
                 const entity: Entity = @intCast(current_id);
 
-                const components = (obj.get("components") orelse continue).object;
+                const components = getComponentsObject(entry) orelse continue;
 
                 // Restore Position (built-in) — only if not in component registry
                 const Position_load = core.Position;
                 if (comptime !isRegistered(Position_load)) {
-                    if (components.get("Position")) |pos_val| {
-                        const pos_obj = pos_val.object;
-                        var px: f32 = 0;
-                        var py: f32 = 0;
-                        if (pos_obj.get("x")) |xv| {
-                            px = switch (xv) {
-                                .float => |f| @floatCast(f),
-                                .integer => |i| @floatFromInt(i),
-                                else => 0,
-                            };
-                        }
-                        if (pos_obj.get("y")) |yv| {
-                            py = switch (yv) {
-                                .float => |f| @floatCast(f),
-                                .integer => |i| @floatFromInt(i),
-                                else => 0,
-                            };
-                        }
-                        self.setPosition(entity, .{ .x = px, .y = py });
+                    if (getObjectField(components, "Position")) |pos_obj| {
+                        self.setPosition(entity, .{
+                            .x = getNumberField(pos_obj, "x"),
+                            .y = getNumberField(pos_obj, "y"),
+                        });
                     }
                 }
 

--- a/src/game/save_load_mixin.zig
+++ b/src/game/save_load_mixin.zig
@@ -48,6 +48,69 @@ pub fn Mixin(comptime Game: type) type {
             };
         }
 
+        /// Safe JSON accessors for the load path. All return `null`
+        /// on a tag mismatch rather than panicking via `.object` /
+        /// `.integer` tag casts — so a malformed save file (wrong
+        /// type, missing field, `null` where an object is expected)
+        /// produces a logged warning and a skipped entity, not a
+        /// debug-assertion panic or release-mode memory corruption.
+        fn getComponentsObject(entry: std.json.Value) ?std.json.ObjectMap {
+            if (entry != .object) return null;
+            const comps_val = entry.object.get("components") orelse return null;
+            return switch (comps_val) {
+                .object => |o| o,
+                else => null,
+            };
+        }
+
+        fn getObjectField(obj: std.json.ObjectMap, name: []const u8) ?std.json.ObjectMap {
+            const v = obj.get(name) orelse return null;
+            return switch (v) {
+                .object => |o| o,
+                else => null,
+            };
+        }
+
+        fn getStringField(obj: std.json.ObjectMap, name: []const u8) ?[]const u8 {
+            const v = obj.get(name) orelse return null;
+            return switch (v) {
+                .string => |s| s,
+                else => null,
+            };
+        }
+
+        /// Read a non-negative integer field as `u64` (for entity IDs).
+        /// Clamps negative and out-of-range values to `null` so the
+        /// caller's `orelse continue` pattern gracefully drops malformed
+        /// entries.
+        fn getU64Field(obj: std.json.ObjectMap, name: []const u8) ?u64 {
+            const v = obj.get(name) orelse return null;
+            return switch (v) {
+                .integer => |i| if (i >= 0) @intCast(i) else null,
+                else => null,
+            };
+        }
+
+        /// Read the top-level `id` of a save entry as `u64`. Missing
+        /// or non-integer `id` fields return `null` so the caller can
+        /// skip the entry instead of panicking.
+        fn getSavedId(entry: std.json.Value) ?u64 {
+            if (entry != .object) return null;
+            return getU64Field(entry.object, "id");
+        }
+
+        /// Read a numeric field as `f32`, accepting both `.float` and
+        /// `.integer` JSON tags; returns 0 for missing or non-numeric
+        /// values. Used for the Position shim in Phase 1a.
+        fn getNumberField(obj: std.json.ObjectMap, name: []const u8) f32 {
+            const v = obj.get(name) orelse return 0;
+            return switch (v) {
+                .float => |f| @floatCast(f),
+                .integer => |i| @floatFromInt(i),
+                else => 0,
+            };
+        }
+
         /// Walk a dotted `children[i]...` path from `root` through
         /// `game.getChildren`, returning the entity at the end or
         /// `null` when the path doesn't resolve (missing index,
@@ -349,40 +412,27 @@ pub fn Mixin(comptime Game: type) type {
 
             // Phase 1a: spawn prefab roots. We need Position for the
             // spawn point; read it from the saved `Position` component.
+            //
+            // Skip entities that ALSO carry a PrefabChild tag — those
+            // are nested-prefab entries where an outer prefab's
+            // `spawnFromPrefab` already reinstantiates this whole
+            // subtree. Calling spawnFromPrefab again here would create
+            // a duplicate "ghost" root alongside the already-spawned
+            // one. Phase 1b maps the nested root through the outer
+            // tree's `(root, local_path)` walk instead.
             for (entities_json.items) |entry| {
-                const obj = entry.object;
-                const components = (obj.get("components") orelse continue).object;
-                const pi_val = components.get("PrefabInstance") orelse continue;
-                const pi_obj = switch (pi_val) {
-                    .object => |o| o,
-                    else => continue,
-                };
-                const path_str = switch (pi_obj.get("path") orelse continue) {
-                    .string => |s| s,
-                    else => continue,
-                };
+                const components = getComponentsObject(entry) orelse continue;
+                const pi_obj = getObjectField(components, "PrefabInstance") orelse continue;
+                if (components.get("PrefabChild") != null) continue;
+                const path_str = getStringField(pi_obj, "path") orelse continue;
 
                 // Extract spawn Position from saved components, defaulting
                 // to (0,0) when absent (the prefab's own Position wins in
                 // that case via `spawnPrefab`'s `parent_offset` path).
                 var spawn_pos: core.Position = .{ .x = 0, .y = 0 };
-                if (components.get("Position")) |pos_val| {
-                    if (pos_val == .object) {
-                        if (pos_val.object.get("x")) |xv| {
-                            spawn_pos.x = switch (xv) {
-                                .float => |f| @floatCast(f),
-                                .integer => |i| @floatFromInt(i),
-                                else => 0,
-                            };
-                        }
-                        if (pos_val.object.get("y")) |yv| {
-                            spawn_pos.y = switch (yv) {
-                                .float => |f| @floatCast(f),
-                                .integer => |i| @floatFromInt(i),
-                                else => 0,
-                            };
-                        }
-                    }
+                if (getObjectField(components, "Position")) |pos_obj| {
+                    spawn_pos.x = getNumberField(pos_obj, "x");
+                    spawn_pos.y = getNumberField(pos_obj, "y");
                 }
 
                 const new_root = self.spawnFromPrefab(path_str, spawn_pos) orelse {
@@ -390,7 +440,7 @@ pub fn Mixin(comptime Game: type) type {
                     continue;
                 };
 
-                const saved_id: u64 = @intCast((obj.get("id") orelse continue).integer);
+                const saved_id = getSavedId(entry) orelse continue;
                 try id_map.put(saved_id, entityToU64(new_root));
             }
 
@@ -399,22 +449,11 @@ pub fn Mixin(comptime Game: type) type {
             // already-spawned child entity. Requires Phase 1a to have
             // populated `id_map` with the root mappings first.
             for (entities_json.items) |entry| {
-                const obj = entry.object;
-                const components = (obj.get("components") orelse continue).object;
-                const pc_val = components.get("PrefabChild") orelse continue;
-                const pc_obj = switch (pc_val) {
-                    .object => |o| o,
-                    else => continue,
-                };
-                const saved_child_id: u64 = @intCast((obj.get("id") orelse continue).integer);
-                const saved_root_id: u64 = switch (pc_obj.get("root") orelse continue) {
-                    .integer => |i| if (i >= 0) @intCast(i) else continue,
-                    else => continue,
-                };
-                const local_path: []const u8 = switch (pc_obj.get("local_path") orelse continue) {
-                    .string => |s| s,
-                    else => continue,
-                };
+                const components = getComponentsObject(entry) orelse continue;
+                const pc_obj = getObjectField(components, "PrefabChild") orelse continue;
+                const saved_child_id = getSavedId(entry) orelse continue;
+                const saved_root_id = getU64Field(pc_obj, "root") orelse continue;
+                const local_path = getStringField(pc_obj, "local_path") orelse continue;
 
                 const current_root_id = id_map.get(saved_root_id) orelse {
                     self.log.warn("[SaveLoad] Phase 1b: PrefabChild root {d} not in id_map — root spawn failed or save is inconsistent", .{saved_root_id});
@@ -434,8 +473,7 @@ pub fn Mixin(comptime Game: type) type {
             // whose prefab resolve failed — gets a fresh `createEntity`
             // so Phase 2 has something to apply components to.
             for (entities_json.items) |entry| {
-                const obj = entry.object;
-                const saved_id: u64 = @intCast((obj.get("id") orelse continue).integer);
+                const saved_id = getSavedId(entry) orelse continue;
                 if (id_map.contains(saved_id)) continue;
                 const new_entity = self.createEntity();
                 try id_map.put(saved_id, entityToU64(new_entity));

--- a/src/game/save_load_mixin.zig
+++ b/src/game/save_load_mixin.zig
@@ -146,6 +146,21 @@ pub fn Mixin(comptime Game: type) type {
             return current;
         }
 
+        /// Recursively insert `root` and every descendant into `set`.
+        /// Used by Phase 1a to record which entities came in through
+        /// `spawnFromPrefab` (and were therefore renderer-tracked by
+        /// the prefab spawn path) so Step 5 can skip re-tracking them.
+        fn markSubtreeRendererTracked(
+            self: *Game,
+            root: Entity,
+            set: *std.AutoHashMap(u64, void),
+        ) !void {
+            try set.put(entityToU64(root), {});
+            for (self.getChildren(root)) |child| {
+                try markSubtreeRendererTracked(self, child, set);
+            }
+        }
+
         /// Write a JSON-escaped string literal (including surrounding
         /// quotes) to `writer`. Used by the built-in save pathway for
         /// components with `[]const u8` fields (PrefabInstance.path,
@@ -433,6 +448,20 @@ pub fn Mixin(comptime Game: type) type {
             var id_map = std.AutoHashMap(u64, u64).init(allocator);
             defer id_map.deinit();
 
+            // Entities spawned via Phase 1a's `spawnFromPrefab` (the
+            // root + every descendant the prefab creates) are already
+            // renderer-tracked by `spawnPrefabImpl` — it routes each
+            // visual component through `game.addSprite`/`addShape`,
+            // which call `renderer.trackEntity` themselves. Step 5
+            // below re-tracks any entity carrying a Sprite/Shape for
+            // the Phase 1c createEntity path (bare entities whose
+            // visuals come via Phase 2's `addComponent`). Without this
+            // set, Phase 1a entities get registered with the renderer
+            // twice — duplicate render-list entries, double cleanup
+            // pressure, etc. Bugbot flagged this on da17581.
+            var renderer_already_tracked = std.AutoHashMap(u64, void).init(allocator);
+            defer renderer_already_tracked.deinit();
+
             // Phase 1a: spawn prefab roots. We need Position for the
             // spawn point; read it from the saved `Position` component.
             //
@@ -470,6 +499,10 @@ pub fn Mixin(comptime Game: type) type {
                 };
 
                 try id_map.put(saved_id, entityToU64(new_root));
+                // Mark the root + every descendant as already-tracked
+                // so Step 5's trackEntity pass skips them (see the
+                // comment on `renderer_already_tracked` above).
+                try markSubtreeRendererTracked(self, new_root, &renderer_already_tracked);
             }
 
             // Phase 1b: for each saved PrefabChild, walk the spawned
@@ -686,7 +719,14 @@ pub fn Mixin(comptime Game: type) type {
                 const entity: Entity = @intCast(current_id);
                 self.addEntityToActiveScene(entity);
 
-                // Re-register visual components with the renderer (#38)
+                // Re-register visual components with the renderer (#38).
+                // Skip entities spawned via Phase 1a's `spawnFromPrefab`
+                // — their Sprite/Shape already went through `addSprite`
+                // / `addShape` during the prefab spawn, which tracks
+                // with the renderer. Double-tracking risks duplicate
+                // render-list entries / mismatched cleanup.
+                if (renderer_already_tracked.contains(entityToU64(entity))) continue;
+
                 if (self.active_world.ecs_backend.hasComponent(entity, Sprite)) {
                     self.renderer.trackEntity(entity, .sprite);
                 } else if (self.active_world.ecs_backend.hasComponent(entity, Shape)) {

--- a/test/save_load_two_phase_test.zig
+++ b/test/save_load_two_phase_test.zig
@@ -288,3 +288,4 @@ test "two-phase load: spawnFromPrefab failure falls back to v2 createEntity" {
     while (view.next()) |_| count += 1;
     try testing.expectEqual(@as(usize, 1), count);
 }
+

--- a/test/save_load_two_phase_test.zig
+++ b/test/save_load_two_phase_test.zig
@@ -1,0 +1,290 @@
+//! Save/load Slice 3 — two-phase load integration tests.
+//!
+//! Phase 1 re-spawns prefab-sourced entities via `spawnFromPrefab`
+//! and maps their saved child IDs to the freshly-spawned entities by
+//! walking `(root, local_path)`. Phase 2 then applies saved component
+//! data on top. The payoff: non-saveable components (Sprite, animation
+//! overlays, etc.) reappear on load without any game-side
+//! re-hydration scripts.
+//!
+//! These tests scaffold a `JsoncSceneBridge` + a prefab jsonc on disk
+//! + a TestGame with a real `ComponentRegistry`, spawn a prefab with
+//! children, save, reset, load, and assert:
+//!
+//! - The prefab root is a freshly-spawned entity (not the saved id).
+//! - Its children are the ones the prefab produced (matched via
+//!   `PrefabChild.local_path`), not newly-created blank entities.
+//! - Saved registered-component values are preserved on both root
+//!   and children (Phase 2 overrides applied on top of Phase 1
+//!   defaults).
+//! - Non-prefab entities in the same save file still load through
+//!   the v2 path unchanged.
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+const core = @import("labelle-core");
+
+const Health = struct {
+    pub const save = core.Saveable(.saveable, @This(), .{});
+    current: f32 = 100,
+    max: f32 = 100,
+};
+
+const TestComponents = engine.ComponentRegistry(.{
+    .Health = Health,
+});
+
+const MockEcs = core.MockEcsBackend(u32);
+const TestGame = engine.game_mod.GameConfig(
+    core.StubRender(MockEcs.Entity),
+    MockEcs,
+    engine.input_mod.StubInput,
+    engine.audio_mod.StubAudio,
+    engine.gui_mod.StubGui,
+    void,
+    core.StubLogSink,
+    TestComponents,
+    &.{},
+    void,
+);
+
+const Bridge = engine.JsoncSceneBridge(TestGame, TestComponents);
+const PrefabInstance = TestGame.PrefabInstanceComp;
+const PrefabChild = TestGame.PrefabChildComp;
+
+const TestFixture = struct {
+    game: TestGame,
+    prefab_dir: []const u8,
+
+    fn deinit(self: *TestFixture) void {
+        self.game.deinit();
+        testing.allocator.free(self.prefab_dir);
+    }
+};
+
+fn setupFixture(
+    tmp_dir: *std.testing.TmpDir,
+    prefab_files: anytype,
+) !TestFixture {
+    try tmp_dir.dir.makeDir("prefabs");
+
+    inline for (std.meta.fields(@TypeOf(prefab_files))) |field| {
+        const path = try std.fmt.allocPrint(testing.allocator, "prefabs/{s}.jsonc", .{field.name});
+        defer testing.allocator.free(path);
+        try tmp_dir.dir.writeFile(.{ .sub_path = path, .data = @field(prefab_files, field.name) });
+    }
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const dir_path = try tmp_dir.dir.realpath(".", &buf);
+    const prefab_dir = try std.fmt.allocPrint(testing.allocator, "{s}/prefabs", .{dir_path});
+    errdefer testing.allocator.free(prefab_dir);
+
+    var game = TestGame.init(testing.allocator);
+    errdefer game.deinit();
+
+    // Empty scene boot — we'll spawn prefabs manually via the runtime API.
+    try Bridge.loadSceneFromSource(&game,
+        \\{ "entities": [] }
+    , prefab_dir);
+
+    return .{ .game = game, .prefab_dir = prefab_dir };
+}
+
+test "two-phase load: prefab root + children re-spawn, saved state applies on top" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    // Prefab with one child. Both root and child carry Health so we
+    // can verify Phase 2 overrides on each.
+    var fixture = try setupFixture(&tmp_dir, .{
+        .unit =
+        \\{
+        \\  "components": { "Health": { "current": 50, "max": 50 } },
+        \\  "children": [
+        \\    { "components": { "Health": { "current": 10, "max": 10 } } }
+        \\  ]
+        \\}
+        ,
+    });
+    defer fixture.deinit();
+
+    // Spawn. Mutate the saved Health to non-default values so we can
+    // distinguish "loaded from save" from "re-spawned from prefab."
+    const root = fixture.game.spawnFromPrefab("unit", .{ .x = 100, .y = 200 }).?;
+    const root_h = fixture.game.active_world.ecs_backend.getComponent(root, Health).?;
+    root_h.current = 33;
+
+    const pre_children = fixture.game.getChildren(root);
+    try testing.expectEqual(@as(usize, 1), pre_children.len);
+    const child = pre_children[0];
+    const child_h = fixture.game.active_world.ecs_backend.getComponent(child, Health).?;
+    child_h.current = 7;
+
+    // Save.
+    const save_path = "test_save_two_phase.json";
+    try fixture.game.saveGameState(save_path);
+    defer std.fs.cwd().deleteFile(save_path) catch {};
+
+    // Reset + load. Phase 1 should spawn the prefab, Phase 2 should
+    // apply the mutated Health values we saved.
+    fixture.game.resetEcsBackend();
+    try fixture.game.loadGameState(save_path);
+
+    // Exactly one PrefabInstance entity — the root. It should NOT be
+    // the saved ID (we reset the ECS) and should carry the mutated
+    // Health value from the save.
+    var root_count: usize = 0;
+    var loaded_root: TestGame.EntityType = 0;
+    {
+        var view = fixture.game.active_world.ecs_backend.view(.{PrefabInstance}, .{});
+        while (view.next()) |ent| {
+            root_count += 1;
+            loaded_root = ent;
+        }
+        view.deinit();
+    }
+    try testing.expectEqual(@as(usize, 1), root_count);
+
+    // Root has the mutated Health (overrides applied on top).
+    const loaded_root_h = fixture.game.active_world.ecs_backend.getComponent(loaded_root, Health).?;
+    try testing.expectApproxEqAbs(@as(f32, 33), loaded_root_h.current, 0.01);
+
+    // The child came back via prefab re-spawn, not a fresh blank
+    // entity. `getChildren` should give us exactly one child with
+    // the mutated saved Health value.
+    const loaded_children = fixture.game.getChildren(loaded_root);
+    try testing.expectEqual(@as(usize, 1), loaded_children.len);
+    const loaded_child_h = fixture.game.active_world.ecs_backend.getComponent(loaded_children[0], Health).?;
+    try testing.expectApproxEqAbs(@as(f32, 7), loaded_child_h.current, 0.01);
+
+    // The child must carry the `PrefabChild` tag (restored through
+    // the save file). A fresh `createEntity` wouldn't have it.
+    try testing.expect(fixture.game.active_world.ecs_backend.hasComponent(loaded_children[0], PrefabChild));
+}
+
+test "two-phase load: no duplicate entities — saved children map to spawned children" {
+    // Phase 1 mustn't create BOTH the prefab-spawned child AND a
+    // fresh blank entity for the saved PrefabChild. Regression guard
+    // for the accidentally-dup-children failure mode.
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var fixture = try setupFixture(&tmp_dir, .{
+        .three_kids =
+        \\{
+        \\  "components": { "Health": { "current": 100, "max": 100 } },
+        \\  "children": [
+        \\    { "components": { "Health": { "current": 1, "max": 1 } } },
+        \\    { "components": { "Health": { "current": 2, "max": 2 } } },
+        \\    { "components": { "Health": { "current": 3, "max": 3 } } }
+        \\  ]
+        \\}
+        ,
+    });
+    defer fixture.deinit();
+
+    _ = fixture.game.spawnFromPrefab("three_kids", .{ .x = 0, .y = 0 }).?;
+
+    const save_path = "test_save_no_dup.json";
+    try fixture.game.saveGameState(save_path);
+    defer std.fs.cwd().deleteFile(save_path) catch {};
+
+    fixture.game.resetEcsBackend();
+    try fixture.game.loadGameState(save_path);
+
+    // Total Health-carrying entities = 4 (1 root + 3 children), same
+    // as before save. No duplicates.
+    var count: usize = 0;
+    var view = fixture.game.active_world.ecs_backend.view(.{Health}, .{});
+    defer view.deinit();
+    while (view.next()) |_| count += 1;
+    try testing.expectEqual(@as(usize, 4), count);
+}
+
+test "two-phase load: non-prefab entities still load through v2 path" {
+    // Phase 1c falls back to `createEntity` for entities without
+    // `PrefabInstance` / `PrefabChild`. Regression guard that
+    // intermixing prefab-sourced and plain entities in the same
+    // save file still works.
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var fixture = try setupFixture(&tmp_dir, .{
+        .prefab_thing =
+        \\{ "components": { "Health": { "current": 50, "max": 50 } } }
+        ,
+    });
+    defer fixture.deinit();
+
+    // Spawn one via prefab, create one plain.
+    _ = fixture.game.spawnFromPrefab("prefab_thing", .{ .x = 0, .y = 0 }).?;
+    const plain = fixture.game.createEntity();
+    fixture.game.active_world.ecs_backend.addComponent(plain, Health{ .current = 999, .max = 999 });
+
+    const save_path = "test_save_mixed.json";
+    try fixture.game.saveGameState(save_path);
+    defer std.fs.cwd().deleteFile(save_path) catch {};
+
+    fixture.game.resetEcsBackend();
+    try fixture.game.loadGameState(save_path);
+
+    // Both entities come back.
+    var prefab_found = false;
+    var plain_found = false;
+    var view = fixture.game.active_world.ecs_backend.view(.{Health}, .{});
+    defer view.deinit();
+    while (view.next()) |ent| {
+        const h = fixture.game.active_world.ecs_backend.getComponent(ent, Health).?;
+        const has_pi = fixture.game.active_world.ecs_backend.hasComponent(ent, PrefabInstance);
+        if (has_pi and @as(i32, @intFromFloat(h.current)) == 50) prefab_found = true;
+        if (!has_pi and @as(i32, @intFromFloat(h.current)) == 999) plain_found = true;
+    }
+    try testing.expect(prefab_found);
+    try testing.expect(plain_found);
+}
+
+test "two-phase load: spawnFromPrefab failure falls back to v2 createEntity" {
+    // The save records a PrefabInstance with a prefab name that
+    // doesn't exist in the current prefab cache (e.g. renamed
+    // between save and load). Phase 1 logs a warning and skips the
+    // entity; Phase 1c's v2 fallback creates it fresh so Phase 2 has
+    // something to apply Health to. Saved Health value is preserved;
+    // PrefabInstance tag is NOT restored (since spawnFromPrefab was
+    // the source of truth for the path and it failed).
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var fixture = try setupFixture(&tmp_dir, .{
+        .known =
+        \\{ "components": { "Health": { "current": 100, "max": 100 } } }
+        ,
+    });
+    defer fixture.deinit();
+
+    // Spawn the known prefab, then hand-edit the save file to say a
+    // different prefab name — simulating a renamed prefab.
+    _ = fixture.game.spawnFromPrefab("known", .{ .x = 0, .y = 0 }).?;
+
+    const save_path = "test_save_rename.json";
+    try fixture.game.saveGameState(save_path);
+    defer std.fs.cwd().deleteFile(save_path) catch {};
+
+    // Read back, replace "known" with "missing", write back.
+    const contents = try std.fs.cwd().readFileAlloc(testing.allocator, save_path, 1024 * 1024);
+    defer testing.allocator.free(contents);
+    const rewritten = try std.mem.replaceOwned(u8, testing.allocator, contents, "\"known\"", "\"missing\"");
+    defer testing.allocator.free(rewritten);
+    try std.fs.cwd().writeFile(.{ .sub_path = save_path, .data = rewritten });
+
+    fixture.game.resetEcsBackend();
+    try fixture.game.loadGameState(save_path);
+
+    // An entity with Health must still exist post-load; Phase 1c
+    // created it fresh when spawnFromPrefab("missing") failed.
+    var count: usize = 0;
+    var view = fixture.game.active_world.ecs_backend.view(.{Health}, .{});
+    defer view.deinit();
+    while (view.next()) |_| count += 1;
+    try testing.expectEqual(@as(usize, 1), count);
+}


### PR DESCRIPTION
## Summary

**Slice 3 — the payoff slice.** Closes the RFC's core promise: prefab-sourced entities come back from `loadGameState` via `spawnFromPrefab`, bringing their non-saveable components (Sprite, animation overlays, etc.) *and* child structure along for free. Saved component values apply on top as overrides.

Once this lands, flying-platform-labelle's `RoomDecor` marker + `restoreSprites` switch table + `HydroponicsPlant.saveable` + `condenser_animation::needsReinit` are all deletable. That's the migration milestone (Phase C).

## The new load flow

```
loadGameState:
  Step 1 — resetEcsBackend (unchanged)
  Step 2 — build id_map (NEW: three-pass)
    Phase 1a: for each saved PrefabInstance:
      new_root = spawnFromPrefab(path, saved_Position)
      id_map[saved_root_id] = new_root
    Phase 1b: for each saved PrefabChild { root, local_path }:
      new_child = walk(id_map[root], local_path)   // via getChildren
      id_map[saved_child_id] = new_child
    Phase 1c: for saved entities not yet in id_map:
      new = createEntity()                          // v2 fallback
      id_map[saved_id] = new
  Step 3 — apply components (UNCHANGED)
```

Phase 2 (the component-restoration loop) is untouched — it just now operates on entities already-populated by Phase 1. Saved component data applies on top as overrides. Non-prefab entities still hit the v2 path via Phase 1c's fallback.

## `findChildByLocalPath` helper

New private helper that parses a `children[i].children[j]...` path (the format `spawnFromPrefab` / the scene-bridge auto-tagger emit) and walks `game.getChildren` step by step. Returns `null` on parse error or missing index — Phase 1b logs a warning and skips rather than asserts, so malformed saves can't panic the load.

## Tests (4 new in `test/save_load_two_phase_test.zig`)

1. **End-to-end round-trip** — spawn prefab with child, mutate Health on both, save, reset, load. Asserts the root's PrefabInstance tag, the mutated Health on root + child, the child came back via `getChildren` (not a fresh blank), and the child still carries `PrefabChild`.
2. **No duplicate entities** — a 3-child prefab loads as exactly 4 entities total (1 root + 3 children), not 7 (4 + 3 ghosts). Regression guard for the Phase 1c fallback firing on PrefabChild entries.
3. **Non-prefab entities still work** — mixed save with 1 prefab-sourced + 1 plain entity round-trips both.
4. **Graceful fallback on missing prefab** — hand-edits a save to reference a non-existent prefab, asserts the entity comes back as a fresh-created fallback. Guards the "renamed prefab between save and load" scenario.

Full engine suite: **219/219 green** (+4 new, and all pre-existing tests still pass against the new Phase 1 path).

## What this does NOT do yet

- **Structured overrides** — `PrefabInstance.overrides` is still `""` on spawn. The call site in Slice 3 reads `Position` from the saved components as a fixed arg to `spawnFromPrefab`. Full "apply caller-supplied component overrides" lands in a follow-up; today's Phase 2 step applies saved component values on top of prefab defaults, which covers the same ground for everything except "save-time values that the prefab prescribes."
- **Scene-bridge child tagging** (deferred from Slice 2b) — scene-loaded prefab entities don't yet get `PrefabChild` tags on their descendants, so scene-only saves lose descendant lineage. Runtime-spawned prefabs (via `spawnFromPrefab`) are fully tagged and round-trip correctly — this slice's tests exercise that path.

## Dependencies

Stacked chain: [#474](https://github.com/labelle-toolkit/labelle-engine/pull/474) (Slice 1b) → [#482](https://github.com/labelle-toolkit/labelle-engine/pull/482) (Slice 2a) → [#483](https://github.com/labelle-toolkit/labelle-engine/pull/483) (Slice 2b) → **this PR**. Merge in order; retarget base as each parent merges.

## RFC end-to-end path

The RFC's migration examples are now achievable after this PR:

- flying-platform-labelle `RoomDecor` marker + `restoreSprites` switch table → **deletable**.
- `HydroponicsPlant.saveable` marker → **`.transient`** (prefab re-instantiation covers it).
- `condenser_animation::needsReinit` / `initOverlays` dance → **deletable** once overlays move into prefabs + `SpriteAnimation` ([#480](https://github.com/labelle-toolkit/labelle-engine/pull/480) / [#481](https://github.com/labelle-toolkit/labelle-engine/pull/481)).

Phase C migration is the next milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)