### PR TITLE
fix(jsonc): strict deserializeEnumSet — reject malformed input (#497)

### DIFF
--- a/src/jsonc/deserializer.zig
+++ b/src/jsonc/deserializer.zig
@@ -241,16 +241,24 @@ fn deserializeTaggedUnion(comptime T: type, value: Value, allocator: std.mem.All
     return null;
 }
 
+/// Deserialize an `EnumSet(K)` from a JSONC object whose entries are
+/// `<enum_member>: <bool>` pairs. Strict on malformed input: returns
+/// `null` if any value is not a bool *or* any key is not a member of
+/// `K`. The lenient variant (silently dropping non-bool values and
+/// unknown keys) was reverted because typos like `"FoodPaket": true`
+/// failed open — the scene loaded with the flag missing and the bug
+/// surfaced much later as wrong gameplay (e.g. a storage refusing
+/// items it should accept). Returning `null` here lets the parent
+/// struct's `default_value_ptr` fallback fire, or — if the field is
+/// required — fails the load with a diagnostic at scene-load time.
+/// See issue #497.
 fn deserializeEnumSet(comptime T: type, value: Value) ?T {
     const obj = value.asObject() orelse return null;
     var set = T.initEmpty();
     for (obj.entries) |entry| {
-        const is_true = entry.value.asBool() orelse false;
-        if (is_true) {
-            if (std.meta.stringToEnum(T.Key, entry.key)) |key| {
-                set.insert(key);
-            }
-        }
+        const is_true = entry.value.asBool() orelse return null;
+        const key = std.meta.stringToEnum(T.Key, entry.key) orelse return null;
+        if (is_true) set.insert(key);
     }
     return set;
 }

--- a/test/jsonc/deserializer_test.zig
+++ b/test/jsonc/deserializer_test.zig
@@ -224,3 +224,58 @@ test "deserialize: EnumSet from object of bools" {
     try testing.expect(got.contains(.meat));
     try testing.expect(!got.contains(.vegetable));
 }
+
+// Strict-on-malformed contract — see issue #497. The lenient variant
+// silently dropped bad entries; that meant a typo like
+// `"vegtable": true` produced an empty set and surfaced as a
+// gameplay bug far from the source. These tests pin the strict
+// behavior: any malformed entry => null, so the parent struct's
+// default fires (or scene load fails loudly at parse time).
+
+test "deserialize: EnumSet rejects non-bool value" {
+    var entries = [_]SceneValue.Object.Entry{
+        .{ .key = "water", .value = .{ .string = "yes" } },
+    };
+    const v = SceneValue{ .object = .{ .entries = &entries } };
+
+    const Set = std.EnumSet(Items);
+    try testing.expect(deserializer.deserialize(Set, v, testing.allocator) == null);
+}
+
+test "deserialize: EnumSet rejects unknown enum key" {
+    var entries = [_]SceneValue.Object.Entry{
+        // typo: `vegtable` instead of `vegetable`
+        .{ .key = "vegtable", .value = .{ .boolean = true } },
+    };
+    const v = SceneValue{ .object = .{ .entries = &entries } };
+
+    const Set = std.EnumSet(Items);
+    try testing.expect(deserializer.deserialize(Set, v, testing.allocator) == null);
+}
+
+test "deserialize: EnumSet rejects mixed valid + invalid entries" {
+    var entries = [_]SceneValue.Object.Entry{
+        .{ .key = "water", .value = .{ .boolean = true } },
+        // unknown key — should poison the whole set
+        .{ .key = "diamond", .value = .{ .boolean = true } },
+    };
+    const v = SceneValue{ .object = .{ .entries = &entries } };
+
+    const Set = std.EnumSet(Items);
+    try testing.expect(deserializer.deserialize(Set, v, testing.allocator) == null);
+}
+
+test "deserialize: EnumSet all-valid bools (mixed true/false) produces expected set" {
+    var entries = [_]SceneValue.Object.Entry{
+        .{ .key = "water", .value = .{ .boolean = true } },
+        .{ .key = "vegetable", .value = .{ .boolean = false } },
+        .{ .key = "meat", .value = .{ .boolean = true } },
+    };
+    const v = SceneValue{ .object = .{ .entries = &entries } };
+
+    const Set = std.EnumSet(Items);
+    const got = deserializer.deserialize(Set, v, testing.allocator).?;
+    try testing.expect(got.contains(.water));
+    try testing.expect(!got.contains(.vegetable));
+    try testing.expect(got.contains(.meat));
+}


### PR DESCRIPTION
Closes #497.

## Summary

- `deserializeEnumSet` now returns `null` when an entry's value is not a bool, or when the key is not a member of the enum. Previously both cases were silently dropped, which let typos like `"FoodPaket": true` fail open — the scene loaded with the flag missing and the symptom surfaced far from the source as wrong gameplay (e.g. a storage refusing items it should accept).
- Returning `null` lets the parent struct's `default_value_ptr` fallback fire, or — if the field is required — fails the scene load with a diagnostic at parse time.
- Carved out of #496 per Bugbot review (that PR was scoped behavior-preserving; tightening this path conflicted with the promise).

## Consumer audit

Audited every `.jsonc` in downstream consumer projects for EnumSet-shaped fields (objects whose values are bools), then cross-referenced each key against the corresponding enum definition.

| Project | EnumSet field | Files checked | Bad keys | Non-bool values |
|---|---|---:|---:|---:|
| flying-platform-labelle | `Storage.accepted_items: std.EnumSet(items.Items)` | 47 prefabs + 28 scenes | 0 | 0 |
| bakery-game | (none — uses `.zon`, not `.jsonc`) | — | — | — |

`enums.Items` members: `Water`, `Vegetable`, `LiveRabbit`, `Meat`, `FoodPacket`. All keys appearing in `accepted_items` blocks are valid; all values are literal `true`. No downstream breakage expected.

The only EnumSet-typed component in either consumer's component set is `Storage.accepted_items`, so no other shapes need auditing.

## Tests

Added four cases in `test/jsonc/deserializer_test.zig` (existing file from #496):

- non-bool value → `null`
- unknown enum key → `null`
- mixed valid + invalid entries → `null` (poisons the whole set)
- all-valid mixed `true`/`false` bools → expected set (regression-guard for the happy path)

Pre-existing `EnumSet from object of bools` test still passes.

## Test plan

- [x] `DEVELOPER_DIR=/Library/Developer/CommandLineTools zig build test` — 299/299 pass
- [ ] CI green
- [ ] Reviewer sanity-check on the audit table — happy to re-grep if there's a corner I missed (e.g. plugin components with their own EnumSets)

## Notes

- No version bump (release-time concern).
- Issue #497 mentioned an optional deprecation-log path for one release. Skipped that here because the audit found zero affected entries — straight strict is safe.