### PR TITLE
feat(preview): watch_entity protocol + filtered component_changed (#534)

### DIFF
--- a/src/preview_mode.zig
+++ b/src/preview_mode.zig
@@ -31,6 +31,8 @@
 ///        {"kind":"bye","reason":"normal"}\n
 ///        {"kind":"subscribe","components":["Position","Velocity"]}\n   (editor → engine)
 ///        {"kind":"unsubscribe","components":["Velocity"]}\n             (editor → engine)
+///        {"kind":"watch_entity","id":42}\n                               (editor → engine, Phase 3)
+///        {"kind":"unwatch_entity","id":42}\n                             (editor → engine, Phase 3)
 ///
 /// 2. **Binary telemetry plane** (Phase 2) — length-prefixed records
 ///    led by an `ESC` (0x1B) magic byte:
@@ -118,6 +120,13 @@ pub const BinaryFrameKind = enum(u8) {
 /// wire traffic at ~4 Hz regardless of frame rate.
 pub const heartbeat_interval_ms: u64 = 250;
 
+/// A (component_name, raw_bytes) pair for `emitEntitySnapshot`. Both
+/// slices are borrowed — they only need to outlive the snapshot call.
+pub const SnapshotComponent = struct {
+    name: []const u8,
+    bytes: []const u8,
+};
+
 pub const ParseError = error{
     InvalidAddress,
     InvalidPort,
@@ -144,9 +153,15 @@ pub const PollError = std.net.Stream.ReadError || error{
 ///   `component_changed` frames for. Default empty: until the editor
 ///   opts in, no component traffic flows. Lifecycle frames
 ///   (`entity_created`/`entity_destroyed`) always emit.
+/// - `watched_entities` — entity IDs the editor has asked to scope
+///   `component_changed` frames to (Phase 3 / #534). Empty set means
+///   "watch everything" (Phase 2 back-compat). Non-empty set means
+///   only IDs in the set emit; the component-name filter still
+///   applies on top.
 /// - `inbox` — partial-read buffer for the editor → engine direction
-///   (newline-delimited JSON: `subscribe`/`unsubscribe`). Sized for a
-///   handful of component names; grows on demand via `inbox_alloc`.
+///   (newline-delimited JSON: `subscribe`/`unsubscribe`/
+///   `watch_entity`/`unwatch_entity`). Sized for a handful of names;
+///   grows on demand via `inbox_alloc`.
 pub const Preview = struct {
     stream: std.net.Stream,
     arena: std.heap.ArenaAllocator,
@@ -163,6 +178,10 @@ pub const Preview = struct {
     /// default — editors that don't care pay zero cost.
     subscribed_flows: std.StringHashMapUnmanaged(void) = .{},
     subs_arena: std.heap.ArenaAllocator,
+    /// Set of entity IDs the editor wants `component_changed` frames
+    /// scoped to. See the field-level doc on `Preview` for the
+    /// empty-set semantics (= "watch everything").
+    watched_entities: std.AutoHashMapUnmanaged(u64, void) = .{},
     /// Inbound newline-framing buffer for `pollSubscription`. Owned
     /// by `inbox_alloc` (the parent allocator) so it can grow past the
     /// initial capacity if a very long subscribe list arrives.
@@ -195,6 +214,7 @@ pub const Preview = struct {
         self.stream.close();
         self.subscribed_components.deinit(self.subs_arena.allocator());
         self.subscribed_flows.deinit(self.subs_arena.allocator());
+        self.watched_entities.deinit(self.subs_arena.allocator());
         self.subs_arena.deinit();
         self.inbox.deinit(self.inbox_alloc);
         self.arena.deinit();
@@ -292,6 +312,11 @@ pub const Preview = struct {
     /// even a single allocation if the editor hasn't asked for this
     /// component yet.
     ///
+    /// Phase 3 (#534): also no-op when `watched_entities` is non-
+    /// empty AND `entity_id` is not in the set. Empty `watched_entities`
+    /// preserves Phase 2 "watch everything" semantics so existing
+    /// callers see no behaviour change until the editor opts in.
+    ///
     /// Payload layout (little-endian):
     ///
     ///     [u64 entity_id] [u16 name_len] [name bytes] [u32 data_len] [data bytes]
@@ -306,6 +331,45 @@ pub const Preview = struct {
         comp_bytes: []const u8,
     ) WriteError!void {
         if (!self.isComponentSubscribed(comp_name)) return;
+        if (!self.isEntityWatched(entity_id)) return;
+        try self.writeComponentChangedFrame(entity_id, comp_name, comp_bytes);
+    }
+
+    /// Emit a one-shot "snapshot" of an entity's components. Mechanically
+    /// just N back-to-back `component_changed` frames — the snapshot is
+    /// the wire-level concept of "all current values right now" rather
+    /// than a distinct frame kind. Useful right after the editor sends
+    /// `watch_entity` so the UI doesn't sit on a stale view until the
+    /// next mutation.
+    ///
+    /// Bypasses the `watched_entities` filter (the caller has obviously
+    /// already decided this entity is interesting) but **honours**
+    /// `subscribed_components` so a snapshot doesn't leak component
+    /// kinds the editor hasn't opted into.
+    ///
+    /// Note: `Preview` does not own the ECS, so it can't walk an entity's
+    /// components on its own — `game.zig` knows that mapping and is
+    /// expected to call this helper from its `watch_entity` arrival
+    /// hook. As of Phase 3 the wiring on the `game.zig` side is still a
+    /// follow-up; this method exposes the wire format so that follow-up
+    /// has a single call site.
+    pub fn emitEntitySnapshot(
+        self: *Preview,
+        entity_id: u64,
+        components: []const SnapshotComponent,
+    ) WriteError!void {
+        for (components) |c| {
+            if (!self.isComponentSubscribed(c.name)) continue;
+            try self.writeComponentChangedFrame(entity_id, c.name, c.bytes);
+        }
+    }
+
+    fn writeComponentChangedFrame(
+        self: *Preview,
+        entity_id: u64,
+        comp_name: []const u8,
+        comp_bytes: []const u8,
+    ) WriteError!void {
         defer _ = self.arena.reset(.retain_capacity);
         const alloc = self.arena.allocator();
         const payload_len: usize = @sizeOf(u64) + @sizeOf(u16) + comp_name.len + @sizeOf(u32) + comp_bytes.len;
@@ -401,6 +465,14 @@ pub const Preview = struct {
         return self.subscribed_flows.contains(flow_name);
     }
 
+    /// Phase 3 (#534) entity-scope check. Returns `true` when the
+    /// caller should emit for `entity_id`. The "empty set means watch
+    /// everything" rule lives here so call sites stay free of policy.
+    pub fn isEntityWatched(self: *const Preview, entity_id: u64) bool {
+        if (self.watched_entities.count() == 0) return true;
+        return self.watched_entities.contains(entity_id);
+    }
+
     // ── Internals ───────────────────────────────────────────────────
 
     fn writeBinaryFrame(
@@ -455,9 +527,9 @@ pub const Preview = struct {
         // Peek the kind first so we can dispatch to a shape-specific
         // parser. `subscribe`/`unsubscribe` carry a `components`
         // array; `subscribe_flow`/`unsubscribe_flow` carry a single
-        // `flow` string. Parsing each against its own shape keeps
-        // the wire forwards-compatible — future kinds just add a
-        // branch here.
+        // `flow` string; `watch_entity`/`unwatch_entity` carry an
+        // `id`. Parsing each against its own shape keeps the wire
+        // forwards-compatible — future kinds just add a branch here.
         const KindOnly = struct { kind: []const u8 };
         const kind_only = std.json.parseFromSliceLeaky(KindOnly, alloc, line, .{
             .ignore_unknown_fields = true,
@@ -498,6 +570,24 @@ pub const Preview = struct {
                 .ignore_unknown_fields = true,
             }) catch return error.MalformedSubscription;
             _ = self.subscribed_flows.remove(parsed.flow);
+        } else if (std.mem.eql(u8, kind_only.kind, "watch_entity")) {
+            // Phase 3 (#534). Empty `watched_entities` means
+            // "watch everything"; once the editor adds an ID we
+            // switch to the strict include-list. The follow-up
+            // snapshot fire is left to the caller in this PR — the
+            // engine doesn't own the ECS, so it can't walk an
+            // entity's components from here. See `emitEntitySnapshot`.
+            const Parsed = struct { kind: []const u8, id: u64 };
+            const parsed = std.json.parseFromSliceLeaky(Parsed, alloc, line, .{
+                .ignore_unknown_fields = true,
+            }) catch return error.MalformedSubscription;
+            try self.watched_entities.put(self.subs_arena.allocator(), parsed.id, {});
+        } else if (std.mem.eql(u8, kind_only.kind, "unwatch_entity")) {
+            const Parsed = struct { kind: []const u8, id: u64 };
+            const parsed = std.json.parseFromSliceLeaky(Parsed, alloc, line, .{
+                .ignore_unknown_fields = true,
+            }) catch return error.MalformedSubscription;
+            _ = self.watched_entities.remove(parsed.id);
         } else {
             return error.MalformedSubscription;
         }

--- a/test/preview_mode_test.zig
+++ b/test/preview_mode_test.zig
@@ -886,6 +886,268 @@ test "pollSubscription: subscribe_flow / unsubscribe_flow update subscribed_flow
     try std.testing.expect(preview.isFlowSubscribed("not_yet_loaded"));
 }
 
+// ── Phase 3 / #534 — watch_entity protocol + filtered emission ──────
+
+/// Spin until `preview.pollSubscription` reports the given entity is
+/// in the watched set. Bounded so a broken implementation can't hang
+/// the test runner.
+fn waitForWatchedEntity(preview: *Preview, id: u64, deadline_ms: u64) !void {
+    const start = std.time.milliTimestamp();
+    while (true) {
+        try preview.pollSubscription();
+        if (preview.watched_entities.contains(id)) return;
+        if (std.time.milliTimestamp() - start > @as(i64, @intCast(deadline_ms))) {
+            return error.WatchEntityDeadlineExceeded;
+        }
+        std.Thread.sleep(1 * std.time.ns_per_ms);
+    }
+}
+
+fn waitForUnwatchedEntity(preview: *Preview, id: u64, deadline_ms: u64) !void {
+    const start = std.time.milliTimestamp();
+    while (preview.watched_entities.contains(id)) {
+        try preview.pollSubscription();
+        if (std.time.milliTimestamp() - start > @as(i64, @intCast(deadline_ms))) {
+            return error.UnwatchEntityDeadlineExceeded;
+        }
+        std.Thread.sleep(1 * std.time.ns_per_ms);
+    }
+}
+
+test "watch_entity: adds id to watched_entities and filters subsequent emits" {
+    const allocator = std.testing.allocator;
+    var harness = try LoopbackHarness.init();
+    defer harness.deinit();
+
+    var host_port_buf: [32]u8 = undefined;
+    const host_port = try harness.hostPort(&host_port_buf);
+    var preview = try Preview.connect(allocator, host_port);
+    defer preview.deinit();
+    try harness.accept();
+
+    // Subscribe to Position so component_changed can actually flow.
+    try harness.writeJsonLine("{\"kind\":\"subscribe\",\"components\":[\"Position\"]}");
+    try waitForSubscription(&preview, "Position", 1000);
+
+    // Empty watched_entities → "watch everything" mode. Both entities
+    // should currently emit.
+    try std.testing.expect(preview.isEntityWatched(42));
+    try std.testing.expect(preview.isEntityWatched(99));
+
+    // Editor watches entity 42.
+    try harness.writeJsonLine("{\"kind\":\"watch_entity\",\"id\":42}");
+    try waitForWatchedEntity(&preview, 42, 1000);
+    try std.testing.expect(preview.isEntityWatched(42));
+    try std.testing.expect(!preview.isEntityWatched(99));
+
+    // Emit on entity 42 — should flow on the wire.
+    try preview.emitComponentChanged(42, "Position", &[_]u8{ 0xAA, 0xBB, 0xCC, 0xDD });
+    // Emit on entity 99 — must NOT flow (watched_entities non-empty,
+    // 99 not in the set).
+    try preview.emitComponentChanged(99, "Position", &[_]u8{ 0x11, 0x22, 0x33, 0x44 });
+    // A second emit on 42 to give us a deterministic "next frame".
+    try preview.emitComponentChanged(42, "Position", &[_]u8{ 0xEE, 0xFF });
+
+    // First frame is the first 42 emit.
+    var payload_buf: [256]u8 = undefined;
+    {
+        const f = try harness.readBinaryFrame(&payload_buf);
+        try std.testing.expectEqual(@intFromEnum(BinaryFrameKind.component_changed), f.kind);
+        try std.testing.expectEqual(@as(u64, 42), std.mem.readInt(u64, f.payload[0..8], .little));
+    }
+    // Second frame must skip 99 entirely and be the second 42 emit.
+    {
+        const f = try harness.readBinaryFrame(&payload_buf);
+        try std.testing.expectEqual(@intFromEnum(BinaryFrameKind.component_changed), f.kind);
+        try std.testing.expectEqual(@as(u64, 42), std.mem.readInt(u64, f.payload[0..8], .little));
+        const name_len = std.mem.readInt(u16, f.payload[8..10], .little);
+        const data_off: usize = 10 + name_len;
+        const data_len = std.mem.readInt(u32, f.payload[data_off..][0..4], .little);
+        try std.testing.expectEqual(@as(u32, 2), data_len);
+        try std.testing.expectEqualSlices(u8, &[_]u8{ 0xEE, 0xFF }, f.payload[data_off + 4 .. data_off + 4 + data_len]);
+    }
+}
+
+test "unwatch_entity: empty set restores Phase 2 'watch everything' behaviour" {
+    // Design decision (#534): when the editor removes the last watched
+    // id, `watched_entities` empties and we fall back to "watch
+    // everything" — i.e. the Phase 2 default. Rationale: multi-entity
+    // tracking is Phase 4+; today's editor watches one entity at a
+    // time, and a strict include-list that goes silent the instant the
+    // user deselects would surprise callers who rely on the Phase 2
+    // contract. The empty-set rule is the single chokepoint
+    // (`isEntityWatched`), so flipping the semantics later is a one-
+    // line change if Phase 4 wants it.
+    const allocator = std.testing.allocator;
+    var harness = try LoopbackHarness.init();
+    defer harness.deinit();
+
+    var host_port_buf: [32]u8 = undefined;
+    const host_port = try harness.hostPort(&host_port_buf);
+    var preview = try Preview.connect(allocator, host_port);
+    defer preview.deinit();
+    try harness.accept();
+
+    try harness.writeJsonLine("{\"kind\":\"subscribe\",\"components\":[\"Position\"]}");
+    try waitForSubscription(&preview, "Position", 1000);
+
+    try harness.writeJsonLine("{\"kind\":\"watch_entity\",\"id\":42}");
+    try waitForWatchedEntity(&preview, 42, 1000);
+
+    // Sanity: while 42 is watched, 99 stays silent.
+    try preview.emitComponentChanged(99, "Position", &[_]u8{0xCC});
+    try preview.emitComponentChanged(42, "Position", &[_]u8{0xDE});
+    var payload_buf: [256]u8 = undefined;
+    {
+        const f = try harness.readBinaryFrame(&payload_buf);
+        try std.testing.expectEqual(@as(u64, 42), std.mem.readInt(u64, f.payload[0..8], .little));
+    }
+
+    // Editor unwatches 42 → set becomes empty → back to "watch all".
+    try harness.writeJsonLine("{\"kind\":\"unwatch_entity\",\"id\":42}");
+    try waitForUnwatchedEntity(&preview, 42, 1000);
+    try std.testing.expectEqual(@as(usize, 0), preview.watched_entities.count());
+    try std.testing.expect(preview.isEntityWatched(42));
+    try std.testing.expect(preview.isEntityWatched(99));
+
+    // Both entities now ride the wire again.
+    try preview.emitComponentChanged(99, "Position", &[_]u8{0xAA});
+    try preview.emitComponentChanged(42, "Position", &[_]u8{0xBB});
+    {
+        const f = try harness.readBinaryFrame(&payload_buf);
+        try std.testing.expectEqual(@as(u64, 99), std.mem.readInt(u64, f.payload[0..8], .little));
+    }
+    {
+        const f = try harness.readBinaryFrame(&payload_buf);
+        try std.testing.expectEqual(@as(u64, 42), std.mem.readInt(u64, f.payload[0..8], .little));
+    }
+}
+
+test "emitEntitySnapshot: writes one component_changed frame per (entity, component)" {
+    const allocator = std.testing.allocator;
+    var harness = try LoopbackHarness.init();
+    defer harness.deinit();
+
+    var host_port_buf: [32]u8 = undefined;
+    const host_port = try harness.hostPort(&host_port_buf);
+    var preview = try Preview.connect(allocator, host_port);
+    defer preview.deinit();
+    try harness.accept();
+
+    try harness.writeJsonLine("{\"kind\":\"subscribe\",\"components\":[\"Position\",\"Velocity\"]}");
+    try waitForSubscription(&preview, "Position", 1000);
+    try waitForSubscription(&preview, "Velocity", 1000);
+
+    const components = [_]preview_mode.SnapshotComponent{
+        .{ .name = "Position", .bytes = &[_]u8{ 0x01, 0x02, 0x03, 0x04 } },
+        .{ .name = "Velocity", .bytes = &[_]u8{ 0x10, 0x20 } },
+    };
+    try preview.emitEntitySnapshot(42, &components);
+
+    var payload_buf: [256]u8 = undefined;
+    // Frame 1: Position.
+    {
+        const f = try harness.readBinaryFrame(&payload_buf);
+        try std.testing.expectEqual(@intFromEnum(BinaryFrameKind.component_changed), f.kind);
+        try std.testing.expectEqual(@as(u64, 42), std.mem.readInt(u64, f.payload[0..8], .little));
+        const name_len = std.mem.readInt(u16, f.payload[8..10], .little);
+        try std.testing.expectEqualStrings("Position", f.payload[10 .. 10 + name_len]);
+        const data_off: usize = 10 + name_len;
+        const data_len = std.mem.readInt(u32, f.payload[data_off..][0..4], .little);
+        try std.testing.expectEqual(@as(u32, 4), data_len);
+        try std.testing.expectEqualSlices(u8, &[_]u8{ 0x01, 0x02, 0x03, 0x04 }, f.payload[data_off + 4 .. data_off + 4 + data_len]);
+    }
+    // Frame 2: Velocity.
+    {
+        const f = try harness.readBinaryFrame(&payload_buf);
+        try std.testing.expectEqual(@intFromEnum(BinaryFrameKind.component_changed), f.kind);
+        try std.testing.expectEqual(@as(u64, 42), std.mem.readInt(u64, f.payload[0..8], .little));
+        const name_len = std.mem.readInt(u16, f.payload[8..10], .little);
+        try std.testing.expectEqualStrings("Velocity", f.payload[10 .. 10 + name_len]);
+        const data_off: usize = 10 + name_len;
+        const data_len = std.mem.readInt(u32, f.payload[data_off..][0..4], .little);
+        try std.testing.expectEqual(@as(u32, 2), data_len);
+        try std.testing.expectEqualSlices(u8, &[_]u8{ 0x10, 0x20 }, f.payload[data_off + 4 .. data_off + 4 + data_len]);
+    }
+}
+
+test "emitEntitySnapshot: skips components the editor did not subscribe to" {
+    // Snapshots bypass the entity filter but still honour the
+    // component-name filter so we don't leak component kinds the
+    // editor never asked for.
+    const allocator = std.testing.allocator;
+    var harness = try LoopbackHarness.init();
+    defer harness.deinit();
+
+    var host_port_buf: [32]u8 = undefined;
+    const host_port = try harness.hostPort(&host_port_buf);
+    var preview = try Preview.connect(allocator, host_port);
+    defer preview.deinit();
+    try harness.accept();
+
+    try harness.writeJsonLine("{\"kind\":\"subscribe\",\"components\":[\"Position\"]}");
+    try waitForSubscription(&preview, "Position", 1000);
+
+    const components = [_]preview_mode.SnapshotComponent{
+        .{ .name = "Position", .bytes = &[_]u8{0xAA} },
+        .{ .name = "Velocity", .bytes = &[_]u8{0xBB} },
+        .{ .name = "Health", .bytes = &[_]u8{0xCC} },
+    };
+    try preview.emitEntitySnapshot(7, &components);
+    // Follow with a sentinel emit on a different entity so we can
+    // bound the read — emitEntitySnapshot bypasses watched_entities
+    // so a watched-entity flip isn't needed to make this emit fire.
+    try preview.emitComponentChanged(8, "Position", &[_]u8{0xFF});
+
+    var payload_buf: [256]u8 = undefined;
+    // Only Position should appear from the snapshot.
+    {
+        const f = try harness.readBinaryFrame(&payload_buf);
+        try std.testing.expectEqual(@intFromEnum(BinaryFrameKind.component_changed), f.kind);
+        try std.testing.expectEqual(@as(u64, 7), std.mem.readInt(u64, f.payload[0..8], .little));
+        const name_len = std.mem.readInt(u16, f.payload[8..10], .little);
+        try std.testing.expectEqualStrings("Position", f.payload[10 .. 10 + name_len]);
+    }
+    // Then the sentinel — proving Velocity/Health were dropped.
+    {
+        const f = try harness.readBinaryFrame(&payload_buf);
+        try std.testing.expectEqual(@as(u64, 8), std.mem.readInt(u64, f.payload[0..8], .little));
+    }
+}
+
+test "emitEntitySnapshot: bypasses watched_entities filter for unwatched ids" {
+    // The editor has asked to watch entity 42 only, but a snapshot of
+    // entity 99 must still go out — by the time the caller invokes
+    // emitEntitySnapshot it has already decided that entity is
+    // interesting (typically because the editor just sent
+    // watch_entity for it; the in-engine wiring lands in a follow-up).
+    const allocator = std.testing.allocator;
+    var harness = try LoopbackHarness.init();
+    defer harness.deinit();
+
+    var host_port_buf: [32]u8 = undefined;
+    const host_port = try harness.hostPort(&host_port_buf);
+    var preview = try Preview.connect(allocator, host_port);
+    defer preview.deinit();
+    try harness.accept();
+
+    try harness.writeJsonLine("{\"kind\":\"subscribe\",\"components\":[\"Position\"]}");
+    try waitForSubscription(&preview, "Position", 1000);
+
+    try harness.writeJsonLine("{\"kind\":\"watch_entity\",\"id\":42}");
+    try waitForWatchedEntity(&preview, 42, 1000);
+
+    const components = [_]preview_mode.SnapshotComponent{
+        .{ .name = "Position", .bytes = &[_]u8{0x55} },
+    };
+    try preview.emitEntitySnapshot(99, &components);
+
+    var payload_buf: [256]u8 = undefined;
+    const f = try harness.readBinaryFrame(&payload_buf);
+    try std.testing.expectEqual(@intFromEnum(BinaryFrameKind.component_changed), f.kind);
+    try std.testing.expectEqual(@as(u64, 99), std.mem.readInt(u64, f.payload[0..8], .little));
+}
+
 test "Game without preview attached: ECS lifecycle is a no-op for telemetry (#520)" {
     // Sanity check that the `if (self.preview) |*p|` guards genuinely
     // short-circuit — a Game with `preview = null` must not crash, write


### PR DESCRIPTION
## Summary

Phase 3 of the PIE preview umbrella (labelle-gui#59). Adds entity-id scoped filtering on top of the Phase 2 component-name filter so the editor can opt into selection-sync ("stream just the selected entity") without breaking the Phase 2 "watch everything" contract.

- New `Preview.watched_entities: AutoHashMapUnmanaged(u64, void)` plus `isEntityWatched` policy chokepoint.
- `pollSubscription` learns two new JSON kinds: `{"kind":"watch_entity","id":42}` and `{"kind":"unwatch_entity","id":42}`. Existing `subscribe` / `unsubscribe` shapes are untouched.
- `emitComponentChanged` now applies the entity filter alongside the existing component-name filter. The Phase 2 binary frame layout is unchanged — the new behaviour is purely an additional gate on emission.
- New `emitEntitySnapshot(id, components)` helper writes N back-to-back `component_changed` frames so the editor doesn't sit on a stale view until the next mutation. Bypasses the entity filter (caller has already decided the entity is interesting) but honours the component-name subscription set.

## Design decision: empty-set semantics

When `watched_entities.count() == 0` the engine falls back to Phase 2 "watch everything" — every entity whose component is subscribed emits. The alternative ("empty set = strict include list, nothing flows") was rejected because:

1. It would break the Phase 2 binary-frame tests and the implicit contract that `subscribed_components` alone is enough to start receiving telemetry.
2. Today's editor watches one entity at a time; an empty set after unwatch will most commonly mean "user deselected", and going silent would surprise callers that rely on the global stream.
3. Multi-entity tracking is Phase 4+; the empty-set rule lives in a single chokepoint (`isEntityWatched`) so flipping the semantics later is a one-line change.

The decision is exercised by the `unwatch_entity` test which asserts the post-unwatch stream resumes for unrelated entities.

## Scope split

The `game.zig` side wiring — translating an inbound `watch_entity` into a walk of the ECS that feeds `emitEntitySnapshot` — is deliberately left to a follow-up issue. The helper's docstring documents the gap. This PR ships the wire-format primitive with full test coverage.

## Test plan

- [x] `zig build test` green.
- [x] Test count delta: **+5** (373 -> 378).
- [x] New tests in `test/preview_mode_test.zig`:
  - `watch_entity: adds id to watched_entities and filters subsequent emits`
  - `unwatch_entity: empty set restores Phase 2 'watch everything' behaviour`
  - `emitEntitySnapshot: writes one component_changed frame per (entity, component)`
  - `emitEntitySnapshot: skips components the editor did not subscribe to`
  - `emitEntitySnapshot: bypasses watched_entities filter for unwatched ids`
- [x] Phase 2 lifecycle test (`#520` wiring) still passes — back-compat verified.

Refs #534, #84.