### PR TITLE
feat(gizmos): honor setGizmosEnabled for declarative *.zon gizmos

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -57,6 +57,7 @@ pub fn build(b: *std.Build) void {
         "test/example_prefab_animation_walkthrough_test.zig",
         "test/jsonc/bridge_deserialize_test.zig",
         "test/jsonc/deserializer_test.zig",
+        "test/jsonc_bridge_gizmo_visibility_test.zig",
     };
 
     for (test_files) |test_file| {

--- a/src/jsonc_scene_bridge.zig
+++ b/src/jsonc_scene_bridge.zig
@@ -50,6 +50,15 @@ pub fn JsoncSceneBridgeWithGizmos(
     const Gizmo = core.GizmoComponent(Entity);
     const Writer = scene_mod.EntityWriter(GameType, Components);
     const GizmoAttached = struct { _: u8 = 1 };
+    // Tags a gizmo entity whose `visible` flag was force-flipped to
+    // `false` by `syncGizmoVisibility` because the global toggle is
+    // off. On toggle-on, only entities carrying this marker get
+    // their visibility restored — author-set
+    // `visible = false` (declared in a `gizmos/*.zon`) stays
+    // hidden across toggles, matching the principle of least
+    // surprise that an explicit declaration outranks the global
+    // override.
+    const GizmoForcedHidden = struct { _: u8 = 1 };
     const BaseBridge = JsoncSceneBridge(GameType, Components);
 
     return struct {
@@ -71,9 +80,107 @@ pub fn JsoncSceneBridgeWithGizmos(
         }
 
         /// Per-frame gizmo reconciliation.
-        fn reconcileGizmos(game: *GameType) void {
+        ///
+        /// Always runs the per-gizmo create pass (so newly-spawned
+        /// matching entities still get their gizmo children), then
+        /// syncs every gizmo entity's `visible` flag to the global
+        /// `setGizmosEnabled` state. Toggling `G` flips visibility
+        /// on all spawned gizmos in one frame — no entity churn,
+        /// no resurrection cost. See labelle-engine#493.
+        pub fn reconcileGizmos(game: *GameType) void {
             inline for (GizmoReg.fields) |field| {
                 reconcileForGizmo(game, field.name);
+            }
+            syncGizmoVisibility(game);
+        }
+
+        /// Bring every Gizmo-tagged entity's `Shape` / `Sprite`
+        /// visibility in sync with `gizmos_enabled`.
+        ///
+        /// Idempotent and self-narrowing: the view filter
+        /// (`GizmoForcedHidden` excluded when disabled, included
+        /// when enabled) means steady-state frames hit a view that
+        /// returns zero entities, so the cost collapses to a
+        /// view-setup + zero iterations once the transition has
+        /// settled. That's why this can run unconditionally
+        /// without a `last_gizmos_enabled` gate — and why no
+        /// per-bridge static state survives across `Game.init` /
+        /// `deinit` cycles.
+        ///
+        /// On disable: hide every currently-visible gizmo and tag
+        /// it with `GizmoForcedHidden`. Gizmos already hidden
+        /// (author-set `visible = false`) are left alone — no
+        /// marker added.
+        ///
+        /// On enable: only unhide entities carrying the marker, so
+        /// author-set hidden gizmos stay hidden across toggle
+        /// cycles. The marker is removed once visibility is
+        /// restored.
+        fn syncGizmoVisibility(game: *GameType) void {
+            const target = game.isGizmosEnabled();
+
+            // Gather first, then mutate. Modifying components
+            // mid-iteration on a view filtered by those same
+            // components is asking for trouble across backends,
+            // and we add/remove `GizmoForcedHidden` here which is
+            // exactly what each branch's view filters on.
+            //
+            // ArrayList over a fixed-size buffer because a hard
+            // cap silently strands gizmos beyond it. Capacity
+            // grows with the count of entities currently in the
+            // wrong state for this transition; once steady, the
+            // list stays empty.
+            var pending: std.ArrayList(Entity) = .{};
+            defer pending.deinit(game.allocator);
+
+            if (target) {
+                var v = game.ecs_backend.view(.{ Gizmo, GizmoForcedHidden }, .{});
+                defer v.deinit();
+                while (v.next()) |entity| {
+                    pending.append(game.allocator, entity) catch return;
+                }
+                for (pending.items) |entity| {
+                    var dirty = false;
+                    if (game.ecs_backend.getComponent(entity, Shape)) |shape| {
+                        if (!shape.visible) {
+                            shape.visible = true;
+                            dirty = true;
+                        }
+                    }
+                    if (game.ecs_backend.getComponent(entity, Sprite)) |sprite| {
+                        if (!sprite.visible) {
+                            sprite.visible = true;
+                            dirty = true;
+                        }
+                    }
+                    game.ecs_backend.removeComponent(entity, GizmoForcedHidden);
+                    if (dirty) game.renderer.markVisualDirty(entity);
+                }
+            } else {
+                var v = game.ecs_backend.view(.{Gizmo}, .{GizmoForcedHidden});
+                defer v.deinit();
+                while (v.next()) |entity| {
+                    pending.append(game.allocator, entity) catch return;
+                }
+                for (pending.items) |entity| {
+                    var forced = false;
+                    if (game.ecs_backend.getComponent(entity, Shape)) |shape| {
+                        if (shape.visible) {
+                            shape.visible = false;
+                            forced = true;
+                        }
+                    }
+                    if (game.ecs_backend.getComponent(entity, Sprite)) |sprite| {
+                        if (sprite.visible) {
+                            sprite.visible = false;
+                            forced = true;
+                        }
+                    }
+                    if (forced) {
+                        game.ecs_backend.addComponent(entity, GizmoForcedHidden{});
+                        game.renderer.markVisualDirty(entity);
+                    }
+                }
             }
         }
 
@@ -184,16 +291,42 @@ pub fn JsoncSceneBridgeWithGizmos(
                     .y = parent_pos.y + offset_y,
                 });
 
+                // Honor whatever `visible` the author wrote into
+                // the gizmo `.zon` (or its struct default). When
+                // gizmos are globally disabled at spawn time, only
+                // flip an *author-shown* gizmo to hidden and tag
+                // it with `GizmoForcedHidden` so the next enable
+                // transition can restore it. Author-set
+                // `visible = false` stays false and gets no
+                // marker — `syncGizmoVisibility`'s enable pass
+                // ignores it, matching the principle of least
+                // surprise that an explicit declaration outranks
+                // the global override.
+                const initial_visible = game.isGizmosEnabled();
+                var forced_hidden = false;
+
                 if (comptime std.mem.eql(u8, field.name, "Shape")) {
                     var shape = Writer.coerce(Shape, gizmo_data);
                     if (comptime @hasField(@TypeOf(shape.layer), "world"))
                         shape.layer = .world;
+                    if (!initial_visible and shape.visible) {
+                        shape.visible = false;
+                        forced_hidden = true;
+                    }
                     game.addShape(gizmo_entity, shape);
                 } else if (comptime std.mem.eql(u8, field.name, "Sprite")) {
                     var sprite = Writer.coerce(Sprite, gizmo_data);
                     if (comptime @hasField(@TypeOf(sprite.layer), "world"))
                         sprite.layer = .world;
+                    if (!initial_visible and sprite.visible) {
+                        sprite.visible = false;
+                        forced_hidden = true;
+                    }
                     game.addSprite(gizmo_entity, sprite);
+                }
+
+                if (forced_hidden) {
+                    game.ecs_backend.addComponent(gizmo_entity, GizmoForcedHidden{});
                 }
             }
         }

--- a/test/jsonc_bridge_gizmo_visibility_test.zig
+++ b/test/jsonc_bridge_gizmo_visibility_test.zig
@@ -1,0 +1,182 @@
+// Regression tests for #494 — gizmo visibility toggling.
+//
+// Verifies that `JsoncSceneBridgeWithGizmos.reconcileGizmos`:
+//   - flips Gizmo entity visibility on `setGizmosEnabled` transitions, and
+//   - leaves author-set `visible = false` gizmos hidden across cycles
+//     (per-entity preservation — the bug this PR fixes).
+//
+// Drives the bridge directly (no JSONC scene) by manually creating
+// `Gizmo`-tagged entities and calling `reconcileGizmos`. The default
+// `engine.Game` carries an empty component registry, and `NoGizmos`
+// keeps the per-gizmo create pass a no-op so the test isolates
+// `syncGizmoVisibility` behaviour.
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+const core = @import("labelle-core");
+
+const Game = engine.Game;
+const Entity = Game.EntityType;
+const Sprite = Game.SpriteComp;
+const Gizmo = core.GizmoComponent(Entity);
+
+const Bridge = engine.JsoncSceneBridgeWithGizmos(
+    Game,
+    Game.ComponentRegistry,
+    engine.NoGizmos,
+);
+
+fn spawnGizmoSprite(game: *Game, parent: Entity, visible: bool) Entity {
+    const e = game.createEntity();
+    game.ecs_backend.addComponent(e, Gizmo{
+        .parent_entity = parent,
+        .offset_x = 0,
+        .offset_y = 0,
+    });
+    game.setPosition(e, .{ .x = 0, .y = 0 });
+    game.addSprite(e, .{ .sprite_name = "g", .visible = visible });
+    return e;
+}
+
+test "gizmo visibility: toggle hides then restores" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const parent = game.createEntity();
+    game.setPosition(parent, .{ .x = 0, .y = 0 });
+    const gz = spawnGizmoSprite(&game, parent, true);
+
+    // First reconcile: starting state = enabled, no transition yet.
+    Bridge.reconcileGizmos(&game);
+    try testing.expect(game.getComponent(gz, Sprite).?.visible);
+
+    // Disable → next reconcile flips visible=false.
+    game.setGizmosEnabled(false);
+    Bridge.reconcileGizmos(&game);
+    try testing.expect(!game.getComponent(gz, Sprite).?.visible);
+
+    // Re-enable → reconcile restores visible=true.
+    game.setGizmosEnabled(true);
+    Bridge.reconcileGizmos(&game);
+    try testing.expect(game.getComponent(gz, Sprite).?.visible);
+}
+
+test "gizmo visibility: author-set hidden survives toggle cycle" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const parent = game.createEntity();
+    game.setPosition(parent, .{ .x = 0, .y = 0 });
+    const author_hidden = spawnGizmoSprite(&game, parent, false);
+    const author_shown = spawnGizmoSprite(&game, parent, true);
+
+    // Initial reconcile while enabled.
+    Bridge.reconcileGizmos(&game);
+    try testing.expect(!game.getComponent(author_hidden, Sprite).?.visible);
+    try testing.expect(game.getComponent(author_shown, Sprite).?.visible);
+
+    // Disable: shown entity hides; author-hidden was already hidden
+    // (no state change either way).
+    game.setGizmosEnabled(false);
+    Bridge.reconcileGizmos(&game);
+    try testing.expect(!game.getComponent(author_hidden, Sprite).?.visible);
+    try testing.expect(!game.getComponent(author_shown, Sprite).?.visible);
+
+    // Re-enable: only the entity we forced hidden gets restored.
+    // The author-hidden one must stay hidden — that's the
+    // per-entity preservation behaviour Copilot flagged on #494.
+    game.setGizmosEnabled(true);
+    Bridge.reconcileGizmos(&game);
+    try testing.expect(!game.getComponent(author_hidden, Sprite).?.visible);
+    try testing.expect(game.getComponent(author_shown, Sprite).?.visible);
+}
+
+// Mirrors what `createGizmoEntities` does internally when a gizmo
+// is spawned while the global toggle is OFF: an author-shown gizmo
+// gets flipped to hidden and tagged so a later enable can restore
+// it. Driven through the public sync path here (spawn visible=true
+// while disabled → first sync hides + tags) rather than exercising
+// `createGizmoEntities` directly, since that path is private and
+// requires a configured `GizmoReg`. The visible-state contract is
+// what the bug is about, and that's what we assert.
+test "gizmo visibility: author-shown spawned while disabled is restored on enable" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    game.setGizmosEnabled(false);
+
+    const parent = game.createEntity();
+    game.setPosition(parent, .{ .x = 0, .y = 0 });
+    const gz = spawnGizmoSprite(&game, parent, true);
+
+    Bridge.reconcileGizmos(&game);
+    try testing.expect(!game.getComponent(gz, Sprite).?.visible);
+
+    game.setGizmosEnabled(true);
+    Bridge.reconcileGizmos(&game);
+    try testing.expect(game.getComponent(gz, Sprite).?.visible);
+}
+
+// Counterpart: a gizmo authored as `visible = false` should never
+// be unhidden by a global toggle, even if the entity was created
+// while the global was OFF. This is the case `createGizmoEntities`
+// previously fumbled — it tagged everything with
+// `GizmoForcedHidden` on disabled-spawn, so the next enable would
+// erroneously show author-hidden gizmos (cursor HIGH on #494).
+test "gizmo visibility: author-hidden spawned while disabled stays hidden on enable" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    game.setGizmosEnabled(false);
+
+    const parent = game.createEntity();
+    game.setPosition(parent, .{ .x = 0, .y = 0 });
+    const gz = spawnGizmoSprite(&game, parent, false);
+
+    Bridge.reconcileGizmos(&game);
+    try testing.expect(!game.getComponent(gz, Sprite).?.visible);
+
+    game.setGizmosEnabled(true);
+    Bridge.reconcileGizmos(&game);
+    try testing.expect(!game.getComponent(gz, Sprite).?.visible);
+}
+
+// Regression for cursor MEDIUM on #494: an earlier revision tracked
+// the previous `gizmos_enabled` state in a per-bridge module-level
+// `var`, which survived `Game.deinit` → `Game.init`. The new
+// instance would then read a stale `last == target` and skip the
+// first sync. With the static dropped, two separate Game instances
+// each sync correctly from scratch.
+test "gizmo visibility: fresh game instance is not poisoned by previous one" {
+    {
+        var game = Game.init(testing.allocator);
+        defer game.deinit();
+        const parent = game.createEntity();
+        game.setPosition(parent, .{ .x = 0, .y = 0 });
+        _ = spawnGizmoSprite(&game, parent, true);
+        game.setGizmosEnabled(false);
+        Bridge.reconcileGizmos(&game);
+    }
+
+    var game2 = Game.init(testing.allocator);
+    defer game2.deinit();
+    const parent = game2.createEntity();
+    game2.setPosition(parent, .{ .x = 0, .y = 0 });
+    const gz = spawnGizmoSprite(&game2, parent, true);
+
+    // game2 starts enabled by default — first sync should leave
+    // visible=true. If the bridge had stale state claiming "last
+    // = false" from game1, it would consider this a no-op
+    // transition and the visible flag could be wrong; with the
+    // static dropped, the marker-less view is empty and visible
+    // stays true.
+    Bridge.reconcileGizmos(&game2);
+    try testing.expect(game2.getComponent(gz, Sprite).?.visible);
+
+    // Disable on game2 should still flip the entity even though
+    // game1 ended in a disabled state.
+    game2.setGizmosEnabled(false);
+    Bridge.reconcileGizmos(&game2);
+    try testing.expect(!game2.getComponent(gz, Sprite).?.visible);
+}


