### PR TITLE
Preview Phase 2 wiring: hook telemetry emitters into game.zig ECS lifecycle

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -15,6 +15,7 @@ const PrefabChild = core.PrefabChild;
 const atlas_mod = @import("atlas.zig");
 const assets_mod = @import("assets/mod.zig");
 const game_log_mod = @import("game_log.zig");
+const preview_mode_mod = @import("preview_mode.zig");
 
 const hierarchy = @import("game/hierarchy.zig");
 const gizmo_draws_mod = @import("game/gizmo_draws.zig");
@@ -285,6 +286,22 @@ pub fn GameConfig(
         /// just stores + dispatches the bool.
         paused: bool = false,
 
+        /// Connect-out preview channel to the labelle-gui editor
+        /// (`--preview-mode <host:port>`). `null` in normal runs — the
+        /// generated `main.zig` constructs a `Preview` and assigns it
+        /// here when the flag is present. Lifetime: owned by `Game`
+        /// when set, but `Preview.deinit` is the caller's
+        /// responsibility (mirrors the spawn-side pattern in
+        /// `preview_mode.zig`'s doc — the assembler-generated main
+        /// calls `sendBye` + `deinit` on shutdown).
+        ///
+        /// When set, ECS lifecycle paths (`createEntity`,
+        /// `destroyEntity`, `addComponent`, `setComponent`,
+        /// `setPosition`) emit Phase 2 telemetry frames. Component
+        /// frames are gated by `Preview.isComponentSubscribed` so an
+        /// idle editor pays nothing per write.
+        preview: ?preview_mode_mod.Preview = null,
+
         // Profiling (debug builds only)
         /// Opaque pointer to ScriptRunner's profile array. Set by generated code.
         script_profile_ptr: ?*const anyopaque = null,
@@ -514,6 +531,11 @@ pub fn GameConfig(
         pub fn createEntity(self: *Self) Entity {
             const entity = self.ecs_backend.createEntity();
             self.emitHook(.{ .entity_created = .{ .entity_id = entity } });
+            // Preview telemetry: the prefab path tags `PrefabInstance`
+            // *after* createEntity returns (see `tagAsPrefabInstance`),
+            // so we can't carry the prefab name here. Emit null; a
+            // future enhancement can re-emit on tag.
+            if (self.preview) |*p| p.emitEntityCreated(@intCast(entity), null) catch {};
             return entity;
         }
 
@@ -663,6 +685,10 @@ pub fn GameConfig(
                     self.destroyEntity(child);
                 }
             }
+            // Preview telemetry emits BEFORE the actual destroy so any
+            // editor-side consumer can still introspect the entity from
+            // a `getComponent` style API while reacting to the frame.
+            if (self.preview) |*p| p.emitEntityDestroyed(@intCast(entity)) catch {};
             self.untrackSceneEntity(entity);
             self.active_world.sprite_cache.invalidate(@intCast(entity));
             self.renderer.untrackEntity(entity);
@@ -672,6 +698,7 @@ pub fn GameConfig(
         }
 
         pub fn destroyEntityOnly(self: *Self, entity: Entity) void {
+            if (self.preview) |*p| p.emitEntityDestroyed(@intCast(entity)) catch {};
             self.untrackSceneEntity(entity);
             self.active_world.sprite_cache.invalidate(@intCast(entity));
             self.renderer.untrackEntity(entity);
@@ -845,6 +872,26 @@ pub fn GameConfig(
         pub fn setPosition(self: *Self, entity: Entity, pos: Position) void {
             self.ecs_backend.addComponent(entity, pos);
             self.renderer.markPositionDirtyWithChildren(EcsImpl, self.ecs_backend, entity);
+            self.notifyComponentChanged(entity, pos);
+        }
+
+        /// Preview-mode helper. No-op unless `self.preview` is set AND
+        /// the editor has subscribed to this component's name. Folded
+        /// out by the compiler in non-preview builds because the
+        /// `preview` field defaults to `null`.
+        ///
+        /// Generic over the component type so it can be called from
+        /// any setter site without forcing the caller to spell out
+        /// `@typeName` + `std.mem.asBytes` boilerplate. The
+        /// subscription check runs first so `comp` is never read in
+        /// the common "nobody's watching" path.
+        inline fn notifyComponentChanged(self: *Self, entity: Entity, comp: anytype) void {
+            if (self.preview) |*p| {
+                const name = @typeName(@TypeOf(comp));
+                if (p.isComponentSubscribed(name)) {
+                    p.emitComponentChanged(@intCast(entity), name, std.mem.asBytes(&comp)) catch {};
+                }
+            }
         }
 
         pub fn getPosition(self: *Self, entity: Entity) Position {
@@ -951,6 +998,7 @@ pub fn GameConfig(
             if (@typeInfo(T) == .@"struct" and @hasDecl(T, "onAdd")) {
                 T.onAdd(ComponentPayload{ .entity_id = @intCast(entity), .game_ptr = @ptrCast(self) });
             }
+            self.notifyComponentChanged(entity, component);
         }
 
         pub fn setComponent(self: *Self, entity: Entity, component: anytype) void {
@@ -964,6 +1012,7 @@ pub fn GameConfig(
                     T.onAdd(ComponentPayload{ .entity_id = @intCast(entity), .game_ptr = @ptrCast(self) });
                 }
             }
+            self.notifyComponentChanged(entity, component);
         }
 
         pub fn getComponent(self: *Self, entity: Entity, comptime T: type) ?*T {

--- a/src/game.zig
+++ b/src/game.zig
@@ -342,6 +342,12 @@ pub fn GameConfig(
 
         pub fn deinit(self: *Self) void {
             self.emitHook(.{ .game_deinit = {} });
+            // `Game` owns the preview channel by value when set, so we
+            // release it here. The generated `main.zig` is expected to
+            // call `game.preview.?.sendBye(...)` before `game.deinit()`
+            // for a graceful shutdown; the socket close + arena tear-down
+            // happens here regardless.
+            if (self.preview) |*p| p.deinit();
             // Tear down the active scene FIRST. Scene teardown runs
             // user-provided `deinit_fn`s that may call `game.assets.*`
             // (release on unload is the natural pattern for the very
@@ -887,9 +893,22 @@ pub fn GameConfig(
         /// the common "nobody's watching" path.
         inline fn notifyComponentChanged(self: *Self, entity: Entity, comp: anytype) void {
             if (self.preview) |*p| {
-                const name = @typeName(@TypeOf(comp));
-                if (p.isComponentSubscribed(name)) {
-                    p.emitComponentChanged(@intCast(entity), name, std.mem.asBytes(&comp)) catch {};
+                // Callers may pass either a value or a `*T` (the
+                // generic `addComponent` / `setComponent` accept
+                // `anytype`). Strip the pointer so the subscription
+                // name and serialized bytes describe the component,
+                // not its address.
+                const T = @TypeOf(comp);
+                if (comptime @typeInfo(T) == .pointer) {
+                    const name = @typeName(@typeInfo(T).pointer.child);
+                    if (p.isComponentSubscribed(name)) {
+                        p.emitComponentChanged(@intCast(entity), name, std.mem.asBytes(comp)) catch {};
+                    }
+                } else {
+                    const name = @typeName(T);
+                    if (p.isComponentSubscribed(name)) {
+                        p.emitComponentChanged(@intCast(entity), name, std.mem.asBytes(&comp)) catch {};
+                    }
                 }
             }
         }

--- a/test/preview_mode_test.zig
+++ b/test/preview_mode_test.zig
@@ -592,7 +592,7 @@ test "Game lifecycle: createEntity + addComponent emit telemetry; destroy + filt
     defer game.deinit();
 
     game.preview = try Preview.connect(allocator, host_port);
-    defer if (game.preview) |*p| p.deinit();
+    // Game.deinit cleans up `preview` — no manual deinit here.
     try harness.accept();
 
     // Phase 1 handshake — hello + heartbeat — proves the JSON plane

--- a/test/preview_mode_test.zig
+++ b/test/preview_mode_test.zig
@@ -545,3 +545,182 @@ test "Preview: bye produces wire bytes the editor can parse" {
         try std.testing.expectEqualStrings(c.expected, out);
     }
 }
+
+// ── Phase 2 wiring (#520) — Game ECS lifecycle → Preview ────────────
+
+const Game = engine.Game;
+
+// Lightweight components defined here so their `@typeName` is stable
+// (`preview_mode_test.TestPos` / `preview_mode_test.TestSprite`) and
+// the subscription filter the test sends matches what the engine
+// emits via `@typeName(@TypeOf(component))` in
+// `notifyComponentChanged`.
+const TestPos = extern struct { x: i32, y: i32 };
+const TestSprite = extern struct { sprite_id: u32, visible: u8 };
+
+const BinaryFrameResult = struct { kind: u8, payload: []u8 };
+
+/// Walk to the next binary frame, draining any JSON noise (heartbeats,
+/// hello/bye, etc.) the engine emits in between. The Phase 2 wiring
+/// only touches binary frames, so JSON traffic mixed in is signal we
+/// can safely discard for this assertion path.
+fn nextBinaryFrame(
+    harness: *LoopbackHarness,
+    out: []u8,
+) !BinaryFrameResult {
+    var scratch: [1024]u8 = undefined;
+    while (true) {
+        const first = try harness.peekByte();
+        if (first == binary_magic) {
+            const f = try harness.readBinaryFrame(out);
+            return .{ .kind = f.kind, .payload = f.payload };
+        }
+        _ = try harness.readFrame(&scratch); // drop one JSON line
+    }
+}
+
+test "Game lifecycle: createEntity + addComponent emit telemetry; destroy + filter respected (#520)" {
+    const allocator = std.testing.allocator;
+
+    var harness = try LoopbackHarness.init();
+    defer harness.deinit();
+
+    var host_port_buf: [32]u8 = undefined;
+    const host_port = try harness.hostPort(&host_port_buf);
+
+    var game = Game.init(allocator);
+    defer game.deinit();
+
+    game.preview = try Preview.connect(allocator, host_port);
+    defer if (game.preview) |*p| p.deinit();
+    try harness.accept();
+
+    // Phase 1 handshake — hello + heartbeat — proves the JSON plane
+    // is alive before binary frames start flowing.
+    try (game.preview.?).sendHello("phase2-wiring", 1);
+    try (game.preview.?).sendHeartbeat(0);
+    {
+        var buf: [512]u8 = undefined;
+        const f = try harness.readFrame(&buf);
+        try std.testing.expect(std.mem.indexOf(u8, f, "\"kind\":\"hello\"") != null);
+    }
+    {
+        var buf: [256]u8 = undefined;
+        const f = try harness.readFrame(&buf);
+        try std.testing.expect(std.mem.indexOf(u8, f, "\"kind\":\"heartbeat\"") != null);
+    }
+
+    // Editor subscribes to the two component names we'll exercise.
+    // The names must match what `@typeName` produces for the types
+    // the engine sees in `addComponent`.
+    const pos_name = @typeName(TestPos);
+    const sprite_name = @typeName(TestSprite);
+
+    var sub_buf: [256]u8 = undefined;
+    const sub_line = try std.fmt.bufPrint(
+        &sub_buf,
+        "{{\"kind\":\"subscribe\",\"components\":[\"{s}\",\"{s}\"]}}",
+        .{ pos_name, sprite_name },
+    );
+    try harness.writeJsonLine(sub_line);
+    try waitForSubscription(&game.preview.?, pos_name, 1000);
+    try waitForSubscription(&game.preview.?, sprite_name, 1000);
+
+    // Create one entity with both components — expect:
+    //   1 × entity_created  (id == 1)
+    //   1 × component_changed (TestPos)
+    //   1 × component_changed (TestSprite)
+    const e1 = game.createEntity();
+    game.addComponent(e1, TestPos{ .x = 10, .y = 20 });
+    game.addComponent(e1, TestSprite{ .sprite_id = 7, .visible = 1 });
+
+    var payload_buf: [512]u8 = undefined;
+
+    // entity_created(e1)
+    {
+        const f = try nextBinaryFrame(&harness, &payload_buf);
+        try std.testing.expectEqual(@intFromEnum(BinaryFrameKind.entity_created), f.kind);
+        const id = std.mem.readInt(u64, f.payload[0..8], .little);
+        try std.testing.expectEqual(@as(u64, @intCast(e1)), id);
+        const name_len = std.mem.readInt(u16, f.payload[8..10], .little);
+        // createEntity emits null prefab name → name_len == 0.
+        try std.testing.expectEqual(@as(u16, 0), name_len);
+    }
+    // component_changed(TestPos)
+    {
+        const f = try nextBinaryFrame(&harness, &payload_buf);
+        try std.testing.expectEqual(@intFromEnum(BinaryFrameKind.component_changed), f.kind);
+        const id = std.mem.readInt(u64, f.payload[0..8], .little);
+        try std.testing.expectEqual(@as(u64, @intCast(e1)), id);
+        const name_len = std.mem.readInt(u16, f.payload[8..10], .little);
+        try std.testing.expectEqualStrings(pos_name, f.payload[10 .. 10 + name_len]);
+        const data_off: usize = 10 + name_len;
+        const data_len = std.mem.readInt(u32, f.payload[data_off..][0..4], .little);
+        try std.testing.expectEqual(@as(u32, @sizeOf(TestPos)), data_len);
+        // Recover the x/y the engine handed us through `asBytes`.
+        const x = std.mem.readInt(i32, f.payload[data_off + 4 ..][0..4], .little);
+        const y = std.mem.readInt(i32, f.payload[data_off + 8 ..][0..4], .little);
+        try std.testing.expectEqual(@as(i32, 10), x);
+        try std.testing.expectEqual(@as(i32, 20), y);
+    }
+    // component_changed(TestSprite)
+    {
+        const f = try nextBinaryFrame(&harness, &payload_buf);
+        try std.testing.expectEqual(@intFromEnum(BinaryFrameKind.component_changed), f.kind);
+        const name_len = std.mem.readInt(u16, f.payload[8..10], .little);
+        try std.testing.expectEqualStrings(sprite_name, f.payload[10 .. 10 + name_len]);
+    }
+
+    // Destroy the entity → expect one entity_destroyed.
+    game.destroyEntity(e1);
+    {
+        const f = try nextBinaryFrame(&harness, &payload_buf);
+        try std.testing.expectEqual(@intFromEnum(BinaryFrameKind.entity_destroyed), f.kind);
+        const id = std.mem.readInt(u64, f.payload[0..8], .little);
+        try std.testing.expectEqual(@as(u64, @intCast(e1)), id);
+    }
+
+    // Subscription filter: touching a component the editor never
+    // subscribed to (and an entity it never asked about) MUST NOT
+    // produce a `component_changed` frame. We still expect the
+    // `entity_created` frame (lifecycle events bypass the filter),
+    // and then the next binary frame after that must be
+    // `entity_destroyed` — proving no Unsubscribed-component frame
+    // sneaked in between.
+    const Unsubscribed = extern struct { v: u32 };
+    const e2 = game.createEntity();
+    game.addComponent(e2, Unsubscribed{ .v = 99 });
+
+    {
+        const f = try nextBinaryFrame(&harness, &payload_buf);
+        try std.testing.expectEqual(@intFromEnum(BinaryFrameKind.entity_created), f.kind);
+        const id = std.mem.readInt(u64, f.payload[0..8], .little);
+        try std.testing.expectEqual(@as(u64, @intCast(e2)), id);
+    }
+
+    game.destroyEntity(e2);
+    {
+        const f = try nextBinaryFrame(&harness, &payload_buf);
+        try std.testing.expectEqual(@intFromEnum(BinaryFrameKind.entity_destroyed), f.kind);
+        const id = std.mem.readInt(u64, f.payload[0..8], .little);
+        try std.testing.expectEqual(@as(u64, @intCast(e2)), id);
+    }
+}
+
+test "Game without preview attached: ECS lifecycle is a no-op for telemetry (#520)" {
+    // Sanity check that the `if (self.preview) |*p|` guards genuinely
+    // short-circuit — a Game with `preview = null` must not crash, write
+    // to any socket, or otherwise misbehave on the lifecycle paths.
+    const allocator = std.testing.allocator;
+    var game = Game.init(allocator);
+    defer game.deinit();
+
+    try std.testing.expect(game.preview == null);
+
+    const e = game.createEntity();
+    game.addComponent(e, TestPos{ .x = 1, .y = 2 });
+    game.setComponent(e, TestPos{ .x = 3, .y = 4 });
+    game.destroyEntity(e);
+
+    try std.testing.expectEqual(@as(usize, 0), game.entityCount());
+}


### PR DESCRIPTION
## Summary

Wires the Phase 2 telemetry emitters shipped in #519 (`emitEntityCreated`, `emitEntityDestroyed`, `emitComponentChanged`) into `Game`'s ECS lifecycle paths. Until now those primitives lived on `Preview` but no engine code reached for them — this is the sub-issue the spike deferred.

- New optional `preview: ?Preview` field on `Game`. Generated `main.zig` (assembler-side, not in this PR) assigns it when `--preview-mode <host:port>` is set; in normal runs the field stays `null` and every emit site folds to a no-op.
- `createEntity` → `emitEntityCreated(id, null)`. Prefab-path attribution (`PrefabInstance.path`) is tagged *after* `createEntity` returns, so the prefab name isn't available at this site yet; a richer attribution pass is left as a follow-up.
- `destroyEntity` / `destroyEntityOnly` → `emitEntityDestroyed(id)` BEFORE the ECS row is actually removed, so an editor consumer can still introspect the entity from a `getComponent`-style API while reacting to the frame.
- `addComponent` / `setComponent` / `setPosition` → all forward to a new inline `notifyComponentChanged(entity, comp)` helper that gates on `Preview.isComponentSubscribed(@typeName(T))` before serializing — idle editor pays zero per-write.
- Every emit is `if (self.preview) |*p| p.emit... catch {}` per the issue's contract: a closed editor socket must never crash the game.

## Test plan

- [x] `zig build` clean.
- [x] `zig build test` green — 347 tests, including two new wiring tests in `test/preview_mode_test.zig`:
  - **End-to-end** — stands up a loopback TCP listener, attaches a `Preview` to a `Game.init(...)`, walks the hello+heartbeat handshake, sends `subscribe([TestPos, TestSprite])`, creates an entity with both components, and asserts the on-wire frame sequence: 1× `entity_created` + 2× `component_changed` + 1× `entity_destroyed`. Then exercises the filter: a component the editor never subscribed to on a different entity produces only its own lifecycle frames, no `component_changed`.
  - **Null-preview sanity** — confirms `preview == null` is a true no-op for the lifecycle paths (no crashes, no writes, entity count returns to zero).

Refs #520, labelle-toolkit/labelle-gui#59.

## Out of scope (intentionally)

- Per-tick batching (TODO already in `preview_mode.zig`).
- Selection sync (#59 Phase 3).
- Editor-side "Entities" panel consumer (separate labelle-gui ticket).
- Prefab-name attribution on `entity_created` — requires re-emitting after `tagAsPrefabInstance`; deferred.