### PR TITLE
feat(scene): addEmbeddedSceneSource for filesystem-free include resolution

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -211,6 +211,17 @@ pub fn GameConfig(
         // Scene management
         scenes: std.StringHashMap(SceneEntry),
         jsonc_scenes: std.StringHashMap(JsoncSceneInfo),
+        /// Embedded JSONC sources keyed by their include-relative path
+        /// (e.g. `"scenes/obstacles.jsonc"`). Mirrors the prefab cache
+        /// pattern: when a scene declares `"include": [...]`, the JSONC
+        /// loader looks here BEFORE falling back to `std.fs.cwd().openFile`,
+        /// so WASM/Android builds (no project directory in cwd) can still
+        /// resolve nested scene fragments. Populated by the assembler-
+        /// generated `addEmbeddedSceneSource` calls in `main()` / `init()`.
+        /// Keys are owned (dupe'd via `self.allocator`); values are
+        /// program-lifetime borrows of `@embedFile` slices and are NOT
+        /// freed by the map.
+        embedded_scene_sources: std.StringHashMap([]const u8),
         /// Entities created by the active scene's loader (e.g. the JSONC
         /// bridge). `unloadCurrentScene` destroys everything in this list
         /// on scene swap so entities from the outgoing scene don't leak
@@ -336,6 +347,7 @@ pub fn GameConfig(
                 .assets = assets_mod.AssetCatalog.init(allocator),
                 .scenes = std.StringHashMap(SceneEntry).init(allocator),
                 .jsonc_scenes = std.StringHashMap(JsoncSceneInfo).init(allocator),
+                .embedded_scene_sources = std.StringHashMap([]const u8).init(allocator),
                 .gizmo_state = gizmo_draws_mod.GizmoState(Entity).init(allocator),
             };
         }
@@ -387,6 +399,11 @@ pub fn GameConfig(
             self.gizmo_state.deinit(self.allocator);
             self.scenes.deinit();
             self.jsonc_scenes.deinit();
+            // Free duplicated keys; values are program-lifetime @embedFile
+            // borrows so they aren't owned by this map.
+            var emb_iter = self.embedded_scene_sources.iterator();
+            while (emb_iter.next()) |entry| self.allocator.free(entry.key_ptr.*);
+            self.embedded_scene_sources.deinit();
             self.atlas_manager.deinit();
         }
 
@@ -1125,6 +1142,24 @@ pub fn GameConfig(
         pub const registerScene = SceneMixin.registerScene;
         pub const registerSceneSimple = SceneMixin.registerSceneSimple;
         pub const registerSceneWithAssets = SceneMixin.registerSceneWithAssets;
+
+        /// Register an embedded JSONC scene source so `"include"`
+        /// directives can resolve against memory instead of disk.
+        /// Mirrors `addEmbeddedPrefab` — the assembler emits one call
+        /// per scene fragment in `main()` / `init()` so WASM and
+        /// Android builds (no project directory in cwd) can still
+        /// resolve nested scene includes. `path` is the include-
+        /// relative path (e.g. `"scenes/obstacles.jsonc"`); `source`
+        /// is typically a comptime `@embedFile(...)` slice. Caller
+        /// retains no ownership — the map dupes the key and borrows
+        /// the source's program-lifetime slice.
+        pub fn addEmbeddedSceneSource(self: *Self, path: []const u8, source: []const u8) !void {
+            const gop = try self.embedded_scene_sources.getOrPut(path);
+            if (!gop.found_existing) {
+                gop.key_ptr.* = try self.allocator.dupe(u8, path);
+            }
+            gop.value_ptr.* = source;
+        }
         pub const setSceneAssets = SceneMixin.setSceneAssets;
         pub const setSceneInitialState = SceneMixin.setSceneInitialState;
         pub const setScene = SceneMixin.setScene;

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -206,11 +206,16 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
 
         /// Load a single scene/fragment file, processing includes
         /// recursively then its own entities.
+        ///
+        /// Source resolution: check `game.embedded_scene_sources` first
+        /// (populated by the assembler-generated `addEmbeddedSceneSource`
+        /// calls — the only mechanism that works on WASM/Android where
+        /// the project directory isn't reachable from cwd), then fall
+        /// back to `std.fs.cwd().openFile(path)` for desktop dev runs.
+        /// Mirrors the embedded-first ordering established by
+        /// `PrefabCache.get` for prefabs.
         fn loadSceneFile(game: *GameType, path: []const u8, prefab_cache: *PrefabCache, include_depth: usize) !void {
             if (include_depth > MAX_DEPTH) return error.IncludeDepthExceeded;
-
-            const file = try std.fs.cwd().openFile(path, .{});
-            defer file.close();
 
             // Use an arena for the scene parser — the source
             // buffer and parsed `Value` tree (entries/items
@@ -220,7 +225,14 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             defer parse_arena.deinit();
             const parse_alloc = parse_arena.allocator();
 
-            const source = try file.readToEndAlloc(parse_alloc, 1024 * 1024);
+            const source: []const u8 = if (game.embedded_scene_sources.get(path)) |embedded|
+                embedded
+            else blk: {
+                const file = try std.fs.cwd().openFile(path, .{});
+                defer file.close();
+                break :blk try file.readToEndAlloc(parse_alloc, 1024 * 1024);
+            };
+
             var parser = JsoncParser.init(parse_alloc, source);
             const scene_value = try parser.parse();
 


### PR DESCRIPTION
## Summary

Adds `Game.addEmbeddedSceneSource(path, source)` so the JSONC scene loader can resolve `"include": [...]` directives against memory instead of `std.fs.cwd().openFile`. Closes the runtime half of labelle-toolkit/labelle-cli#200 (raylib WASM panics on `failed to set initial scene`).

## Why

On WASM the working dir is the emscripten VFS root `/`, not the project directory. A scene that did `"include": ["scenes/obstacles.jsonc"]` would `FileNotFound` and `setScene` bubbled it as `failed to set initial scene`. Verified live in headed Chrome before/after the fix: before — panic; after — reaches the frame loop.

Mirrors the existing `addEmbeddedPrefab` precedent. The "!!! CRITICAL !!! DO NOT REPLACE WITH `initPersistentCache`" comment in `scene_loader.zig` documents the parallel mobile/Android failure mode that already exists for prefabs.

## Files

- `src/game.zig` — new `embedded_scene_sources: StringHashMap([]const u8)` field, init/deinit, `pub fn addEmbeddedSceneSource`.
- `src/jsonc/scene_loader.zig` — `loadSceneFile` checks the map BEFORE the file-I/O fallback. Desktop dev runs still work via the fallback for scenes/fragments that aren't pre-registered.

Pairs with labelle-toolkit/labelle-assembler PR that emits `addEmbeddedSceneSource(...)` calls in the generated `main()` / `init()`.

## Test plan

- [x] `zig build test` — passes.
- [x] Live verification: raylib WASM build with main.jsonc → include obstacles.jsonc reaches the frame loop in headed Chrome (no panic, frame loop running).

🤖 Generated with [Claude Code](https://claude.com/claude-code)