### PR TITLE
test(walkthrough): exercise null-entry hide path after save/load

### DIFF
--- a/test/example_prefab_animation_walkthrough_test.zig
+++ b/test/example_prefab_animation_walkthrough_test.zig
@@ -28,6 +28,10 @@
 //!      declared animation components (via respawn); a single post-
 //!      load tick re-resolves the field-driven child against the
 //!      restored level.
+//!   6. Drive the field to a lookup-table entry whose `sprite_name`
+//!      is JSONC `null`, demonstrating that the tick toggles
+//!      `Sprite.visible = false` end-to-end (null survives optional
+//!      deserialization + save-skipping transient + prefab respawn).
 //!
 //! Runnable under `zig build test`. Uses `MockEcs` + `StubRender` so
 //! there's no window, GPU, or atlas — the pipeline itself is what
@@ -302,4 +306,19 @@ test "walkthrough: prefab + animation + save/load round-trips end-to-end" {
         "leaf_lvl3.png",
         game.ecs_backend.getComponent(field_child_post, Sprite).?.sprite_name,
     );
+
+    // ── Step 5: null entries hide the sprite ────────────────────
+    //
+    // The prefab's entries[0] has `{ "key": 0, "sprite_name": null }`
+    // — a JSONC null that rode through the bridge's optional
+    // deserialize branch (#488 / #489) as `null`. When the driver
+    // matches this entry, the tick system is contracted to toggle
+    // `Sprite.visible = false` rather than rewriting the name. This
+    // exercises the full null-entry path: parse-time optional
+    // deserialization → save survives (via prefab respawn, since the
+    // component is `.transient`) → tick reads the null and hides.
+    game.ecs_backend.getComponent(root_post, PlantLevel).?.level = 0;
+    engine.spriteByFieldTick(game, 0);
+    const sprite_hidden = game.ecs_backend.getComponent(field_child_post, Sprite).?;
+    try testing.expect(!sprite_hidden.visible);
 }


### PR DESCRIPTION
## Summary

Small follow-up on top of [#488](https://github.com/labelle-toolkit/labelle-engine/pull/488) + [#489](https://github.com/labelle-toolkit/labelle-engine/pull/489). The walkthrough test previously asserted that a JSONC `null` in a \`SpriteByField.entries\` table survived parse time (\`entries[0].sprite_name == null\`), but stopped there. This PR adds a new step at the end that drives the driver field to `0` after save/load and confirms the tick toggles `Sprite.visible = false` — demonstrating the full null-entry pipeline end-to-end.

## Why it matters

The null-entry case is the one that rides through every moving part:

1. **Parse**: bridge's optional deserialize branch (the one #488 added and #489 fixed).
2. **Save**: component is `.transient`, so the null doesn't round-trip through the save file.
3. **Load**: Phase 1 prefab respawn redeclares the entries table fresh from the jsonc.
4. **Tick**: `spriteByFieldTick` reads the null entry and toggles `Sprite.visible` instead of rewriting `sprite_name`.

Without this assertion the walkthrough could silently regress on any of those four stages and still look passing.

## Test plan

- [x] `zig build test` green (267/267, no new test files — extended the existing walkthrough)

🤖 Generated with [Claude Code](https://claude.com/claude-code)