### PR TITLE
feat(game): setSpriteFlip helper bundles flip_x + markVisualDirty

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -59,6 +59,7 @@ pub fn build(b: *std.Build) void {
         "test/jsonc/deserializer_test.zig",
         "test/jsonc_bridge_gizmo_visibility_test.zig",
         "test/collect_entities_test.zig",
+        "test/set_sprite_flip_test.zig",
     };
 
     for (test_files) |test_file| {

--- a/src/game.zig
+++ b/src/game.zig
@@ -690,6 +690,7 @@ pub fn GameConfig(
         pub const removeShape = Visuals.removeShape;
         pub const removeText = Visuals.removeText;
         pub const setZIndex = Visuals.setZIndex;
+        pub const setSpriteFlip = Visuals.setSpriteFlip;
 
         // ── View collection helpers (#510) ────────────────────────
         //

--- a/src/game/visuals.zig
+++ b/src/game/visuals.zig
@@ -89,5 +89,23 @@ pub fn Mixin(comptime Game: type) type {
                 self.renderer.markVisualDirty(entity);
             }
         }
+
+        /// Set the sprite's horizontal flip and mark the entity's visuals
+        /// dirty so the renderer picks up the change on the next sync.
+        ///
+        /// Bundles the `sprite.flip_x = X` + `renderer.markVisualDirty(entity)`
+        /// pair that callers previously had to write by hand — forgetting the
+        /// dirty-mark was a silent bug (visual stayed stale).
+        ///
+        /// Returns silently if the entity has no `Sprite` component — callers
+        /// that need to assert presence should `getComponent` themselves first.
+        /// Short-circuits when the flip value already matches, avoiding a
+        /// wasted dirty-mark.
+        pub fn setSpriteFlip(self: *Game, entity: Entity, flip_x: bool) void {
+            const sprite = self.ecs_backend.getComponent(entity, Sprite) orelse return;
+            if (sprite.flip_x == flip_x) return;
+            sprite.flip_x = flip_x;
+            self.renderer.markVisualDirty(entity);
+        }
     };
 }

