### PR TITLE
feat(game): public collectEntities helpers (heap + stack-buffered)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -58,6 +58,7 @@ pub fn build(b: *std.Build) void {
         "test/jsonc/bridge_deserialize_test.zig",
         "test/jsonc/deserializer_test.zig",
         "test/jsonc_bridge_gizmo_visibility_test.zig",
+        "test/collect_entities_test.zig",
     };
 
     for (test_files) |test_file| {

--- a/src/game.zig
+++ b/src/game.zig
@@ -691,6 +691,74 @@ pub fn GameConfig(
         pub const removeText = Visuals.removeText;
         pub const setZIndex = Visuals.setZIndex;
 
+        // ── View collection helpers (#510) ────────────────────────
+        //
+        // Iterating an ECS view while mutating the world (adding /
+        // removing components, destroying entities) risks
+        // invalidating the iterator on backends that don't tolerate
+        // concurrent mutation. The two helpers below absorb the
+        // "collect first, then mutate" boilerplate every dispatcher
+        // / hook / tick was hand-rolling.
+        //
+        // Both forward `include` and `exclude` straight to
+        // `self.active_world.ecs_backend.view(include, exclude)` and
+        // close the view via `defer view.deinit()`. The include /
+        // exclude tuple shape mirrors what the caller would have
+        // passed to `view` directly, so the migration from
+        // hand-rolled to helper is just lifting the iteration
+        // boilerplate out.
+
+        /// Heap-allocated collection. Returns an `ArrayList(Entity)`
+        /// the caller `deinit`s. Picks the heap path when the
+        /// expected size is unknown or large (save / load,
+        /// debug-snapshot scans, one-shot batch ops).
+        pub fn collectEntities(
+            self: *Self,
+            comptime include: anytype,
+            comptime exclude: anytype,
+            allocator: std.mem.Allocator,
+        ) !std.ArrayList(Entity) {
+            var buf: std.ArrayList(Entity) = .{};
+            errdefer buf.deinit(allocator);
+            var view = self.ecs_backend.view(include, exclude);
+            defer view.deinit();
+            while (view.next()) |ent| {
+                try buf.append(allocator, ent);
+            }
+            return buf;
+        }
+
+        /// Stack-allocated collection. Fills `buf` and returns the
+        /// number of entities written. Sets `overflowed.*` to true
+        /// if the view contained more entities than `buf.len`. Use
+        /// for per-tick scans where allocating in the hot loop
+        /// would be wasteful and the worst-case set is bounded.
+        ///
+        /// On overflow the caller decides what to do — typically
+        /// `log.warn(...)` + retry next frame (matches the existing
+        /// `sleep_hooks.frame_end` convention).
+        pub fn collectEntitiesBuf(
+            self: *Self,
+            comptime include: anytype,
+            comptime exclude: anytype,
+            buf: []Entity,
+            overflowed: *bool,
+        ) usize {
+            overflowed.* = false;
+            var count: usize = 0;
+            var view = self.ecs_backend.view(include, exclude);
+            defer view.deinit();
+            while (view.next()) |ent| {
+                if (count < buf.len) {
+                    buf[count] = ent;
+                    count += 1;
+                } else {
+                    overflowed.* = true;
+                }
+            }
+            return count;
+        }
+
         // ── Position & Hierarchy ──────────────────────────────────
 
         pub fn setPosition(self: *Self, entity: Entity, pos: Position) void {

--- a/src/game/save_load_mixin.zig
+++ b/src/game/save_load_mixin.zig
@@ -187,6 +187,12 @@ pub fn Mixin(comptime Game: type) type {
         }
 
         /// Collect entities from a view into an ArrayList, closing the view after.
+        ///
+        /// Local convenience over the public `Game.collectEntities`
+        /// (game.zig). save/load callers reach the ecs backend
+        /// directly (no `Game` handle in scope), so this thin
+        /// wrapper keeps the same single-type signature while the
+        /// shape stays identical to the public helper.
         fn collectEntities(comptime T: type, ecs: anytype, allocator: std.mem.Allocator) !std.ArrayList(Entity) {
             var buf: std.ArrayList(Entity) = .{};
             errdefer buf.deinit(allocator);

--- a/test/collect_entities_test.zig
+++ b/test/collect_entities_test.zig
@@ -1,0 +1,164 @@
+//! `Game.collectEntities` / `Game.collectEntitiesBuf` — public
+//! view-collection helpers that absorb the "collect first, then
+//! mutate" boilerplate every game-side dispatcher / hook / tick
+//! was hand-rolling. Issue #510.
+
+const std = @import("std");
+const testing = std.testing;
+
+const engine = @import("engine");
+const game_mod = engine.game_mod;
+
+const TestGame = game_mod.Game;
+
+const Health = struct {
+    current: f32 = 0,
+    max: f32 = 100,
+};
+
+const Velocity = struct {
+    x: f32 = 0,
+    y: f32 = 0,
+};
+
+const Dying = struct {
+    timer: f32 = 0,
+};
+
+// ── Heap variant ────────────────────────────────────────────────────
+
+test "collectEntities: empty view returns an empty list" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    var list = try game.collectEntities(.{Health}, .{}, testing.allocator);
+    defer list.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 0), list.items.len);
+}
+
+test "collectEntities: gathers every entity matching the include set" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const e1 = game.createEntity();
+    const e2 = game.createEntity();
+    const e3 = game.createEntity();
+    game.ecs_backend.addComponent(e1, Health{ .current = 50 });
+    game.ecs_backend.addComponent(e2, Health{ .current = 75 });
+    // e3 has no Health — should be excluded.
+    game.ecs_backend.addComponent(e3, Velocity{ .x = 1 });
+
+    var list = try game.collectEntities(.{Health}, .{}, testing.allocator);
+    defer list.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 2), list.items.len);
+}
+
+test "collectEntities: exclude tuple drops matching entities" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const e1 = game.createEntity();
+    const e2 = game.createEntity();
+    game.ecs_backend.addComponent(e1, Health{ .current = 100 });
+    game.ecs_backend.addComponent(e2, Health{ .current = 0 });
+    // e2 is also dying — should be excluded by the `Dying` filter.
+    game.ecs_backend.addComponent(e2, Dying{});
+
+    var list = try game.collectEntities(.{Health}, .{Dying}, testing.allocator);
+    defer list.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 1), list.items.len);
+}
+
+test "collectEntities: caller can mutate the world while iterating the result" {
+    // The whole reason this helper exists — collecting first means
+    // we can `addComponent` / `destroyEntity` on every returned
+    // entity without worrying about the view's iterator going
+    // stale mid-mutation.
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const e1 = game.createEntity();
+    const e2 = game.createEntity();
+    game.ecs_backend.addComponent(e1, Health{ .current = 0 });
+    game.ecs_backend.addComponent(e2, Health{ .current = 0 });
+
+    var list = try game.collectEntities(.{Health}, .{}, testing.allocator);
+    defer list.deinit(testing.allocator);
+
+    for (list.items) |ent| {
+        game.ecs_backend.addComponent(ent, Dying{});
+    }
+
+    try testing.expect(game.ecs_backend.hasComponent(e1, Dying));
+    try testing.expect(game.ecs_backend.hasComponent(e2, Dying));
+}
+
+// ── Stack-buffered variant ──────────────────────────────────────────
+
+test "collectEntitiesBuf: empty view returns 0, overflowed stays false" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    var buf: [4]@TypeOf(game).EntityType = undefined;
+    var overflowed = true; // intentional non-default — verify reset.
+    const n = game.collectEntitiesBuf(.{Health}, .{}, &buf, &overflowed);
+    try testing.expectEqual(@as(usize, 0), n);
+    try testing.expect(!overflowed);
+}
+
+test "collectEntitiesBuf: fills the buffer up to its capacity" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    var i: usize = 0;
+    while (i < 3) : (i += 1) {
+        const ent = game.createEntity();
+        game.ecs_backend.addComponent(ent, Health{});
+    }
+
+    var buf: [4]@TypeOf(game).EntityType = undefined;
+    var overflowed = false;
+    const n = game.collectEntitiesBuf(.{Health}, .{}, &buf, &overflowed);
+    try testing.expectEqual(@as(usize, 3), n);
+    try testing.expect(!overflowed);
+}
+
+test "collectEntitiesBuf: sets overflowed when the view exceeds the buffer" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    // Spawn more entities than the buffer can hold so the overflow
+    // flag has to fire.
+    var i: usize = 0;
+    while (i < 6) : (i += 1) {
+        const ent = game.createEntity();
+        game.ecs_backend.addComponent(ent, Health{});
+    }
+
+    var buf: [4]@TypeOf(game).EntityType = undefined;
+    var overflowed = false;
+    const n = game.collectEntitiesBuf(.{Health}, .{}, &buf, &overflowed);
+    // Buffer caps the count — overflowed signals "there were more".
+    try testing.expectEqual(@as(usize, 4), n);
+    try testing.expect(overflowed);
+}
+
+test "collectEntitiesBuf: exclude tuple drops matching entities" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const alive = game.createEntity();
+    const dying = game.createEntity();
+    game.ecs_backend.addComponent(alive, Health{});
+    game.ecs_backend.addComponent(dying, Health{});
+    game.ecs_backend.addComponent(dying, Dying{});
+
+    var buf: [4]@TypeOf(game).EntityType = undefined;
+    var overflowed = false;
+    const n = game.collectEntitiesBuf(.{Health}, .{Dying}, &buf, &overflowed);
+    try testing.expectEqual(@as(usize, 1), n);
+    try testing.expectEqual(alive, buf[0]);
+}


