### PR TITLE
feat(scene): expose pendingSceneName() accessor for in-flight swaps (#504)

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -915,6 +915,7 @@ pub fn GameConfig(
         pub const queueSceneChange = SceneMixin.queueSceneChange;
         pub const queueSceneChangeAtomic = SceneMixin.queueSceneChangeAtomic;
         pub const getCurrentSceneName = SceneMixin.getCurrentSceneName;
+        pub const pendingSceneName = SceneMixin.pendingSceneName;
 
         /// Register a runtime JSONC scene by name.
         /// The scene file is loaded from disk when setScene() is called.

--- a/src/game/scene_mixin.zig
+++ b/src/game/scene_mixin.zig
@@ -557,6 +557,31 @@ pub fn Mixin(comptime Game: type) type {
             return self.current_scene_name;
         }
 
+        /// Returns the name of the scene currently being loaded — i.e. the
+        /// `setScene`/`setSceneAtomic` target whose asset-manifest gate
+        /// is still deferring (atlases decoding, etc.). Returns `null`
+        /// when no swap is in flight.
+        ///
+        /// Distinct from `getCurrentSceneName()`, which returns the
+        /// COMMITTED scene (the one whose entities + scripts are
+        /// active). During the asset-loading deferral period:
+        ///   - `getCurrentSceneName()` returns the previous scene
+        ///     (or `null` on initial boot)
+        ///   - `pendingSceneName()` returns the requested scene
+        ///
+        /// Consumers writing scene-aware recovery code (e.g. "if no
+        /// scene is loaded, set this default scene") should check both:
+        ///
+        ///   const intended = game.getCurrentSceneName() orelse
+        ///       game.pendingSceneName() orelse return;
+        ///
+        /// Otherwise their recovery races with the deferred swap and
+        /// can hijack the user's requested scene before it lands —
+        /// see issue #504 for the surfaced case.
+        pub fn pendingSceneName(self: *const Game) ?[]const u8 {
+            return self.pending_scene_assets;
+        }
+
         pub fn setActiveScene(
             self: *Game,
             ptr: *anyopaque,

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -346,6 +346,61 @@ test "Game: setScene with explicit manifest does NOT eager-load other resources"
     try testing.expectEqual(@as(u32, 0), game.assets.entries.get("not_declared").?.refcount);
 }
 
+test "Game: pendingSceneName returns null when no swap is in flight" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    try testing.expect(game.pendingSceneName() == null);
+}
+
+test "Game: pendingSceneName returns target name during asset-loading deferral (issue #504)" {
+    // Reproduces the race from issue #504: setScene's manifest gate
+    // defers while atlases decode. During that window, consumers used
+    // to see `getCurrentSceneName() == null` and erroneously assume
+    // no scene was loaded. `pendingSceneName()` lets them tell the
+    // difference between "no swap requested" and "swap in flight".
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    try game.assets.register("background", .image, "png", "fake-bytes");
+
+    const emptyLoader = struct {
+        fn load(_: *Game) anyerror!void {}
+    }.load;
+
+    game.registerSceneSimple("late_loader", emptyLoader);
+
+    // Asset is .registered (not .ready) — gate will defer.
+    _ = game.setScene("late_loader") catch {};
+
+    // Committed scene is still null (gate deferred), but the pending
+    // marker reflects the user's intent.
+    try testing.expect(game.getCurrentSceneName() == null);
+    try testing.expectEqualStrings("late_loader", game.pendingSceneName().?);
+}
+
+test "Game: pendingSceneName clears after the swap commits" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    try game.assets.register("background", .image, "png", "fake-bytes");
+    {
+        const e = game.assets.entries.getPtr("background").?;
+        e.state = .ready;
+    }
+
+    const emptyLoader = struct {
+        fn load(_: *Game) anyerror!void {}
+    }.load;
+
+    game.registerSceneSimple("instant_loader", emptyLoader);
+
+    _ = game.setScene("instant_loader") catch {};
+
+    try testing.expectEqualStrings("instant_loader", game.getCurrentSceneName().?);
+    try testing.expect(game.pendingSceneName() == null);
+}
+
 test "Game: setSceneAtomic without initial_state leaves game_state untouched" {
     var game = Game.init(testing.allocator);
     defer game.deinit();


### PR DESCRIPTION
## Summary

Closes #504. Adds a public \`pendingSceneName()\` accessor for the marker the manifest gate already tracks (\`pending_scene_assets\`). Consumers can now distinguish \"no scene requested\" from \"swap in flight, asset gate deferring\".

## Background

\`setScene(target)\` updates \`current_scene_name\` only AFTER the asset-manifest gate proves \`allReady\`. During the deferral period (frames 0..N while atlases decode + upload), \`getCurrentSceneName()\` returns the previous scene (or \`null\` on initial boot). Per-tick consumers reacting to \`null\` can call \`setScene(other)\` and override the user's request before it lands.

The race surfaced in flying-platform-labelle's [\`save_load_smoke_controller\`](https://github.com/Flying-Platform/flying-platform-labelle/blob/main/scripts/save_load_smoke_controller.zig#L85-L87)'s null-recovery after the eager-fallback (#502/#503) made manifest-less scenes deferrable for the first time. Repro details in #504.

## Why this approach (option B)

#504 sketched two fixes:

| | Option A: pre-set current_scene_name | **Option B: pendingSceneName accessor (this PR)** |
|---|---|---|
| Engine change size | ~20 lines (restructuring previous-name tracking) | 4 lines |
| Reentry leak risk | Yes — re-entry during deferral re-captures \"previous\" as the just-pre-set name | None |
| Consumer API | Single source of truth (\`getCurrentSceneName()\`) | Two fields, consumers check both |
| Behavior change for existing consumers | Yes — \`getCurrentSceneName\` semantics shift | No — pure addition |

B wins on safety and minimality. The single-source-of-truth ergonomic loss is small: consumers wanting \"intended scene\" call both:

\`\`\`zig
const intended = game.getCurrentSceneName() orelse
    game.pendingSceneName() orelse return;
\`\`\`

…which is exactly what the new accessor's docstring shows.

## Tests

310/310 (+3 new):

- \`pendingSceneName() == null\` with no swap in flight
- \`pendingSceneName() == target\` during the asset-loading deferral (the #504 repro)
- \`pendingSceneName() == null\` after the swap commits

## Coordination

Pure addition — no behavior change. Existing consumers see no difference. Once released, downstream code (e.g. FP's smoke controller) can update their recovery logic to check both accessors and the #504 race resolves.

## Test plan

- [ ] CI green
- [ ] Reviewer can spot-check the new accessor's contract: register asset (state stays \`.registered\`), register scene, call \`setScene\`, observe \`getCurrentSceneName == null\` and \`pendingSceneName == target\`
- [ ] Reviewer aware that the FP smoke-controller fix lands separately (FP-side update to use both accessors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)