### PR DESCRIPTION
Closes #493.

## Problem

Declarative gizmos defined via `gizmos/*.zon` spawn ECS entities with `Shape` / `Sprite` components and render through the normal sprite/shape pipeline. `renderGizmos` only gates the imperative `drawGizmo*` queue, so `setGizmosEnabled(false)` had no effect on `.zon`-defined gizmos — they always rendered. Authors of these files reasonably expect `G` to toggle them; the gap was a footgun (flying-platform-labelle hit it and worked around with deletion in PR #300).

## Fix

`reconcileGizmos` now runs a small `syncGizmoVisibility` sweep after the per-gizmo create pass. Every entity carrying the internal `Gizmo` component has its `Shape.visible` / `Sprite.visible` flipped to match `gizmos_enabled`. Entities aren't destroyed — keeping them across toggles avoids churn, save/load surprises, and respects the user's clarification "we may need to show them later."

Steady-state cost: one ECS view scan per frame (already happens for the create pass) plus a per-entity visibility check. The `markVisualDirty` call is gated behind a `visible != target` test, so a frame with nothing to change is a no-op for the renderer.

## Test plan

- [x] `zig build test` — full engine test suite green (no regressions).
- [ ] End-to-end smoke in flying-platform-labelle:
  1. Restore the deleted `gizmos/{eis,iis,ios,eos,workstation}.zon` files (#300 workaround).
  2. Bump the engine pin to this PR's hash.
  3. Run `labelle run`. Gizmos start visible (default `gizmos_enabled = true`).
  4. Press `G` — all five `.zon` shapes hide together.
  5. Press `G` again — they come back, identical to step 3.

No new unit test in this PR: `JsoncSceneBridgeWithGizmos` has no existing fixture and bootstrapping one for a single-line behaviour check would be disproportionate. Open to adding it if the gizmo path picks up further behavior we want pinned.