### PR TITLE
refactor(font_types): make POD structs extern for cross-repo bitcast

### DIFF
--- a/src/font_types.zig
+++ b/src/font_types.zig
@@ -25,7 +25,15 @@ pub const FontId = struct {
 /// already incorporate the glyph's bearing — the renderer just adds
 /// them to the pen position. `advance` moves the pen for the next
 /// glyph. See `RFC-FONT-LOADER.md` §3.
-pub const Glyph = struct {
+///
+/// `extern struct` so the assembler-generated `FontBackendAdapter` can
+/// `@ptrCast` slices between `[]BackendGfx.Glyph` and `[]engine.Glyph`
+/// (and the equivalent sokol-side types) — the three repos define
+/// structurally-identical-but-nominally-distinct `Glyph` types and
+/// rely on a zero-cost reinterpret at the codegen marshal boundary.
+/// Without `extern` the layout is unspecified and the reinterpret is
+/// UB. Layout-compatible across all three definitions: u16×4 then f32×3.
+pub const Glyph = extern struct {
     u0: u16,
     v0: u16,
     u1: u16,
@@ -38,16 +46,18 @@ pub const Glyph = struct {
 
 /// Sorted (by `codepoint`) lookup from Unicode codepoint to dense
 /// index in the `glyphs` array. Renderers binary-search this per
-/// glyph. Built from `FontBakeParams.ranges` at bake time.
-pub const CodepointEntry = struct {
+/// glyph. Built from `FontBakeParams.ranges` at bake time. `extern`
+/// for the same reason as `Glyph`.
+pub const CodepointEntry = extern struct {
     codepoint: u32,
     glyph_index: u32,
 };
 
 /// One GPOS kern pair. `advance` is added to the pen advance when
 /// `first` is followed by `second`. Empty slice when kerning is
-/// disabled or the font has no GPOS kern table.
-pub const KernPair = struct {
+/// disabled or the font has no GPOS kern table. `extern` for the
+/// same reason as `Glyph`.
+pub const KernPair = extern struct {
     first: u32,
     second: u32,
     advance: f32,


### PR DESCRIPTION
## Summary

\`Glyph\`, \`CodepointEntry\`, and \`KernPair\` are three structurally-identical-but-nominally-distinct types defined in three places:

- \`labelle-engine/src/font_types.zig\` (this PR)
- \`labelle-gfx/src/backend.zig\` (sibling PR coming)
- Concrete backends (the first one being labelle-assembler#108's sokol impl)

The assembler-generated \`FontBackendAdapter\` (from #525 / labelle-assembler#103+#105+#107) marshals between them at the codegen boundary. For flat fields the marshal is a plain \`.advance = d.advance\` assignment. For slice fields (\`.glyphs\`, \`.codepoint_index\`, \`.kerning\`) the fix is a zero-cost \`@ptrCast\` between \`[]BackendGfx.Glyph\` and \`[]engine.Glyph\`. For that ptrcast to be safe-by-spec, both element types must have guaranteed layout — i.e. \`extern struct\`.

The codegen \`@ptrCast\` lands in a sibling labelle-assembler PR.

## Why now

labelle-assembler#108 (sokol Phase 4 font + audio impl) flagged this as a real concern when reviewing its codegen interaction. Until #108, no concrete backend had implemented the font traits, so the slice-marshal codegen had never actually compiled. Now it has to.

## Test plan

- [x] \`zig build test\` — 373/373 passing.
- [x] No behavioural change — \`extern struct\` only restricts field ordering, doesn't change size or alignment for these all-primitive structs. Existing size-stability test in \`test/font_types_test.zig\` (locks Glyph=20, CodepointEntry=8, KernPair=12) continues to pass.

## References

- labelle-assembler#108 — sokol Phase 4 impl that flagged this
- labelle-engine#447 / #448 — Phase 4 tracking
- labelle-engine#529 — original font_types