### PR TITLE
feat(scene): allow scenes to declare their required initial_state (#500)

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -129,11 +129,12 @@ pub fn GameConfig(
             /// do `game.scenes.get("main").?.assets` without a null check.
             assets: []const []const u8 = &.{},
             /// Optional state the scene wants the game to be in when it loads.
-            /// `setScene` calls `setState(initial_state.?)` after the scene's
-            /// assets are ready and the entity load finishes. Populated by the
-            /// assembler from each scene's `"initial_state": "<name>"` field
-            /// (issue #500). `null` (default) means the scene doesn't request
-            /// a state change — current behavior preserved.
+            /// Both `setScene` and `setSceneAtomic` call `setState(initial_state.?)`
+            /// after the scene's assets are ready and the entity load finishes.
+            /// Populated by the assembler from each scene's
+            /// `"initial_state": "<name>"` field (issue #500). `null` (default)
+            /// means the scene doesn't request a state change — current behavior
+            /// preserved.
             ///
             /// Lifetime: stored by reference, must outlive the `Game`. The
             /// assembler emits a string-literal slice, which is program-lifetime.

--- a/src/game.zig
+++ b/src/game.zig
@@ -128,6 +128,16 @@ pub fn GameConfig(
             /// registered via the legacy (non-manifest) path; scripts can then
             /// do `game.scenes.get("main").?.assets` without a null check.
             assets: []const []const u8 = &.{},
+            /// Optional state the scene wants the game to be in when it loads.
+            /// `setScene` calls `setState(initial_state.?)` after the scene's
+            /// assets are ready and the entity load finishes. Populated by the
+            /// assembler from each scene's `"initial_state": "<name>"` field
+            /// (issue #500). `null` (default) means the scene doesn't request
+            /// a state change — current behavior preserved.
+            ///
+            /// Lifetime: stored by reference, must outlive the `Game`. The
+            /// assembler emits a string-literal slice, which is program-lifetime.
+            initial_state: ?[]const u8 = null,
         };
 
         /// Runtime JSONC scene path info.
@@ -898,6 +908,7 @@ pub fn GameConfig(
         pub const registerSceneSimple = SceneMixin.registerSceneSimple;
         pub const registerSceneWithAssets = SceneMixin.registerSceneWithAssets;
         pub const setSceneAssets = SceneMixin.setSceneAssets;
+        pub const setSceneInitialState = SceneMixin.setSceneInitialState;
         pub const setScene = SceneMixin.setScene;
         pub const setSceneAtomic = SceneMixin.setSceneAtomic;
         pub const queueSceneChange = SceneMixin.queueSceneChange;

--- a/src/game/scene_mixin.zig
+++ b/src/game/scene_mixin.zig
@@ -457,6 +457,18 @@ pub fn Mixin(comptime Game: type) type {
                 self.allocator.free(p);
                 self.pending_scene_assets = null;
             }
+
+            // Honor the scene's declared `initial_state` (issue #500).
+            // Mirrors `setScene` — keep the two paths in sync so a scene
+            // loaded via `setSceneAtomic` (or `queueSceneChangeAtomic`)
+            // gets the same state-transition treatment as `setScene`.
+            // `entry` is already in scope (line 365) so no re-lookup.
+            if (entry.initial_state) |state| {
+                if (!std.mem.eql(u8, self.game_state, state)) {
+                    std.log.info("[Scene] '{s}' set state '{s}' → '{s}'", .{ name, self.game_state, state });
+                }
+                self.setState(state);
+            }
         }
 
         pub fn queueSceneChange(self: *Game, name: []const u8) void {

--- a/src/game/scene_mixin.zig
+++ b/src/game/scene_mixin.zig
@@ -237,6 +237,30 @@ pub fn Mixin(comptime Game: type) type {
             entry.assets = assets;
         }
 
+        /// Attach a declared `initial_state` to a previously-registered scene.
+        /// `setScene` will call `setState(state)` after the scene loads.
+        ///
+        /// Returns `error.SceneNotFound` if `name` was never registered.
+        ///
+        /// Used by the assembler to thread each scene's `"initial_state": "<name>"`
+        /// JSONC field into `SceneEntry.initial_state` (issue #500). Same setter
+        /// pattern as `setSceneAssets` so the assembler can call both after the
+        /// `registerSceneSimple` loop.
+        ///
+        /// Lifetime: `state` is stored by reference and must outlive the `Game`.
+        /// The assembler emits a string-literal slice (program-lifetime). Runtime
+        /// callers passing a stack-allocated slice would leave
+        /// `SceneEntry.initial_state` dangling — prefer an allocator-owned or
+        /// static slice.
+        pub fn setSceneInitialState(
+            self: *Game,
+            name: []const u8,
+            state: []const u8,
+        ) error{SceneNotFound}!void {
+            const entry = self.scenes.getPtr(name) orelse return error.SceneNotFound;
+            entry.initial_state = state;
+        }
+
         pub fn setScene(self: *Game, name: []const u8) !void {
             // Phase 2 of the Asset Streaming RFC (#437) — gate the
             // swap on the new scene's `assets:` manifest. Acquires
@@ -315,6 +339,21 @@ pub fn Mixin(comptime Game: type) type {
             if (self.pending_scene_assets) |p| {
                 self.allocator.free(p);
                 self.pending_scene_assets = null;
+            }
+
+            // Honor the scene's declared `initial_state` (issue #500).
+            // This runs LAST so all the scene's entities + scripts are
+            // in place when state-gated scripts start ticking on the
+            // next frame. Logging the transition makes scene-driven
+            // state changes visible — anyone debugging the state
+            // machine can grep for `[Scene] '<name>' set state`.
+            if (self.scenes.get(name)) |entry| {
+                if (entry.initial_state) |state| {
+                    if (!std.mem.eql(u8, self.game_state, state)) {
+                        std.log.info("[Scene] '{s}' set state '{s}' → '{s}'", .{ name, self.game_state, state });
+                    }
+                    self.setState(state);
+                }
             }
         }
 

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -269,6 +269,46 @@ test "Game: setScene without initial_state leaves game_state untouched" {
     try testing.expectEqualStrings("custom_state", game.getState());
 }
 
+test "Game: setSceneAtomic honors SceneEntry.initial_state (mirrors setScene)" {
+    // Regression check: setSceneAtomic was the parallel code path that
+    // initially missed the initial_state handling — flagged by Cursor /
+    // gemini on PR #501. Both setScene and setSceneAtomic must apply
+    // the declared state, otherwise scenes loaded atomically silently
+    // ignore their preference (the exact bug #500 was filed to fix).
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const emptyLoader = struct {
+        fn load(_: *Game) anyerror!void {}
+    }.load;
+
+    game.registerSceneSimple("combat_arena", emptyLoader);
+    try game.setSceneInitialState("combat_arena", "playing");
+
+    try testing.expectEqualStrings("running", game.getState());
+
+    try game.setSceneAtomic("combat_arena");
+
+    try testing.expectEqualStrings("playing", game.getState());
+}
+
+test "Game: setSceneAtomic without initial_state leaves game_state untouched" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const emptyLoader = struct {
+        fn load(_: *Game) anyerror!void {}
+    }.load;
+
+    game.registerSceneSimple("plain", emptyLoader);
+
+    game.setState("custom_state");
+
+    try game.setSceneAtomic("plain");
+
+    try testing.expectEqualStrings("custom_state", game.getState());
+}
+
 test "Game: slash-named scene preserves original name for lookup" {
     var game = Game.init(testing.allocator);
     defer game.deinit();

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -198,6 +198,77 @@ test "Game: setSceneAssets threads manifest into existing SceneEntry" {
     try testing.expectError(error.SceneNotFound, game.setSceneAssets("nope", menu_assets));
 }
 
+test "Game: SceneEntry.initial_state defaults to null for legacy registration" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const emptyLoader = struct {
+        fn load(_: *Game) anyerror!void {}
+    }.load;
+
+    game.registerSceneSimple("legacy", emptyLoader);
+
+    try testing.expect(game.scenes.get("legacy").?.initial_state == null);
+}
+
+test "Game: setSceneInitialState threads state into existing SceneEntry" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const emptyLoader = struct {
+        fn load(_: *Game) anyerror!void {}
+    }.load;
+
+    game.registerSceneSimple("combat_arena", emptyLoader);
+
+    // Before — legacy default.
+    try testing.expect(game.scenes.get("combat_arena").?.initial_state == null);
+
+    try game.setSceneInitialState("combat_arena", "playing");
+    try testing.expectEqualStrings("playing", game.scenes.get("combat_arena").?.initial_state.?);
+
+    // Unknown scene returns an error instead of silently dropping.
+    try testing.expectError(error.SceneNotFound, game.setSceneInitialState("nope", "playing"));
+}
+
+test "Game: setScene honors SceneEntry.initial_state and transitions game_state" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const emptyLoader = struct {
+        fn load(_: *Game) anyerror!void {}
+    }.load;
+
+    game.registerSceneSimple("combat_arena", emptyLoader);
+    try game.setSceneInitialState("combat_arena", "playing");
+
+    // Default starting state — see game.zig:261.
+    try testing.expectEqualStrings("running", game.getState());
+
+    try game.setScene("combat_arena");
+
+    try testing.expectEqualStrings("playing", game.getState());
+}
+
+test "Game: setScene without initial_state leaves game_state untouched" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const emptyLoader = struct {
+        fn load(_: *Game) anyerror!void {}
+    }.load;
+
+    game.registerSceneSimple("plain", emptyLoader);
+
+    // Caller-set initial state must survive a setScene() with no
+    // initial_state declared on the scene — opt-in behavior.
+    game.setState("custom_state");
+
+    try game.setScene("plain");
+
+    try testing.expectEqualStrings("custom_state", game.getState());
+}
+
 test "Game: slash-named scene preserves original name for lookup" {
     var game = Game.init(testing.allocator);
     defer game.deinit();


### PR DESCRIPTION
## Summary

Closes the engine half of #500. Adds an optional \`initial_state: ?[]const u8\` field to \`SceneEntry\` and honors it in \`setScene\` so a scene can declare what game state it needs to run in.

## Why

Today, ad-hoc test scenes that need scripts gated to a specific state (e.g. \`scripts/playing/*\` running the bandit raid loop in flying-platform-labelle) silently fail with \`labelle run --scene=...\` because the state stays at the project's first-declared value (typically \"loading\"). The fix the user has to discover is to either reorder \`project.labelle\`'s \`.states\`, patch the loading_controller, or write a wrapper script. Scene-declared state closes that gap — the scene knows what it needs, the scene says so.

See #500 for the full motivation.

## Wiring

- **\`SceneEntry.initial_state: ?[]const u8 = null\`** — opt-in; default \`null\` preserves current behavior for every scene that doesn't declare one.
- **\`setSceneInitialState(name, state) error{SceneNotFound}!void\`** — setter that mirrors \`setSceneAssets\`. Lifetime: stored by reference, must outlive the \`Game\` (program-lifetime string-literal slice from the assembler-emitted manifest).
- **\`setScene(name)\`** — at the end of the swap (after entity load + previous-scene asset release), if the entry has a non-null \`initial_state\`, calls \`setState(initial_state)\`. Emits \`std.log.info(\"[Scene] '{s}' set state '{s}' → '{s}'\", ...)\` so scene-driven state changes are never invisible.

## Tests

303/303 (+4 new):
- \`SceneEntry.initial_state\` defaults to null for legacy registration
- \`setSceneInitialState\` happy path + \`error.SceneNotFound\` rejection
- \`setScene\` applies the declared state on swap
- \`setScene\` without \`initial_state\` leaves \`game_state\` untouched (regression check)

## Coordination

Sibling PR in labelle-assembler parses the \`\"initial_state\": \"<name>\"\` field from scene \`.jsonc\` and emits the corresponding \`setSceneInitialState\` calls. Until both ship, generated code that calls \`setSceneInitialState\` won't compile against unreleased engine versions — same lockstep coordination pattern as the asset-streaming RFC (#437/#445).

Once both released, downstream consumers (e.g. flying-platform-labelle) can declare \`\"initial_state\": \"playing\"\` in their debug scenes and \`labelle run --scene=...\` Just Works.

## Test plan

- [ ] CI green
- [ ] Reviewer can spot-check setScene's new code path: register a scene with \`setSceneInitialState\`, call \`setScene\`, observe \`getState()\` reflects the declared state
- [ ] Reviewer confirms the log line format suits the project's logging style

🤖 Generated with [Claude Code](https://claude.com/claude-code)