### PR TITLE
feat(audio_backend): in-tree sub-package replacing labelle-audio (#530)

### DIFF
--- a/audio_backend/README.md
+++ b/audio_backend/README.md
@@ -1,0 +1,37 @@
+# audio_backend
+
+Decoder-side audio backend traits for the labelle-toolkit. Sub-package
+of `labelle-engine`, mirroring the `spatial_grid` / `tilemap` / `camera`
+sub-packages inside `labelle-gfx`.
+
+Defines a comptime-validated `Backend(Impl)` wrapper and a `DecodedAudio`
+POD that concrete decoder backends (raylib-audio, sokol-audio,
+miniaudio, …) implement; `labelle-assembler` adapts the result to
+`labelle-engine`'s `AudioBackend` struct (`src/assets/loaders/audio.zig`)
+at codegen time.
+
+This is the audio sibling of [labelle-gfx][gfx]'s image and font backend
+traits (see [labelle-gfx#258][gfx258]). Runtime playback
+(`AudioInterface`-style) lives in `labelle-core` and is intentionally
+not part of this sub-package.
+
+Concrete backends consume this via path dep on `labelle-engine`:
+
+```zig
+// in a concrete backend's build.zig.zon
+.dependencies = .{
+    .labelle_engine = .{ .path = "../labelle-engine" },
+},
+```
+
+```zig
+// in build.zig
+const engine_dep = b.dependency("labelle_engine", ...);
+const audio_backend = engine_dep.module("audio_backend");
+```
+
+Tracking issue: [labelle-engine#530][issue530].
+
+[gfx]: https://github.com/labelle-toolkit/labelle-gfx
+[gfx258]: https://github.com/labelle-toolkit/labelle-gfx/pull/258
+[issue530]: https://github.com/labelle-toolkit/labelle-engine/issues/530

--- a/audio_backend/build.zig
+++ b/audio_backend/build.zig
@@ -1,0 +1,35 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const audio_backend_module = b.addModule("audio_backend", .{
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const test_step = b.step("test", "Run audio_backend tests");
+
+    const src_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/root.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    test_step.dependOn(&b.addRunArtifact(src_tests).step);
+
+    const root_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("test/root_test.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "audio_backend", .module = audio_backend_module },
+            },
+        }),
+    });
+    test_step.dependOn(&b.addRunArtifact(root_tests).step);
+}

--- a/audio_backend/build.zig.zon
+++ b/audio_backend/build.zig.zon
@@ -1,0 +1,13 @@
+.{
+    .fingerprint = 0xb052c0adfb7832ac,
+    .name = .audio_backend,
+    .version = "0.1.0",
+    .minimum_zig_version = "0.15.2",
+    .dependencies = .{},
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        "README.md",
+    },
+}

