### PR TITLE
fix(scene): bridge late-uploaded atlases per-tick (#508)

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -916,6 +916,7 @@ pub fn GameConfig(
         pub const queueSceneChangeAtomic = SceneMixin.queueSceneChangeAtomic;
         pub const getCurrentSceneName = SceneMixin.getCurrentSceneName;
         pub const pendingSceneName = SceneMixin.pendingSceneName;
+        pub const bridgeAllReadyImageAssets = SceneMixin.bridgeAllReadyImageAssets;
 
         /// Register a runtime JSONC scene by name.
         /// The scene file is loaded from disk when setScene() is called.
@@ -1243,6 +1244,15 @@ pub fn GameConfig(
             // through pause states.
             self.assets.pump();
 
+            // Wire late-uploaded atlases into atlas_manager (#508). The
+            // setScene-time bridge is a no-op for any asset that wasn't
+            // .ready yet (eager-fallback path completes setScene before
+            // assets reach .ready). Without this per-tick walk those
+            // atlases keep texture_id=0, every sprite samples from
+            // texture 0, and rendering looks wrong. Idempotent — already-
+            // bridged atlases are silently skipped.
+            self.bridgeAllReadyImageAssets();
+
             // Always run: logging, audio, input, renderer sync, gizmo reconciliation.
             // These must run even when paused so the game remains responsive.
             self.log.update(dt);
@@ -1517,6 +1527,11 @@ pub fn GameConfig(
                     return err;
                 }
                 self.assets.pump();
+                // Don't bridge here — `loadAtlasIfNeeded` (the shim
+                // calling this loop) does its own `markPendingLoaded`
+                // after the asset reaches .ready, and double-bridging
+                // returns AtlasNotPending. The main tick loop catches
+                // late-uploaded atlases for the eager-fallback path.
                 std.Thread.yield() catch {};
             }
 

--- a/src/game/scene_mixin.zig
+++ b/src/game/scene_mixin.zig
@@ -210,6 +210,41 @@ fn bridgeImageAssetsToAtlasManager(game: anytype, assets: []const []const u8) vo
     }
 }
 