### PR DESCRIPTION
Closes #510.

## Summary

Two `pub` helpers on `Game` that absorb the "collect first, then mutate" boilerplate every game-side dispatcher / hook / tick hand-rolls.

```zig
pub fn collectEntities(
    self: *Self,
    comptime include: anytype,
    comptime exclude: anytype,
    allocator: std.mem.Allocator,
) !std.ArrayList(Entity);

pub fn collectEntitiesBuf(
    self: *Self,
    comptime include: anytype,
    comptime exclude: anytype,
    buf: []Entity,
    overflowed: *bool,
) usize;
```

Both wrap `self.ecs_backend.view(include, exclude)` and close the view via `defer view.deinit()` — the `include` / `exclude` tuple shape mirrors `view`'s contract so the migration is just lifting the iteration boilerplate out.

## Why two flavors

* **Heap**: save / load scans, batch ops, debug snapshots — worst case is unknown / large.
* **Stack-buffered**: per-tick scans where allocation in the hot loop is wasteful and the worst case is bounded. `overflowed` lets the caller log + retry next tick (mirrors `sleep_hooks.frame_end` convention).

## Test plan

- [x] `zig build test --summary all` — 319/319 pass.
- [x] New `test/collect_entities_test.zig` covers:
  - heap: empty view, include-match, exclude filter, mutation-while-iterating safety.
  - stack: empty, exact-fit, overflow flag set, exclude filter.

## Downstream caller

`Flying-Platform/flying-platform-labelle` will collapse ~7 hook / dispatcher sites onto these helpers once the new engine version cuts.