### PR TITLE
Preview mode Phase 2: binary state telemetry frames (#518)

### DIFF
--- a/src/preview_mode.zig
+++ b/src/preview_mode.zig
@@ -2,7 +2,9 @@
 ///
 /// Phase 0 spike for the Play-in-Editor preview umbrella
 /// (labelle-gui#59). Architecture decision is in labelle-gui#60 and the
-/// engine-side issue is labelle-engine#516.
+/// engine-side issue is labelle-engine#516. Phase 2 (labelle-engine#518)
+/// extends the JSON control plane with a binary state-telemetry channel
+/// multiplexed on the same TCP socket.
 ///
 /// ## Model
 ///
@@ -17,20 +19,43 @@
 ///
 /// ## Protocol
 ///
-/// Newline-delimited JSON. One frame per message. The Phase 0 subset
-/// is three messages, all engine → editor:
+/// Two interleaved framings share the same TCP socket:
 ///
-///     {"kind":"hello","engine_version":"…","pid":12345,"protocol_version":1}\n
-///     {"kind":"heartbeat","t":847291}\n
-///     {"kind":"bye","reason":"normal"}\n
+/// 1. **JSON control plane** (Phase 1) — newline-delimited JSON. One
+///    document per `\n`-terminated chunk. JSON documents always start
+///    with `{`, never `0x1B`, so the reader can disambiguate by
+///    peeking the first byte.
+///
+///        {"kind":"hello","engine_version":"…","pid":12345,"protocol_version":1}\n
+///        {"kind":"heartbeat","t":847291}\n
+///        {"kind":"bye","reason":"normal"}\n
+///        {"kind":"subscribe","components":["Position","Velocity"]}\n   (editor → engine)
+///        {"kind":"unsubscribe","components":["Velocity"]}\n             (editor → engine)
+///
+/// 2. **Binary telemetry plane** (Phase 2) — length-prefixed records
+///    led by an `ESC` (0x1B) magic byte:
+///
+///        [u8 magic=0x1B] [u8 kind] [u32 length, little-endian] [payload]
+///
+///    `kind` is `BinaryFrameKind`; `length` is the byte count of
+///    `payload` only (does not include the 6-byte header). Strings
+///    inside payloads use a `[u16 length-LE] [bytes]` shape. The
+///    editor reads the first byte: if it's `0x1B` it decodes a binary
+///    frame; otherwise it accumulates until `\n` and parses JSON.
 ///
 /// `bye.reason` is one of `normal`, `crashed`, `killed`. Only `normal`
 /// is emitted by the spike — the other two are reserved for future
 /// shutdown paths. Editor reads EOF as "engine died abnormally".
 ///
-/// Phase 2 will replace newline framing with a length-prefixed binary
-/// channel once telemetry shows up (entity state, flow events). Until
-/// then JSON keeps the wire human-readable for spike debugging.
+/// ## TODO (Phase 2 polish)
+///
+/// - **Per-tick batching**: today every `emitComponentChanged` issues
+///   its own `writeAll`. For a real game with thousands of touches per
+///   tick we'll want to buffer into a per-frame digest and flush once
+///   at end-of-tick (see #518's "Throttling" section). The shape would
+///   be a single `component_digest` frame containing N tuples — wire-
+///   compatible with the current `component_changed` decoder by being
+///   a separate kind.
 ///
 /// ## Lifecycle
 ///
@@ -71,6 +96,22 @@ pub const ByeReason = enum {
 /// incompatible way.
 pub const protocol_version: u32 = 1;
 
+/// Magic byte that flags a binary telemetry frame on the multiplexed
+/// socket. Chosen as `ESC` (0x1B) because no valid JSON document or
+/// whitespace prefix can begin with it — the editor's reader peeks
+/// the first byte to discriminate.
+pub const binary_magic: u8 = 0x1B;
+
+/// Kinds of binary frames emitted by the engine. Numbered explicitly
+/// because these go on the wire — appending is safe, reordering is a
+/// protocol break.
+pub const BinaryFrameKind = enum(u8) {
+    entity_created = 1,
+    entity_destroyed = 2,
+    component_changed = 3,
+    _,
+};
+
 /// Default heartbeat interval. The game loop is welcome to poll
 /// `Preview.tickHeartbeat` every frame — the rate-limit keeps the
 /// wire traffic at ~4 Hz regardless of frame rate.
@@ -85,12 +126,40 @@ pub const ConnectError = std.net.TcpConnectToAddressError || ParseError;
 
 pub const WriteError = std.net.Stream.WriteError || error{OutOfMemory};
 
+/// Errors that `pollSubscription` can surface. Read errors propagate;
+/// JSON shape errors fold into a single `MalformedSubscription` so the
+/// caller can decide whether to log-and-continue or tear down.
+pub const PollError = std.net.Stream.ReadError || error{
+    OutOfMemory,
+    MalformedSubscription,
+};
+
 /// The connect-out control channel. Owned by the game; one per
 /// process. Cheap to construct — single arena + one TCP fd.
+///
+/// Holds two pieces of long-lived state past Phase 1:
+///
+/// - `subscribed_components` — names the editor has asked to receive
+///   `component_changed` frames for. Default empty: until the editor
+///   opts in, no component traffic flows. Lifecycle frames
+///   (`entity_created`/`entity_destroyed`) always emit.
+/// - `inbox` — partial-read buffer for the editor → engine direction
+///   (newline-delimited JSON: `subscribe`/`unsubscribe`). Sized for a
+///   handful of component names; grows on demand via `inbox_alloc`.
 pub const Preview = struct {
     stream: std.net.Stream,
     arena: std.heap.ArenaAllocator,
     last_heartbeat_ms: u64 = 0,
+    /// Set of component names the editor wants `component_changed`
+    /// frames for. Keys allocated in `subs_arena` so the editor can
+    /// churn the set without leaking into the per-frame `arena`.
+    subscribed_components: std.StringHashMapUnmanaged(void) = .{},
+    subs_arena: std.heap.ArenaAllocator,
+    /// Inbound newline-framing buffer for `pollSubscription`. Owned
+    /// by `inbox_alloc` (the parent allocator) so it can grow past the
+    /// initial capacity if a very long subscribe list arrives.
+    inbox: std.ArrayListUnmanaged(u8) = .{},
+    inbox_alloc: std.mem.Allocator,
 
     /// Dial the editor's listener. `host_port` is the literal string
     /// pulled from `--preview-mode <host:port>` — `127.0.0.1:54321`
@@ -106,6 +175,8 @@ pub const Preview = struct {
         return .{
             .stream = stream,
             .arena = std.heap.ArenaAllocator.init(parent_alloc),
+            .subs_arena = std.heap.ArenaAllocator.init(parent_alloc),
+            .inbox_alloc = parent_alloc,
         };
     }
 
@@ -114,6 +185,9 @@ pub const Preview = struct {
         // so the caller can still observe write failures; we always
         // close here.
         self.stream.close();
+        self.subscribed_components.deinit(self.subs_arena.allocator());
+        self.subs_arena.deinit();
+        self.inbox.deinit(self.inbox_alloc);
         self.arena.deinit();
     }
 
@@ -165,6 +239,190 @@ pub const Preview = struct {
             reason: []const u8,
         };
         try self.writeFrame(Msg{ .reason = reason.asString() });
+    }
+
+    // ── Binary telemetry frames (Phase 2 / #518) ────────────────────
+
+    /// Emit an `entity_created` binary frame.
+    ///
+    /// Payload layout (little-endian):
+    ///
+    ///     [u64 entity_id] [u16 name_len] [name_len bytes prefab_name]
+    ///
+    /// `prefab_name == null` is encoded as `name_len = 0`. Always
+    /// emits regardless of subscription state — lifecycle events are
+    /// cheap and the editor always wants them.
+    pub fn emitEntityCreated(
+        self: *Preview,
+        entity_id: u64,
+        prefab_name: ?[]const u8,
+    ) WriteError!void {
+        defer _ = self.arena.reset(.retain_capacity);
+        const alloc = self.arena.allocator();
+        const name = prefab_name orelse "";
+        const payload_len: usize = @sizeOf(u64) + @sizeOf(u16) + name.len;
+        const buf = try alloc.alloc(u8, payload_len);
+        std.mem.writeInt(u64, buf[0..8], entity_id, .little);
+        std.mem.writeInt(u16, buf[8..10], @intCast(name.len), .little);
+        @memcpy(buf[10 .. 10 + name.len], name);
+        try self.writeBinaryFrame(.entity_created, buf);
+    }
+
+    /// Emit an `entity_destroyed` binary frame.
+    ///
+    /// Payload layout: `[u64 entity_id]`. Always emits.
+    pub fn emitEntityDestroyed(self: *Preview, entity_id: u64) WriteError!void {
+        var buf: [@sizeOf(u64)]u8 = undefined;
+        std.mem.writeInt(u64, &buf, entity_id, .little);
+        try self.writeBinaryFrame(.entity_destroyed, &buf);
+    }
+
+    /// Emit a `component_changed` binary frame. **No-op when the
+    /// component name is not in `subscribed_components`** — this is
+    /// the hot path, so the early-out keeps the engine from doing
+    /// even a single allocation if the editor hasn't asked for this
+    /// component yet.
+    ///
+    /// Payload layout (little-endian):
+    ///
+    ///     [u64 entity_id] [u16 name_len] [name bytes] [u32 data_len] [data bytes]
+    ///
+    /// `comp_bytes` is opaque to the engine — the editor decides how
+    /// to interpret it based on `comp_name`. The current expectation
+    /// is the same byte layout the serializer plugin already writes.
+    pub fn emitComponentChanged(
+        self: *Preview,
+        entity_id: u64,
+        comp_name: []const u8,
+        comp_bytes: []const u8,
+    ) WriteError!void {
+        if (!self.isComponentSubscribed(comp_name)) return;
+        defer _ = self.arena.reset(.retain_capacity);
+        const alloc = self.arena.allocator();
+        const payload_len: usize = @sizeOf(u64) + @sizeOf(u16) + comp_name.len + @sizeOf(u32) + comp_bytes.len;
+        const buf = try alloc.alloc(u8, payload_len);
+        var off: usize = 0;
+        std.mem.writeInt(u64, buf[off..][0..8], entity_id, .little);
+        off += 8;
+        std.mem.writeInt(u16, buf[off..][0..2], @intCast(comp_name.len), .little);
+        off += 2;
+        @memcpy(buf[off .. off + comp_name.len], comp_name);
+        off += comp_name.len;
+        std.mem.writeInt(u32, buf[off..][0..4], @intCast(comp_bytes.len), .little);
+        off += 4;
+        @memcpy(buf[off .. off + comp_bytes.len], comp_bytes);
+        try self.writeBinaryFrame(.component_changed, buf);
+    }
+
+    /// Drain any pending `subscribe` / `unsubscribe` JSON frames sent
+    /// by the editor and apply them to `subscribed_components`. Non-
+    /// blocking — reads only what's currently available on the
+    /// socket. Safe to call once per tick.
+    ///
+    /// Wire shapes:
+    ///
+    ///     {"kind":"subscribe","components":["Position","Velocity"]}\n
+    ///     {"kind":"unsubscribe","components":["Velocity"]}\n
+    ///
+    /// Returns `MalformedSubscription` if a frame parses as JSON but
+    /// the shape doesn't match; the caller can choose to log + drop.
+    pub fn pollSubscription(self: *Preview) PollError!void {
+        // Pull whatever bytes are currently available on the socket
+        // into `inbox` without blocking. We poll only — never wait —
+        // so the game loop isn't stalled by an idle editor.
+        try self.fillInboxNonBlocking();
+
+        while (true) {
+            const nl_idx = std.mem.indexOfScalar(u8, self.inbox.items, '\n') orelse break;
+            const line = self.inbox.items[0..nl_idx];
+            try self.applySubscriptionFrame(line);
+            // Drop the consumed line (including the `\n`).
+            const remaining = self.inbox.items.len - (nl_idx + 1);
+            std.mem.copyForwards(u8, self.inbox.items[0..remaining], self.inbox.items[nl_idx + 1 ..]);
+            self.inbox.shrinkRetainingCapacity(remaining);
+        }
+    }
+
+    /// Returns `true` if `emitComponentChanged` would emit a frame
+    /// for this component. Useful as a guard around the cost of
+    /// serializing the component bytes.
+    pub fn isComponentSubscribed(self: *const Preview, comp_name: []const u8) bool {
+        return self.subscribed_components.contains(comp_name);
+    }
+
+    // ── Internals ───────────────────────────────────────────────────
+
+    fn writeBinaryFrame(
+        self: *Preview,
+        kind: BinaryFrameKind,
+        payload: []const u8,
+    ) WriteError!void {
+        // Build the header + payload in one buffer so we hit the wire
+        // with a single `writeAll` — torn frames here would force the
+        // editor to deal with mid-record short reads.
+        defer _ = self.arena.reset(.retain_capacity);
+        const alloc = self.arena.allocator();
+        const total = 1 + 1 + 4 + payload.len;
+        const framed = try alloc.alloc(u8, total);
+        framed[0] = binary_magic;
+        framed[1] = @intFromEnum(kind);
+        std.mem.writeInt(u32, framed[2..6], @intCast(payload.len), .little);
+        @memcpy(framed[6..total], payload);
+        try self.stream.writeAll(framed);
+    }
+
+    fn fillInboxNonBlocking(self: *Preview) PollError!void {
+        // POSIX-only fast path. Set non-blocking, read until `EAGAIN`,
+        // restore flags. The stream stays in blocking mode for write
+        // calls so we don't have to worry about partial sends.
+        if (!@hasDecl(std.posix, "fcntl")) return;
+        const fd = self.stream.handle;
+        const F = std.posix.F;
+        const orig_flags = std.posix.fcntl(fd, F.GETFL, 0) catch return;
+        const nonblock_flag: usize = @as(usize, 1) << @bitOffsetOf(std.posix.O, "NONBLOCK");
+        _ = std.posix.fcntl(fd, F.SETFL, orig_flags | nonblock_flag) catch return;
+        defer _ = std.posix.fcntl(fd, F.SETFL, orig_flags) catch {};
+
+        var scratch: [1024]u8 = undefined;
+        while (true) {
+            const n = self.stream.read(&scratch) catch |err| switch (err) {
+                error.WouldBlock => return,
+                else => return err,
+            };
+            if (n == 0) return; // EOF — caller infers from subsequent write failures.
+            try self.inbox.appendSlice(self.inbox_alloc, scratch[0..n]);
+        }
+    }
+
+    fn applySubscriptionFrame(self: *Preview, line: []const u8) error{ OutOfMemory, MalformedSubscription }!void {
+        // The arena is per-frame scratch — fine for transient JSON
+        // parsing. Subscription names that survive get copied into
+        // `subs_arena` so they outlive the next emit.
+        defer _ = self.arena.reset(.retain_capacity);
+        const alloc = self.arena.allocator();
+
+        const Parsed = struct {
+            kind: []const u8,
+            components: []const []const u8,
+        };
+        const parsed = std.json.parseFromSliceLeaky(Parsed, alloc, line, .{
+            .ignore_unknown_fields = true,
+        }) catch return error.MalformedSubscription;
+
+        if (std.mem.eql(u8, parsed.kind, "subscribe")) {
+            const subs_alloc = self.subs_arena.allocator();
+            for (parsed.components) |name| {
+                if (self.subscribed_components.contains(name)) continue;
+                const owned = try subs_alloc.dupe(u8, name);
+                try self.subscribed_components.put(subs_alloc, owned, {});
+            }
+        } else if (std.mem.eql(u8, parsed.kind, "unsubscribe")) {
+            for (parsed.components) |name| {
+                _ = self.subscribed_components.remove(name);
+            }
+        } else {
+            return error.MalformedSubscription;
+        }
     }
 
     fn writeFrame(self: *Preview, msg: anytype) WriteError!void {

--- a/src/root.zig
+++ b/src/root.zig
@@ -178,6 +178,9 @@ pub const ByeReason = preview_mode_mod.ByeReason;
 pub const preview_protocol_version = preview_mode_mod.protocol_version;
 pub const preview_heartbeat_interval_ms = preview_mode_mod.heartbeat_interval_ms;
 pub const parsePreviewArgs = preview_mode_mod.parseArgs;
+// Phase 2 / #518 — binary state telemetry frame types.
+pub const PreviewBinaryFrameKind = preview_mode_mod.BinaryFrameKind;
+pub const preview_binary_magic = preview_mode_mod.binary_magic;
 
 // ── JSONC Scene Bridge ──
 pub const JsoncSceneBridge = @import("jsonc_scene_bridge.zig").JsoncSceneBridge;

--- a/test/preview_mode_test.zig
+++ b/test/preview_mode_test.zig
@@ -12,6 +12,8 @@ const preview_mode = engine.preview_mode_mod;
 
 const Preview = preview_mode.Preview;
 const ByeReason = preview_mode.ByeReason;
+const BinaryFrameKind = preview_mode.BinaryFrameKind;
+const binary_magic = preview_mode.binary_magic;
 
 test "parseArgs: returns null when flag is absent" {
     const argv = [_][]const u8{ "game", "--scene=main" };
@@ -89,7 +91,69 @@ const LoopbackHarness = struct {
             self.read_len += n;
         }
     }
+
+    /// Read exactly `n` bytes from the inbound buffer, blocking on
+    /// the socket if more is needed. Used by binary-frame readers.
+    fn readExact(self: *LoopbackHarness, out: []u8) !void {
+        const stream = self.conn.?.stream;
+        while (self.read_len < out.len) {
+            const n = try stream.read(self.read_buf[self.read_len..]);
+            if (n == 0) return error.EndOfStream;
+            self.read_len += n;
+        }
+        @memcpy(out, self.read_buf[0..out.len]);
+        const remaining = self.read_len - out.len;
+        std.mem.copyForwards(u8, self.read_buf[0..remaining], self.read_buf[out.len..self.read_len]);
+        self.read_len = remaining;
+    }
+
+    /// Read one binary frame: `[magic][kind][u32 len][payload]`.
+    /// Asserts the magic byte. Returns `kind` + a copy of the payload
+    /// in `out` (truncated to `out.len`).
+    fn readBinaryFrame(self: *LoopbackHarness, out: []u8) !struct { kind: u8, payload: []u8 } {
+        var header: [6]u8 = undefined;
+        try self.readExact(&header);
+        if (header[0] != binary_magic) return error.NotBinaryFrame;
+        const kind = header[1];
+        const len = std.mem.readInt(u32, header[2..6], .little);
+        if (len > out.len) return error.PayloadBufferTooSmall;
+        try self.readExact(out[0..len]);
+        return .{ .kind = kind, .payload = out[0..len] };
+    }
+
+    /// Peek the next byte without consuming. Blocks until at least
+    /// one byte is available.
+    fn peekByte(self: *LoopbackHarness) !u8 {
+        const stream = self.conn.?.stream;
+        while (self.read_len == 0) {
+            const n = try stream.read(self.read_buf[self.read_len..]);
+            if (n == 0) return error.EndOfStream;
+            self.read_len += n;
+        }
+        return self.read_buf[0];
+    }
+
+    /// Editor → engine direction: write a newline-terminated JSON
+    /// frame to the accepted connection.
+    fn writeJsonLine(self: *LoopbackHarness, line: []const u8) !void {
+        const stream = self.conn.?.stream;
+        try stream.writeAll(line);
+        try stream.writeAll("\n");
+    }
 };
+
+/// Spin until `preview.pollSubscription` reports a non-empty filter
+/// set. Bounded so a broken implementation can't hang the test runner.
+fn waitForSubscription(preview: *Preview, comp_name: []const u8, deadline_ms: u64) !void {
+    const start = std.time.milliTimestamp();
+    while (true) {
+        try preview.pollSubscription();
+        if (preview.isComponentSubscribed(comp_name)) return;
+        const now = std.time.milliTimestamp();
+        if (now - start > @as(i64, @intCast(deadline_ms))) return error.SubscriptionDeadlineExceeded;
+        std.Thread.sleep(1 * std.time.ns_per_ms);
+    }
+}
 
 test "Preview: hello round-trip over loopback TCP" {
     const allocator = std.testing.allocator;
@@ -239,6 +303,227 @@ test "Preview: full lifecycle — hello, heartbeats, bye, EOF" {
     var eof_buf: [16]u8 = undefined;
     const n = try harness.conn.?.stream.read(&eof_buf);
     try std.testing.expectEqual(@as(usize, 0), n);
+}
+
+// ── Phase 2 / #518 — binary state telemetry ─────────────────────────
+
+test "emitEntityCreated: writes magic+kind+length+payload with optional prefab name" {
+    const allocator = std.testing.allocator;
+    var harness = try LoopbackHarness.init();
+    defer harness.deinit();
+
+    var host_port_buf: [32]u8 = undefined;
+    const host_port = try harness.hostPort(&host_port_buf);
+    var preview = try Preview.connect(allocator, host_port);
+    defer preview.deinit();
+    try harness.accept();
+
+    try preview.emitEntityCreated(42, "Player");
+
+    var payload_buf: [256]u8 = undefined;
+    const frame = try harness.readBinaryFrame(&payload_buf);
+    try std.testing.expectEqual(@intFromEnum(BinaryFrameKind.entity_created), frame.kind);
+    try std.testing.expectEqual(@as(u64, 42), std.mem.readInt(u64, frame.payload[0..8], .little));
+    try std.testing.expectEqual(@as(u16, 6), std.mem.readInt(u16, frame.payload[8..10], .little));
+    try std.testing.expectEqualStrings("Player", frame.payload[10..16]);
+
+    // null prefab name → name_len = 0, no name bytes.
+    try preview.emitEntityCreated(43, null);
+    const frame2 = try harness.readBinaryFrame(&payload_buf);
+    try std.testing.expectEqual(@intFromEnum(BinaryFrameKind.entity_created), frame2.kind);
+    try std.testing.expectEqual(@as(u64, 43), std.mem.readInt(u64, frame2.payload[0..8], .little));
+    try std.testing.expectEqual(@as(u16, 0), std.mem.readInt(u16, frame2.payload[8..10], .little));
+    try std.testing.expectEqual(@as(usize, 10), frame2.payload.len);
+}
+
+test "emitEntityDestroyed: writes magic+kind+length+entity_id" {
+    const allocator = std.testing.allocator;
+    var harness = try LoopbackHarness.init();
+    defer harness.deinit();
+
+    var host_port_buf: [32]u8 = undefined;
+    const host_port = try harness.hostPort(&host_port_buf);
+    var preview = try Preview.connect(allocator, host_port);
+    defer preview.deinit();
+    try harness.accept();
+
+    try preview.emitEntityDestroyed(0xDEADBEEF);
+
+    var payload_buf: [64]u8 = undefined;
+    const frame = try harness.readBinaryFrame(&payload_buf);
+    try std.testing.expectEqual(@intFromEnum(BinaryFrameKind.entity_destroyed), frame.kind);
+    try std.testing.expectEqual(@as(usize, 8), frame.payload.len);
+    try std.testing.expectEqual(@as(u64, 0xDEADBEEF), std.mem.readInt(u64, frame.payload[0..8], .little));
+}
+
+test "emitComponentChanged: only emits when component is subscribed" {
+    const allocator = std.testing.allocator;
+    var harness = try LoopbackHarness.init();
+    defer harness.deinit();
+
+    var host_port_buf: [32]u8 = undefined;
+    const host_port = try harness.hostPort(&host_port_buf);
+    var preview = try Preview.connect(allocator, host_port);
+    defer preview.deinit();
+    try harness.accept();
+
+    // Default: empty subscription set → no traffic.
+    try std.testing.expect(!preview.isComponentSubscribed("Position"));
+    try preview.emitComponentChanged(1, "Position", "ignored");
+
+    // Subscribe via the editor → engine path.
+    try harness.writeJsonLine("{\"kind\":\"subscribe\",\"components\":[\"Position\"]}");
+    try waitForSubscription(&preview, "Position", 1000);
+    try std.testing.expect(preview.isComponentSubscribed("Position"));
+
+    // Subscribed components ride the wire; the wrong-name path stays silent.
+    try preview.emitComponentChanged(7, "Velocity", "still ignored");
+    try preview.emitComponentChanged(7, "Position", &[_]u8{ 0x11, 0x22, 0x33, 0x44 });
+
+    var payload_buf: [256]u8 = undefined;
+    const frame = try harness.readBinaryFrame(&payload_buf);
+    try std.testing.expectEqual(@intFromEnum(BinaryFrameKind.component_changed), frame.kind);
+    // [u64 entity_id][u16 name_len][name][u32 data_len][data]
+    try std.testing.expectEqual(@as(u64, 7), std.mem.readInt(u64, frame.payload[0..8], .little));
+    const name_len = std.mem.readInt(u16, frame.payload[8..10], .little);
+    try std.testing.expectEqual(@as(u16, 8), name_len);
+    try std.testing.expectEqualStrings("Position", frame.payload[10 .. 10 + name_len]);
+    const data_off: usize = 10 + name_len;
+    const data_len = std.mem.readInt(u32, frame.payload[data_off..][0..4], .little);
+    try std.testing.expectEqual(@as(u32, 4), data_len);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x11, 0x22, 0x33, 0x44 }, frame.payload[data_off + 4 .. data_off + 4 + data_len]);
+}
+
+test "pollSubscription: decodes subscribe and unsubscribe from editor" {
+    const allocator = std.testing.allocator;
+    var harness = try LoopbackHarness.init();
+    defer harness.deinit();
+
+    var host_port_buf: [32]u8 = undefined;
+    const host_port = try harness.hostPort(&host_port_buf);
+    var preview = try Preview.connect(allocator, host_port);
+    defer preview.deinit();
+    try harness.accept();
+
+    try harness.writeJsonLine("{\"kind\":\"subscribe\",\"components\":[\"Position\",\"Velocity\",\"Health\"]}");
+    try waitForSubscription(&preview, "Health", 1000);
+    try std.testing.expect(preview.isComponentSubscribed("Position"));
+    try std.testing.expect(preview.isComponentSubscribed("Velocity"));
+    try std.testing.expect(preview.isComponentSubscribed("Health"));
+    try std.testing.expect(!preview.isComponentSubscribed("MissingOne"));
+
+    try harness.writeJsonLine("{\"kind\":\"unsubscribe\",\"components\":[\"Velocity\"]}");
+    // Wait until Velocity drops out of the filter set.
+    const start = std.time.milliTimestamp();
+    while (preview.isComponentSubscribed("Velocity")) {
+        try preview.pollSubscription();
+        if (std.time.milliTimestamp() - start > 1000) return error.UnsubscribeDeadlineExceeded;
+        std.Thread.sleep(1 * std.time.ns_per_ms);
+    }
+    try std.testing.expect(preview.isComponentSubscribed("Position"));
+    try std.testing.expect(!preview.isComponentSubscribed("Velocity"));
+    try std.testing.expect(preview.isComponentSubscribed("Health"));
+}
+
+test "Preview: JSON heartbeats and binary frames multiplex on one socket" {
+    // The full Phase 2 wire scenario: editor sends a JSON subscribe,
+    // engine answers with binary frames interleaved with JSON
+    // heartbeats. Reader-side disambiguates by peeking the first
+    // byte (0x1B → binary, otherwise → JSON).
+    const allocator = std.testing.allocator;
+    var harness = try LoopbackHarness.init();
+    defer harness.deinit();
+
+    var host_port_buf: [32]u8 = undefined;
+    const host_port = try harness.hostPort(&host_port_buf);
+    var preview = try Preview.connect(allocator, host_port);
+    defer preview.deinit();
+    try harness.accept();
+
+    // Editor opts in to Position telemetry.
+    try harness.writeJsonLine("{\"kind\":\"subscribe\",\"components\":[\"Position\"]}");
+    try waitForSubscription(&preview, "Position", 1000);
+
+    // Engine emits an interleaved stream.
+    try preview.sendHello("phase2-spike", 99);
+    try preview.emitEntityCreated(101, "Goblin");
+    try preview.sendHeartbeat(500);
+    try preview.emitComponentChanged(101, "Position", &[_]u8{ 1, 0, 0, 0, 2, 0, 0, 0 });
+    try preview.emitEntityDestroyed(101);
+    try preview.sendBye(.normal);
+
+    // 1. hello (JSON)
+    {
+        try std.testing.expect((try harness.peekByte()) != binary_magic);
+        var buf: [256]u8 = undefined;
+        const f = try harness.readFrame(&buf);
+        try std.testing.expect(std.mem.indexOf(u8, f, "\"kind\":\"hello\"") != null);
+    }
+    // 2. entity_created (binary)
+    {
+        try std.testing.expectEqual(binary_magic, try harness.peekByte());
+        var buf: [256]u8 = undefined;
+        const f = try harness.readBinaryFrame(&buf);
+        try std.testing.expectEqual(@intFromEnum(BinaryFrameKind.entity_created), f.kind);
+    }
+    // 3. heartbeat (JSON)
+    {
+        try std.testing.expect((try harness.peekByte()) != binary_magic);
+        var buf: [256]u8 = undefined;
+        const f = try harness.readFrame(&buf);
+        try std.testing.expect(std.mem.indexOf(u8, f, "\"kind\":\"heartbeat\"") != null);
+    }
+    // 4. component_changed (binary)
+    {
+        try std.testing.expectEqual(binary_magic, try harness.peekByte());
+        var buf: [256]u8 = undefined;
+        const f = try harness.readBinaryFrame(&buf);
+        try std.testing.expectEqual(@intFromEnum(BinaryFrameKind.component_changed), f.kind);
+    }
+    // 5. entity_destroyed (binary)
+    {
+        try std.testing.expectEqual(binary_magic, try harness.peekByte());
+        var buf: [256]u8 = undefined;
+        const f = try harness.readBinaryFrame(&buf);
+        try std.testing.expectEqual(@intFromEnum(BinaryFrameKind.entity_destroyed), f.kind);
+    }
+    // 6. bye (JSON)
+    {
+        try std.testing.expect((try harness.peekByte()) != binary_magic);
+        var buf: [256]u8 = undefined;
+        const f = try harness.readFrame(&buf);
+        try std.testing.expect(std.mem.indexOf(u8, f, "\"kind\":\"bye\"") != null);
+    }
+}
+
+test "pollSubscription: malformed JSON surfaces MalformedSubscription" {
+    const allocator = std.testing.allocator;
+    var harness = try LoopbackHarness.init();
+    defer harness.deinit();
+
+    var host_port_buf: [32]u8 = undefined;
+    const host_port = try harness.hostPort(&host_port_buf);
+    var preview = try Preview.connect(allocator, host_port);
+    defer preview.deinit();
+    try harness.accept();
+
+    try harness.writeJsonLine("{\"kind\":\"subscribe\",\"components\":\"not-an-array\"}");
+
+    // Spin until the bytes have arrived in the engine's inbox and we
+    // can decode them.
+    const start = std.time.milliTimestamp();
+    while (true) {
+        const r = preview.pollSubscription();
+        if (r) {
+            // No bytes yet — try again.
+            if (std.time.milliTimestamp() - start > 1000) return error.NoMalformedFrameSurfaced;
+            std.Thread.sleep(1 * std.time.ns_per_ms);
+            continue;
+        } else |err| {
+            try std.testing.expectEqual(@as(anyerror, error.MalformedSubscription), err);
+            break;
+        }
+    }
 }
 
 test "Preview: bye produces wire bytes the editor can parse" {


### PR DESCRIPTION
## Summary

Phase 2 of the PIE preview umbrella (labelle-toolkit/labelle-gui#59). Extends the Phase 1 JSON control channel (#516 / #517) with a length-prefixed binary plane multiplexed on the same TCP socket. Resolves #518.

- Engine -> editor: \`entity_created\`, \`entity_destroyed\`, \`component_changed\` binary frames.
- Editor -> engine: \`subscribe\` / \`unsubscribe\` JSON frames consumed by \`pollSubscription\`.
- Reader disambiguates planes by peeking the first byte: \`0x1B\` (ESC) = binary, anything else = newline-delimited JSON.

### Wire envelope

\`\`\`
[u8 magic=0x1B] [u8 kind] [u32 length, little-endian] [payload bytes...]
\`\`\`

### API additions to \`Preview\`

- \`emitEntityCreated(entity_id, prefab_name)\` — always emits.
- \`emitEntityDestroyed(entity_id)\` — always emits.
- \`emitComponentChanged(entity_id, comp_name, comp_bytes)\` — no-op unless subscribed.
- \`pollSubscription()\` — non-blocking drain that updates a \`StringHashMapUnmanaged(void)\`.
- \`isComponentSubscribed(comp_name)\` — cheap guard for serializer cost.

### Out of scope (intentional per #518 ticket)

- Per-tick batching — single emits today, batching deferred to a Phase 2 polish PR. Documented as a \`TODO\` block in \`preview_mode.zig\`.
- Game-loop wiring (\`game.zig\` calling \`emit*\`) ships in a sibling integration PR.
- Selection sync / pin watch values (Phase 3+).

## Test plan

- [x] \`zig build\` passes.
- [x] \`zig build test\` passes (16 tests in \`preview_mode_test.zig\` — 10 Phase 1 + 6 Phase 2).
- [x] \`emitEntityCreated\` writes magic + kind + length + payload with optional prefab name (\`name_len = 0\` when null).
- [x] \`emitEntityDestroyed\` writes the expected envelope.
- [x] \`emitComponentChanged\` is gated on subscription; subscribed components round-trip with payload bytes intact.
- [x] \`pollSubscription\` decodes \`subscribe\` / \`unsubscribe\` and updates the filter set.
- [x] JSON heartbeats + binary frames interleave on a single socket; reader peeks the magic byte to discriminate.
- [x] Malformed subscription JSON surfaces as \`error.MalformedSubscription\`.

Refs: umbrella labelle-toolkit/labelle-gui#59, Phase 1 #516 / #517.