+/// Walks every `.image` asset currently in `.ready` state and bridges
+/// it into `atlas_manager`. Idempotent via `markPendingLoaded` (already-
+/// bridged atlases return `AtlasNotPending`, silently skipped).
+///
+/// Called every tick after the catalog pump (`Game.tick`'s pump call)
+/// so atlases that finish uploading AFTER the manifest-gate path's
+/// `bridgeImageAssetsToAtlasManager` call still get their texture_id
+/// wired before `resolveAtlasSprites` runs in the same frame.
+///
+/// Without this per-tick walk, the eager-fallback path (#502/#503/#506)
+/// — which intentionally completes setScene before assets reach
+/// `.ready` — leaves every atlas's texture_id at 0. `findSprite`
+/// returns 0, every sprite samples from texture 0, and the world
+/// renders with all-wrong UVs (issue #508).
+///
+/// For the production manifest-gated path this walk is redundant
+/// (assets are already `.ready` at setScene time, the bridge ran
+/// once and succeeded) — every per-tick call is a no-op. Cost is
+/// one HashMap iteration per frame; the catalog typically holds
+/// <20 entries.
+fn bridgeAllReadyImageAssets_impl(game: anytype) void {
+    var iter = game.assets.entries.iterator();
+    while (iter.next()) |kv| {
+        const entry = kv.value_ptr;
+        if (entry.loader_kind != .image) continue;
+        if (entry.state != .ready) continue;
+        const resource = entry.resource orelse continue;
+        const handle = switch (resource) {
+            .image => |t| t,
+            else => continue,
+        };
+        game.atlas_manager.markPendingLoaded(kv.key_ptr.*, handle, null) catch {};
+    }
+}
+
 /// Returns the scene management mixin for a given Game type.
 pub fn Mixin(comptime Game: type) type {
     return struct {
@@ -236,6 +271,14 @@ pub fn Mixin(comptime Game: type) type {
             comptime loader_fn: fn (*Game) anyerror!void,
         ) void {
             self.registerScene(name, loader_fn, .{});
+        }
+
+        /// Bridge late-uploaded atlases on every tick (issue #508).
+        /// Game.tick should call this after `self.assets.pump()` so
+        /// atlases finishing upload this frame are wired before
+        /// `resolveAtlasSprites` runs. See the free fn for details.
+        pub fn bridgeAllReadyImageAssets(self: *Game) void {
+            bridgeAllReadyImageAssets_impl(self);
         }
 
         /// Register a scene together with its declared asset manifest.


### PR DESCRIPTION
## Summary

Closes #508.

\`bridgeImageAssetsToAtlasManager\` only ran once at \`setScene\` time. For the production manifest-gated path that's fine — by the time setScene completes, every manifest entry has \`state == .ready\` and \`entry.resource\` is populated.

But the eager-fallback path (#502/#503/#506/#507) intentionally completes setScene WITHOUT waiting for \`allReady\`. Atlases finish uploading several frames later. The bridge ran at setScene time when \`entry.resource\` was still \`null\` for every atlas → no-op. Late-uploaded atlases never got bridged → \`atlas.texture_id\` stayed at 0 → \`findSprite\` returned 0 → every sprite sampled from texture 0 (\"all sprites wrong\" rendering bug).

The exact failure mode the bridge function's own docstring warns against:

> Without this the catalog owns the texture (and the renderer has it via labelle-gfx#248's \`registerCatalogTexture\`), but \`atlas.texture_id\` stays at 0 — \`findSprite\` returns 0, \`resolveAtlasSprites\` writes 0 into every sprite, and all non-first atlases render with the wrong UVs.

## Fix

Per-tick bridging in the main \`Game.tick\` loop after the catalog pump. New helper \`bridgeAllReadyImageAssets\` walks every \`.image\` asset in \`.ready\` state and calls \`markPendingLoaded\` — idempotent via the existing \`AtlasNotPending\` guard, so already-bridged atlases are silently skipped. Atlases that JUST finished uploading get wired before \`resolveAtlasSprites\` runs in the same frame.

\`\`\`zig
self.assets.pump();
self.bridgeAllReadyImageAssets();  // NEW: catches late-uploaded atlases
\`\`\`

Cost: one HashMap iteration per tick (typically <20 entries) plus 1-2 hashmap lookups per \`.ready .image\` entry. Almost all calls across the game's lifetime are idempotent no-ops since each atlas only needs bridging once.

## Important: shim busy-pump NOT instrumented

The shim's busy-pump loop in \`loadAtlasIfNeeded\` (line ~1529) does its own \`markPendingLoaded\` after the loop exits. Adding the bridge there would race and surface \`AtlasNotPending\` errors — caught this regression by adding the bridge in both places initially and watching 5 shim tests fail. Inline comment documents why the second pump-call is intentionally bridge-less.

## Tests

311/311 still passing — no new tests added because the existing shim suite would have caught the wrong-place bridge (it did, immediately, on the first iteration). End-to-end verification done with a \`local:\` engine pin in flying-platform-labelle:

\`\`\`
$ labelle run --scene=debug/bandit/bandit_full_chain --timeout=15s
info: [Scene] '...' eager-loaded 6 resources (Debug build)
info: [Scene] '...' set state 'loading' → 'playing'
INFO: TEXTURE: [ID 3-9] Texture loaded successfully  ← atlases upload after setScene
[4.896s] INFO  [FightResolver] Fight! Bandit 235 vs Worker 126
[8.224s] INFO  [FightResolver] Worker 126 defeated Bandit 235
\`\`\`

## Coordination

Standalone engine fix. After release:
- Eager-fallback consumers see correct sprite rendering.
- Production path (declared manifests) — same behavior; the per-tick walk is a redundant no-op there since the bridge already ran successfully at setScene time.

## Test plan

- [ ] CI green
- [ ] Reviewer can build flying-platform-labelle with this engine and run \`labelle run --scene=debug/bandit/<name>\` — sprites should render correctly (characters, ship, rooms all from their own atlases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)