### PR TITLE
feat(assets): real audio loader vtable — Phase 4 (#447)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -60,6 +60,7 @@ pub fn build(b: *std.Build) void {
         "test/jsonc/nested_lifecycle_test.zig",
         "test/scene_ref_test.zig",
         "test/asset_catalog_test.zig",
+        "test/audio_loader_test.zig",
         "test/font_types_test.zig",
         "test/asset_streaming_shim_test.zig",
         "test/animation_def_test.zig",

--- a/src/assets/loaders/audio.zig
+++ b/src/assets/loaders/audio.zig
@@ -1,16 +1,118 @@
-//! Placeholder audio loader vtable.
+//! Audio loader — CPU-decode on the worker, audio-device upload on the
+//! main thread, backed by a runtime-injected `AudioBackend`.
 //!
-//! Stub identical in shape to `loaders/image.zig`. Real `decodeAudio`
-//! / `uploadAudio` arrives in ticket #441 (Phase 4 of the RFC).
+//! Structural twin of `loaders/image.zig`. Read that file's preamble
+//! for the full rationale on why this module exposes a runtime hook
+//! struct instead of importing an audio backend directly — the same
+//! dependency-boundary argument applies here. The engine crate does
+//! not depend on raylib-audio, sokol-audio, or any other concrete
+//! audio backend; the assembler injects adapters at `Game.init` time
+//! via `setBackend`.
+//!
+//! ## Threading
+//!
+//! * `decode` runs on the asset worker thread. It calls
+//!   `backend.decode(file_type, data, allocator)` — single-header
+//!   decoders (`dr_wav`, `stb_vorbis`) on the backend side are pure
+//!   CPU, no device calls, so that is safe.
+//! * `upload`, `drop`, `free` all run on the main thread from
+//!   `AssetCatalog.pump()` / `AssetCatalog.deinit()` / the unload path.
+//!   `upload` and `free` call back into the backend on the main thread
+//!   for audio-device operations.
+//!
+//! ## Ownership of `DecodedAudio.samples`
+//!
+//! * `decode` allocates the sample buffer through the provided
+//!   allocator — same allocator the worker hands in, same allocator
+//!   that later frees the buffer.
+//! * `upload` calls `backend.upload` (which **copies** the samples to
+//!   the audio device) and then frees the CPU buffer via `allocator`.
+//!   The backend contract says `upload` does NOT take ownership.
+//! * `drop` is the refcount-zero-during-decode path: free the CPU
+//!   buffer, leave the device alone.
+//! * `free` is the refcount-zero-on-ready path: release the
+//!   `SoundId` through `backend.unload`; the CPU buffer is already gone.
+//!
+//! ## Why `audio_types.SoundId` instead of a loader-local handle?
+//!
+//! The engine already has `audio_types.SoundId` — a `{ index, generation }`
+//! struct with `isValid` + generation-based staleness detection, used
+//! across the runtime audio interface in `src/audio.zig`. Minting a
+//! second handle type here would split the sound-handle vocabulary in
+//! two. The backend builds a `SoundId` from whatever raw integer the
+//! native audio device hands back; the catalog and the rest of the
+//! engine only ever see the shared struct.
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+
+const audio_types = @import("audio_types");
 
 const loader = @import("../loader.zig");
 
 const AssetLoaderVTable = loader.AssetLoaderVTable;
 const DecodedPayload = loader.DecodedPayload;
+const UploadedResource = loader.UploadedResource;
 const AssetEntry = loader.AssetEntry;
+
+/// CPU-side decoded interleaved 16-bit PCM, allocator-owned. Kept
+/// intentionally plain so the backend adapter can bridge it to
+/// whatever `DecodedAudio` shape the native single-header decoders
+/// produce on its side of the dependency boundary without a
+/// nominal-type conflict. See RFC §2 for sample-format rationale.
+pub const DecodedAudio = struct {
+    samples: []i16, // interleaved signed 16-bit PCM, allocator-owned
+    sample_rate: u32, // 22050, 44100, 48000, …
+    channels: u8, // 1 = mono, 2 = stereo
+};
+
+/// Runtime backend hook. The assembler fills this in at `Game.init`
+/// by calling `setBackend` with adapters that forward to e.g.
+/// raylib-audio's `LoadSoundFromWave` / `UnloadSound` (via the
+/// backend's `dr_wav` / `stb_vorbis` decoders). Tests inject a mock
+/// the same way — see `test/audio_loader_test.zig`.
+pub const AudioBackend = struct {
+    /// Worker-thread CPU decode. Returns a `DecodedAudio` whose
+    /// `samples` slice is owned by `allocator`. Errors bubble to
+    /// `WorkResult.err`.
+    decode: *const fn (
+        file_type: [:0]const u8,
+        data: []const u8,
+        allocator: Allocator,
+    ) anyerror!DecodedAudio,
+
+    /// Main-thread audio-device upload. Copies samples to a new
+    /// device-side buffer and returns the `SoundId`. Does NOT take
+    /// ownership of `decoded.samples` — the caller frees.
+    upload: *const fn (decoded: DecodedAudio) anyerror!audio_types.SoundId,
+
+    /// Main-thread audio-device release. The counterpart to `upload`.
+    unload: *const fn (sound: audio_types.SoundId) void,
+};
+
+/// Private module-level slot for the injected backend. `null` until
+/// the assembler calls `setBackend` — backends that have not wired the
+/// hook yet surface as `error.AudioBackendNotInitialized` rather than a
+/// null deref. Identical pattern to `loaders/image.zig`.
+var active_backend: ?AudioBackend = null;
+
+/// Install the runtime backend. Call exactly once during game init,
+/// before any audio asset is acquired. Idempotent for tests: the
+/// second call just overwrites the slot.
+pub fn setBackend(b: AudioBackend) void {
+    active_backend = b;
+}
+
+/// Clear the backend slot. Used by tests to return to a clean state
+/// between runs so one test's mock does not leak into the next.
+pub fn clearBackend() void {
+    active_backend = null;
+}
+
+/// Read-side accessor for tests / diagnostics.
+pub fn currentBackend() ?AudioBackend {
+    return active_backend;
+}
 
 fn decode(
     file_type: [:0]const u8,
@@ -18,27 +120,69 @@ fn decode(
     params: ?*const anyopaque,
     allocator: Allocator,
 ) anyerror!DecodedPayload {
-    _ = file_type;
-    _ = data;
-    _ = params;
-    _ = allocator;
-    return error.NotImplemented;
+    _ = params; // audio loader doesn't take decode params
+    const b = active_backend orelse return error.AudioBackendNotInitialized;
+    const decoded = try b.decode(file_type, data, allocator);
+    return .{ .audio = .{
+        .samples = decoded.samples,
+        .sample_rate = decoded.sample_rate,
+        .channels = decoded.channels,
+    } };
 }
 
-fn upload(entry: *AssetEntry, decoded: DecodedPayload, allocator: Allocator) anyerror!void {
-    _ = entry;
-    _ = decoded;
-    _ = allocator;
-    return error.NotImplemented;
+fn upload(
+    entry: *AssetEntry,
+    decoded_payload: DecodedPayload,
+    allocator: Allocator,
+) anyerror!void {
+    const b = active_backend orelse return error.AudioBackendNotInitialized;
+    const audio = switch (decoded_payload) {
+        .audio => |a| a,
+        else => return error.WrongDecodedPayloadKind,
+    };
+
+    // Hand the samples to the audio device first — if this errors we
+    // still want the CPU buffer freed by `drop` on the teardown path,
+    // so leave it alive here and let the error propagate.
+    const sound = try b.upload(.{
+        .samples = audio.samples,
+        .sample_rate = audio.sample_rate,
+        .channels = audio.channels,
+    });
+
+    // Upload succeeded: the device has its own copy, so we can release
+    // the allocator-owned CPU buffer now. The backend contract says
+    // `upload` does NOT take ownership of `samples`.
+    allocator.free(audio.samples);
+
+    entry.resource = .{ .audio = sound };
 }
 
-fn drop(allocator: Allocator, decoded: DecodedPayload) void {
-    _ = allocator;
-    _ = decoded;
+fn drop(allocator: Allocator, decoded_payload: DecodedPayload) void {
+    switch (decoded_payload) {
+        .audio => |a| allocator.free(a.samples),
+        // Other variants never reach the audio loader's drop hook —
+        // the catalog dispatches on the vtable carried by the
+        // `WorkResult`, not on `DecodedPayload`'s tag. Keep the arms
+        // exhaustive so this file compiles cleanly against future
+        // payload shapes.
+        else => {},
+    }
 }
 
 fn free(entry: *AssetEntry) void {
-    _ = entry;
+    const resource = entry.resource orelse return;
+    // Release the device-side handle if a backend is installed. If
+    // the backend was cleared (e.g. a test's `clearBackend`) after an
+    // asset uploaded, we can't reach the device — skip the `unload`
+    // call but STILL clear `entry.resource` so callers that check
+    // `entry.resource != null` as a cleanup-completed flag get the
+    // contract `loader.zig` documents. Mirrors `image.zig::free`.
+    if (active_backend) |b| switch (resource) {
+        .audio => |sound| b.unload(sound),
+        else => {},
+    };
+    entry.resource = null;
 }
 
 pub const vtable: AssetLoaderVTable = .{

--- a/src/assets/mod.zig
+++ b/src/assets/mod.zig
@@ -30,6 +30,13 @@ pub const WorkResult = worker_mod.WorkResult;
 /// mock backend via `engine.ImageLoader.setBackend`.
 pub const image_loader = @import("loaders/image.zig");
 
+/// Re-exported so the assembler-generated `main.zig` can call
+/// `setBackend` with adapters that forward to the chosen audio
+/// backend (raylib-audio, sokol-audio, …) via `dr_wav` / `stb_vorbis`.
+/// Tests inject a mock via `engine.AudioLoader.setBackend`. See
+/// `src/assets/loaders/audio.zig` for the full rationale.
+pub const audio_loader = @import("loaders/audio.zig");
+
 test {
     // Pull every file in the module tree into the test binary. The
     // `zig build test` step rooted at this file (see `build.zig`'s

--- a/src/root.zig
+++ b/src/root.zig
@@ -64,6 +64,14 @@ pub const StubAudio = audio_mod.StubAudio;
 pub const SoundId = audio_mod.SoundId;
 pub const MusicId = audio_mod.MusicId;
 pub const AudioError = audio_mod.AudioError;
+/// Runtime backend hook for the audio asset loader. The assembler
+/// populates this at `Game.init` via `AudioLoader.setBackend(...)`
+/// with adapters that forward to the chosen audio backend's
+/// `decode` (dr_wav / stb_vorbis) / `upload` / `unload` calls. See
+/// `src/assets/loaders/audio.zig` for the full rationale.
+pub const AudioLoader = assets_mod.audio_loader;
+pub const AudioBackend = assets_mod.audio_loader.AudioBackend;
+pub const DecodedAudio = assets_mod.audio_loader.DecodedAudio;
 
 // ── Fonts ──
 pub const FontId = font_types_mod.FontId;

--- a/test/audio_loader_test.zig
+++ b/test/audio_loader_test.zig
@@ -1,0 +1,278 @@
+//! Unit tests for the audio asset loader (RFC-AUDIO-LOADER §7).
+//!
+//! Mirrors the in-source mock-backend test pattern from
+//! `src/assets/loaders/image.zig` — round-trip through the loader
+//! vtable with an injected `AudioBackend` that records every call and
+//! returns a sentinel `SoundId`. No real WAV / OGG bytes here; the
+//! decode is mocked. Real-decoder coverage lives backend-side
+//! (raylib-audio, sokol-audio) per the RFC migration plan.
+//!
+//! Tests live in `test/*.zig` rather than as inline `test {}` blocks
+//! in `src/` per the engine's CLAUDE.md convention — `build.zig`'s
+//! per-test-file `addTest` chain runs each file as its own binary.
+
+const std = @import("std");
+const testing = std.testing;
+
+const engine = @import("engine");
+
+const AudioLoader = engine.AudioLoader;
+const AudioBackend = engine.AudioBackend;
+const DecodedAudio = engine.DecodedAudio;
+const SoundId = engine.SoundId;
+const AssetEntry = engine.AssetEntry;
+const DecodedPayload = engine.DecodedPayload;
+const UploadedResource = engine.UploadedResource;
+
+// Sentinel handle the mock returns from `upload`. Generation must be
+// non-zero so `SoundId.isValid()` is true — that's what differentiates
+// a real handle from `SoundId.invalid` in the runtime audio path.
+const sentinel_sound: SoundId = .{ .index = 42, .generation = 7 };
+
+/// Mock backend that records every call. `decodeFn` allocates a fixed
+/// sample buffer through the caller's allocator so we can exercise
+/// both the happy path (upload frees) and the discard path (drop
+/// frees) under `testing.allocator` — a GPA that flags leaks and
+/// double-frees.
+const MockBackend = struct {
+    var decode_calls: u32 = 0;
+    var upload_calls: u32 = 0;
+    var unload_calls: u32 = 0;
+    var last_uploaded: ?DecodedAudio = null;
+    var last_unloaded: SoundId = SoundId.invalid;
+    var decode_fails: bool = false;
+    var upload_fails: bool = false;
+
+    // Fixed shape — interleaved stereo, 4 frames = 8 samples. Sample
+    // values are recognisable so an over-zealous backend that
+    // truncates or reorders gets caught.
+    const sample_count: usize = 8;
+    const sample_rate: u32 = 44100;
+    const channels: u8 = 2;
+    const fill_value: i16 = 0x1234;
+
+    fn reset() void {
+        decode_calls = 0;
+        upload_calls = 0;
+        unload_calls = 0;
+        last_uploaded = null;
+        last_unloaded = SoundId.invalid;
+        decode_fails = false;
+        upload_fails = false;
+    }
+
+    fn decodeFn(
+        file_type: [:0]const u8,
+        data: []const u8,
+        allocator: std.mem.Allocator,
+    ) anyerror!DecodedAudio {
+        _ = file_type;
+        _ = data;
+        decode_calls += 1;
+        if (decode_fails) return error.MockDecodeError;
+        const samples = try allocator.alloc(i16, sample_count);
+        // Fill with a recognisable value so the upload mock can
+        // assert it received the same bytes the decode produced.
+        @memset(samples, fill_value);
+        return .{
+            .samples = samples,
+            .sample_rate = sample_rate,
+            .channels = channels,
+        };
+    }
+
+    fn uploadFn(decoded: DecodedAudio) anyerror!SoundId {
+        upload_calls += 1;
+        if (upload_fails) return error.MockUploadError;
+        last_uploaded = decoded;
+        return sentinel_sound;
+    }
+
+    fn unloadFn(sound: SoundId) void {
+        unload_calls += 1;
+        last_unloaded = sound;
+    }
+
+    const backend_value: AudioBackend = .{
+        .decode = decodeFn,
+        .upload = uploadFn,
+        .unload = unloadFn,
+    };
+};
+
+test "audio loader: decode without backend errors cleanly" {
+    AudioLoader.clearBackend();
+    defer AudioLoader.clearBackend();
+    try testing.expectError(
+        error.AudioBackendNotInitialized,
+        AudioLoader.vtable.decode("wav", "fake", null, testing.allocator),
+    );
+}
+
+test "audio loader: mock backend decode → upload → free round-trip" {
+    MockBackend.reset();
+    AudioLoader.setBackend(MockBackend.backend_value);
+    defer AudioLoader.clearBackend();
+
+    // 1. decode on the worker thread (synchronous in the test).
+    const payload = try AudioLoader.vtable.decode("wav", "fake-wav-bytes", null, testing.allocator);
+    try testing.expectEqual(@as(u32, 1), MockBackend.decode_calls);
+    try testing.expectEqual(MockBackend.sample_rate, payload.audio.sample_rate);
+    try testing.expectEqual(MockBackend.channels, payload.audio.channels);
+    try testing.expectEqual(MockBackend.sample_count, payload.audio.samples.len);
+    try testing.expectEqual(MockBackend.fill_value, payload.audio.samples[0]);
+
+    // 2. upload on the main thread. The loader owns the free of the
+    //    CPU-side samples after a successful upload.
+    var entry: AssetEntry = .{
+        .state = .decoding,
+        .refcount = 1,
+        .loader = &AudioLoader.vtable,
+        .loader_kind = .audio,
+        .raw_bytes = "fake-wav-bytes",
+        .file_type = "wav",
+        .decoded = payload,
+        .resource = null,
+        .params = null,
+        .last_error = null,
+    };
+    try AudioLoader.vtable.upload(&entry, payload, testing.allocator);
+    try testing.expectEqual(@as(u32, 1), MockBackend.upload_calls);
+    try testing.expect(entry.resource != null);
+    const got: SoundId = entry.resource.?.audio;
+    try testing.expectEqual(sentinel_sound.index, got.index);
+    try testing.expectEqual(sentinel_sound.generation, got.generation);
+    try testing.expect(got.isValid());
+
+    // The upload mock recorded the same sample buffer the decode produced.
+    try testing.expect(MockBackend.last_uploaded != null);
+    try testing.expectEqual(MockBackend.sample_count, MockBackend.last_uploaded.?.samples.len);
+
+    // 3. free on the main thread — refcount hit zero on a `.ready`
+    //    entry. Releases the device handle through the backend, mirrors
+    //    what the catalog's #446 unload path will call.
+    AudioLoader.vtable.free(&entry);
+    try testing.expectEqual(@as(u32, 1), MockBackend.unload_calls);
+    try testing.expectEqual(sentinel_sound.index, MockBackend.last_unloaded.index);
+    try testing.expectEqual(sentinel_sound.generation, MockBackend.last_unloaded.generation);
+    try testing.expectEqual(@as(?UploadedResource, null), entry.resource);
+
+    // `testing.allocator` (a GPA under the hood) would flag a leak of
+    // the sample buffer here if upload had failed to free it, or a
+    // double-free if drop ran afterwards by mistake.
+}
+
+test "audio loader: drop path frees samples without touching device" {
+    MockBackend.reset();
+    AudioLoader.setBackend(MockBackend.backend_value);
+    defer AudioLoader.clearBackend();
+
+    // Simulate a decode landing on the result ring but the refcount
+    // dropping back to zero before pump() can finalise — the catalog
+    // routes the payload straight to `drop`.
+    const payload = try AudioLoader.vtable.decode("wav", "fake", null, testing.allocator);
+    AudioLoader.vtable.drop(testing.allocator, payload);
+
+    try testing.expectEqual(@as(u32, 0), MockBackend.upload_calls);
+    try testing.expectEqual(@as(u32, 0), MockBackend.unload_calls);
+}
+
+test "audio loader: upload error leaves samples alive for drop cleanup" {
+    MockBackend.reset();
+    AudioLoader.setBackend(MockBackend.backend_value);
+    MockBackend.upload_fails = true;
+    defer AudioLoader.clearBackend();
+
+    const payload = try AudioLoader.vtable.decode("ogg", "fake", null, testing.allocator);
+    var entry: AssetEntry = .{
+        .state = .decoding,
+        .refcount = 1,
+        .loader = &AudioLoader.vtable,
+        .loader_kind = .audio,
+        .raw_bytes = "fake",
+        .file_type = "ogg",
+        .decoded = payload,
+        .resource = null,
+        .params = null,
+        .last_error = null,
+    };
+    try testing.expectError(
+        error.MockUploadError,
+        AudioLoader.vtable.upload(&entry, payload, testing.allocator),
+    );
+    try testing.expectEqual(@as(?UploadedResource, null), entry.resource);
+    // On the failure path, `upload` must NOT have freed the buffer —
+    // the catalog still needs to hand it to `drop`. Do that here to
+    // keep `testing.allocator` happy.
+    AudioLoader.vtable.drop(testing.allocator, payload);
+}
+
+test "audio loader: free without a backend or resource is a no-op" {
+    AudioLoader.clearBackend();
+    var entry: AssetEntry = .{
+        .state = .registered,
+        .refcount = 0,
+        .loader = &AudioLoader.vtable,
+        .loader_kind = .audio,
+        .raw_bytes = "",
+        .file_type = "wav",
+        .decoded = null,
+        .resource = null,
+        .params = null,
+        .last_error = null,
+    };
+    AudioLoader.vtable.free(&entry);
+    try testing.expectEqual(@as(?UploadedResource, null), entry.resource);
+}
+
+test "audio loader: free with cleared backend still nulls entry.resource" {
+    // Contract from `loader.zig`: callers that check
+    // `entry.resource != null` as a cleanup-completed flag must get
+    // null even when the backend was torn down mid-run. Matches the
+    // image loader's free behaviour exactly.
+    MockBackend.reset();
+    AudioLoader.setBackend(MockBackend.backend_value);
+
+    const payload = try AudioLoader.vtable.decode("wav", "fake", null, testing.allocator);
+    var entry: AssetEntry = .{
+        .state = .decoding,
+        .refcount = 1,
+        .loader = &AudioLoader.vtable,
+        .loader_kind = .audio,
+        .raw_bytes = "fake",
+        .file_type = "wav",
+        .decoded = payload,
+        .resource = null,
+        .params = null,
+        .last_error = null,
+    };
+    try AudioLoader.vtable.upload(&entry, payload, testing.allocator);
+    try testing.expect(entry.resource != null);
+
+    AudioLoader.clearBackend();
+    AudioLoader.vtable.free(&entry);
+    try testing.expectEqual(@as(u32, 0), MockBackend.unload_calls);
+    try testing.expectEqual(@as(?UploadedResource, null), entry.resource);
+}
+
+test "audio loader: decode propagates backend errors" {
+    MockBackend.reset();
+    AudioLoader.setBackend(MockBackend.backend_value);
+    MockBackend.decode_fails = true;
+    defer AudioLoader.clearBackend();
+
+    try testing.expectError(
+        error.MockDecodeError,
+        AudioLoader.vtable.decode("wav", "fake", null, testing.allocator),
+    );
+    try testing.expectEqual(@as(u32, 1), MockBackend.decode_calls);
+}
+
+test "audio loader: setBackend / clearBackend / currentBackend are wired" {
+    AudioLoader.clearBackend();
+    try testing.expectEqual(@as(?AudioBackend, null), AudioLoader.currentBackend());
+    AudioLoader.setBackend(MockBackend.backend_value);
+    try testing.expect(AudioLoader.currentBackend() != null);
+    AudioLoader.clearBackend();
+    try testing.expectEqual(@as(?AudioBackend, null), AudioLoader.currentBackend());
+}


### PR DESCRIPTION
## Summary

- Replace the three `error.NotImplemented` stubs in `src/assets/loaders/audio.zig` with a real vtable per RFC §5.
- Add `pub const AudioBackend = struct { decode, upload, unload }` per RFC §3 — runtime hook the assembler injects at `Game.init`, structural twin of `ImageBackend`.
- Reuse the existing `audio_types.SoundId` `{ index, generation }` handle for `UploadedResource.audio` (per the RFC reconciliation commit) — no new SoundId minted.
- `setBackend` / `clearBackend` / `currentBackend` on a module-level `active_backend: ?AudioBackend` slot, mirroring `image.zig`.
- `free` clears `entry.resource = null` unconditionally and only gates the `backend.unload` call on backend presence — matches the image-loader cleanup-completed-flag contract.

## Wiring

- `src/assets/mod.zig` — re-exports `audio_loader` (mirrors `image_loader`).
- `src/root.zig` — adds `AudioLoader` / `AudioBackend` / `DecodedAudio` under the existing `// ── Audio ──` section.
- `build.zig` — picks up `test/audio_loader_test.zig` in the `test_files` array, alphabetical with the other asset tests.

## Test plan

- [x] `zig build test` — green (all suites, including the new `audio_loader_test`).
- [x] 8 new tests in `test/audio_loader_test.zig`:
  - decode without backend → `AudioBackendNotInitialized`
  - decode → upload → free round-trip with a mock backend recording every call and returning a sentinel `SoundId`
  - drop path frees samples without touching the device
  - upload error leaves samples alive for drop cleanup (no leak under `testing.allocator`)
  - free with no backend / no resource is a no-op
  - free after `clearBackend` still nulls `entry.resource`
  - decode propagates backend errors verbatim
  - setBackend / clearBackend / currentBackend round-trip
- [x] Existing image / catalog / streaming tests untouched and still green.
- [ ] Real-decoder coverage (dr_wav, stb_vorbis) lands per the RFC migration plan: assembler-side codegen (Phase 4b), then one PR per backend adapter (raylib-audio, sokol-audio).

## Notes

- Base branch is `feat/asset-streaming-loader-payload-types` (PR #525), not `main` — the shared `DecodedPayload.audio` / `UploadedResource.audio` variants this PR fills come from there. Retarget to `main` after #525 merges.
- No changes to `src/assets/loader.zig`, `src/assets/catalog.zig`, `src/assets/worker.zig`, or anything font-related — out of scope.
- Per CLAUDE.md, tests live in `test/*.zig`, not inline `test {}` blocks in `src/`.

## References

- RFC: #463 (RFC-AUDIO-LOADER.md) — Phase 4 design doc.
- Shared payload types: #525 (parent branch).
- Tracking issue: #447.
- Reference impl mirrored: `src/assets/loaders/image.zig`.