--- a/src/game/visuals.zig
+++ b/src/game/visuals.zig
@@ -101,7 +101,13 @@ pub fn Mixin(comptime Game: type) type {
         /// that need to assert presence should `getComponent` themselves first.
         /// Short-circuits when the flip value already matches, avoiding a
         /// wasted dirty-mark.
+        ///
+        /// Comptime no-op on backends whose `Sprite` doesn't carry a `flip_x`
+        /// field (`StubRender`, mock renderers in downstream tests). Keeps the
+        /// helper safe to call uniformly across renderers without a wrapper.
         pub fn setSpriteFlip(self: *Game, entity: Entity, flip_x: bool) void {
+            if (comptime !@hasField(Sprite, "flip_x")) return;
+            self.assertEntityAlive(entity, "setSpriteFlip");
             const sprite = self.ecs_backend.getComponent(entity, Sprite) orelse return;
             if (sprite.flip_x == flip_x) return;
             sprite.flip_x = flip_x;

--- a/test/set_sprite_flip_test.zig
+++ b/test/set_sprite_flip_test.zig
@@ -1,0 +1,156 @@
+//! `Game.setSpriteFlip` — the wrapped sprite-flip mutation that bundles
+//! `sprite.flip_x = X` + `renderer.markVisualDirty(entity)`.
+//!
+//! Background: downstream call sites used to write this pair by hand
+//! across worker_animation / worker_controller / hunger_hooks /
+//! ship_animation, and forgetting the dirty-mark was a silent bug —
+//! the field would update but the renderer wouldn't pick up the
+//! visual change until something else (position move, frame flip)
+//! re-dirtied the entity. Mirrors `setZIndex` / `setPosition` in
+//! `src/game/visuals.zig`.
+//!
+//! Coverage:
+//! - happy path: helper writes `flip_x` AND bumps the renderer's
+//!   `markVisualDirty` invocation counter exactly once.
+//! - idempotent: calling with the value the sprite already has must
+//!   short-circuit — neither write nor dirty-mark fires.
+//! - missing-Sprite: the helper returns silently rather than panicking;
+//!   the dirty-mark counter stays at zero.
+//!
+//! Uses a local `FlipRenderer` instead of `StubRender` because
+//! StubRender's `Sprite` doesn't carry a `flip_x` field (and its
+//! `markVisualDirty` is a pure no-op with no observable side effect).
+//! Adding the field + a counter to StubRender would require a
+//! labelle-core change; the local renderer keeps this PR
+//! engine-only.
+
+const std = @import("std");
+const testing = std.testing;
+const core = @import("labelle-core");
+const engine = @import("engine");
+
+const MockEcs = core.MockEcsBackend(u32);
+
+/// Minimal renderer with the bits `setSpriteFlip` actually touches:
+/// a `Sprite.flip_x` field to mutate, and a `markVisualDirty` that
+/// increments a test-observable counter.
+fn FlipRenderer(comptime Entity: type) type {
+    return struct {
+        const Self = @This();
+
+        pub const Sprite = struct {
+            sprite_name: []const u8 = "",
+            visible: bool = true,
+            z_index: i16 = 0,
+            flip_x: bool = false,
+            layer: enum { default } = .default,
+        };
+
+        pub const Shape = struct {
+            visible: bool = true,
+            z_index: i16 = 0,
+            layer: enum { default } = .default,
+        };
+
+        visual_dirty_count: usize = 0,
+
+        pub fn init(_: std.mem.Allocator) Self {
+            return .{};
+        }
+        pub fn deinit(_: *Self) void {}
+        pub fn trackEntity(_: *Self, _: Entity, _: core.VisualType) void {}
+        pub fn untrackEntity(_: *Self, _: Entity) void {}
+        pub fn markPositionDirty(_: *Self, _: Entity) void {}
+        pub fn markPositionDirtyWithChildren(_: *Self, comptime _: type, _: anytype, _: Entity) void {}
+        pub fn updateHierarchyFlag(_: *Self, _: Entity, _: bool) void {}
+        pub fn markVisualDirty(self: *Self, _: Entity) void {
+            self.visual_dirty_count += 1;
+        }
+        pub fn sync(_: *Self, comptime _: type, _: anytype) void {}
+        pub fn render(_: *Self) void {}
+        pub fn setScreenHeight(_: *Self, _: f32) void {}
+        pub fn clear(_: *Self) void {}
+        pub fn renderGizmoDraws(_: *Self, _: []const core.GizmoDraw) void {}
+        pub fn hasEntity(_: *const Self, _: Entity) bool {
+            return false;
+        }
+    };
+}
+
+const EmptyComponents = struct {
+    pub fn has(comptime _: []const u8) bool {
+        return false;
+    }
+    pub fn names() []const []const u8 {
+        return &.{};
+    }
+};
+
+const TestGame = engine.GameConfig(
+    FlipRenderer(MockEcs.Entity),
+    MockEcs,
+    engine.StubInput,
+    engine.StubAudio,
+    engine.StubGui,
+    void,
+    engine.StubLogSink,
+    EmptyComponents,
+    &.{},
+    void,
+);
+
+const Sprite = TestGame.SpriteComp;
+
+test "setSpriteFlip: writes flip_x and marks visual dirty" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const entity = game.createEntity();
+    game.addSprite(entity, .{ .sprite_name = "worker", .flip_x = false });
+
+    // Baseline: addSprite tracks the entity but doesn't mark it dirty.
+    const dirty_before = game.renderer.visual_dirty_count;
+
+    game.setSpriteFlip(entity, true);
+
+    const sprite = game.getComponent(entity, Sprite).?;
+    try testing.expect(sprite.flip_x);
+    try testing.expectEqual(dirty_before + 1, game.renderer.visual_dirty_count);
+}
+
+test "setSpriteFlip: no-op when flip already matches (no dirty-mark)" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const entity = game.createEntity();
+    game.addSprite(entity, .{ .sprite_name = "worker", .flip_x = true });
+
+    const dirty_before = game.renderer.visual_dirty_count;
+
+    // Same value → short-circuit. The dirty-mark is the load-bearing
+    // observation here: a naive "always write + always mark" impl would
+    // bump the counter and waste a render-side resync.
+    game.setSpriteFlip(entity, true);
+
+    const sprite = game.getComponent(entity, Sprite).?;
+    try testing.expect(sprite.flip_x);
+    try testing.expectEqual(dirty_before, game.renderer.visual_dirty_count);
+}
+
+test "setSpriteFlip: entity without Sprite returns silently" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    // No `addSprite` — the entity has no Sprite component.
+    const entity = game.createEntity();
+
+    const dirty_before = game.renderer.visual_dirty_count;
+
+    // Must not panic, must not mark dirty. Callers that need an
+    // assertion can `getComponent` first; the helper's defensive
+    // posture matches `setZIndex` (which silently skips missing
+    // visuals).
+    game.setSpriteFlip(entity, true);
+
+    try testing.expectEqual(dirty_before, game.renderer.visual_dirty_count);
+}

