### PR TITLE
feat(preview): node_entered emitter (#535)

### DIFF
--- a/src/preview_mode.zig
+++ b/src/preview_mode.zig
@@ -109,6 +109,7 @@ pub const BinaryFrameKind = enum(u8) {
     entity_created = 1,
     entity_destroyed = 2,
     component_changed = 3,
+    node_entered = 4,
     _,
 };
 
@@ -154,6 +155,13 @@ pub const Preview = struct {
     /// frames for. Keys allocated in `subs_arena` so the editor can
     /// churn the set without leaking into the per-frame `arena`.
     subscribed_components: std.StringHashMapUnmanaged(void) = .{},
+    /// Set of flow names (the `.flow.zon` file stem, no path / no
+    /// extension) the editor wants `node_entered` frames for. Inverse
+    /// default vs. `subscribed_components`: empty set means **no**
+    /// emit. Flow nodes fire much more frequently than component
+    /// changes (60+ Hz across many flows), so opt-in is the safer
+    /// default — editors that don't care pay zero cost.
+    subscribed_flows: std.StringHashMapUnmanaged(void) = .{},
     subs_arena: std.heap.ArenaAllocator,
     /// Inbound newline-framing buffer for `pollSubscription`. Owned
     /// by `inbox_alloc` (the parent allocator) so it can grow past the
@@ -186,6 +194,7 @@ pub const Preview = struct {
         // close here.
         self.stream.close();
         self.subscribed_components.deinit(self.subs_arena.allocator());
+        self.subscribed_flows.deinit(self.subs_arena.allocator());
         self.subs_arena.deinit();
         self.inbox.deinit(self.inbox_alloc);
         self.arena.deinit();
@@ -314,8 +323,41 @@ pub const Preview = struct {
         try self.writeBinaryFrame(.component_changed, buf);
     }
 
-    /// Drain any pending `subscribe` / `unsubscribe` JSON frames sent
-    /// by the editor and apply them to `subscribed_components`. Non-
+    /// Emit a `node_entered` binary frame. **No-op when the flow
+    /// name is not in `subscribed_flows`** — flow nodes fire at
+    /// frame rate across many flows, so the early-out keeps the
+    /// engine from doing even a single allocation if the editor
+    /// hasn't asked for this flow yet.
+    ///
+    /// Payload layout (little-endian):
+    ///
+    ///     [u16 flow_name_len] [flow_name bytes (UTF-8)] [u32 node_id]
+    ///
+    /// `flow_name` is the `.flow.zon` file stem (no path, no
+    /// extension); `node_id` is the stable u32 id the flow_io parser
+    /// assigns to each node.
+    pub fn emitNodeEntered(
+        self: *Preview,
+        flow_name: []const u8,
+        node_id: u32,
+    ) WriteError!void {
+        if (!self.isFlowSubscribed(flow_name)) return;
+        defer _ = self.arena.reset(.retain_capacity);
+        const alloc = self.arena.allocator();
+        const payload_len: usize = @sizeOf(u16) + flow_name.len + @sizeOf(u32);
+        const buf = try alloc.alloc(u8, payload_len);
+        var off: usize = 0;
+        std.mem.writeInt(u16, buf[off..][0..2], @intCast(flow_name.len), .little);
+        off += 2;
+        @memcpy(buf[off .. off + flow_name.len], flow_name);
+        off += flow_name.len;
+        std.mem.writeInt(u32, buf[off..][0..4], node_id, .little);
+        try self.writeBinaryFrame(.node_entered, buf);
+    }
+
+    /// Drain any pending `subscribe` / `unsubscribe` / `subscribe_flow`
+    /// / `unsubscribe_flow` JSON frames sent by the editor and apply
+    /// them to `subscribed_components` / `subscribed_flows`. Non-
     /// blocking — reads only what's currently available on the
     /// socket. Safe to call once per tick.
     ///
@@ -323,6 +365,8 @@ pub const Preview = struct {
     ///
     ///     {"kind":"subscribe","components":["Position","Velocity"]}\n
     ///     {"kind":"unsubscribe","components":["Velocity"]}\n
+    ///     {"kind":"subscribe_flow","flow":"player_state_machine"}\n
+    ///     {"kind":"unsubscribe_flow","flow":"player_state_machine"}\n
     ///
     /// Returns `MalformedSubscription` if a frame parses as JSON but
     /// the shape doesn't match; the caller can choose to log + drop.
@@ -348,6 +392,13 @@ pub const Preview = struct {
     /// serializing the component bytes.
     pub fn isComponentSubscribed(self: *const Preview, comp_name: []const u8) bool {
         return self.subscribed_components.contains(comp_name);
+    }
+
+    /// Returns `true` if `emitNodeEntered` would emit a frame for
+    /// this flow. Useful as a guard around the cost of resolving the
+    /// flow name string at the call site.
+    pub fn isFlowSubscribed(self: *const Preview, flow_name: []const u8) bool {
+        return self.subscribed_flows.contains(flow_name);
     }
 
     // ── Internals ───────────────────────────────────────────────────
@@ -401,25 +452,52 @@ pub const Preview = struct {
         defer _ = self.arena.reset(.retain_capacity);
         const alloc = self.arena.allocator();
 
-        const Parsed = struct {
-            kind: []const u8,
-            components: []const []const u8,
-        };
-        const parsed = std.json.parseFromSliceLeaky(Parsed, alloc, line, .{
+        // Peek the kind first so we can dispatch to a shape-specific
+        // parser. `subscribe`/`unsubscribe` carry a `components`
+        // array; `subscribe_flow`/`unsubscribe_flow` carry a single
+        // `flow` string. Parsing each against its own shape keeps
+        // the wire forwards-compatible — future kinds just add a
+        // branch here.
+        const KindOnly = struct { kind: []const u8 };
+        const kind_only = std.json.parseFromSliceLeaky(KindOnly, alloc, line, .{
             .ignore_unknown_fields = true,
         }) catch return error.MalformedSubscription;
 
-        if (std.mem.eql(u8, parsed.kind, "subscribe")) {
+        if (std.mem.eql(u8, kind_only.kind, "subscribe")) {
+            const Parsed = struct { kind: []const u8, components: []const []const u8 };
+            const parsed = std.json.parseFromSliceLeaky(Parsed, alloc, line, .{
+                .ignore_unknown_fields = true,
+            }) catch return error.MalformedSubscription;
             const subs_alloc = self.subs_arena.allocator();
             for (parsed.components) |name| {
                 if (self.subscribed_components.contains(name)) continue;
                 const owned = try subs_alloc.dupe(u8, name);
                 try self.subscribed_components.put(subs_alloc, owned, {});
             }
-        } else if (std.mem.eql(u8, parsed.kind, "unsubscribe")) {
+        } else if (std.mem.eql(u8, kind_only.kind, "unsubscribe")) {
+            const Parsed = struct { kind: []const u8, components: []const []const u8 };
+            const parsed = std.json.parseFromSliceLeaky(Parsed, alloc, line, .{
+                .ignore_unknown_fields = true,
+            }) catch return error.MalformedSubscription;
             for (parsed.components) |name| {
                 _ = self.subscribed_components.remove(name);
             }
+        } else if (std.mem.eql(u8, kind_only.kind, "subscribe_flow")) {
+            const Parsed = struct { kind: []const u8, flow: []const u8 };
+            const parsed = std.json.parseFromSliceLeaky(Parsed, alloc, line, .{
+                .ignore_unknown_fields = true,
+            }) catch return error.MalformedSubscription;
+            if (!self.subscribed_flows.contains(parsed.flow)) {
+                const subs_alloc = self.subs_arena.allocator();
+                const owned = try subs_alloc.dupe(u8, parsed.flow);
+                try self.subscribed_flows.put(subs_alloc, owned, {});
+            }
+        } else if (std.mem.eql(u8, kind_only.kind, "unsubscribe_flow")) {
+            const Parsed = struct { kind: []const u8, flow: []const u8 };
+            const parsed = std.json.parseFromSliceLeaky(Parsed, alloc, line, .{
+                .ignore_unknown_fields = true,
+            }) catch return error.MalformedSubscription;
+            _ = self.subscribed_flows.remove(parsed.flow);
         } else {
             return error.MalformedSubscription;
         }

--- a/test/preview_mode_test.zig
+++ b/test/preview_mode_test.zig
@@ -707,6 +707,185 @@ test "Game lifecycle: createEntity + addComponent emit telemetry; destroy + filt
     }
 }
 
+// ── Phase 3 / #535 — node_entered binary telemetry ──────────────────
+
+/// Spin until the engine reports the given flow as subscribed. Mirror
+/// of `waitForSubscription` for the flow opt-in set.
+fn waitForFlowSubscription(preview: *Preview, flow_name: []const u8, deadline_ms: u64) !void {
+    const start = std.time.milliTimestamp();
+    while (true) {
+        try preview.pollSubscription();
+        if (preview.isFlowSubscribed(flow_name)) return;
+        const now = std.time.milliTimestamp();
+        if (now - start > @as(i64, @intCast(deadline_ms))) return error.SubscriptionDeadlineExceeded;
+        std.Thread.sleep(1 * std.time.ns_per_ms);
+    }
+}
+
+fn waitForFlowUnsubscribed(preview: *Preview, flow_name: []const u8, deadline_ms: u64) !void {
+    const start = std.time.milliTimestamp();
+    while (preview.isFlowSubscribed(flow_name)) {
+        try preview.pollSubscription();
+        const now = std.time.milliTimestamp();
+        if (now - start > @as(i64, @intCast(deadline_ms))) return error.UnsubscribeDeadlineExceeded;
+        std.Thread.sleep(1 * std.time.ns_per_ms);
+    }
+}
+
+test "emitNodeEntered: emits one binary frame when flow is subscribed" {
+    const allocator = std.testing.allocator;
+    var harness = try LoopbackHarness.init();
+    defer harness.deinit();
+
+    var host_port_buf: [32]u8 = undefined;
+    const host_port = try harness.hostPort(&host_port_buf);
+    var preview = try Preview.connect(allocator, host_port);
+    defer preview.deinit();
+    try harness.accept();
+
+    try harness.writeJsonLine("{\"kind\":\"subscribe_flow\",\"flow\":\"test_flow\"}");
+    try waitForFlowSubscription(&preview, "test_flow", 1000);
+
+    try preview.emitNodeEntered("test_flow", 42);
+
+    var payload_buf: [256]u8 = undefined;
+    const frame = try harness.readBinaryFrame(&payload_buf);
+    try std.testing.expectEqual(@intFromEnum(BinaryFrameKind.node_entered), frame.kind);
+    // [u16 flow_name_len][flow_name][u32 node_id]
+    const name_len = std.mem.readInt(u16, frame.payload[0..2], .little);
+    try std.testing.expectEqual(@as(u16, 9), name_len);
+    try std.testing.expectEqualStrings("test_flow", frame.payload[2 .. 2 + name_len]);
+    const id_off: usize = 2 + name_len;
+    try std.testing.expectEqual(@as(u32, 42), std.mem.readInt(u32, frame.payload[id_off..][0..4], .little));
+    // Payload tightly sized — no trailing bytes.
+    try std.testing.expectEqual(id_off + 4, frame.payload.len);
+}
+
+test "emitNodeEntered: no-op when flow is not subscribed" {
+    // Default empty subscription set → opt-in semantics → silence.
+    const allocator = std.testing.allocator;
+    var harness = try LoopbackHarness.init();
+    defer harness.deinit();
+
+    var host_port_buf: [32]u8 = undefined;
+    const host_port = try harness.hostPort(&host_port_buf);
+    var preview = try Preview.connect(allocator, host_port);
+    defer preview.deinit();
+    try harness.accept();
+
+    try std.testing.expect(!preview.isFlowSubscribed("test_flow"));
+    try preview.emitNodeEntered("test_flow", 1);
+    try preview.emitNodeEntered("other_flow", 2);
+
+    // Send a single JSON frame so the harness has something to read
+    // after the (silent) emits — proves no binary bytes preceded it.
+    try preview.sendHeartbeat(500);
+    var buf: [256]u8 = undefined;
+    try std.testing.expect((try harness.peekByte()) != binary_magic);
+    const f = try harness.readFrame(&buf);
+    try std.testing.expect(std.mem.indexOf(u8, f, "\"kind\":\"heartbeat\"") != null);
+}
+
+test "emitNodeEntered: stops firing after unsubscribe_flow" {
+    const allocator = std.testing.allocator;
+    var harness = try LoopbackHarness.init();
+    defer harness.deinit();
+
+    var host_port_buf: [32]u8 = undefined;
+    const host_port = try harness.hostPort(&host_port_buf);
+    var preview = try Preview.connect(allocator, host_port);
+    defer preview.deinit();
+    try harness.accept();
+
+    try harness.writeJsonLine("{\"kind\":\"subscribe_flow\",\"flow\":\"player_state_machine\"}");
+    try waitForFlowSubscription(&preview, "player_state_machine", 1000);
+    try preview.emitNodeEntered("player_state_machine", 7);
+
+    // Consume the one expected frame.
+    var payload_buf: [256]u8 = undefined;
+    const frame = try harness.readBinaryFrame(&payload_buf);
+    try std.testing.expectEqual(@intFromEnum(BinaryFrameKind.node_entered), frame.kind);
+
+    try harness.writeJsonLine("{\"kind\":\"unsubscribe_flow\",\"flow\":\"player_state_machine\"}");
+    try waitForFlowUnsubscribed(&preview, "player_state_machine", 1000);
+
+    // After unsubscribe the emit must be a no-op. Probe with a
+    // heartbeat so we can prove no binary frame slipped through.
+    try preview.emitNodeEntered("player_state_machine", 8);
+    try preview.sendHeartbeat(999);
+    try std.testing.expect((try harness.peekByte()) != binary_magic);
+    var buf: [256]u8 = undefined;
+    const f = try harness.readFrame(&buf);
+    try std.testing.expect(std.mem.indexOf(u8, f, "\"kind\":\"heartbeat\"") != null);
+}
+
+test "emitNodeEntered: exact wire-format guard against drift" {
+    // Hand-compose the bytes we expect on the wire for one frame and
+    // diff against `emitNodeEntered`'s output byte-for-byte. Guards
+    // against accidental layout changes — the editor parses this
+    // exact shape.
+    const allocator = std.testing.allocator;
+    var harness = try LoopbackHarness.init();
+    defer harness.deinit();
+
+    var host_port_buf: [32]u8 = undefined;
+    const host_port = try harness.hostPort(&host_port_buf);
+    var preview = try Preview.connect(allocator, host_port);
+    defer preview.deinit();
+    try harness.accept();
+
+    try harness.writeJsonLine("{\"kind\":\"subscribe_flow\",\"flow\":\"hud\"}");
+    try waitForFlowSubscription(&preview, "hud", 1000);
+
+    try preview.emitNodeEntered("hud", 0x01020304);
+
+    // Header: magic(1) + kind(1) + length(4, LE)
+    // Payload: u16 name_len LE + "hud" + u32 node_id LE
+    // payload_len = 2 + 3 + 4 = 9
+    const expected = [_]u8{
+        binary_magic,
+        @intFromEnum(BinaryFrameKind.node_entered),
+        9, 0, 0, 0, // length LE
+        3, 0, // name_len LE
+        'h', 'u', 'd',
+        0x04, 0x03, 0x02, 0x01, // node_id LE
+    };
+    var actual: [expected.len]u8 = undefined;
+    try harness.readExact(&actual);
+    try std.testing.expectEqualSlices(u8, &expected, &actual);
+}
+
+test "pollSubscription: subscribe_flow / unsubscribe_flow update subscribed_flows" {
+    const allocator = std.testing.allocator;
+    var harness = try LoopbackHarness.init();
+    defer harness.deinit();
+
+    var host_port_buf: [32]u8 = undefined;
+    const host_port = try harness.hostPort(&host_port_buf);
+    var preview = try Preview.connect(allocator, host_port);
+    defer preview.deinit();
+    try harness.accept();
+
+    try harness.writeJsonLine("{\"kind\":\"subscribe_flow\",\"flow\":\"alpha\"}");
+    try harness.writeJsonLine("{\"kind\":\"subscribe_flow\",\"flow\":\"beta\"}");
+    try waitForFlowSubscription(&preview, "alpha", 1000);
+    try waitForFlowSubscription(&preview, "beta", 1000);
+    try std.testing.expect(preview.isFlowSubscribed("alpha"));
+    try std.testing.expect(preview.isFlowSubscribed("beta"));
+    try std.testing.expect(!preview.isFlowSubscribed("gamma"));
+
+    // Speculative subscribe to a flow that doesn't exist yet must
+    // silently succeed — editors subscribe before flows load.
+    try harness.writeJsonLine("{\"kind\":\"subscribe_flow\",\"flow\":\"not_yet_loaded\"}");
+    try waitForFlowSubscription(&preview, "not_yet_loaded", 1000);
+
+    try harness.writeJsonLine("{\"kind\":\"unsubscribe_flow\",\"flow\":\"beta\"}");
+    try waitForFlowUnsubscribed(&preview, "beta", 1000);
+    try std.testing.expect(preview.isFlowSubscribed("alpha"));
+    try std.testing.expect(!preview.isFlowSubscribed("beta"));
+    try std.testing.expect(preview.isFlowSubscribed("not_yet_loaded"));
+}
+
 test "Game without preview attached: ECS lifecycle is a no-op for telemetry (#520)" {
     // Sanity check that the `if (self.preview) |*p|` guards genuinely
     // short-circuit — a Game with `preview = null` must not crash, write


### PR DESCRIPTION
## Summary

Phase 3 of the PIE preview umbrella (labelle-gui#59). Adds the engine-side primitive for the editor's "active flow node" highlight: a `node_entered(flow_name, node_id)` binary telemetry frame on the existing preview socket.

- New `BinaryFrameKind.node_entered = 4` (appended; discriminators 1-3 unchanged).
- New `subscribed_flows: StringHashMap(void)` with **opt-in** default (inverse of `subscribed_components`): empty set means no emit. Flow nodes fire at frame rate across many flows, so editors that don't care pay zero cost.
- `Preview.emitNodeEntered(flow_name, node_id)` writes `[u16 name_len LE][name][u32 node_id LE]` after the standard `[0x1B][kind][u32 len LE]` header. Early-out before allocation when not subscribed.
- `pollSubscription` now also decodes `{"kind":"subscribe_flow","flow":"..."}` / `{"kind":"unsubscribe_flow","flow":"..."}` control-plane frames. Caller-owned strings are duped into `subs_arena` to match the existing pattern.

## Flow-runtime hookup: deferred to #536

The hookup at the per-node dispatch site (`if (game.preview) |*p| p.emitNodeEntered(flow_name, node.id) catch {};`) is **not in this PR** because the Flows runtime referenced in #535's "Dependencies" section is not present on `main`: no `Flow` type, no `flow.tick()`, no `.flow.zon` loader, and no node-enter callback to hook into. The umbrella issue list (#43-#56) tracks runtime work that has not landed yet.

Once that infrastructure lands, the integration is a one-liner; #536 tracks it.

## Test plan

- [x] `zig build test` green locally (266 insertions, 9 deletions; 5 new tests).
- [x] Subscribed emit → asserts binary frame contents (kind, name_len, name bytes, node_id, tight payload sizing).
- [x] Unsubscribed default → no binary bytes precede a subsequent heartbeat (proves silence).
- [x] Subscribe + unsubscribe → emit after unsubscribe is silent (proves the membership flip works).
- [x] Hand-composed wire-format guard → exact byte-for-byte comparison of a `node_entered` frame against the spec in the issue.
- [x] Speculative subscribe to a not-yet-loaded flow name silently succeeds (matches acceptance criterion in #535).
- [x] Phase 1 / Phase 2 tests (hello, heartbeat, bye, entity_created, entity_destroyed, component_changed, malformed JSON) continue to pass.

## References

- Closes #535 (emitter + control-plane support; runtime hookup tracked in #536).
- Filed #536 for the runtime call-site once Flows lands.
- Extends #518 (Phase 2 binary frame design).
- labelle-gui#59 — PIE preview umbrella; Phase 3 names this work as "see the flow running".