### PR TITLE
fix(scene): eager-fallback acquire-and-proceed instead of defer (#506)

### DIFF
--- a/src/game/scene_mixin.zig
+++ b/src/game/scene_mixin.zig
@@ -44,6 +44,34 @@ const ManifestGate = union(enum) {
     asset_error: anyerror,
 };
 
+/// Acquire any not-yet-acquired assets in `target_assets`. Idempotent
+/// across frames via `game.pending_scene_assets`. Used by both the
+/// readiness gate (`gateOnManifest`) and the dev-mode eager-fallback
+/// (`acquireImmediately`) — separates the acquire batch from the
+/// classify step so the eager-fallback can skip the `allReady` wait
+/// without duplicating the rollback logic. See issue #506.
+fn acquireBatch(game: anytype, target_name: []const u8, target_assets: []const []const u8) !void {
+    const already_acquired = if (game.pending_scene_assets) |p|
+        std.mem.eql(u8, p, target_name)
+    else
+        false;
+    if (already_acquired) return;
+
+    for (target_assets) |asset_name| {
+        _ = game.assets.acquire(asset_name) catch |err| {
+            // Roll back any prior acquires in this batch.
+            for (target_assets) |rb| {
+                if (game.assets.entries.getPtr(rb)) |e| {
+                    if (e.refcount > 0) game.assets.release(rb);
+                }
+            }
+            return err;
+        };
+    }
+    if (game.pending_scene_assets) |old| game.allocator.free(old);
+    game.pending_scene_assets = game.allocator.dupe(u8, target_name) catch null;
+}
+
 /// Acquire any not-yet-acquired assets in `target_assets`, then
 /// classify the current state. Idempotent across frames via
 /// `game.pending_scene_assets` — same scene name = same acquire
@@ -51,30 +79,24 @@ const ManifestGate = union(enum) {
 fn gateOnManifest(game: anytype, target_name: []const u8, target_assets: []const []const u8) ManifestGate {
     if (target_assets.len == 0) return .proceed;
 
-    const already_acquired = if (game.pending_scene_assets) |p|
-        std.mem.eql(u8, p, target_name)
-    else
-        false;
-
-    if (!already_acquired) {
-        for (target_assets) |asset_name| {
-            _ = game.assets.acquire(asset_name) catch |err| {
-                // Roll back any prior acquires in this batch.
-                for (target_assets) |rb| {
-                    if (game.assets.entries.getPtr(rb)) |e| {
-                        if (e.refcount > 0) game.assets.release(rb);
-                    }
-                }
-                return .{ .acquire_error = err };
-            };
-        }
-        if (game.pending_scene_assets) |old| game.allocator.free(old);
-        game.pending_scene_assets = game.allocator.dupe(u8, target_name) catch null;
-    }
+    acquireBatch(game, target_name, target_assets) catch |err| {
+        return .{ .acquire_error = err };
+    };
 
     if (game.assets.anyFailed(target_assets)) |err| return .{ .asset_error = err };
     if (!game.assets.allReady(target_assets)) return .not_ready;
     return .proceed;
+}
+
+/// Acquire-and-proceed counterpart to `gateOnManifest`. Used by the
+/// dev-mode eager-fallback (#502/#503) to skip the `allReady` wait —
+/// no retrier exists for non-`main` scenes (issue #506) and pop-in is
+/// acceptable in Debug. Production-path scenes with declared
+/// manifests still go through `gateOnManifest` and its readiness
+/// gate. The acquire-batch error path remains the same.
+fn acquireImmediately(game: anytype, target_name: []const u8, target_assets: []const []const u8) !void {
+    if (target_assets.len == 0) return;
+    try acquireBatch(game, target_name, target_assets);
 }
 
 /// Run the gate and interpret the result. Returns `true` iff the
@@ -323,7 +345,17 @@ pub fn Mixin(comptime Game: type) type {
                 break :blk @as([]const []const u8, all);
             } else declared_assets;
 
-            if (!try gateOrDefer(self, "setScene", name, target_assets)) return;
+            // Manifest gate: eager-fallback skips the allReady wait
+            // and proceeds with whatever's currently loaded, accepting
+            // progressive atlas pop-in. The assembler-emitted main.zig
+            // calls setScene exactly once at startup, and there's no
+            // retrier for non-main scenes — without this branch, an
+            // eager-fallback that defers stays pending forever (issue
+            // #506). Production scenes with declared manifests still
+            // go through the full gate.
+            if (eager_buf != null) {
+                try acquireImmediately(self, name, target_assets);
+            } else if (!try gateOrDefer(self, "setScene", name, target_assets)) return;
 
             // Bridge catalog-uploaded image handles into
             // atlas_manager so findSprite can return the right
@@ -433,7 +465,12 @@ pub fn Mixin(comptime Game: type) type {
             // same idempotent acquire/release cycle so callers can
             // mix `setScene` and `setSceneAtomic` without confusing
             // the gate.
-            if (!try gateOrDefer(self, "setSceneAtomic", name, target_assets)) return;
+            //
+            // Eager-fallback skips allReady (issue #506); see setScene
+            // for the rationale.
+            if (eager_buf != null) {
+                try acquireImmediately(self, name, target_assets);
+            } else if (!try gateOrDefer(self, "setSceneAtomic", name, target_assets)) return;
 
             bridgeImageAssetsToAtlasManager(self, target_assets);
 

--- a/test/root_test.zig
+++ b/test/root_test.zig
@@ -359,6 +359,11 @@ test "Game: pendingSceneName returns target name during asset-loading deferral (
     // to see `getCurrentSceneName() == null` and erroneously assume
     // no scene was loaded. `pendingSceneName()` lets them tell the
     // difference between "no swap requested" and "swap in flight".
+    //
+    // Use a declared manifest (not the eager-fallback) so the gate
+    // engages and defers. Post-#506 the eager-fallback path skips
+    // the gate, so this test must explicitly set assets to exercise
+    // the deferral semantics it cares about.
     var game = Game.init(testing.allocator);
     defer game.deinit();
 
@@ -369,6 +374,8 @@ test "Game: pendingSceneName returns target name during asset-loading deferral (
     }.load;
 
     game.registerSceneSimple("late_loader", emptyLoader);
+    const manifest: []const []const u8 = &.{"background"};
+    try game.setSceneAssets("late_loader", manifest);
 
     // Asset is .registered (not .ready) — gate will defer.
     _ = game.setScene("late_loader") catch {};
@@ -377,6 +384,35 @@ test "Game: pendingSceneName returns target name during asset-loading deferral (
     // marker reflects the user's intent.
     try testing.expect(game.getCurrentSceneName() == null);
     try testing.expectEqualStrings("late_loader", game.pendingSceneName().?);
+}
+
+test "Game: eager-fallback completes setScene even when assets aren't .ready (issue #506)" {
+    // Regression check: pre-#506 the eager-fallback routed through the
+    // same allReady gate as a declared manifest, so a setScene call
+    // would defer forever — no retrier exists for non-main scenes,
+    // and the assembler-emitted main.zig only calls setScene once.
+    // The fix: eager-fallback path uses acquireImmediately, accepting
+    // progressive atlas pop-in.
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    try game.assets.register("background", .image, "png", "fake-bytes-1");
+    try game.assets.register("ship", .image, "png", "fake-bytes-2");
+    // Note: assets stay in `.registered` state — no backend, never reach .ready.
+
+    const emptyLoader = struct {
+        fn load(_: *Game) anyerror!void {}
+    }.load;
+
+    game.registerSceneSimple("debug/peek", emptyLoader);
+
+    _ = game.setScene("debug/peek") catch {};
+
+    // The swap committed despite assets not being .ready.
+    try testing.expectEqualStrings("debug/peek", game.getCurrentSceneName().?);
+    try testing.expect(game.pendingSceneName() == null);
+    try testing.expectEqual(@as(u32, 1), game.assets.entries.get("background").?.refcount);
+    try testing.expectEqual(@as(u32, 1), game.assets.entries.get("ship").?.refcount);
 }
 
 test "Game: pendingSceneName clears after the swap commits" {


### PR DESCRIPTION
## Summary

Closes #506.

#503's Debug-mode eager-load fallback (#502) routed manifest-less scenes through \`gateOnManifest\`'s \`allReady\` wait. The wait expects the caller to retry every frame — but the assembler-emitted \`main.zig\` calls \`setScene\` exactly once at startup, and only the canonical \"main\" scene has a retrier (FP's \`loading_controller\`). For \`labelle run --scene=<other>\`, the fallback's deferral left the swap pending forever → black screen, no \`scene_load\` hook, no scripts ticking, no \`initial_state\` transition. End user impact: every debug scene became unrunnable visually after #503.

## Fix

Split the gate's acquire batch from its readiness check so the eager-fallback path can use just the acquire half. Production scenes with declared manifests still get the full readiness wait.

\`\`\`zig
if (eager_buf != null) {
    try acquireImmediately(self, name, target_assets);  // skip allReady
} else if (!try gateOrDefer(self, ...)) return;          // strict path
\`\`\`

Atlases pop in progressively as they decode — acceptable in Debug (the only place eager-fallback fires). The intent of #502 was dev ergonomics, not production streaming. Refactored \`gateOnManifest\` to share \`acquireBatch\` with the new \`acquireImmediately\` helper so the rollback-on-acquire-error logic isn't duplicated.

## Tests

311/311 (+1):

- **\`eager-fallback completes setScene even when assets aren't .ready\`** — registers two assets in \`.registered\` state (no backend, never reach \`.ready\`), calls \`setScene\` on a manifest-less scene, verifies the swap committed (\`getCurrentSceneName == \"debug/peek\"\`, \`pendingSceneName == null\`, refcounts bumped).

The existing #504 test for \`pendingSceneName()\` during deferral was also updated — post-#506, the eager-fallback path doesn't defer, so testing deferral semantics requires an explicit \`setSceneAssets\` call. The semantic the test pins is unchanged.

## Coordination

Standalone engine fix. After release:
- Downstream consumers see \`--scene=<debug>\` actually render the requested scene in Debug builds (with progressive atlas pop-in for the first few frames).
- Production behavior unchanged (declared-manifest scenes still go through the strict gate).
- The FP smoke-controller fix from #505 remains correct (\`getCurrentSceneName() orelse pendingSceneName()\` still does what's needed).

## Test plan

- [ ] CI green
- [ ] Reviewer can build a Debug consumer (e.g. flying-platform-labelle on the \`fix/smoke-controller-uses-pending-scene\` branch with engine pointed at this PR's tip) and run \`labelle run --scene=debug/bandit/<name>\` — should see the bandit-fight gameplay with sprites appearing as atlases load
- [ ] Reviewer can build the same consumer with \`-Doptimize=ReleaseSafe\` and confirm a manifest-less scene still silent-blacks (production behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)