### PR TITLE
feat(game): collectEntitiesIf / collectEntitiesBufIf predicate variants

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -759,6 +759,62 @@ pub fn GameConfig(
             return count;
         }
 
+        /// Same shape as `collectEntities`, with an extra runtime
+        /// `predicate(self, entity) bool` filter. Use when the
+        /// caller needs to check a component **field value** (or any
+        /// derived condition) — the comptime include / exclude
+        /// tuple only filters on component existence. The predicate
+        /// receives the live `Game` pointer so it can
+        /// `getComponent(...)` for whatever runtime state the
+        /// filter inspects.
+        pub fn collectEntitiesIf(
+            self: *Self,
+            comptime include: anytype,
+            comptime exclude: anytype,
+            allocator: std.mem.Allocator,
+            predicate: *const fn (*Self, Entity) bool,
+        ) !std.ArrayList(Entity) {
+            var buf: std.ArrayList(Entity) = .{};
+            errdefer buf.deinit(allocator);
+            var view = self.ecs_backend.view(include, exclude);
+            defer view.deinit();
+            while (view.next()) |ent| {
+                if (predicate(self, ent)) {
+                    try buf.append(allocator, ent);
+                }
+            }
+            return buf;
+        }
+
+        /// Same shape as `collectEntitiesBuf`, with the runtime
+        /// `predicate` filter. Useful for the per-tick scan path
+        /// where the worst case is bounded and a heap allocation
+        /// per frame would be wasteful — same `overflowed`
+        /// out-pointer contract.
+        pub fn collectEntitiesBufIf(
+            self: *Self,
+            comptime include: anytype,
+            comptime exclude: anytype,
+            buf: []Entity,
+            overflowed: *bool,
+            predicate: *const fn (*Self, Entity) bool,
+        ) usize {
+            overflowed.* = false;
+            var count: usize = 0;
+            var view = self.ecs_backend.view(include, exclude);
+            defer view.deinit();
+            while (view.next()) |ent| {
+                if (!predicate(self, ent)) continue;
+                if (count < buf.len) {
+                    buf[count] = ent;
+                    count += 1;
+                } else {
+                    overflowed.* = true;
+                }
+            }
+            return count;
+        }
+
         // ── Position & Hierarchy ──────────────────────────────────
 
         pub fn setPosition(self: *Self, entity: Entity, pos: Position) void {

--- a/src/game.zig
+++ b/src/game.zig
@@ -767,6 +767,16 @@ pub fn GameConfig(
         /// receives the live `Game` pointer so it can
         /// `getComponent(...)` for whatever runtime state the
         /// filter inspects.
+        ///
+        /// **Predicate contract: read-only.** The whole point of the
+        /// `collect*` helpers is to *avoid* mutating the world
+        /// inside the view's iteration. The predicate runs while
+        /// the iterator is live; adding / removing components or
+        /// destroying entities from inside it risks the same
+        /// concurrent-mutation hazard the helpers exist to dodge.
+        /// Use the predicate to *inspect* state (via
+        /// `getComponent`, etc.); commit mutations in the loop the
+        /// caller writes over the returned list.
         pub fn collectEntitiesIf(
             self: *Self,
             comptime include: anytype,
@@ -791,6 +801,19 @@ pub fn GameConfig(
         /// where the worst case is bounded and a heap allocation
         /// per frame would be wasteful — same `overflowed`
         /// out-pointer contract.
+        ///
+        /// **Predicate contract: read-only** — same rule as
+        /// `collectEntitiesIf`. The hot-path stack variant is the
+        /// one most likely to be tempted with a per-tick mutation
+        /// inside the predicate; resist. Inspect only.
+        ///
+        /// On overflow the iteration breaks early: once the buffer
+        /// is full and we've seen one more predicate-accepted
+        /// entity, there's nothing the caller can do with the rest
+        /// (they go in next tick's pass), so spending more
+        /// predicate calls is wasted work. Predicate-rejected
+        /// entities don't count toward the cap — a view full of
+        /// rejects never trips the overflow flag.
         pub fn collectEntitiesBufIf(
             self: *Self,
             comptime include: anytype,
@@ -810,6 +833,7 @@ pub fn GameConfig(
                     count += 1;
                 } else {
                     overflowed.* = true;
+                    break;
                 }
             }
             return count;

--- a/test/collect_entities_test.zig
+++ b/test/collect_entities_test.zig
@@ -244,9 +244,8 @@ test "collectEntitiesBufIf: predicate variant fills stack buffer" {
     try testing.expect(!overflowed);
 }
 
-test "collectEntitiesBufIf: overflowed fires only on predicate-accepted entities" {
-    // Buffer is smaller than the *accepted* set — entities the
-    // predicate rejects don't count toward the cap.
+test "collectEntitiesBufIf: overflowed fires when accepted set exceeds the buffer" {
+    // All accepted, more than the buffer holds — overflow trips.
     var game = TestGame.init(testing.allocator);
     defer game.deinit();
 
@@ -261,4 +260,28 @@ test "collectEntitiesBufIf: overflowed fires only on predicate-accepted entities
     const n = game.collectEntitiesBufIf(.{Health}, .{}, &buf, &overflowed, isCritical);
     try testing.expectEqual(@as(usize, 4), n);
     try testing.expect(overflowed);
+}
+
+test "collectEntitiesBufIf: predicate-rejected entities don't count toward the cap" {
+    // Mix: 3 accepted + 7 rejected, buffer holds 5. The 7 rejects
+    // do NOT trip the overflow flag — only entities the predicate
+    // accepts count toward the cap. Caught by Copilot review:
+    // the previous test labelled this behavior but actually
+    // exercised the all-accepted overflow case instead.
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    var i: usize = 0;
+    while (i < 10) : (i += 1) {
+        const ent = game.createEntity();
+        game.ecs_backend.addComponent(ent, Health{
+            .current = if (i < 3) 0 else 80, // 3 critical, 7 healthy
+        });
+    }
+
+    var buf: [5]@TypeOf(game).EntityType = undefined;
+    var overflowed = false;
+    const n = game.collectEntitiesBufIf(.{Health}, .{}, &buf, &overflowed, isCritical);
+    try testing.expectEqual(@as(usize, 3), n);
+    try testing.expect(!overflowed);
 }

--- a/test/collect_entities_test.zig
+++ b/test/collect_entities_test.zig
@@ -162,3 +162,103 @@ test "collectEntitiesBuf: exclude tuple drops matching entities" {
     try testing.expectEqual(@as(usize, 1), n);
     try testing.expectEqual(alive, buf[0]);
 }
+
+// ── Predicate variants ──────────────────────────────────────────────
+
+/// Test-local predicate. Returns true when the entity's Health is
+/// at or below zero — the kind of runtime field check the
+/// comptime include / exclude tuple can't express.
+fn isCritical(game: *TestGame, entity: TestGame.EntityType) bool {
+    const h = game.ecs_backend.getComponent(entity, Health) orelse return false;
+    return h.current <= 0;
+}
+
+test "collectEntitiesIf: filters by runtime field check" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const healthy = game.createEntity();
+    const critical = game.createEntity();
+    game.ecs_backend.addComponent(healthy, Health{ .current = 80 });
+    game.ecs_backend.addComponent(critical, Health{ .current = 0 });
+
+    var list = try game.collectEntitiesIf(.{Health}, .{}, testing.allocator, isCritical);
+    defer list.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 1), list.items.len);
+    try testing.expectEqual(critical, list.items[0]);
+}
+
+test "collectEntitiesIf: predicate returning false on every entity yields an empty list" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const e = game.createEntity();
+    game.ecs_backend.addComponent(e, Health{ .current = 100 });
+
+    var list = try game.collectEntitiesIf(.{Health}, .{}, testing.allocator, isCritical);
+    defer list.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 0), list.items.len);
+}
+
+test "collectEntitiesIf: predicate composes with exclude tuple" {
+    // Two critical entities; the predicate would accept both, but
+    // the `Dying` exclude filter strips one before the predicate
+    // sees it. Proves the predicate runs *after* the view filter,
+    // not as a replacement.
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const e1 = game.createEntity();
+    const e2 = game.createEntity();
+    game.ecs_backend.addComponent(e1, Health{ .current = 0 });
+    game.ecs_backend.addComponent(e2, Health{ .current = 0 });
+    game.ecs_backend.addComponent(e2, Dying{});
+
+    var list = try game.collectEntitiesIf(.{Health}, .{Dying}, testing.allocator, isCritical);
+    defer list.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 1), list.items.len);
+    try testing.expectEqual(e1, list.items[0]);
+}
+
+test "collectEntitiesBufIf: predicate variant fills stack buffer" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    var i: usize = 0;
+    while (i < 5) : (i += 1) {
+        const ent = game.createEntity();
+        // Half critical, half healthy.
+        game.ecs_backend.addComponent(ent, Health{
+            .current = if (i % 2 == 0) 0 else 50,
+        });
+    }
+
+    var buf: [8]@TypeOf(game).EntityType = undefined;
+    var overflowed = false;
+    const n = game.collectEntitiesBufIf(.{Health}, .{}, &buf, &overflowed, isCritical);
+    // 3 critical entities (indices 0, 2, 4) — predicate accepts.
+    try testing.expectEqual(@as(usize, 3), n);
+    try testing.expect(!overflowed);
+}
+
+test "collectEntitiesBufIf: overflowed fires only on predicate-accepted entities" {
+    // Buffer is smaller than the *accepted* set — entities the
+    // predicate rejects don't count toward the cap.
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    var i: usize = 0;
+    while (i < 10) : (i += 1) {
+        const ent = game.createEntity();
+        game.ecs_backend.addComponent(ent, Health{ .current = 0 }); // all critical
+    }
+
+    var buf: [4]@TypeOf(game).EntityType = undefined;
+    var overflowed = false;
+    const n = game.collectEntitiesBufIf(.{Health}, .{}, &buf, &overflowed, isCritical);
+    try testing.expectEqual(@as(usize, 4), n);
+    try testing.expect(overflowed);
+}