--- a/audio_backend/src/backend.zig
+++ b/audio_backend/src/backend.zig
@@ -1,0 +1,85 @@
+const std = @import("std");
+
+/// CPU-decoded audio owned by the caller's allocator.
+///
+/// Mirrors the audio-loader split that `labelle-gfx`'s `DecodedImage` and
+/// `DecodedFont` introduced for the Asset Streaming RFC: pure CPU decode
+/// happens on a worker thread; "upload" (audio-device-side registration)
+/// happens on the main thread. The sample buffer is allocator-owned so the
+/// asset catalog can free it on BOTH the success path and the discard path
+/// (when a refcount hits zero between decode and upload).
+///
+/// Structurally identical to `labelle-engine`'s
+/// `DecodedPayload.audio` inline struct so the assembler adapter is a 1:1
+/// field copy — same trick used for `DecodedImage` and `DecodedFont`.
+pub const DecodedAudio = struct {
+    /// Interleaved PCM samples (channels interleaved per frame). Length is
+    /// `frame_count * channels`. Owned by the allocator passed to
+    /// `decodeAudio`; the caller frees via that same allocator on both the
+    /// success and discard paths.
+    samples: []i16,
+    sample_rate: u32,
+    channels: u8,
+};
+
+/// Creates a validated backend interface from an implementation type.
+///
+/// The wrapper enforces the audio-loader contract — concrete decoder
+/// backends (raylib-audio, sokol-audio, miniaudio, …) implement `Impl`;
+/// the assembler adapts the resulting wrapper to `labelle-engine`'s
+/// `AudioBackend` struct of function pointers at codegen time. Same shape
+/// as `labelle-gfx`'s `Backend(Impl)` for images and fonts.
+///
+/// Runtime audio playback (`AudioInterface`-style) lives in `labelle-core`
+/// and stays there — this repo is decoder/loader-side only.
+pub fn Backend(comptime Impl: type) type {
+    comptime {
+        if (!@hasDecl(Impl, "Sound")) @compileError("Backend must define 'Sound' type");
+    }
+
+    comptime {
+        if (!@hasDecl(Impl, "decodeAudio")) @compileError("Backend must define 'decodeAudio' (worker-thread safe CPU decode)");
+        if (!@hasDecl(Impl, "uploadSound")) @compileError("Backend must define 'uploadSound' (main-thread audio-device registration)");
+        if (!@hasDecl(Impl, "unloadSound")) @compileError("Backend must define 'unloadSound'");
+    }
+
+    return struct {
+        pub const Implementation = Impl;
+
+        /// Opaque backend-side sound handle. Resolves to the backend's
+        /// own type — the adapter on the assembler side narrows this to
+        /// `labelle-engine`'s `SoundId` shape (same marshalling trick
+        /// `labelle-gfx` uses for `Texture` vs the engine's `Texture`
+        /// POD).
+        pub const Sound = Impl.Sound;
+
+        /// Pure CPU decode, safe to call from a worker thread. Returns a
+        /// `DecodedAudio` whose `samples` buffer is owned by `allocator` —
+        /// the caller frees it via that same allocator on BOTH the success
+        /// and the discard paths (see `uploadSound`).
+        pub inline fn decodeAudio(
+            file_type: [:0]const u8,
+            data: []const u8,
+            allocator: std.mem.Allocator,
+        ) !DecodedAudio {
+            return Impl.decodeAudio(file_type, data, allocator);
+        }
+
+        /// Main-thread audio-device registration. Hands the decoded
+        /// samples to the backend's mixer / audio device and returns a
+        /// backend `Sound` handle. Does NOT take ownership of
+        /// `decoded.samples` — the caller is responsible for freeing the
+        /// buffer on both the success path and the discard path (e.g.
+        /// when the asset catalog drops the asset between decode and
+        /// upload).
+        pub inline fn uploadSound(decoded: DecodedAudio) !Sound {
+            return Impl.uploadSound(decoded);
+        }
+
+        /// Releases the audio-device-side resource that `uploadSound`
+        /// allocated. Counterpart to `uploadSound`.
+        pub inline fn unloadSound(sound: Sound) void {
+            Impl.unloadSound(sound);
+        }
+    };
+}

