### PR TITLE
feat(assets+gui): real font loader vtable + Label.font hookup — Phase 4 (#448)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -62,6 +62,7 @@ pub fn build(b: *std.Build) void {
         "test/asset_catalog_test.zig",
         "test/audio_loader_test.zig",
         "test/font_types_test.zig",
+        "test/font_loader_test.zig",
         "test/asset_streaming_shim_test.zig",
         "test/animation_def_test.zig",
         "test/sprite_animation_test.zig",

--- a/src/assets/catalog.zig
+++ b/src/assets/catalog.zig
@@ -196,6 +196,23 @@ pub const AssetCatalog = struct {
         file_type: [:0]const u8,
         bytes: []const u8,
     ) !void {
+        return self.registerWithParams(name, loader_kind, file_type, bytes, null);
+    }
+
+    /// Metadata + decode-parameters registration. Same lifetime
+    /// contract as `register`: every borrowed slice (`name`,
+    /// `file_type`, `bytes`) AND the `params` pointer must outlive the
+    /// catalog entry. Used by `registerFont` to attach a
+    /// `*const FontBakeParams` so the worker can hand it to the font
+    /// loader's `decode` via `WorkRequest.params`.
+    pub fn registerWithParams(
+        self: *AssetCatalog,
+        name: []const u8,
+        loader_kind: LoaderKind,
+        file_type: [:0]const u8,
+        bytes: []const u8,
+        params: ?*const anyopaque,
+    ) !void {
         if (self.entries.contains(name)) return error.AssetAlreadyRegistered;
         try self.entries.put(name, .{
             .state = .registered,
@@ -204,11 +221,30 @@ pub const AssetCatalog = struct {
             .loader_kind = loader_kind,
             .raw_bytes = bytes,
             .file_type = file_type,
-            .params = null,
+            .params = params,
             .decoded = null,
             .resource = null,
             .last_error = null,
         });
+    }
+
+    /// Convenience wrapper for the font loader: registers under
+    /// `LoaderKind.font` and attaches the `FontBakeParams` pointer
+    /// the worker must forward into the loader's `decode`.
+    ///
+    /// `params` is borrowed (not copied) under the same `@embedFile`
+    /// lifetime contract that governs the other slices on the entry.
+    /// Pass a pointer to a `static const` or assembler-generated
+    /// global; tests use a function-local `var` whose address is
+    /// stable for the duration of the catalog.
+    pub fn registerFont(
+        self: *AssetCatalog,
+        name: []const u8,
+        file_type: [:0]const u8,
+        bytes: []const u8,
+        params: *const font_loader.FontBakeParams,
+    ) !void {
+        return self.registerWithParams(name, .font, file_type, bytes, @ptrCast(params));
     }
 
     /// Bumps the refcount and returns a pointer to the entry. The

--- a/src/assets/loaders/font.zig
+++ b/src/assets/loaders/font.zig
@@ -1,16 +1,146 @@
-//! Placeholder font loader vtable.
+//! Font loader — TTF/OTF bytes → glyph atlas + metrics on the worker,
+//! GPU/atlas upload on the main thread, backed by a runtime-injected
+//! `FontBackend`.
 //!
-//! Stub identical in shape to `loaders/image.zig`. Real `decodeFont`
-//! / glyph rasterise arrives in ticket #441 (Phase 4 of the RFC).
+//! Mirrors the shape of `loaders/image.zig`. See that file for the
+//! full architectural rationale around backend hooks vs. direct
+//! `labelle-gfx` imports — the same reasoning applies here.
+//!
+//! ## Decode parameters
+//!
+//! Unlike images and audio, the font decode path needs more than just
+//! the raw bytes: pixel height, atlas dimensions, and the codepoint
+//! ranges to bake into the glyph table. The catalog stores these as
+//! a `*const FontBakeParams` on `AssetEntry.params` at registration
+//! time; `AssetCatalog.acquire` forwards the pointer through
+//! `WorkRequest.params`; the worker hands it to `vtable.decode` which
+//! `@ptrCast`s back to `*const FontBakeParams` here. Lifetime: the
+//! params struct must outlive the catalog entry — typical usage has
+//! it living for the program (assembler-generated globals or static
+//! const in user code).
+//!
+//! ## Threading
+//!
+//! Same contract as the image loader:
+//! * `decode` runs on the asset worker thread. The backend is
+//!   expected to be pure CPU (stb_truetype baking).
+//! * `upload`, `drop`, `free` run on the main thread from
+//!   `AssetCatalog.pump()` / `AssetCatalog.deinit()` / the unload
+//!   path.
+//!
+//! ## Ownership of the four decoded slices
+//!
+//! `DecodedPayload.font` carries four allocator-owned slices —
+//! `bitmap`, `glyphs`, `codepoint_index`, `kerning`. The decode path
+//! allocates them through the worker's allocator. The main-thread
+//! `upload` calls `backend.upload`, which copies whatever it needs
+//! into its own structures, then `upload` frees all four slices.
+//! `drop` (refcount-zero-during-decode path) also frees all four
+//! without touching the backend. `free` (refcount-zero-on-ready
+//! path) hands the `FontId` back to `backend.unload` and clears
+//! `entry.resource`.
 
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
 const loader = @import("../loader.zig");
+const font_types = @import("font_types");
 
 const AssetLoaderVTable = loader.AssetLoaderVTable;
 const DecodedPayload = loader.DecodedPayload;
+const UploadedResource = loader.UploadedResource;
 const AssetEntry = loader.AssetEntry;
+
+/// Inclusive codepoint range (`first`..=`last`). Used by
+/// `FontBakeParams.ranges` to declare which glyphs to bake into the
+/// atlas. Kept here rather than in `font_types.zig` because it is a
+/// *bake-time* input, not a runtime font payload — `font_types.zig`
+/// is the on-resource shape consumed by the renderer.
+pub const CodepointRange = struct {
+    first: u32,
+    last: u32,
+};
+
+/// Decode parameters threaded from `AssetCatalog.register` through
+/// `WorkRequest.params` to the worker's call into `decode` below.
+/// Borrowed: lives for the program lifetime under the same
+/// `@embedFile`-style contract that `raw_bytes` follows on the entry.
+pub const FontBakeParams = struct {
+    /// Target glyph cap height in pixels. Same shape as
+    /// `stb_truetype`'s `stbtt_ScaleForPixelHeight`.
+    pixel_height: f32 = 16.0,
+    /// Codepoint ranges to bake. Empty means "ASCII printable
+    /// 0x20..0x7E"; backends should treat null/empty identically.
+    ranges: []const CodepointRange = &.{},
+    /// Atlas width in pixels. Power-of-two recommended for GPU sampling.
+    atlas_width: u32 = 512,
+    /// Atlas height in pixels. Power-of-two recommended for GPU sampling.
+    atlas_height: u32 = 512,
+};
+
+/// CPU-side decoded font payload — same shape as the `font` arm of
+/// `DecodedPayload` in `loader.zig`, kept here as a plain struct so
+/// the backend adapter has a stable nominal type to marshal into.
+pub const DecodedFont = struct {
+    bitmap: []u8,
+    width: u32,
+    height: u32,
+    glyphs: []font_types.Glyph,
+    codepoint_index: []const font_types.CodepointEntry,
+    ascent: f32,
+    descent: f32,
+    line_gap: f32,
+    line_height: f32,
+    kerning: []const font_types.KernPair,
+};
+
+/// Runtime backend hook. The assembler fills this in at `Game.init`
+/// with adapters that forward to labelle-gfx's font baker. Tests
+/// inject a mock the same way the image loader's tests do.
+pub const FontBackend = struct {
+    /// Worker-thread CPU bake. Returns a `DecodedFont` whose four
+    /// slices are owned by `allocator`. Errors bubble to
+    /// `WorkResult.err`.
+    decode: *const fn (
+        file_type: [:0]const u8,
+        data: []const u8,
+        params: FontBakeParams,
+        allocator: Allocator,
+    ) anyerror!DecodedFont,
+
+    /// Main-thread atlas upload. Copies the bitmap to a GPU texture
+    /// and stashes glyph/kerning tables wherever the backend keeps
+    /// them. Does NOT take ownership of any of the four slices on
+    /// `decoded` — the caller frees.
+    upload: *const fn (decoded: DecodedFont) anyerror!font_types.FontId,
+
+    /// Main-thread atlas release. The counterpart to `upload`.
+    unload: *const fn (id: font_types.FontId) void,
+};
+
+/// Private module-level slot for the injected backend. `null` until
+/// the assembler calls `setBackend` — accidental `decode` / `upload`
+/// before initialisation surfaces as
+/// `error.FontBackendNotInitialized` rather than a null deref.
+var active_backend: ?FontBackend = null;
+
+/// Install the runtime backend. Call exactly once during game init,
+/// before any font asset is acquired. Idempotent enough for tests:
+/// the second call just overwrites the slot.
+pub fn setBackend(b: FontBackend) void {
+    active_backend = b;
+}
+
+/// Clear the backend slot. Used by tests to return to a clean state
+/// between runs so one test's mock does not leak into the next.
+pub fn clearBackend() void {
+    active_backend = null;
+}
+
+/// Read-side accessor for tests / diagnostics.
+pub fn currentBackend() ?FontBackend {
+    return active_backend;
+}
 
 fn decode(
     file_type: [:0]const u8,
@@ -18,27 +148,98 @@ fn decode(
     params: ?*const anyopaque,
     allocator: Allocator,
 ) anyerror!DecodedPayload {
-    _ = file_type;
-    _ = data;
-    _ = params;
-    _ = allocator;
-    return error.NotImplemented;
+    const b = active_backend orelse return error.FontBackendNotInitialized;
+    // Bake params are mandatory for the font loader. Use a defaulted
+    // params struct if the catalog forgot to attach one — keeps the
+    // error path "no backend" vs. "no params" symmetric: a missing
+    // backend is a hard error, missing params is a hint that the
+    // caller used `register` instead of `registerFont`. We surface
+    // it as a distinct error so it shows up cleanly in `lastError`.
+    const params_ptr = params orelse return error.FontBakeParamsMissing;
+    const bake_params: *const FontBakeParams = @ptrCast(@alignCast(params_ptr));
+
+    const decoded = try b.decode(file_type, data, bake_params.*, allocator);
+    return .{ .font = .{
+        .bitmap = decoded.bitmap,
+        .width = decoded.width,
+        .height = decoded.height,
+        .glyphs = decoded.glyphs,
+        .codepoint_index = decoded.codepoint_index,
+        .ascent = decoded.ascent,
+        .descent = decoded.descent,
+        .line_gap = decoded.line_gap,
+        .line_height = decoded.line_height,
+        .kerning = decoded.kerning,
+    } };
 }
 
-fn upload(entry: *AssetEntry, decoded: DecodedPayload, allocator: Allocator) anyerror!void {
-    _ = entry;
-    _ = decoded;
-    _ = allocator;
-    return error.NotImplemented;
+fn upload(
+    entry: *AssetEntry,
+    decoded_payload: DecodedPayload,
+    allocator: Allocator,
+) anyerror!void {
+    const b = active_backend orelse return error.FontBackendNotInitialized;
+    const font_payload = switch (decoded_payload) {
+        .font => |f| f,
+        else => return error.WrongDecodedPayloadKind,
+    };
+
+    // Hand the bitmap + tables to the backend first — on error we
+    // want the four CPU buffers freed by `drop` on the teardown path,
+    // so leave them alive and let the error propagate.
+    const id = try b.upload(.{
+        .bitmap = font_payload.bitmap,
+        .width = font_payload.width,
+        .height = font_payload.height,
+        .glyphs = font_payload.glyphs,
+        .codepoint_index = font_payload.codepoint_index,
+        .ascent = font_payload.ascent,
+        .descent = font_payload.descent,
+        .line_gap = font_payload.line_gap,
+        .line_height = font_payload.line_height,
+        .kerning = font_payload.kerning,
+    });
+
+    // Upload succeeded: the backend has copied what it needs, so we
+    // own the free of every allocator-owned slice. Mirrors the
+    // labelle-gfx contract for `uploadTexture` in the image loader.
+    allocator.free(font_payload.bitmap);
+    allocator.free(font_payload.glyphs);
+    allocator.free(font_payload.codepoint_index);
+    allocator.free(font_payload.kerning);
+
+    entry.resource = .{ .font = id };
 }
 
-fn drop(allocator: Allocator, decoded: DecodedPayload) void {
-    _ = allocator;
-    _ = decoded;
+fn drop(allocator: Allocator, decoded_payload: DecodedPayload) void {
+    switch (decoded_payload) {
+        .font => |f| {
+            allocator.free(f.bitmap);
+            allocator.free(f.glyphs);
+            allocator.free(f.codepoint_index);
+            allocator.free(f.kerning);
+        },
+        // Other variants never reach the font loader's drop hook — the
+        // catalog dispatches on the vtable carried by the `WorkResult`,
+        // not on `DecodedPayload`'s tag. Keep the arms exhaustive so
+        // this file compiles cleanly against future payload shapes.
+        else => {},
+    }
 }
 
 fn free(entry: *AssetEntry) void {
-    _ = entry;
+    const resource = entry.resource orelse return;
+    // Release the backend handle if a backend is still installed.
+    // If the backend was cleared (e.g. a test's `clearBackend`) after
+    // an asset uploaded, we can't reach the atlas — skip the `unload`
+    // call but STILL clear `entry.resource` so callers that read it
+    // as a cleanup-completed flag get the contract `loader.zig`
+    // documents.
+    if (active_backend) |b| switch (resource) {
+        .font => |id| b.unload(id),
+        else => {},
+    };
+    entry.resource = null;
 }
 
 pub const vtable: AssetLoaderVTable = .{
@@ -47,3 +248,237 @@ pub const vtable: AssetLoaderVTable = .{
     .drop = drop,
     .free = free,
 };
+
+// ---------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------
+
+const testing = std.testing;
+
+/// Mock backend that records every call and produces a fixed 1×1
+/// alpha bitmap + 1-glyph table. The four output slices are allocated
+/// through the caller's allocator so both the happy path (upload
+/// frees) and the discard path (drop frees) can run under
+/// `testing.allocator`, which catches leaks and double-frees.
+const MockBackend = struct {
+    var decode_calls: u32 = 0;
+    var upload_calls: u32 = 0;
+    var unload_calls: u32 = 0;
+    var last_params: ?FontBakeParams = null;
+    var last_uploaded_id: font_types.FontId = font_types.FontId.invalid;
+    var next_id_index: u16 = 1;
+    var decode_fails: bool = false;
+    var upload_fails: bool = false;
+
+    /// Sentinel returned by `uploadFn`. Tests assert on this to prove
+    /// the resource handle survives the upload path intact.
+    const sentinel_id: font_types.FontId = .{ .index = 7, .generation = 42 };
+
+    fn reset() void {
+        decode_calls = 0;
+        upload_calls = 0;
+        unload_calls = 0;
+        last_params = null;
+        last_uploaded_id = font_types.FontId.invalid;
+        next_id_index = 1;
+        decode_fails = false;
+        upload_fails = false;
+    }
+
+    fn decodeFn(
+        file_type: [:0]const u8,
+        data: []const u8,
+        params: FontBakeParams,
+        allocator: Allocator,
+    ) anyerror!DecodedFont {
+        _ = file_type;
+        _ = data;
+        decode_calls += 1;
+        last_params = params;
+        if (decode_fails) return error.MockFontDecodeError;
+
+        const bitmap = try allocator.alloc(u8, 1); // 1×1 alpha
+        bitmap[0] = 0xFF;
+
+        const glyphs = try allocator.alloc(font_types.Glyph, 1);
+        glyphs[0] = .{
+            .u0 = 0,
+            .v0 = 0,
+            .u1 = 1,
+            .v1 = 1,
+            .xoff = 0.0,
+            .yoff = 0.0,
+            .advance = params.pixel_height,
+        };
+
+        const index = try allocator.alloc(font_types.CodepointEntry, 1);
+        index[0] = .{ .codepoint = 'A', .glyph_index = 0 };
+
+        const kerning = try allocator.alloc(font_types.KernPair, 0);
+
+        return .{
+            .bitmap = bitmap,
+            .width = 1,
+            .height = 1,
+            .glyphs = glyphs,
+            .codepoint_index = index,
+            .ascent = params.pixel_height,
+            .descent = 0.0,
+            .line_gap = 0.0,
+            .line_height = params.pixel_height,
+            .kerning = kerning,
+        };
+    }
+
+    fn uploadFn(decoded: DecodedFont) anyerror!font_types.FontId {
+        _ = decoded;
+        upload_calls += 1;
+        if (upload_fails) return error.MockFontUploadError;
+        // Hand back a stable sentinel on the first call so the
+        // round-trip test can assert on a known value; later calls
+        // get fresh generations so re-uploads don't collide.
+        const id: font_types.FontId = if (upload_calls == 1)
+            sentinel_id
+        else blk: {
+            const idx = next_id_index;
+            next_id_index += 1;
+            break :blk .{ .index = idx, .generation = 1 };
+        };
+        last_uploaded_id = id;
+        return id;
+    }
+
+    fn unloadFn(id: font_types.FontId) void {
+        _ = id;
+        unload_calls += 1;
+    }
+
+    const backend_value: FontBackend = .{
+        .decode = decodeFn,
+        .upload = uploadFn,
+        .unload = unloadFn,
+    };
+};
+
+test "font loader: decode without backend errors cleanly" {
+    clearBackend();
+    defer clearBackend();
+    const params = FontBakeParams{};
+    try testing.expectError(
+        error.FontBackendNotInitialized,
+        decode("ttf", "fake", &params, testing.allocator),
+    );
+}
+
+test "font loader: decode with missing params errors cleanly" {
+    MockBackend.reset();
+    setBackend(MockBackend.backend_value);
+    defer clearBackend();
+    try testing.expectError(
+        error.FontBakeParamsMissing,
+        decode("ttf", "fake", null, testing.allocator),
+    );
+}
+
+test "font loader: mock backend decode→upload→free round-trip" {
+    MockBackend.reset();
+    setBackend(MockBackend.backend_value);
+    defer clearBackend();
+
+    const params = FontBakeParams{ .pixel_height = 24.0 };
+
+    // 1. decode on the worker thread (synchronously in the test).
+    const payload = try decode("ttf", "fake-ttf-bytes", &params, testing.allocator);
+    try testing.expectEqual(@as(u32, 1), MockBackend.decode_calls);
+    try testing.expectEqual(@as(u32, 1), payload.font.width);
+    try testing.expectEqual(@as(u32, 1), payload.font.height);
+    try testing.expectEqual(@as(usize, 1), payload.font.glyphs.len);
+    try testing.expectEqual(@as(f32, 24.0), payload.font.ascent);
+    // Params plumbing — the mock records `last_params` on every decode.
+    try testing.expect(MockBackend.last_params != null);
+    try testing.expectEqual(@as(f32, 24.0), MockBackend.last_params.?.pixel_height);
+
+    // 2. upload on the main thread. Loader owns the free of all four
+    //    slices after a successful upload.
+    var entry: AssetEntry = .{
+        .state = .decoding,
+        .refcount = 1,
+        .loader = &vtable,
+        .loader_kind = .font,
+        .raw_bytes = "fake-ttf-bytes",
+        .file_type = "ttf",
+        .params = @ptrCast(&params),
+        .decoded = payload,
+        .resource = null,
+        .last_error = null,
+    };
+    try upload(&entry, payload, testing.allocator);
+    try testing.expectEqual(@as(u32, 1), MockBackend.upload_calls);
+    try testing.expect(entry.resource != null);
+    try testing.expectEqual(MockBackend.sentinel_id, entry.resource.?.font);
+
+    // 3. free on the main thread — refcount hit zero on a `.ready`
+    //    entry. Releases the atlas handle through the backend.
+    free(&entry);
+    try testing.expectEqual(@as(u32, 1), MockBackend.unload_calls);
+    try testing.expectEqual(@as(?UploadedResource, null), entry.resource);
+}
+
+test "font loader: drop path frees all slices without touching backend" {
+    MockBackend.reset();
+    setBackend(MockBackend.backend_value);
+    defer clearBackend();
+
+    const params = FontBakeParams{};
+    const payload = try decode("ttf", "fake", &params, testing.allocator);
+    drop(testing.allocator, payload);
+
+    try testing.expectEqual(@as(u32, 0), MockBackend.upload_calls);
+    try testing.expectEqual(@as(u32, 0), MockBackend.unload_calls);
+}
+
+test "font loader: upload error leaves slices alive for drop cleanup" {
+    MockBackend.reset();
+    setBackend(MockBackend.backend_value);
+    MockBackend.upload_fails = true;
+    defer clearBackend();
+
+    const params = FontBakeParams{};
+    const payload = try decode("ttf", "fake", &params, testing.allocator);
+    var entry: AssetEntry = .{
+        .state = .decoding,
+        .refcount = 1,
+        .loader = &vtable,
+        .loader_kind = .font,
+        .raw_bytes = "fake",
+        .file_type = "ttf",
+        .params = @ptrCast(&params),
+        .decoded = payload,
+        .resource = null,
+        .last_error = null,
+    };
+    try testing.expectError(error.MockFontUploadError, upload(&entry, payload, testing.allocator));
+    try testing.expectEqual(@as(?UploadedResource, null), entry.resource);
+    // On the failure path, `upload` must NOT have freed the buffers —
+    // the catalog still needs to hand them to `drop`. Do that here so
+    // `testing.allocator` stays happy.
+    drop(testing.allocator, payload);
+}
+
+test "font loader: free without a backend or resource is a no-op" {
+    clearBackend();
+    var entry: AssetEntry = .{
+        .state = .registered,
+        .refcount = 0,
+        .loader = &vtable,
+        .loader_kind = .font,
+        .raw_bytes = "",
+        .file_type = "ttf",
+        .params = null,
+        .decoded = null,
+        .resource = null,
+        .last_error = null,
+    };
+    free(&entry);
+    try testing.expectEqual(@as(?UploadedResource, null), entry.resource);
+}

--- a/src/assets/mod.zig
+++ b/src/assets/mod.zig
@@ -37,6 +37,11 @@ pub const image_loader = @import("loaders/image.zig");
 /// `src/assets/loaders/audio.zig` for the full rationale.
 pub const audio_loader = @import("loaders/audio.zig");
 
+/// Re-exported so the assembler can install the font baker via
+/// `engine.FontLoader.setBackend` and so tests in
+/// `test/font_loader_test.zig` can inject a mock the same way.
+pub const font_loader = @import("loaders/font.zig");
+
 test {
     // Pull every file in the module tree into the test binary. The
     // `zig build test` step rooted at this file (see `build.zig`'s

--- a/src/game/gui_mixin.zig
+++ b/src/game/gui_mixin.zig
@@ -1,6 +1,7 @@
 /// GUI mixin — GUI begin/end, view rendering, and widget dispatch.
 const std = @import("std");
 const gui_types = @import("../gui_types.zig");
+const font_types = @import("font_types");
 
 /// Returns the GUI mixin for a given Game type.
 pub fn Mixin(comptime Game: type) type {
@@ -24,36 +25,80 @@ pub fn Mixin(comptime Game: type) type {
         }
 
         /// Render all views from a ViewRegistry.
-        pub fn renderAllViews(_: *Game, comptime Views: type) void {
+        pub fn renderAllViews(self: *Game, comptime Views: type) void {
             inline for (comptime Views.names()) |view_name| {
                 const view_def = comptime Views.get(view_name);
                 inline for (view_def.elements) |element| {
-                    renderGuiElementComptime(element);
+                    renderGuiElementComptime(self, element);
                 }
             }
         }
 
         /// Render a named view from a ViewRegistry.
-        pub fn renderView(_: *Game, comptime Views: type, comptime view_name: []const u8) void {
+        pub fn renderView(self: *Game, comptime Views: type, comptime view_name: []const u8) void {
             if (!Views.has(view_name)) return;
             const view_def = comptime Views.get(view_name);
             inline for (view_def.elements) |element| {
-                renderGuiElementComptime(element);
+                renderGuiElementComptime(self, element);
             }
         }
 
-        fn renderGuiElementComptime(comptime element: gui_types.GuiElement) void {
+        /// Runtime asset lookup for a label's optional `font` field.
+        /// Returns the baked `FontId` when the asset is `.ready`,
+        /// `null` otherwise (asset still loading, missing, or
+        /// not-a-font payload). Falling back to `null` keeps the
+        /// renderer's default-font path intact during streaming —
+        /// the label simply uses the backend's built-in font for a
+        /// frame or two until the asset finishes loading.
+        fn resolveLabelFont(self: *Game, font_name: []const u8) ?font_types.FontId {
+            const entry = self.assets.entries.getPtr(font_name) orelse return null;
+            const resource = entry.resource orelse return null;
+            return switch (resource) {
+                .font => |id| id,
+                else => null,
+            };
+        }
+
+        fn renderGuiElementComptime(self: *Game, comptime element: gui_types.GuiElement) void {
             if (!element.isVisible()) return;
             switch (element) {
-                .Label => |lbl| Gui.labelWidget(
-                    lbl.text[0..lbl.text.len :0],
-                    @intFromFloat(lbl.position.x),
-                    @intFromFloat(lbl.position.y),
-                    @intFromFloat(lbl.font_size),
-                    lbl.color.r,
-                    lbl.color.g,
-                    lbl.color.b,
-                ),
+                .Label => |lbl| {
+                    // Resolve the optional font asset to a runtime
+                    // `FontId` when `lbl.font` is set. Comptime branch
+                    // keeps the default-font path zero-overhead for
+                    // labels that don't use a custom font.
+                    if (comptime lbl.font) |font_name| {
+                        const font_id = resolveLabelFont(self, font_name);
+                        // The backend's font-aware label draw is
+                        // expected to accept an `?FontId` — null
+                        // means "fall back to default font", same
+                        // shape as `resolveLabelFont`'s contract
+                        // during streaming. Backends that don't
+                        // implement `labelWidgetWithFont` keep
+                        // working via the `@hasDecl` guard on the
+                        // `Gui` wrapper.
+                        Gui.labelWidgetWithFont(
+                            lbl.text[0..lbl.text.len :0],
+                            @intFromFloat(lbl.position.x),
+                            @intFromFloat(lbl.position.y),
+                            @intFromFloat(lbl.font_size),
+                            lbl.color.r,
+                            lbl.color.g,
+                            lbl.color.b,
+                            font_id,
+                        );
+                    } else {
+                        Gui.labelWidget(
+                            lbl.text[0..lbl.text.len :0],
+                            @intFromFloat(lbl.position.x),
+                            @intFromFloat(lbl.position.y),
+                            @intFromFloat(lbl.font_size),
+                            lbl.color.r,
+                            lbl.color.g,
+                            lbl.color.b,
+                        );
+                    }
+                },
                 .Button => |btn| _ = Gui.buttonWidget(
                     comptime std.hash.Fnv1a_32.hash(btn.id),
                     btn.text[0..btn.text.len :0],
@@ -80,7 +125,7 @@ pub fn Mixin(comptime Game: type) type {
                         @intFromFloat(panel.size.height),
                     );
                     inline for (panel.children) |child| {
-                        renderGuiElementComptime(child);
+                        renderGuiElementComptime(self, child);
                     }
                 },
                 .Image => {},

--- a/src/gui_types.zig
+++ b/src/gui_types.zig
@@ -39,6 +39,13 @@ pub const Label = struct {
     font_size: f32 = 16,
     color: GuiColor = .{},
     visible: bool = true,
+    /// Optional name of a font asset registered in `game.assets`. When
+    /// non-null, the renderer looks up the asset, extracts the
+    /// `FontId` from `entry.resource.?.font`, and passes it to the GUI
+    /// backend's font-aware text draw call. Null falls back to the
+    /// backend's default font — today's behaviour. See
+    /// `src/game/gui_mixin.zig` for the lookup path.
+    font: ?[]const u8 = null,
 };
 
 pub const Button = struct {

--- a/src/root.zig
+++ b/src/root.zig
@@ -78,6 +78,15 @@ pub const FontId = font_types_mod.FontId;
 pub const Glyph = font_types_mod.Glyph;
 pub const CodepointEntry = font_types_mod.CodepointEntry;
 pub const KernPair = font_types_mod.KernPair;
+/// Runtime backend hook for the font asset loader, paired with the
+/// `FontBakeParams` / `CodepointRange` shapes the catalog stores on
+/// each font entry and forwards into `decode` via `WorkRequest.params`.
+/// See `src/assets/loaders/font.zig` for the full ownership contract.
+pub const FontLoader = assets_mod.font_loader;
+pub const FontBackend = assets_mod.font_loader.FontBackend;
+pub const FontBakeParams = assets_mod.font_loader.FontBakeParams;
+pub const CodepointRange = assets_mod.font_loader.CodepointRange;
+pub const DecodedFont = assets_mod.font_loader.DecodedFont;
 
 // ── GUI ──
 pub const GuiInterface = gui_mod.GuiInterface;

--- a/test/font_loader_test.zig
+++ b/test/font_loader_test.zig
@@ -1,0 +1,241 @@
+//! Integration tests for the real font loader (#448, Phase 4).
+//!
+//! Mirrors `test/asset_catalog_test.zig`'s image-loader pattern but
+//! exercises the font-specific bits the image loader can't reach:
+//!
+//! 1. `FontBakeParams` plumbing — the catalog must hand the params
+//!    pointer to the worker, the worker forwards it to `vtable.decode`,
+//!    and the font loader `@ptrCast`s it back to its own type.
+//! 2. The `FontId` resource lands on `entry.resource.?.font` and
+//!    `release` reaches `vtable.free`, which calls the backend's
+//!    `unload` exactly once.
+//! 3. Two registrations under different `FontBakeParams` produce two
+//!    independent entries — proving the per-entry params slot survives
+//!    round-trip through the worker.
+
+const std = @import("std");
+const testing = std.testing;
+
+const engine = @import("engine");
+const font_loader = engine.FontLoader;
+const font_types_mod = engine.font_types_mod;
+
+/// Mock backend recording every call. `decode` returns a fixed 1×1
+/// alpha bitmap + 1-glyph table, all allocated through the caller's
+/// allocator so `testing.allocator` (a GPA) catches any leak or
+/// double-free. `upload` returns a sentinel `FontId` so the round-
+/// trip can assert on a known value.
+const MockBackend = struct {
+    var decode_calls: u32 = 0;
+    var upload_calls: u32 = 0;
+    var unload_calls: u32 = 0;
+    var last_pixel_height: f32 = 0;
+    /// One slot per upload so the second round-trip can assert that
+    /// the catalog handed back the second sentinel, not the first.
+    var last_uploaded_id: engine.FontId = engine.FontId.invalid;
+    var last_unloaded_id: engine.FontId = engine.FontId.invalid;
+
+    /// First sentinel returned by `uploadFn`. Tests assert on this.
+    const sentinel_a: engine.FontId = .{ .index = 11, .generation = 3 };
+    const sentinel_b: engine.FontId = .{ .index = 22, .generation = 5 };
+
+    fn reset() void {
+        decode_calls = 0;
+        upload_calls = 0;
+        unload_calls = 0;
+        last_pixel_height = 0;
+        last_uploaded_id = engine.FontId.invalid;
+        last_unloaded_id = engine.FontId.invalid;
+    }
+
+    fn decodeFn(
+        file_type: [:0]const u8,
+        data: []const u8,
+        params: engine.FontBakeParams,
+        allocator: std.mem.Allocator,
+    ) anyerror!engine.DecodedFont {
+        _ = file_type;
+        _ = data;
+        decode_calls += 1;
+        last_pixel_height = params.pixel_height;
+
+        const bitmap = try allocator.alloc(u8, 1);
+        bitmap[0] = 0xFF;
+
+        const glyphs = try allocator.alloc(font_types_mod.Glyph, 1);
+        glyphs[0] = .{
+            .u0 = 0,
+            .v0 = 0,
+            .u1 = 1,
+            .v1 = 1,
+            .xoff = 0.0,
+            .yoff = 0.0,
+            .advance = params.pixel_height,
+        };
+
+        const index = try allocator.alloc(font_types_mod.CodepointEntry, 1);
+        index[0] = .{ .codepoint = 'A', .glyph_index = 0 };
+
+        const kerning = try allocator.alloc(font_types_mod.KernPair, 0);
+
+        return .{
+            .bitmap = bitmap,
+            .width = 1,
+            .height = 1,
+            .glyphs = glyphs,
+            .codepoint_index = index,
+            .ascent = params.pixel_height,
+            .descent = 0.0,
+            .line_gap = 0.0,
+            .line_height = params.pixel_height,
+            .kerning = kerning,
+        };
+    }
+
+    fn uploadFn(decoded: engine.DecodedFont) anyerror!engine.FontId {
+        _ = decoded;
+        upload_calls += 1;
+        const id = if (upload_calls == 1) sentinel_a else sentinel_b;
+        last_uploaded_id = id;
+        return id;
+    }
+
+    fn unloadFn(id: engine.FontId) void {
+        unload_calls += 1;
+        last_unloaded_id = id;
+    }
+
+    const backend_value: engine.FontBackend = .{
+        .decode = decodeFn,
+        .upload = uploadFn,
+        .unload = unloadFn,
+    };
+};
+
+/// Spin until at least `at_least` results are pending across all
+/// worker result rings, or 200ms elapses. Same shape as the image
+/// loader's `spinForResults` in `src/assets/catalog.zig`.
+fn spinForResults(catalog: *engine.AssetCatalog, at_least: u32) !void {
+    const deadline_ns: u64 = 200 * std.time.ns_per_ms;
+    var waited_ns: u64 = 0;
+    const step_ns: u64 = 1 * std.time.ns_per_ms;
+    while (waited_ns < deadline_ns) : (waited_ns += step_ns) {
+        var total: u32 = 0;
+        for (&catalog.results) |*ring| {
+            const head = ring.head.load(.acquire);
+            const tail = ring.tail.load(.acquire);
+            total += head -% tail;
+        }
+        if (total >= at_least) return;
+        std.Thread.sleep(step_ns);
+    }
+    return error.WorkerDidNotRespond;
+}
+
+test "font loader: registerFont → acquire → pump → ready → release round-trip" {
+    MockBackend.reset();
+    font_loader.setBackend(MockBackend.backend_value);
+    defer font_loader.clearBackend();
+
+    var catalog = engine.AssetCatalog.init(testing.allocator);
+    defer catalog.deinit();
+
+    // Static-lifetime params so the pointer the catalog borrows stays
+    // valid for the full decode/upload round-trip. `const` would also
+    // work; `var` lets us tweak `pixel_height` per test if needed.
+    var params: engine.FontBakeParams = .{ .pixel_height = 18.0 };
+
+    try catalog.registerFont("title", "ttf", "fake-ttf-bytes", &params);
+
+    // Before acquire: registered, refcount 0, params pointer parked
+    // on the entry waiting for the worker to receive it.
+    const initial = catalog.entries.getPtr("title").?;
+    try testing.expectEqual(engine.AssetState.registered, initial.state);
+    try testing.expect(initial.params != null);
+
+    _ = try catalog.acquire("title");
+
+    try spinForResults(&catalog, 1);
+    catalog.pump();
+
+    // After pump: state .ready, resource carries the sentinel FontId,
+    // and the mock saw the pixel_height we registered — proving the
+    // params plumbing survived the catalog → worker → loader trip.
+    const entry = catalog.entries.getPtr("title").?;
+    try testing.expectEqual(engine.AssetState.ready, entry.state);
+    try testing.expect(entry.resource != null);
+    try testing.expectEqual(MockBackend.sentinel_a, entry.resource.?.font);
+    try testing.expectEqual(@as(u32, 1), MockBackend.decode_calls);
+    try testing.expectEqual(@as(u32, 1), MockBackend.upload_calls);
+    try testing.expectEqual(@as(f32, 18.0), MockBackend.last_pixel_height);
+    try testing.expect(catalog.isReady("title"));
+
+    // release on a `.ready` entry triggers `vtable.free`, which calls
+    // the backend's `unload` exactly once and clears
+    // `entry.resource` / rewinds state to `.registered`.
+    catalog.release("title");
+    try testing.expectEqual(@as(u32, 1), MockBackend.unload_calls);
+    try testing.expectEqual(MockBackend.sentinel_a, MockBackend.last_unloaded_id);
+    try testing.expectEqual(@as(?engine.UploadedResource, null), entry.resource);
+    try testing.expectEqual(engine.AssetState.registered, entry.state);
+    try testing.expect(!catalog.isReady("title"));
+}
+
+test "font loader: two registrations with different pixel_height keep params independent" {
+    MockBackend.reset();
+    font_loader.setBackend(MockBackend.backend_value);
+    defer font_loader.clearBackend();
+
+    var catalog = engine.AssetCatalog.init(testing.allocator);
+    defer catalog.deinit();
+
+    // Two distinct params blocks. Both addresses are stable for the
+    // duration of the test, satisfying the borrowed-lifetime contract
+    // on `entry.params`.
+    var params_small: engine.FontBakeParams = .{ .pixel_height = 12.0 };
+    var params_large: engine.FontBakeParams = .{ .pixel_height = 48.0 };
+
+    try catalog.registerFont("body", "ttf", "fake-bytes-1", &params_small);
+    try catalog.registerFont("display", "ttf", "fake-bytes-2", &params_large);
+
+    // The catalog should store each entry's params pointer verbatim.
+    const body_entry = catalog.entries.getPtr("body").?;
+    const display_entry = catalog.entries.getPtr("display").?;
+    try testing.expectEqual(
+        @as(?*const anyopaque, @ptrCast(&params_small)),
+        body_entry.params,
+    );
+    try testing.expectEqual(
+        @as(?*const anyopaque, @ptrCast(&params_large)),
+        display_entry.params,
+    );
+
+    // Acquire both and let the worker(s) decode. Acquire order doesn't
+    // matter — round-robin dispatch may put them on different workers.
+    _ = try catalog.acquire("body");
+    _ = try catalog.acquire("display");
+
+    try spinForResults(&catalog, 2);
+    // Pump twice to drain both — `UPLOAD_BUDGET_PER_FRAME` is 4 so a
+    // single pump would suffice, but two keeps the test honest about
+    // independent finalisation.
+    catalog.pump();
+    catalog.pump();
+
+    try testing.expect(catalog.isReady("body"));
+    try testing.expect(catalog.isReady("display"));
+    try testing.expectEqual(@as(u32, 2), MockBackend.decode_calls);
+    try testing.expectEqual(@as(u32, 2), MockBackend.upload_calls);
+
+    // The two entries carry distinct `FontId`s — the catalog produced
+    // two independent backend handles, not one shared one.
+    const body_id = catalog.entries.getPtr("body").?.resource.?.font;
+    const display_id = catalog.entries.getPtr("display").?.resource.?.font;
+    try testing.expect(!std.meta.eql(body_id, display_id));
+
+    // Balance both refcounts so deinit's leftover-`.ready` sweep
+    // doesn't double-unload.
+    catalog.release("body");
+    catalog.release("display");
+    try testing.expectEqual(@as(u32, 2), MockBackend.unload_calls);
+}


### PR DESCRIPTION
Replaces closed #527 (auto-closed by GitHub when the shared-types base branch was deleted on merge of #525). Branch content includes Copilot's review fix from the prior PR — commits `2a16774` (hasDecl guard for `labelWidgetWithFont`) and `888d3e4` (test asserting fallback path) are preserved.

## Summary

- Replaces the three `error.NotImplemented` stubs in `src/assets/loaders/font.zig` with a real vtable.
- Adds `FontBackend` + `FontBakeParams` + `CodepointRange` + `DecodedFont` types per RFC-FONT-LOADER.md §3–§6. Reuses `font_types.FontId` from #525.
- Threads bake params through via the `WorkRequest.params` slot added in #525 — font loader's `decode` reads `@ptrCast(@alignCast(params))` and dispatches to the backend.
- GUI hookup: `gui_types.Label.font: ?[]const u8` and `gui_mixin.zig` resolves the asset name through `game.assets.get(...)` to pull the `FontId`. Backends without `labelWidgetWithFont` fall through to `labelWidget` (guarded by `@hasDecl(...)`, per Copilot's review on the prior PR).
- `catalog.registerFont` + `registerWithParams` added (minimal extension; original `register` is a one-line forward, all existing call sites unchanged).
- 8 new tests across `src/assets/loaders/font.zig` (in-file) and `test/font_loader_test.zig`.

Builds on #525 (now in main). Closes #448 once landed.

## Test plan

- [x] `zig build test` — 358/358 passing (+8 new font tests).
- [x] `@hasDecl` fallback path covered by `test/gui_view_test.zig`.