### PR TITLE
fix(wasm): route persistent allocators through libc on emscripten

### DIFF
--- a/src/jsonc/deserializer.zig
+++ b/src/jsonc/deserializer.zig
@@ -17,8 +17,23 @@
 //!    `nested_entity_arena`, which resets on `resetEcsBackend`.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const jsonc = @import("jsonc");
 const Value = jsonc.Value;
+
+// Persistent backing allocator for the intern arena. On
+// `wasm32-emscripten` `std.heap.page_allocator` resolves to
+// `WasmAllocator`, which uses `@wasmMemoryGrow` directly and bypasses
+// `_emscripten_resize_heap` / `updateMemoryViews()`. The next
+// `std.debug.print` to stderr after a grow then aborts on a detached
+// `HEAPU32`. Use `c_allocator` on emscripten (libc malloc routes
+// through emscripten's resize path), keep `page_allocator` on desktop
+// so GPA leak-detection ignores deliberately-unfreed game-lifetime
+// data. See `labelle-cli/docs/wasm-segfault-investigation.md` (#196).
+const intern_backing_allocator: std.mem.Allocator = if (builtin.target.os.tag == .emscripten)
+    std.heap.c_allocator
+else
+    std.heap.page_allocator;
 
 // ── String intern pool ──────────────────────────────────────────────
 //