--- a/audio_backend/src/mock_backend.zig
+++ b/audio_backend/src/mock_backend.zig
@@ -1,0 +1,79 @@
+const std = @import("std");
+const backend_mod = @import("backend.zig");
+
+/// Mock backend for testing — produces stub decoded audio + stub sound
+/// handles without any native dependencies. Mirrors `labelle-gfx`'s
+/// `MockBackend` shape for images and fonts.
+pub const MockBackend = struct {
+    pub const DecodedAudio = backend_mod.DecodedAudio;
+
+    /// Mock sound handle — generation-tagged to detect use-after-free
+    /// under test, parallel to `labelle-gfx`'s `Texture.id` / `FontAtlas.id`.
+    pub const Sound = struct {
+        id: u32,
+        sample_rate: u32,
+        channels: u8,
+    };
+
+    threadlocal var allocator_ref: ?std.mem.Allocator = null;
+    threadlocal var sound_counter: u32 = 1;
+    threadlocal var sound_unload_calls: u32 = 0;
+
+    pub fn initMock(allocator: std.mem.Allocator) void {
+        allocator_ref = allocator;
+        sound_counter = 1;
+        sound_unload_calls = 0;
+    }
+
+    pub fn deinitMock() void {
+        allocator_ref = null;
+    }
+
+    pub fn resetMock() void {
+        sound_counter = 1;
+        sound_unload_calls = 0;
+    }
+
+    pub fn getSoundUnloadCalls() u32 {
+        return sound_unload_calls;
+    }
+
+    // Backend interface implementation.
+
+    /// Stub CPU decode: returns a 4-sample mono PCM buffer allocated from
+    /// the caller's allocator. Worker-thread safe (no shared mutable state
+    /// is touched). The caller owns `samples` and must free it through the
+    /// same allocator on both the success and the discard paths.
+    pub fn decodeAudio(
+        _: [:0]const u8,
+        _: []const u8,
+        allocator: std.mem.Allocator,
+    ) !backend_mod.DecodedAudio {
+        const samples = try allocator.alloc(i16, 4);
+        samples[0] = 0;
+        samples[1] = 1;
+        samples[2] = 2;
+        samples[3] = 3;
+        return .{
+            .samples = samples,
+            .sample_rate = 44_100,
+            .channels = 1,
+        };
+    }
+
+    /// Stub upload: returns a fresh mock `Sound` and records nothing about
+    /// the sample buffer (the caller still owns it).
+    pub fn uploadSound(decoded: backend_mod.DecodedAudio) !Sound {
+        const id = sound_counter;
+        sound_counter += 1;
+        return Sound{
+            .id = id,
+            .sample_rate = decoded.sample_rate,
+            .channels = decoded.channels,
+        };
+    }
+
+    pub fn unloadSound(_: Sound) void {
+        sound_unload_calls += 1;
+    }
+};

--- a/audio_backend/src/root.zig
+++ b/audio_backend/src/root.zig
@@ -1,0 +1,18 @@
+//! Public surface of the `audio_backend` sub-package.
+//!
+//! Lives inside `labelle-engine` (mirroring the `spatial_grid` / `tilemap` /
+//! `camera` sub-packages inside `labelle-gfx`) so concrete audio backends
+//! (raylib-audio, sokol-audio, miniaudio, …) can depend on a narrow
+//! decoder-side contract without pulling the whole engine.
+//!
+//! Runtime playback (`AudioInterface`-style) lives in `labelle-core`; this
+//! sub-package is decoder/loader-side only.
+//!
+//! See `labelle-engine#530` for the tracking issue.
+
+pub const backend_mod = @import("backend.zig");
+pub const mock_backend_mod = @import("mock_backend.zig");
+
+pub const Backend = backend_mod.Backend;
+pub const DecodedAudio = backend_mod.DecodedAudio;
+pub const MockBackend = mock_backend_mod.MockBackend;

