### PR TITLE
chore(jsonc): pin zspec to v0.8.0

### DIFF
--- a/jsonc/build.zig.zon
+++ b/jsonc/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.15.2",
     .dependencies = .{
         .zspec = .{
-            .url = "https://github.com/apotema/zspec/archive/refs/heads/main.tar.gz",
-            .hash = "zspec-0.7.0-jaKLbVqmAwDxLB7GYHuw354BQp7_uBSN9rSBUIfAx5xy",
+            .url = "https://github.com/apotema/zspec/archive/v0.8.0.tar.gz",
+            .hash = "zspec-0.8.0-jaKLbSK-AwD6myJjkg3OfGAKJyj5iaFzFfVu-pcUsUn1",
         },
     },
     .paths = .{


### PR DESCRIPTION
## Summary

The \`jsonc\` subpackage's zspec dep used \`archive/refs/heads/main.tar.gz\` with a v0.7.0-content hash. When [apotema/zspec](https://github.com/apotema/zspec) main moved to v0.8.0 (release: https://github.com/apotema/zspec/releases/tag/v0.8.0), the hash check failed against the freshly fetched main.

## Fix

Switch to a versioned URL (\`archive/v0.8.0.tar.gz\`) + matching hash so future zspec releases don't silently break our build graph.

## Why this matters

Surfaced via labelle-cli's Docker WASM CI failing after [labelle-toolkit/labelle-cli#190](https://github.com/labelle-toolkit/labelle-cli/pull/190) bumped its own zspec to v0.8.0 — the engine's still-v0.7.0 hash conflicted with the v0.8.0 hash from CLI when both were pulled into the same project's build graph.

Coordinated with sibling PRs in labelle-gfx and flying-platform-labelle so the whole ecosystem moves to v0.8.0 in lockstep.

## Tests

- 299/299 still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)