@@ -54,7 +69,7 @@ fn internString(s: []const u8) ?[]const u8 {
     defer intern_mutex.unlock();
 
     if (intern_arena == null) {
-        intern_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+        intern_arena = std.heap.ArenaAllocator.init(intern_backing_allocator);
         intern_map = std.StringHashMap(void).init(intern_arena.?.allocator());
     }
     if (intern_map.?.getKey(s)) |existing| return existing;

--- a/src/jsonc/prefab_cache.zig
+++ b/src/jsonc/prefab_cache.zig
@@ -14,9 +14,27 @@
 //! `loadSceneFromSource`.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const jsonc = @import("jsonc");
 const Value = jsonc.Value;
 const JsoncParser = jsonc.JsoncParser;
+
+// Persistent allocator for game-lifetime data. On `wasm32-emscripten`
+// we MUST go through libc (emscripten's malloc), because libc's
+// allocator routes through `_emscripten_resize_heap` which calls
+// `updateMemoryViews()` after `wasmMemory.grow()`. Zig's
+// `page_allocator` resolves to `WasmAllocator` on emscripten and
+// issues `@wasmMemoryGrow` directly — that bypasses the JS-side view
+// rebinding, leaving `HEAPU32` detached, and the next `_fd_write`
+// (i.e. the first `std.debug.print` after a page-alloc grow) aborts
+// with a spurious "segmentation fault". Desktop targets keep
+// `page_allocator` so GPA leak-detection ignores deliberately-unfreed
+// game-lifetime allocations. See
+// `labelle-cli/docs/wasm-segfault-investigation.md` (issue #196).
+const persistent_allocator: std.mem.Allocator = if (builtin.target.os.tag == .emscripten)
+    std.heap.c_allocator
+else
+    std.heap.page_allocator;
 
 pub const PrefabCache = struct {
     prefabs: std.StringHashMap(Value),
@@ -25,7 +43,7 @@ pub const PrefabCache = struct {
     prefab_dir: []const u8,
 
     pub fn init(allocator: std.mem.Allocator, prefab_dir: []const u8) PrefabCache {
-        const persistent = std.heap.page_allocator;
+        const persistent = persistent_allocator;
         return .{
             .prefabs = std.StringHashMap(Value).init(persistent),
             .persistent = persistent,
@@ -62,7 +80,7 @@ pub const PrefabCache = struct {
 /// engine's full `Game` type — any struct with a `prefab_cache_ptr:
 /// ?*anyopaque` field and an `allocator` works.
 pub fn initPersistentCache(game: anytype, prefab_dir: []const u8) !*PrefabCache {
-    const persistent = std.heap.page_allocator;
+    const persistent = persistent_allocator;
     const cache = try persistent.create(PrefabCache);
     cache.* = PrefabCache.init(game.allocator, prefab_dir);
     game.prefab_cache_ptr = cache;

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -15,11 +15,26 @@
 //! signature the rest of the codebase already calls into.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const jsonc = @import("jsonc");
 const Value = jsonc.Value;
 const JsoncParser = jsonc.JsoncParser;
 const core = @import("labelle-core");
 const Position = core.Position;
+
+// Game-lifetime allocator for persistent ID arrays. On
+// `wasm32-emscripten` we MUST use libc malloc, not Zig's
+// `page_allocator` (which is `WasmAllocator` there) — the latter
+// calls `@wasmMemoryGrow` directly, bypassing emscripten's
+// `updateMemoryViews()` and detaching the JS-side `HEAPU32`. The next
+// `_fd_write` (i.e. the first `std.debug.print` after a grow) aborts.
+// Desktop targets keep `page_allocator` so the existing convention
+// "deliberately not freed → page allocator so GPA doesn't flag" is
+// preserved. See `labelle-cli/docs/wasm-segfault-investigation.md` (#196).
+const persistent_id_allocator: std.mem.Allocator = if (builtin.target.os.tag == .emscripten)
+    std.heap.c_allocator
+else
+    std.heap.page_allocator;
 
 const prefab_cache_mod = @import("prefab_cache.zig");
 const PrefabCache = prefab_cache_mod.PrefabCache;
@@ -517,10 +532,12 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                 if (entity_count == 0) continue;
 
                 // Spawn entities and collect IDs. Uses
-                // `page_allocator` because IDs are stored in
+                // `persistent_id_allocator` (page_allocator on
+                // desktop, c_allocator on wasm32-emscripten — see
+                // file-top comment) because IDs are stored in
                 // component fields (`[]const u64`) and live for
                 // the game's lifetime.
-                const ids = std.heap.page_allocator.alloc(u64, entity_count) catch continue;
+                const ids = persistent_id_allocator.alloc(u64, entity_count) catch continue;
                 var idx: usize = 0;
                 for (arr.items) |item| {
                     if (ApplyHelpers.isEntityLike(item)) {


### PR DESCRIPTION
## Summary

Fixes the WASM raylib runtime abort tracked in [labelle-toolkit/labelle-cli#196](https://github.com/labelle-toolkit/labelle-cli/issues/196).

Root cause (full writeup in `labelle-cli/docs/wasm-segfault-investigation.md`): on `wasm32-emscripten`, `std.heap.page_allocator` resolves to `WasmAllocator`, which calls `@wasmMemoryGrow` directly. That bypasses emscripten's `_emscripten_resize_heap` and `updateMemoryViews()`, so the JS-side `HEAPU32` view stays bound to the detached pre-grow `ArrayBuffer`. The next `_fd_write` (i.e. the first `std.debug.print` to stderr after the grow) aborts inside `assert(offset >= 0)`, which `SAFE_HEAP=1` re-stringifies as `Aborted(segmentation fault)`.

Three engine call sites grew memory through `page_allocator` before any Zig stderr write under the raylib WASM example, making this the first observable failure:

- `src/jsonc/prefab_cache.zig` — game-lifetime `PrefabCache` (struct + entries map + parsed `Value` arena)
- `src/jsonc/deserializer.zig` — interned-string arena (lives process-lifetime)
- `src/jsonc/scene_loader.zig` — persistent ID array per scene entity array

Each switches to `c_allocator` on emscripten (libc malloc IS routed via `_emscripten_resize_heap`) and keeps `page_allocator` on desktop so the existing GPA-leak-detection convention is preserved. Gating is `comptime` via `builtin.target.os.tag` — no runtime cost on desktop.

Companion PR in `labelle-gfx` patches the analogous `loadTextureFromMemory` decode buffer: [labelle-toolkit/labelle-gfx#PENDING_GFX_PR](https://github.com/labelle-toolkit/labelle-gfx/pulls) (cross-repo dependency — both must land for #196 to clear).

## Test plan

- [x] `zig build test` — all engine tests pass.
- [x] Rebuild `labelle-assembler/examples/raylib` for `--platform=wasm` — build succeeds.
- [x] Loaded `game.html` in a real headed Chrome with `SAFE_HEAP=1` (default Debug). The `_fd_write` segfault stack from the investigation doc no longer appears; the example now runs all the way through atlas decode + upload, prints its first Zig-side stderr line (`info: [Scene] 'main' has no manifest, eager-loaded 1 resources (Debug build)`), and then hits the documented out-of-scope downstream issue (`panic: failed to set initial scene`, emscripten VFS scene-loader fallback — explicitly carved out in the investigation doc as a separate bug).
- [x] Re-ran with `SAFE_HEAP` removed: the abort path matches the investigation doc's "Validation" section exactly (texture upload succeeds, scene-info stderr write succeeds, downstream `failed to set initial scene` panic).

Browser-side verification used a headed Chrome instance driven via the Chrome DevTools Protocol from this shell to capture the console stream — the doc explicitly warns that headless Chrome's software WebGL masks the real path, so a headed Chrome was used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)