### PR TITLE
feat(game): registerSound + registerFont helpers — Phase 4 (#447, #448)

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -1845,12 +1845,23 @@ pub fn GameConfig(
             _ = try self.loadSoundIfNeeded(name);
         }
 
-        /// Decode + upload a previously-registered sound if it hasn't
-        /// already been loaded. No-op (returns `false`) on already-ready
-        /// entries. Mirrors `loadAtlasIfNeeded`'s busy-pump shape; see
-        /// the long-form rationale there for the `errdefer release`,
-        /// `resetFailed`, and `std.Thread.yield` choices.
-        pub fn loadSoundIfNeeded(self: *Self, name: []const u8) !bool {
+        /// Shared busy-pump used by `loadSoundIfNeeded` and
+        /// `loadFontIfNeeded`. The atlas counterpart
+        /// (`loadAtlasIfNeededImpl`) does NOT delegate here because
+        /// it threads a `markPendingLoaded` call into the
+        /// `TextureManager` after the upload — the audio + font paths
+        /// have no equivalent post-upload bridging.
+        ///
+        /// Lifecycle (see `loadAtlasIfNeededImpl` for the long-form
+        /// rationale this mirrors): bumps the catalog refcount so the
+        /// worker enqueues the decode, then busy-pumps until the entry
+        /// is `.ready` (happy path) or `lastError` is set (decode /
+        /// upload failed). `errdefer release` keeps the refcount
+        /// consistent on every failure path so a retry after a failed
+        /// load actually re-triggers the decode (without the
+        /// `resetFailed`, `acquire` would only re-enqueue on a fresh
+        /// `.registered` entry).
+        fn loadAssetIfNeededInternal(self: *Self, name: []const u8) !bool {
             if (self.assets.isReady(name)) return false;
             _ = try self.assets.acquire(name);
             errdefer self.assets.release(name);
@@ -1863,6 +1874,13 @@ pub fn GameConfig(
                 std.Thread.yield() catch {};
             }
             return true;
+        }
+
+        /// Decode + upload a previously-registered sound if it hasn't
+        /// already been loaded. No-op (returns `false`) on already-ready
+        /// entries.
+        pub fn loadSoundIfNeeded(self: *Self, name: []const u8) !bool {
+            return self.loadAssetIfNeededInternal(name);
         }
 
         // ── Font asset shims (Phase 4 of Asset Streaming RFC, #448) ──
@@ -1904,21 +1922,10 @@ pub fn GameConfig(
         }
 
         /// Decode + upload a previously-registered font if it hasn't
-        /// already been loaded. Same busy-pump shape as
-        /// `loadAtlasIfNeeded` / `loadSoundIfNeeded`.
+        /// already been loaded. Delegates to the shared
+        /// `loadAssetIfNeededInternal` busy-pump.
         pub fn loadFontIfNeeded(self: *Self, name: []const u8) !bool {
-            if (self.assets.isReady(name)) return false;
-            _ = try self.assets.acquire(name);
-            errdefer self.assets.release(name);
-            while (!self.assets.isReady(name)) {
-                if (self.assets.lastError(name)) |err| {
-                    self.assets.resetFailed(name);
-                    return err;
-                }
-                self.assets.pump();
-                std.Thread.yield() catch {};
-            }
-            return true;
+            return self.loadAssetIfNeededInternal(name);
         }
 
         /// Whether an atlas's PNG has been decoded. Returns `false`

--- a/src/game.zig
+++ b/src/game.zig
@@ -1815,6 +1815,112 @@ pub fn GameConfig(
             return true;
         }
 
+        // ── Audio asset shims (Phase 4 of Asset Streaming RFC, #447) ──
+
+        /// Register a sound effect in deferred mode: the catalog keeps
+        /// a pointer to the encoded WAV/OGG bytes; decode + upload
+        /// happen the first time `loadSoundIfNeeded(name)` (or the
+        /// scene-manifest acquire path) bumps the refcount above zero.
+        ///
+        /// `audio_data` must outlive the catalog entry — typically a
+        /// slice from `@embedFile`. `file_type` is the lower-case
+        /// extension without the leading dot (e.g. `"wav"`, `"ogg"`).
+        ///
+        /// Idempotent against repeat-registration of the same name —
+        /// the assembler-generated scene manifest may register the
+        /// asset before this shim, and re-registering identical bytes
+        /// is a no-op.
+        pub fn registerSoundFromMemory(self: *Self, name: []const u8, file_type: [:0]const u8, audio_data: []const u8) !void {
+            self.assets.register(name, .audio, file_type, audio_data) catch |err| switch (err) {
+                error.AssetAlreadyRegistered => {},
+                else => return err,
+            };
+        }
+
+        /// Convenience: `registerSoundFromMemory` + `loadSoundIfNeeded`.
+        /// Blocks the calling frame until decode + upload finish, same
+        /// surface contract as `loadAtlasFromMemory` for images.
+        pub fn loadSoundFromMemory(self: *Self, name: []const u8, file_type: [:0]const u8, audio_data: []const u8) !void {
+            try self.registerSoundFromMemory(name, file_type, audio_data);
+            _ = try self.loadSoundIfNeeded(name);
+        }
+
+        /// Decode + upload a previously-registered sound if it hasn't
+        /// already been loaded. No-op (returns `false`) on already-ready
+        /// entries. Mirrors `loadAtlasIfNeeded`'s busy-pump shape; see
+        /// the long-form rationale there for the `errdefer release`,
+        /// `resetFailed`, and `std.Thread.yield` choices.
+        pub fn loadSoundIfNeeded(self: *Self, name: []const u8) !bool {
+            if (self.assets.isReady(name)) return false;
+            _ = try self.assets.acquire(name);
+            errdefer self.assets.release(name);
+            while (!self.assets.isReady(name)) {
+                if (self.assets.lastError(name)) |err| {
+                    self.assets.resetFailed(name);
+                    return err;
+                }
+                self.assets.pump();
+                std.Thread.yield() catch {};
+            }
+            return true;
+        }
+
+        // ── Font asset shims (Phase 4 of Asset Streaming RFC, #448) ──
+
+        /// Register a font in deferred mode: the catalog stores the
+        /// encoded TTF/OTF bytes alongside the bake params; rasterise +
+        /// atlas upload happen the first time `loadFontIfNeeded(name)`
+        /// (or the scene-manifest acquire path) bumps the refcount.
+        ///
+        /// `font_data` and `params` are borrowed — both must outlive
+        /// the catalog entry. `params` rides through `WorkRequest.params`
+        /// as a `?*const anyopaque` and is cast back to
+        /// `*const FontBakeParams` inside the font loader's `decode`
+        /// (RFC-FONT-LOADER §7). `file_type` is the lower-case
+        /// extension without the leading dot (`"ttf"`, `"otf"`).
+        pub fn registerFontFromMemory(
+            self: *Self,
+            name: []const u8,
+            file_type: [:0]const u8,
+            font_data: []const u8,
+            params: *const assets_mod.font_loader.FontBakeParams,
+        ) !void {
+            self.assets.registerFont(name, file_type, font_data, params) catch |err| switch (err) {
+                error.AssetAlreadyRegistered => {},
+                else => return err,
+            };
+        }
+
+        /// Convenience: `registerFontFromMemory` + `loadFontIfNeeded`.
+        pub fn loadFontFromMemory(
+            self: *Self,
+            name: []const u8,
+            file_type: [:0]const u8,
+            font_data: []const u8,
+            params: *const assets_mod.font_loader.FontBakeParams,
+        ) !void {
+            try self.registerFontFromMemory(name, file_type, font_data, params);
+            _ = try self.loadFontIfNeeded(name);
+        }
+
+        /// Decode + upload a previously-registered font if it hasn't
+        /// already been loaded. Same busy-pump shape as
+        /// `loadAtlasIfNeeded` / `loadSoundIfNeeded`.
+        pub fn loadFontIfNeeded(self: *Self, name: []const u8) !bool {
+            if (self.assets.isReady(name)) return false;
+            _ = try self.assets.acquire(name);
+            errdefer self.assets.release(name);
+            while (!self.assets.isReady(name)) {
+                if (self.assets.lastError(name)) |err| {
+                    self.assets.resetFailed(name);
+                    return err;
+                }
+                self.assets.pump();
+                std.Thread.yield() catch {};
+            }
+            return true;
+        }
+
         /// Whether an atlas's PNG has been decoded. Returns `false`
         /// for unregistered atlases too — both states mean "you can't
         /// use it yet". Used by loading scripts to decide which

--- a/test/asset_streaming_shim_test.zig
+++ b/test/asset_streaming_shim_test.zig
@@ -370,3 +370,241 @@ test "shim: double register through the shim is tolerated" {
     _ = try game.loadAtlasIfNeeded("shared");
     try testing.expect(game.isAtlasLoaded("shared"));
 }
+
+// ── Audio shim (Phase 4, #447) ──
+//
+// `registerSoundFromMemory` / `loadSoundFromMemory` / `loadSoundIfNeeded`
+// are the audio siblings of the atlas shim methods above. The mock
+// backend below mirrors `Mock` for images: process-global slot, reset
+// between tests, counters for decode / upload / unload.
+
+const MockAudio = struct {
+    var decode_calls: u32 = 0;
+    var upload_calls: u32 = 0;
+    var unload_calls: u32 = 0;
+    const sentinel: engine.SoundId = .{ .index = 7, .generation = 1 };
+
+    fn reset() void {
+        decode_calls = 0;
+        upload_calls = 0;
+        unload_calls = 0;
+    }
+
+    fn decodeFn(_: [:0]const u8, _: []const u8, allocator: std.mem.Allocator) anyerror!engine.DecodedAudio {
+        decode_calls += 1;
+        // 4 frames stereo, recognisable fill so a sloppy backend gets
+        // caught by `last_uploaded` assertions in the loader test.
+        const samples = try allocator.alloc(i16, 8);
+        @memset(samples, 0x1234);
+        return .{ .samples = samples, .sample_rate = 44100, .channels = 2 };
+    }
+
+    fn uploadFn(_: engine.DecodedAudio) anyerror!engine.SoundId {
+        upload_calls += 1;
+        return sentinel;
+    }
+
+    fn unloadFn(_: engine.SoundId) void {
+        unload_calls += 1;
+    }
+
+    const backend: engine.AudioBackend = .{
+        .decode = decodeFn,
+        .upload = uploadFn,
+        .unload = unloadFn,
+    };
+};
+
+const fake_wav: []const u8 = "fake-wav-bytes";
+const audio_file_type: [:0]const u8 = "wav";
+
+test "audio shim: registerSoundFromMemory + loadSoundIfNeeded round-trip" {
+    MockAudio.reset();
+    engine.AudioLoader.setBackend(MockAudio.backend);
+    defer engine.AudioLoader.clearBackend();
+
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    try game.registerSoundFromMemory("sfx", audio_file_type, fake_wav);
+    try testing.expect(!game.assets.isReady("sfx"));
+
+    const did_load = try game.loadSoundIfNeeded("sfx");
+    try testing.expect(did_load);
+    try testing.expect(game.assets.isReady("sfx"));
+    try testing.expectEqual(@as(u32, 1), MockAudio.decode_calls);
+    try testing.expectEqual(@as(u32, 1), MockAudio.upload_calls);
+}
+
+test "audio shim: loadSoundFromMemory is eager — ready before it returns" {
+    MockAudio.reset();
+    engine.AudioLoader.setBackend(MockAudio.backend);
+    defer engine.AudioLoader.clearBackend();
+
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    try game.loadSoundFromMemory("eager_sfx", audio_file_type, fake_wav);
+    try testing.expect(game.assets.isReady("eager_sfx"));
+}
+
+test "audio shim: loadSoundIfNeeded twice is idempotent" {
+    MockAudio.reset();
+    engine.AudioLoader.setBackend(MockAudio.backend);
+    defer engine.AudioLoader.clearBackend();
+
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    try game.registerSoundFromMemory("twice", audio_file_type, fake_wav);
+    const first = try game.loadSoundIfNeeded("twice");
+    const second = try game.loadSoundIfNeeded("twice");
+
+    try testing.expect(first);
+    try testing.expect(!second);
+    try testing.expectEqual(@as(u32, 1), MockAudio.decode_calls);
+    try testing.expectEqual(@as(u32, 1), MockAudio.upload_calls);
+}
+
+test "audio shim: double register through the shim is tolerated" {
+    MockAudio.reset();
+    engine.AudioLoader.setBackend(MockAudio.backend);
+    defer engine.AudioLoader.clearBackend();
+
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    // Manifest-style direct register, then shim register — must not
+    // propagate `AssetAlreadyRegistered`.
+    try game.assets.register("shared_sfx", .audio, audio_file_type, fake_wav);
+    try game.registerSoundFromMemory("shared_sfx", audio_file_type, fake_wav);
+    _ = try game.loadSoundIfNeeded("shared_sfx");
+    try testing.expect(game.assets.isReady("shared_sfx"));
+}
+
+// ── Font shim (Phase 4, #448) ──
+//
+// `registerFontFromMemory` / `loadFontFromMemory` / `loadFontIfNeeded`.
+// The font loader is the only loader that takes decode-time params
+// (`FontBakeParams`); the shim borrows a pointer that must outlive
+// the catalog entry.
+
+const MockFont = struct {
+    var decode_calls: u32 = 0;
+    var upload_calls: u32 = 0;
+    var unload_calls: u32 = 0;
+    var last_params_pixel_height: f32 = 0;
+    const sentinel: engine.FontId = .{ .index = 9, .generation = 1 };
+
+    fn reset() void {
+        decode_calls = 0;
+        upload_calls = 0;
+        unload_calls = 0;
+        last_params_pixel_height = 0;
+    }
+
+    fn decodeFn(_: [:0]const u8, _: []const u8, params: engine.FontBakeParams, allocator: std.mem.Allocator) anyerror!engine.DecodedFont {
+        decode_calls += 1;
+        // Capture the params the loader unmarshalled from
+        // `WorkRequest.params` so tests can assert the shim's
+        // pointer plumbing through `registerFont`.
+        last_params_pixel_height = params.pixel_height;
+        // 1×1 alpha atlas, single ASCII space glyph — minimum viable
+        // payload that exercises the full slice-ownership contract.
+        const bitmap = try allocator.alloc(u8, 1);
+        bitmap[0] = 0xFF;
+        const glyphs = try allocator.alloc(engine.Glyph, 1);
+        glyphs[0] = .{ .u0 = 0, .v0 = 0, .u1 = 1, .v1 = 1, .xoff = 0, .yoff = 0, .advance = 8 };
+        const idx = try allocator.alloc(engine.CodepointEntry, 1);
+        idx[0] = .{ .codepoint = 0x20, .glyph_index = 0 };
+        const kern = try allocator.alloc(engine.KernPair, 0);
+        return .{
+            .bitmap = bitmap,
+            .width = 1,
+            .height = 1,
+            .glyphs = glyphs,
+            .codepoint_index = idx,
+            .ascent = 12,
+            .descent = -4,
+            .line_gap = 0,
+            .line_height = 16,
+            .kerning = kern,
+        };
+    }
+
+    fn uploadFn(_: engine.DecodedFont) anyerror!engine.FontId {
+        upload_calls += 1;
+        return sentinel;
+    }
+
+    fn unloadFn(_: engine.FontId) void {
+        unload_calls += 1;
+    }
+
+    const backend: engine.FontBackend = .{
+        .decode = decodeFn,
+        .upload = uploadFn,
+        .unload = unloadFn,
+    };
+};
+
+const fake_ttf: []const u8 = "fake-ttf-bytes";
+const font_file_type: [:0]const u8 = "ttf";
+
+test "font shim: registerFontFromMemory + loadFontIfNeeded round-trip" {
+    MockFont.reset();
+    engine.FontLoader.setBackend(MockFont.backend);
+    defer engine.FontLoader.clearBackend();
+
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const params: engine.FontBakeParams = .{ .pixel_height = 24 };
+    try game.registerFontFromMemory("ui", font_file_type, fake_ttf, &params);
+    try testing.expect(!game.assets.isReady("ui"));
+
+    const did_load = try game.loadFontIfNeeded("ui");
+    try testing.expect(did_load);
+    try testing.expect(game.assets.isReady("ui"));
+    try testing.expectEqual(@as(u32, 1), MockFont.decode_calls);
+    try testing.expectEqual(@as(u32, 1), MockFont.upload_calls);
+    // The shim must have routed `params` through `WorkRequest.params`
+    // so the loader's `@ptrCast(@alignCast(...))` casts back to the
+    // exact value we passed in.
+    try testing.expectEqual(@as(f32, 24), MockFont.last_params_pixel_height);
+}
+
+test "font shim: loadFontFromMemory is eager — ready before it returns" {
+    MockFont.reset();
+    engine.FontLoader.setBackend(MockFont.backend);
+    defer engine.FontLoader.clearBackend();
+
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const params: engine.FontBakeParams = .{ .pixel_height = 16 };
+    try game.loadFontFromMemory("eager_font", font_file_type, fake_ttf, &params);
+    try testing.expect(game.assets.isReady("eager_font"));
+}
+
+test "font shim: distinct registrations with different params produce distinct entries" {
+    MockFont.reset();
+    engine.FontLoader.setBackend(MockFont.backend);
+    defer engine.FontLoader.clearBackend();
+
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const small: engine.FontBakeParams = .{ .pixel_height = 12 };
+    const large: engine.FontBakeParams = .{ .pixel_height = 48 };
+    try game.registerFontFromMemory("font_small", font_file_type, fake_ttf, &small);
+    try game.registerFontFromMemory("font_large", font_file_type, fake_ttf, &large);
+
+    _ = try game.loadFontIfNeeded("font_small");
+    _ = try game.loadFontIfNeeded("font_large");
+
+    try testing.expect(game.assets.isReady("font_small"));
+    try testing.expect(game.assets.isReady("font_large"));
+    try testing.expectEqual(@as(u32, 2), MockFont.decode_calls);
+    try testing.expectEqual(@as(u32, 2), MockFont.upload_calls);
+}


### PR DESCRIPTION
## Summary

Six new methods on `Game`, mirroring the existing `registerAtlasFromMemory` / `loadAtlasFromMemory` / `loadAtlasIfNeeded` trio so the assembler can emit consistent register/load calls for `.wav`/`.ogg`/`.ttf`/`.otf` resources alongside today's `.png` atlases:

- `registerSoundFromMemory(name, file_type, audio_data)`
- `loadSoundFromMemory(name, file_type, audio_data)`
- `loadSoundIfNeeded(name)`
- `registerFontFromMemory(name, file_type, font_data, params)`
- `loadFontFromMemory(name, file_type, font_data, params)`
- `loadFontIfNeeded(name)`

Same surface contract as the atlas helpers: `register*` is deferred (catalog stores the bytes; decode + upload run on the first `acquire`); `load*FromMemory` is eager (register + busy-pump); the `IfNeeded` path bumps the catalog refcount with the matching errdefer-release + `resetFailed` pattern.

Font helpers thread a `*const FontBakeParams` pointer through `catalog.registerFont`; the loader casts it back from `?*const anyopaque` inside its `decode` (RFC-FONT-LOADER §7).

Both helpers swallow `error.AssetAlreadyRegistered` to match the atlas pattern — assembler-generated scene manifest code may have registered the same name directly on the catalog before the shim fires.

## Why now

This is the engine half of the third follow-up listed in [labelle-assembler#102][a102] and [labelle-assembler#103][a103]. The next assembler PR will grow `ProjectConfig.resources` to accept audio + font resource shapes and dispatch the codegen between `loadAtlasFromMemory` and these new helpers based on the file extension. Without these helpers, the assembler would have to emit raw `game.assets.register(...)` / `game.assets.registerFont(...)` calls, which works but breaks symmetry with the image path.

[a102]: https://github.com/labelle-toolkit/labelle-assembler/pull/102
[a103]: https://github.com/labelle-toolkit/labelle-assembler/pull/103

## Test plan

- [x] `zig build test` — 373/373 passing (+7 new in `test/asset_streaming_shim_test.zig`).
- [x] New tests cover: register+load round-trip, eager variant, idempotent re-load, double-register tolerance (audio), distinct-params produce distinct entries (font).
- [x] `MockFont.decodeFn` captures `params.pixel_height` so the shim's pointer-threading through `catalog.registerFont` is verified end-to-end.
- [ ] Once merged: labelle-assembler PR for `ProjectConfig` audio/font resource shape + extension dispatch (separate PR).

## References

- #447 — audio loader tracking
- #448 — font loader tracking
- labelle-assembler#102 — audio codegen scaffolding (calls these helpers' Sound counterparts in its emitted adapter)
- labelle-assembler#103 — font codegen scaffolding