### PR TITLE
feat(assets): shared loader payload types for Phase 4 (#447, #448)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -13,6 +13,21 @@ pub fn build(b: *std.Build) void {
     const jsonc_dep = b.dependency("jsonc", .{ .target = target, .optimize = optimize });
     const jsonc_module = jsonc_dep.module("jsonc");
 
+    // Backend-agnostic handle/POD types referenced from both the
+    // engine module and the standalone `src/assets/` test root.
+    // Promoted to named modules so loader.zig can `@import("audio_types")` /
+    // `@import("font_types")` and resolve identically in both compilations.
+    const audio_types_module = b.createModule(.{
+        .root_source_file = b.path("src/audio_types.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const font_types_module = b.createModule(.{
+        .root_source_file = b.path("src/font_types.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
     const engine_module = b.addModule("engine", .{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
@@ -21,6 +36,8 @@ pub fn build(b: *std.Build) void {
     engine_module.addImport("labelle-core", core_module);
     engine_module.addImport("scene", scene_module);
     engine_module.addImport("jsonc", jsonc_module);
+    engine_module.addImport("audio_types", audio_types_module);
+    engine_module.addImport("font_types", font_types_module);
 
     const test_step = b.step("test", "Run engine tests");
 
@@ -43,6 +60,7 @@ pub fn build(b: *std.Build) void {
         "test/jsonc/nested_lifecycle_test.zig",
         "test/scene_ref_test.zig",
         "test/asset_catalog_test.zig",
+        "test/font_types_test.zig",
         "test/asset_streaming_shim_test.zig",
         "test/animation_def_test.zig",
         "test/sprite_animation_test.zig",
@@ -88,13 +106,14 @@ pub fn build(b: *std.Build) void {
     // own where `_ = @import("...")` chains actually cascade the
     // test blocks into the binary. Added as part of #440 while the
     // real image loader started writing its own in-source tests.
-    const assets_tests = b.addTest(.{
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("src/assets/mod.zig"),
-            .target = target,
-            .optimize = optimize,
-        }),
+    const assets_tests_module = b.createModule(.{
+        .root_source_file = b.path("src/assets/mod.zig"),
+        .target = target,
+        .optimize = optimize,
     });
+    assets_tests_module.addImport("audio_types", audio_types_module);
+    assets_tests_module.addImport("font_types", font_types_module);
+    const assets_tests = b.addTest(.{ .root_module = assets_tests_module });
     test_step.dependOn(&b.addRunArtifact(assets_tests).step);
 
     // Issue #461 regression guard: the asset pipeline must compile
@@ -105,13 +124,14 @@ pub fn build(b: *std.Build) void {
     // regression at `zig build test` time (the step it's wired to) —
     // no runtime needed because the point is the type-checker
     // reaching `std.Thread.spawn`.
-    const assets_single_threaded = b.addTest(.{
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("src/assets/mod.zig"),
-            .target = target,
-            .optimize = optimize,
-            .single_threaded = true,
-        }),
+    const assets_single_threaded_module = b.createModule(.{
+        .root_source_file = b.path("src/assets/mod.zig"),
+        .target = target,
+        .optimize = optimize,
+        .single_threaded = true,
     });
+    assets_single_threaded_module.addImport("audio_types", audio_types_module);
+    assets_single_threaded_module.addImport("font_types", font_types_module);
+    const assets_single_threaded = b.addTest(.{ .root_module = assets_single_threaded_module });
     test_step.dependOn(&assets_single_threaded.step);
 }

--- a/src/assets/catalog.zig
+++ b/src/assets/catalog.zig
@@ -204,6 +204,7 @@ pub const AssetCatalog = struct {
             .loader_kind = loader_kind,
             .raw_bytes = bytes,
             .file_type = file_type,
+            .params = null,
             .decoded = null,
             .resource = null,
             .last_error = null,
@@ -242,6 +243,7 @@ pub const AssetCatalog = struct {
                 .vtable = entry.loader,
                 .file_type = entry.file_type,
                 .bytes = entry.raw_bytes,
+                .params = entry.params,
             };
             // Round-robin across the worker pool so decode load is
             // spread. If the picked ring is full (shouldn't happen in

--- a/src/assets/loader.zig
+++ b/src/assets/loader.zig
@@ -133,9 +133,16 @@ pub const AssetLoaderVTable = struct {
     /// Worker-thread CPU decode. Allocator-owned output stored on the
     /// resulting `WorkResult.decoded`. May return error → result.err
     /// is set and the entry transitions to `.failed` in `pump()`.
+    ///
+    /// `params` is the loader-specific decode parameter pointer
+    /// forwarded from `WorkRequest.params`. The concrete loader
+    /// `@ptrCast`s it to its own params type (e.g. the font loader
+    /// reads `*const FontBakeParams`). `null` for loaders that don't
+    /// take parameters (image, audio today).
     decode: *const fn (
         file_type: [:0]const u8,
         data: []const u8,
+        params: ?*const anyopaque,
         allocator: Allocator,
     ) anyerror!DecodedPayload,
 

--- a/src/assets/loader.zig
+++ b/src/assets/loader.zig
@@ -32,6 +32,9 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
+const audio_types = @import("audio_types");
+const font_types = @import("font_types");
+
 /// Discriminator for `DecodedPayload` and for selecting a loader at
 /// `AssetCatalog.register` time. Stored on the entry; callers do not
 /// need to namespace asset names per loader.
@@ -45,27 +48,42 @@ pub const Texture = u32;
 
 /// Worker-thread output. Variants are populated on the worker, then
 /// either uploaded (success path) or dropped (refcount-zero discard
-/// path) on the main thread. Real payload shapes for `audio` and
-/// `font` arrive in Phase 4 — they are placeholders for now.
+/// path) on the main thread. Audio and font variants land in Phase 4
+/// (#447 / #448 RFCs); the loader implementations behind them stay
+/// stubbed until those PRs ship.
 pub const DecodedPayload = union(LoaderKind) {
     image: struct {
         pixels: []u8, // RGBA8, allocator-owned
         width: u32,
         height: u32,
     },
-    audio: struct {}, // placeholder for Phase 4 (#441)
-    font: struct {}, // placeholder for Phase 4 (#441)
+    audio: struct {
+        samples: []i16, // interleaved PCM, allocator-owned
+        sample_rate: u32,
+        channels: u8,
+    },
+    font: struct {
+        bitmap: []u8, // 8-bit alpha atlas, allocator-owned
+        width: u32,
+        height: u32,
+        glyphs: []font_types.Glyph,
+        codepoint_index: []const font_types.CodepointEntry,
+        ascent: f32,
+        descent: f32, // negative (below baseline)
+        line_gap: f32,
+        line_height: f32, // precomputed: ascent - descent + line_gap
+        kerning: []const font_types.KernPair,
+    },
 };
 
 /// Main-thread "after upload" payload. Populated by `loader.upload`
 /// once the CPU-side `DecodedPayload` has been handed to the backend
 /// (GPU for images, audio device for sounds, atlas for fonts). Cleared
-/// by `loader.free` on the unload path (#446). The `audio` and `font`
-/// variants are placeholders until #441.
+/// by `loader.free` on the unload path (#446).
 pub const UploadedResource = union(LoaderKind) {
     image: Texture,
-    audio: struct {}, // placeholder for Phase 4 (#441)
-    font: struct {}, // placeholder for Phase 4 (#441)
+    audio: audio_types.SoundId,
+    font: font_types.FontId,
 };
 
 /// Lifecycle of a single entry.
@@ -86,6 +104,13 @@ pub const AssetEntry = struct {
     raw_bytes: []const u8,
     /// Borrowed sentinel-terminated string — program lifetime.
     file_type: [:0]const u8,
+    /// Loader-specific decode parameters, borrowed at registration
+    /// time. Forwarded into `WorkRequest.params` so the worker can
+    /// hand it back to `loader.decode` via the concrete loader's cast.
+    /// `null` for loaders that don't take params (image, audio).
+    /// Currently exercised only by the font loader's `FontBakeParams`
+    /// (RFC-FONT-LOADER §7).
+    params: ?*const anyopaque,
     /// Populated by the worker's decode path and consumed by
     /// `loader.upload`. Cleared back to `null` by `pump()` (#442) once
     /// the upload has moved ownership into `resource`, or by

--- a/src/assets/loaders/audio.zig
+++ b/src/assets/loaders/audio.zig
@@ -15,10 +15,12 @@ const AssetEntry = loader.AssetEntry;
 fn decode(
     file_type: [:0]const u8,
     data: []const u8,
+    params: ?*const anyopaque,
     allocator: Allocator,
 ) anyerror!DecodedPayload {
     _ = file_type;
     _ = data;
+    _ = params;
     _ = allocator;
     return error.NotImplemented;
 }

--- a/src/assets/loaders/font.zig
+++ b/src/assets/loaders/font.zig
@@ -15,10 +15,12 @@ const AssetEntry = loader.AssetEntry;
 fn decode(
     file_type: [:0]const u8,
     data: []const u8,
+    params: ?*const anyopaque,
     allocator: Allocator,
 ) anyerror!DecodedPayload {
     _ = file_type;
     _ = data;
+    _ = params;
     _ = allocator;
     return error.NotImplemented;
 }

--- a/src/assets/loaders/image.zig
+++ b/src/assets/loaders/image.zig
@@ -125,8 +125,10 @@ pub fn currentBackend() ?ImageBackend {
 fn decode(
     file_type: [:0]const u8,
     data: []const u8,
+    params: ?*const anyopaque,
     allocator: Allocator,
 ) anyerror!DecodedPayload {
+    _ = params; // image loader doesn't take params
     const b = backend orelse return error.ImageBackendNotInitialized;
     const decoded = try b.decode(file_type, data, allocator);
     return .{ .image = .{
@@ -276,7 +278,7 @@ test "image loader: decode without backend errors cleanly" {
     defer clearBackend();
     try testing.expectError(
         error.ImageBackendNotInitialized,
-        decode("png", "fake", testing.allocator),
+        decode("png", "fake", null, testing.allocator),
     );
 }
 
@@ -286,7 +288,7 @@ test "image loader: mock backend decode→upload→free round-trip" {
     defer clearBackend();
 
     // 1. decode on the worker thread (synchronously in the test).
-    const payload = try decode("png", "fake-png-bytes", testing.allocator);
+    const payload = try decode("png", "fake-png-bytes", null, testing.allocator);
     try testing.expectEqual(@as(u32, 1), MockBackend.decode_calls);
     try testing.expectEqual(@as(u32, 2), payload.image.width);
     try testing.expectEqual(@as(u32, 2), payload.image.height);
@@ -334,7 +336,7 @@ test "image loader: drop path frees pixels without touching GPU" {
     // Simulate a decode landing on the result ring but the refcount
     // dropping back to zero before pump() can finalise — the catalog
     // routes the payload straight to `drop`.
-    const payload = try decode("png", "fake", testing.allocator);
+    const payload = try decode("png", "fake", null, testing.allocator);
     drop(testing.allocator, payload);
 
     try testing.expectEqual(@as(u32, 0), MockBackend.upload_calls);
@@ -347,7 +349,7 @@ test "image loader: upload error leaves pixels alive for drop cleanup" {
     MockBackend.upload_fails = true;
     defer clearBackend();
 
-    const payload = try decode("png", "fake", testing.allocator);
+    const payload = try decode("png", "fake", null, testing.allocator);
     var entry: AssetEntry = .{
         .state = .decoding,
         .refcount = 1,
@@ -394,7 +396,7 @@ test "image loader: decode propagates backend errors" {
 
     try testing.expectError(
         error.MockDecodeError,
-        decode("png", "fake", testing.allocator),
+        decode("png", "fake", null, testing.allocator),
     );
     try testing.expectEqual(@as(u32, 1), MockBackend.decode_calls);
 }

--- a/src/assets/loaders/image.zig
+++ b/src/assets/loaders/image.zig
@@ -304,6 +304,7 @@ test "image loader: mock backend decode→upload→free round-trip" {
         .file_type = "png",
         .decoded = payload,
         .resource = null,
+        .params = null,
         .last_error = null,
     };
     try upload(&entry, payload, testing.allocator);
@@ -356,6 +357,7 @@ test "image loader: upload error leaves pixels alive for drop cleanup" {
         .file_type = "png",
         .decoded = payload,
         .resource = null,
+        .params = null,
         .last_error = null,
     };
     try testing.expectError(error.MockUploadError, upload(&entry, payload, testing.allocator));
@@ -377,6 +379,7 @@ test "image loader: free without a backend or resource is a no-op" {
         .file_type = "png",
         .decoded = null,
         .resource = null,
+        .params = null,
         .last_error = null,
     };
     free(&entry);

--- a/src/assets/worker.zig
+++ b/src/assets/worker.zig
@@ -49,11 +49,21 @@ pub const ring_capacity: u32 = 64;
 /// `entry_name`, `file_type` and `bytes` all live for the program's
 /// entire lifetime (see the `@embedFile` invariant on the catalog),
 /// so the worker can read them without touching the catalog.
+///
+/// `params` is a loader-specific input that some decoders need
+/// alongside the raw bytes (e.g. fonts need pixel height + glyph
+/// ranges to bake an atlas — see RFC-FONT-LOADER §7). Type-erased so
+/// `WorkRequest` itself stays loader-agnostic; the concrete loader
+/// casts to its own params struct. Lifetime matches `bytes`: the
+/// catalog stores the params alongside the entry and the pointer
+/// stays valid until the entry is removed. `null` for loaders that
+/// don't need parameters (image, audio).
 pub const WorkRequest = struct {
     entry_name: []const u8,
     vtable: *const AssetLoaderVTable,
     file_type: [:0]const u8,
     bytes: []const u8,
+    params: ?*const anyopaque = null,
 };
 
 /// Worker → main message. Either `decoded` is set (success) or

--- a/src/assets/worker.zig
+++ b/src/assets/worker.zig
@@ -333,6 +333,7 @@ pub const AssetWorker = struct {
         const decoded_or_err = request.vtable.decode(
             request.file_type,
             request.bytes,
+            request.params,
             allocator,
         );
         return if (decoded_or_err) |decoded|

--- a/src/audio.zig
+++ b/src/audio.zig
@@ -4,7 +4,7 @@ pub const AudioInterface = core.AudioInterface;
 pub const StubAudio = core.StubAudio;
 
 // Engine-owned audio types (backend-agnostic)
-pub const audio_types = @import("audio_types.zig");
+pub const audio_types = @import("audio_types");
 pub const SoundId = audio_types.SoundId;
 pub const MusicId = audio_types.MusicId;
 pub const AudioError = audio_types.AudioError;

--- a/src/font_types.zig
+++ b/src/font_types.zig
@@ -1,0 +1,54 @@
+//! Font Types
+//!
+//! Shared types for the font system, used across all backends and the
+//! asset catalog. Backend-agnostic — actual atlas baking and glyph
+//! rasterising is delegated to a `FontBackend` hook injected by the
+//! assembler at `Game.init`, mirroring `AudioBackend` and `ImageBackend`.
+
+/// Opaque handle for a loaded font (baked glyph atlas + metrics).
+/// Same shape as `audio_types.SoundId` — generation-tagged so the
+/// runtime can detect use-after-free against a stale handle.
+pub const FontId = struct {
+    index: u16,
+    generation: u16,
+
+    pub const invalid: FontId = .{ .index = 0, .generation = 0 };
+
+    pub fn isValid(self: FontId) bool {
+        return self.generation != 0;
+    }
+};
+
+/// One baked glyph. UV rect is in *pixels* of the atlas (not
+/// normalised) so the renderer can divide by atlas size once at
+/// upload time. `xoff` / `yoff` are pen-relative blit offsets that
+/// already incorporate the glyph's bearing — the renderer just adds
+/// them to the pen position. `advance` moves the pen for the next
+/// glyph. See `RFC-FONT-LOADER.md` §3.
+pub const Glyph = struct {
+    u0: u16,
+    v0: u16,
+    u1: u16,
+    v1: u16,
+
+    xoff: f32,
+    yoff: f32,
+    advance: f32,
+};
+
+/// Sorted (by `codepoint`) lookup from Unicode codepoint to dense
+/// index in the `glyphs` array. Renderers binary-search this per
+/// glyph. Built from `FontBakeParams.ranges` at bake time.
+pub const CodepointEntry = struct {
+    codepoint: u32,
+    glyph_index: u32,
+};
+
+/// One GPOS kern pair. `advance` is added to the pen advance when
+/// `first` is followed by `second`. Empty slice when kerning is
+/// disabled or the font has no GPOS kern table.
+pub const KernPair = struct {
+    first: u32,
+    second: u32,
+    advance: f32,
+};

--- a/src/root.zig
+++ b/src/root.zig
@@ -7,6 +7,7 @@ pub const game_mod = @import("game.zig");
 pub const game_log_mod = @import("game_log.zig");
 pub const input_mod = @import("input.zig");
 pub const audio_mod = @import("audio.zig");
+pub const font_types_mod = @import("font_types");
 pub const gui_mod = @import("gui.zig");
 pub const gui_runtime_state_mod = @import("gui_runtime_state.zig");
 pub const form_binder_mod = @import("form_binder.zig");
@@ -63,6 +64,12 @@ pub const StubAudio = audio_mod.StubAudio;
 pub const SoundId = audio_mod.SoundId;
 pub const MusicId = audio_mod.MusicId;
 pub const AudioError = audio_mod.AudioError;
+
+// ── Fonts ──
+pub const FontId = font_types_mod.FontId;
+pub const Glyph = font_types_mod.Glyph;
+pub const CodepointEntry = font_types_mod.CodepointEntry;
+pub const KernPair = font_types_mod.KernPair;
 
 // ── GUI ──
 pub const GuiInterface = gui_mod.GuiInterface;

--- a/test/font_types_test.zig
+++ b/test/font_types_test.zig
@@ -1,0 +1,21 @@
+const std = @import("std");
+const engine = @import("engine");
+
+test "FontId.invalid fails isValid" {
+    const id = engine.FontId.invalid;
+    try std.testing.expect(!id.isValid());
+}
+
+test "FontId with non-zero generation is valid" {
+    const id: engine.FontId = .{ .index = 0, .generation = 1 };
+    try std.testing.expect(id.isValid());
+}
+
+test "Glyph / CodepointEntry / KernPair sizes are stable PODs" {
+    // Lock the wire shape so the worker → main payload doesn't grow
+    // accidental padding. If a field is added intentionally, update
+    // this test alongside loader.zig's DecodedPayload.font.
+    try std.testing.expectEqual(@as(usize, 20), @sizeOf(engine.Glyph));
+    try std.testing.expectEqual(@as(usize, 8), @sizeOf(engine.CodepointEntry));
+    try std.testing.expectEqual(@as(usize, 12), @sizeOf(engine.KernPair));
+}


### PR DESCRIPTION
## Summary

- Fills in the `audio:` + `font:` variants of `DecodedPayload` / `UploadedResource` in `src/assets/loader.zig` so the audio loader ([#447](https://github.com/labelle-toolkit/labelle-engine/issues/447)) and font loader ([#448](https://github.com/labelle-toolkit/labelle-engine/issues/448)) implementation PRs can land in parallel without colliding on this file. No loader logic changes — the stubs in `loaders/audio.zig` and `loaders/font.zig` still return `error.NotImplemented`; this PR is type plumbing only.
- Adds `src/font_types.zig` with `FontId` / `Glyph` / `CodepointEntry` / `KernPair`, mirroring the `audio_types.zig` shape. Re-exported via `root.zig`. Exercised by `test/font_types_test.zig` (size-stability locks + handle-validity round-trip).
- Adds `WorkRequest.params` and `AssetEntry.params` as type-erased `?*const anyopaque` so loaders that need decode-time parameters can ride the existing worker pipeline. Image and audio register-sites pass `null`; fonts wire this up in the font-loader PR per [RFC-FONT-LOADER §7](https://github.com/labelle-toolkit/labelle-engine/pull/524).
- Module plumbing: `audio_types` and `font_types` promoted to named modules so the same import resolves identically from both the engine module root (`src/root.zig`) and the standalone assets-tests root (`src/assets/mod.zig`).

Unblocks parallel work on [#463](https://github.com/labelle-toolkit/labelle-engine/pull/463) (audio loader RFC) and [#524](https://github.com/labelle-toolkit/labelle-engine/pull/524) (font loader RFC) implementations. Should merge before either implementation PR.

## Test plan

- [x] `zig build test` — 350/350 passing (3 new in `font_types_test.zig`).
- [ ] Confirm the `WorkRequest.params` lifetime contract reads right (borrowed at register time, lives as long as the entry).
- [ ] Sanity-check that the named-module promotion of `audio_types` / `font_types` doesn't break any downstream consumer that imports them by path (`src/audio.zig` and `src/root.zig` updated; no other path imports found).