### PR DESCRIPTION
Closes #512.

## Summary

Sibling helpers to the `collectEntities` / `collectEntitiesBuf` shipped in v1.33.0 (#510), with one extra runtime `predicate(*Game, Entity) bool` filter. Covers the case the comptime include / exclude tuple can't express — a component **field value** check, a TTL comparison, a derived condition — which left four sites unconverted in the first downstream adoption pass (`Flying-Platform/flying-platform-labelle#386`).

```zig
pub fn collectEntitiesIf(
    self: *Self,
    comptime include: anytype,
    comptime exclude: anytype,
    allocator: std.mem.Allocator,
    predicate: *const fn (*Self, Entity) bool,
) !std.ArrayList(Entity);

pub fn collectEntitiesBufIf(
    self: *Self,
    comptime include: anytype,
    comptime exclude: anytype,
    buf: []Entity,
    overflowed: *bool,
    predicate: *const fn (*Self, Entity) bool,
) usize;
```

The predicate receives the live `Game` pointer so it can `getComponent(...)` for runtime state — sufficient for every filter shape today's downstream sites need.

## Semantics

* The view's include / exclude tuple runs first; the predicate sees only entities that pass the comptime filter.
* In the buf variant, only **predicate-accepted** entities count toward the buffer cap — a view full of rejects doesn't trip the overflow flag.

## Test plan

- [x] `zig build test --summary all` — 324/324 pass.
- [x] New tests cover:
  - heap: predicate-positive selection, predicate-rejects-everything, predicate composes with exclude tuple.
  - stack: predicate fills buffer, overflow flag fires only on accepted entities.

## Downstream caller

`Flying-Platform/flying-platform-labelle#387` — adopt at four call sites once this lands.