### PR TITLE
feat(scene): dev-mode eager-load fallback when scene has no assets manifest (#502)

### DIFF
--- a/src/game/scene_mixin.zig
+++ b/src/game/scene_mixin.zig
@@ -1,5 +1,28 @@
 /// Scene mixin — scene registration, loading, transitions, and lifecycle.
 const std = @import("std");
+const builtin = @import("builtin");
+
+/// Collect every asset name currently registered in the catalog into a
+/// fresh allocator-owned slice. The returned slice borrows the name
+/// pointers from the catalog — they're string literals from the
+/// assembler-emitted `register` calls (program-lifetime), so the caller
+/// only needs to free the slice itself.
+///
+/// Used by `setScene` / `setSceneAtomic`'s dev-mode eager-fallback
+/// (issue #502): when a scene declares no `assets:`, in Debug builds we
+/// load every project resource so the scene renders without forcing
+/// the developer to author a manifest just to peek at it. Production
+/// builds keep the strict explicit-declaration behavior.
+fn collectAllRegisteredAssetNames(allocator: std.mem.Allocator, catalog: anytype) ![][]const u8 {
+    var list = std.ArrayList([]const u8){};
+    errdefer list.deinit(allocator);
+    try list.ensureTotalCapacityPrecise(allocator, catalog.entries.count());
+    var iter = catalog.entries.keyIterator();
+    while (iter.next()) |key| {
+        try list.append(allocator, key.*);
+    }
+    return list.toOwnedSlice(allocator);
+}
 
 /// Possible outcomes of the asset-manifest gate fired at the start
 /// of `setScene`/`setSceneAtomic` (Phase 2 of the Asset Streaming
@@ -270,10 +293,36 @@ pub fn Mixin(comptime Game: type) type {
             // the gate entirely. Scenes registered via the legacy
             // `registerSceneSimple` (no manifest) have `assets ==
             // &.{}` and behave identically to before this change.
-            const target_assets: []const []const u8 = if (self.scenes.get(name)) |e|
+            const declared_assets: []const []const u8 = if (self.scenes.get(name)) |e|
                 e.assets
             else
                 &.{};
+
+            // Dev-mode eager-load fallback (issue #502) — if the scene
+            // declared no assets and we're a Debug build, load every
+            // registered project resource so the scene renders without
+            // forcing the developer to author a manifest just to peek
+            // at it. Production builds keep the silent-black behavior:
+            // a missing manifest there is a real bug that should be
+            // caught during smoke tests, not papered over.
+            //
+            // The collected slice is freed at end-of-function. Names
+            // inside it are borrows of the catalog's keys (string
+            // literals from the assembler-emitted register calls), so
+            // they outlive this call comfortably.
+            var eager_buf: ?[][]const u8 = null;
+            defer if (eager_buf) |b| self.allocator.free(b);
+            const target_assets: []const []const u8 = if (declared_assets.len == 0 and comptime builtin.mode == .Debug) blk: {
+                const all = collectAllRegisteredAssetNames(self.allocator, &self.assets) catch break :blk declared_assets;
+                if (all.len == 0) {
+                    self.allocator.free(all);
+                    break :blk declared_assets;
+                }
+                std.log.info("[Scene] '{s}' has no manifest, eager-loaded {d} resources (Debug build)", .{ name, all.len });
+                eager_buf = all;
+                break :blk @as([]const []const u8, all);
+            } else declared_assets;
+
             if (!try gateOrDefer(self, "setScene", name, target_assets)) return;
 
             // Bridge catalog-uploaded image handles into
@@ -364,19 +413,34 @@ pub fn Mixin(comptime Game: type) type {
         pub fn setSceneAtomic(self: *Game, name: []const u8) !void {
             const entry = self.scenes.get(name) orelse return error.SceneNotFound;
 
+            // Dev-mode eager-load fallback (issue #502) — same logic as
+            // setScene, kept in sync. See setScene for the full rationale.
+            var eager_buf: ?[][]const u8 = null;
+            defer if (eager_buf) |b| self.allocator.free(b);
+            const target_assets: []const []const u8 = if (entry.assets.len == 0 and comptime builtin.mode == .Debug) blk: {
+                const all = collectAllRegisteredAssetNames(self.allocator, &self.assets) catch break :blk entry.assets;
+                if (all.len == 0) {
+                    self.allocator.free(all);
+                    break :blk entry.assets;
+                }
+                std.log.info("[Scene] '{s}' has no manifest, eager-loaded {d} resources (Debug build)", .{ name, all.len });
+                eager_buf = all;
+                break :blk @as([]const []const u8, all);
+            } else entry.assets;
+
             // Manifest gate — see `setScene` for the full
             // explanation. Both entry points participate in the
             // same idempotent acquire/release cycle so callers can
             // mix `setScene` and `setSceneAtomic` without confusing
             // the gate.
-            if (!try gateOrDefer(self, "setSceneAtomic", name, entry.assets)) return;
+            if (!try gateOrDefer(self, "setSceneAtomic", name, target_assets)) return;
 
-            bridgeImageAssetsToAtlasManager(self, entry.assets);
+            bridgeImageAssetsToAtlasManager(self, target_assets);
 
             const previous_name = if (self.current_scene_name) |n| self.allocator.dupe(u8, n) catch null else null;
             defer if (previous_name) |p| self.allocator.free(p);
 
-            self.emitHook(.{ .scene_assets_acquire = .{ .name = name, .assets = entry.assets } });
+            self.emitHook(.{ .scene_assets_acquire = .{ .name = name, .assets = target_assets } });
 
             // `scene_before_reset` fires BEFORE any entity
             // destruction — plugin controllers with per-world heap

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -292,6 +292,60 @@ test "Game: setSceneAtomic honors SceneEntry.initial_state (mirrors setScene)" {
     try testing.expectEqualStrings("playing", game.getState());
 }
 
+test "Game: setScene with no manifest acquires all registered assets in Debug (issue #502)" {
+    // The eager-fallback is comptime-gated to `builtin.mode == .Debug`.
+    // The test binary IS a Debug build (Zig's default for `zig build test`),
+    // so this exercises the production-path-of-record behavior.
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    try game.assets.register("background", .image, "png", "fake-bytes-1");
+    try game.assets.register("ship", .image, "png", "fake-bytes-2");
+
+    const emptyLoader = struct {
+        fn load(_: *Game) anyerror!void {}
+    }.load;
+
+    // Scene registered without a manifest — exactly the case #502 fixes.
+    game.registerSceneSimple("debug/peek", emptyLoader);
+
+    // Pre-condition: no acquires yet.
+    try testing.expectEqual(@as(u32, 0), game.assets.entries.get("background").?.refcount);
+    try testing.expectEqual(@as(u32, 0), game.assets.entries.get("ship").?.refcount);
+
+    // setScene defers the swap (assets aren't .ready without a backend),
+    // but the eager-fallback should still have acquire'd them — that's
+    // the half of the gate this test pins. The deferred swap is fine.
+    _ = game.setScene("debug/peek") catch {};
+
+    try testing.expectEqual(@as(u32, 1), game.assets.entries.get("background").?.refcount);
+    try testing.expectEqual(@as(u32, 1), game.assets.entries.get("ship").?.refcount);
+}
+
+test "Game: setScene with explicit manifest does NOT eager-load other resources" {
+    // The fallback only fires when the scene's `assets:` is empty —
+    // a scene that explicitly opts in to one resource shouldn't
+    // accidentally pull in the rest of the project's catalog.
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    try game.assets.register("declared", .image, "png", "a");
+    try game.assets.register("not_declared", .image, "png", "b");
+
+    const emptyLoader = struct {
+        fn load(_: *Game) anyerror!void {}
+    }.load;
+
+    game.registerSceneSimple("scoped", emptyLoader);
+    const manifest: []const []const u8 = &.{"declared"};
+    try game.setSceneAssets("scoped", manifest);
+
+    _ = game.setScene("scoped") catch {};
+
+    try testing.expectEqual(@as(u32, 1), game.assets.entries.get("declared").?.refcount);
+    try testing.expectEqual(@as(u32, 0), game.assets.entries.get("not_declared").?.refcount);
+}
+
 test "Game: setSceneAtomic without initial_state leaves game_state untouched" {
     var game = Game.init(testing.allocator);
     defer game.deinit();


### PR DESCRIPTION
## Summary

Closes #502. When a scene declares no \`assets:\` manifest, every sprite lookup misses and the window renders solid black — even though the scripts and entity logic run correctly. This came up running \`scenes/debug/bandit/*\` visually after #500 unlocked debug-scene runnability: those scenes were authored for log-based testing and intentionally omit the manifest.

## Fix

Comptime build-mode gate in \`setScene\` and \`setSceneAtomic\`. When the new entry's \`assets.len == 0\` AND \`builtin.mode == .Debug\`, walk the asset catalog and use every registered name as the target manifest. Production builds keep the silent-black behavior so missing manifests stay caught by smoke tests.

| build mode | scene declares \`assets:\` | scene omits \`assets:\` |
|---|---|---|
| Debug | streaming load (current) | **eager-load fallback (new)** |
| Release* | streaming load (current) | silent black (current) |

The fallback emits an info log so the dev knows it fired:
> \`[Scene] '<name>' has no manifest, eager-loaded N resources (Debug build)\`

## No assembler changes needed

The issue mentioned an \`AllProjectResources\` manifest from the assembler, but that turned out redundant — the catalog already gets populated with every project resource via the existing assembler-emitted \`g.assets.register(...)\` calls at init time (asset-streaming RFC #437/#445 machinery). The new \`collectAllRegisteredAssetNames\` helper just walks \`self.assets.entries\` directly.

## Tests

307/307 (+2 new):

- **\`setScene with no manifest acquires all registered assets in Debug\`** — the production-path-of-record. Registers two assets, registers a manifest-less scene, calls \`setScene\`, verifies both assets got refcount-bumped.
- **\`setScene with explicit manifest does NOT eager-load other resources\`** — regression check that the fallback only fires when \`assets.len == 0\`. A scene that explicitly opts in to one resource shouldn't accidentally pull in the rest.

## Lifetime / safety

The collected slice is allocator-owned and freed at end-of-function via \`defer\`. The names inside are borrows of the catalog's keys (string literals from \`register\` calls = program-lifetime), so they outlive the call comfortably.

Allocation failure during collection silently falls back to the empty manifest (silent-black behavior) rather than propagating — losing rendering in dev is annoying but not catastrophic, and surfacing OOM here would mask the original allocation failure with a confusing scene error.

## Test plan

- [ ] CI green
- [ ] Reviewer can run a Debug build of any consumer (e.g. flying-platform-labelle) with a scene that omits \`assets:\` and observe the \`[Scene] '...' has no manifest, eager-loaded N resources\` log + working sprites
- [ ] Reviewer can build the same consumer with \`-Doptimize=ReleaseSafe\` and confirm the same scene renders black (production behavior preserved)

## Coordination

Standalone — no assembler/CLI changes needed. Once released, downstream consumers (e.g. \`flying-platform-labelle\`) just bump their \`engine_version\` to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)