--- a/audio_backend/test/root_test.zig
+++ b/audio_backend/test/root_test.zig
@@ -1,0 +1,64 @@
+//! Round-trip tests for `Backend(MockBackend)`.
+//!
+//! Mirrors the font-backend tests at
+//! `labelle-gfx/test/root_test.zig:122-191` — same allocator-ownership
+//! contract, same decode/upload/unload lifecycle, same discard-path
+//! coverage so the asset catalog can drop an asset between decode and
+//! upload without leaking or double-freeing.
+
+const std = @import("std");
+const testing = std.testing;
+
+const audio = @import("audio_backend");
+
+const Backend = audio.Backend;
+const DecodedAudio = audio.DecodedAudio;
+const MockBackend = audio.MockBackend;
+
+test "Backend(MockBackend) validates successfully" {
+    const B = Backend(MockBackend);
+    try testing.expect(@sizeOf(B.Sound) > 0);
+}
+
+test "Backend: audio decode -> upload -> unload round trip" {
+    const B = Backend(MockBackend);
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    const decoded = try B.decodeAudio("wav", &[_]u8{}, testing.allocator);
+
+    // Stub returns 4 i16 mono samples at 44.1kHz.
+    try testing.expectEqual(@as(usize, 4), decoded.samples.len);
+    try testing.expectEqual(@as(u32, 44_100), decoded.sample_rate);
+    try testing.expectEqual(@as(u8, 1), decoded.channels);
+
+    const sound = try B.uploadSound(decoded);
+    try testing.expect(sound.id != 0);
+    try testing.expectEqual(@as(u32, 44_100), sound.sample_rate);
+    try testing.expectEqual(@as(u8, 1), sound.channels);
+
+    // Caller owns the sample buffer on the success path — uploadSound
+    // does NOT take ownership.
+    testing.allocator.free(decoded.samples);
+
+    try testing.expectEqual(@as(u32, 0), MockBackend.getSoundUnloadCalls());
+    B.unloadSound(sound);
+    try testing.expectEqual(@as(u32, 1), MockBackend.getSoundUnloadCalls());
+}
+
+test "Backend: audio discard path frees decoded samples without uploadSound" {
+    const B = Backend(MockBackend);
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    // Simulate the asset catalog: decode runs on a worker, then the
+    // refcount hits zero before uploadSound is called. The catalog must
+    // be able to free the buffer via the same allocator with no
+    // audio-device-side state to undo.
+    const decoded = try B.decodeAudio("wav", &[_]u8{}, testing.allocator);
+
+    // Discard without uploading. testing.allocator (a GPA) will assert
+    // on any leak or double-free — proves uploadSound does not own
+    // decoded.samples.
+    testing.allocator.free(decoded.samples);
+}

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -13,6 +13,9 @@
         .jsonc = .{
             .path = "jsonc",
         },
+        .audio_backend = .{
+            .path = "audio_backend",
+        },
     },
     .paths = .{
         "build.zig",
@@ -21,5 +24,6 @@
         "scene",
         "jsonc",
         "codegen",
+        "audio_backend",
     },
 }


### PR DESCRIPTION
Reopens #530 with a different home for the audio backend abstraction: an in-tree sub-package of `labelle-engine` instead of a standalone `labelle-audio` repo. Mirrors the `spatial_grid` / `tilemap` / `camera` convention inside `labelle-gfx`.

## Why the change

The standalone-repo decision (bootstrapped just before this) was over-engineered. labelle-audio's content is one trait + mock + three tests — not enough surface to justify dedicated-repo ceremony (CI, version bumps, dep wiring in every consumer). labelle-gfx is its own repo because it's a real graphics library; labelle-audio doesn't have that weight.

Sub-package gets us:

- **One repo to maintain.** No parallel CI, no version-bumping two repos in lockstep.
- **Narrow imports for concrete backends.** raylib-audio / sokol-audio depend on `labelle-engine` the repo but import only the `audio_backend` module via `engine_dep.module(\"audio_backend\")` — same shape gfx's spatial_grid consumers use today.
- **Audio types live next to the audio loader** (`src/assets/loaders/audio.zig`, `src/audio_types.zig`). Right neighbourhood.

## What changed

- New directory `audio_backend/` with its own `build.zig` + `build.zig.zon`, `src/`, `test/`, `README.md`. Content moved verbatim from the labelle-audio bootstrap (commit `487cc6d`): `Backend(Impl)` wrapper, `DecodedAudio` POD, `MockBackend`, three round-trip / discard-path tests.
- Module renamed `labelle-audio` → `audio_backend` (underscore convention, matches `spatial_grid` etc.). Test import updated.
- README rewritten for the sub-package location, with a snippet showing how concrete backends pull just the audio module via `engine_dep.module(\"audio_backend\")`.
- Parent `build.zig.zon` gains the path dep + paths entry. No parent `build.zig` changes — engine source doesn't import this sub-package, only downstream consumers do (same dep direction gfx uses for `spatial_grid`).

## Test plan

- [x] `zig build test` in `audio_backend/` — 3/3 passing.
- [x] `zig build test` at engine root — 350/350 passing (no regression from the path-dep addition).
- [ ] Once merged, archive the standalone labelle-audio repo and update issue #530 to reflect the new home.