--- a/test/set_sprite_flip_test.zig
+++ b/test/set_sprite_flip_test.zig
@@ -16,6 +16,10 @@
 //!   short-circuit — neither write nor dirty-mark fires.
 //! - missing-Sprite: the helper returns silently rather than panicking;
 //!   the dirty-mark counter stays at zero.
+//! - comptime no-op: a renderer whose `Sprite` lacks a `flip_x` field
+//!   (StubRender, custom mocks) still compiles and runs through the
+//!   helper as a no-op — the `@hasField` guard catches it before any
+//!   field access.
 //!
 //! Uses a local `FlipRenderer` instead of `StubRender` because
 //! StubRender's `Sprite` doesn't carry a `flip_x` field (and its
@@ -150,6 +154,83 @@ test "setSpriteFlip: entity without Sprite returns silently" {
     // assertion can `getComponent` first; the helper's defensive
     // posture matches `setZIndex` (which silently skips missing
     // visuals).
+    game.setSpriteFlip(entity, true);
+
+    try testing.expectEqual(dirty_before, game.renderer.visual_dirty_count);
+}
+
+/// Renderer whose `Sprite` has no `flip_x` field — exercises the
+/// `comptime @hasField(Sprite, "flip_x")` guard at the top of the
+/// helper. Mirror of `FlipRenderer` minus the field.
+fn NoFlipRenderer(comptime Entity: type) type {
+    return struct {
+        const Self = @This();
+
+        pub const Sprite = struct {
+            sprite_name: []const u8 = "",
+            visible: bool = true,
+            z_index: i16 = 0,
+            layer: enum { default } = .default,
+        };
+
+        pub const Shape = struct {
+            visible: bool = true,
+            z_index: i16 = 0,
+            layer: enum { default } = .default,
+        };
+
+        visual_dirty_count: usize = 0,
+
+        pub fn init(_: std.mem.Allocator) Self {
+            return .{};
+        }
+        pub fn deinit(_: *Self) void {}
+        pub fn trackEntity(_: *Self, _: Entity, _: core.VisualType) void {}
+        pub fn untrackEntity(_: *Self, _: Entity) void {}
+        pub fn markPositionDirty(_: *Self, _: Entity) void {}
+        pub fn markPositionDirtyWithChildren(_: *Self, comptime _: type, _: anytype, _: Entity) void {}
+        pub fn updateHierarchyFlag(_: *Self, _: Entity, _: bool) void {}
+        pub fn markVisualDirty(self: *Self, _: Entity) void {
+            self.visual_dirty_count += 1;
+        }
+        pub fn sync(_: *Self, comptime _: type, _: anytype) void {}
+        pub fn render(_: *Self) void {}
+        pub fn setScreenHeight(_: *Self, _: f32) void {}
+        pub fn clear(_: *Self) void {}
+        pub fn renderGizmoDraws(_: *Self, _: []const core.GizmoDraw) void {}
+        pub fn hasEntity(_: *const Self, _: Entity) bool {
+            return false;
+        }
+    };
+}
+
+const NoFlipGame = engine.GameConfig(
+    NoFlipRenderer(MockEcs.Entity),
+    MockEcs,
+    engine.StubInput,
+    engine.StubAudio,
+    engine.StubGui,
+    void,
+    engine.StubLogSink,
+    EmptyComponents,
+    &.{},
+    void,
+);
+
+test "setSpriteFlip: comptime no-op when Sprite has no flip_x field" {
+    var game = NoFlipGame.init(testing.allocator);
+    defer game.deinit();
+
+    const entity = game.createEntity();
+    game.addSprite(entity, .{ .sprite_name = "worker" });
+
+    const dirty_before = game.renderer.visual_dirty_count;
+
+    // The point of this test is the *compile*: a backend whose Sprite
+    // doesn't have `flip_x` (StubRender, custom mocks) must still be
+    // able to call `setSpriteFlip` without a type error. The
+    // `@hasField` guard short-circuits before any field access. At
+    // runtime, dirty-count stays at zero.
     game.setSpriteFlip(entity, true);
 
     try testing.expectEqual(dirty_before, game.renderer.visual_dirty_count);


### PR DESCRIPTION
## Summary

Adds a wrapped sprite-flip mutation on `Game` — sibling to the existing `setZIndex` / `setPosition` / `setParent` helpers — that bundles the `sprite.flip_x = X` + `renderer.markVisualDirty(entity)` pair downstream call sites currently spell out by hand.

The `markVisualDirty` half is load-bearing: without it the renderer doesn't pick up the flip until something else (a position move, a frame flip) re-dirties the entity. Forgetting it is a **silent bug** — the field updates, but the visual stays stale. This already cost a rev round on a flying-platform PR (the pilot-sprite mirror in `ship_animation.zig` originally landed without the dirty-mark and was caught in review on PR #367).

Closes #514.

## Behaviour

```zig
pub fn setSpriteFlip(self: *Game, entity: Entity, flip_x: bool) void {
    const sprite = self.ecs_backend.getComponent(entity, Sprite) orelse return;
    if (sprite.flip_x == flip_x) return; // no-op short-circuit
    sprite.flip_x = flip_x;
    self.renderer.markVisualDirty(entity);
}
```

* **No-op short-circuit** when the flip value already matches — avoids wasted dirty-marks and subsumes the `if (sprite.flip_x != X) { ... }` guard several call sites already write by hand.
* **Silent skip** on missing-Sprite — matches `setZIndex`'s defensive posture. Callers that need to assert presence `getComponent` first.
* **Out of scope**: a parallel `setSpriteFlipY` — `flip_y` is unused at every current downstream call site. Easy to add later if anyone needs it.

## Implementation

* `src/game/visuals.zig` — helper body added next to `setZIndex` (same Mixin pattern).
* `src/game.zig` — wired in via `pub const setSpriteFlip = Visuals.setSpriteFlip;` next to the other `Visuals.*` re-exports.
* `test/set_sprite_flip_test.zig` — three unit tests (happy path / no-op / missing-Sprite). Registered in `build.zig`.

The test uses a local `FlipRenderer` rather than the shared `StubRender` because StubRender's `Sprite` doesn't carry a `flip_x` field and its `markVisualDirty` is a pure no-op. Adding both to StubRender would have required a parallel labelle-core change; the local renderer keeps this PR self-contained inside labelle-engine.

## Game-side adoption candidates

Flying-platform call sites that match the pattern and are ready for adoption once a release lands and the engine pin is bumped (the user gates "Bump" / adoption on the release per the established workflow — not in scope here):

| File | Lines | Notes |
|---|---|---|
| `hooks/hunger_hooks.zig` | 73-74 | Pure flip + dirty pair — direct one-line replacement |
| `scripts/playing/ship_animation.zig` | 84-88 | Pure flip + dirty inside an `if (sprite.flip_x != X)` guard. Helper subsumes the guard. |
| `scripts/playing/ship_animation.zig` | 185-192 | Pilot-sprite mirror. The L189 comment explicitly calls out the markVisualDirty-pairing rule from PR #367 review — exactly the footgun this helper closes. |
| `scripts/worker_animation.zig` | 375-378 | Pure flip + dirty in the else-branch of a frame-flip check |
| `scripts/worker_animation.zig` | 362-374 | The if-branch bundles flip with sprite_name + texture changes under one markVisualDirty — **partial adoption only**, may not benefit. |
| `scripts/bandit_animation.zig` | 162-174 | Flip is bundled with other resolves under a shared `dirty` flag + single trailing markVisualDirty — **partial adoption only**. |

Six call sites total; four are clean drop-ins, two bundle flip with other mutations and would need review to decide whether the helper helps or hurts readability.

## Test plan

- [x] `zig build test` — all engine tests pass (existing + 3 new)
- [x] `zig build` — clean compile
- [ ] After release + pin bump, downstream adoption PR on flying-platform-labelle exercises the helper at the four clean drop-in sites