### PR TITLE
feat(preview): pin_value binary frame + subscribe_pin_values control kind

### DIFF
--- a/src/preview_mode.zig
+++ b/src/preview_mode.zig
@@ -112,6 +112,7 @@ pub const BinaryFrameKind = enum(u8) {
     entity_destroyed = 2,
     component_changed = 3,
     node_entered = 4,
+    pin_value = 5,
     _,
 };
 
@@ -177,6 +178,13 @@ pub const Preview = struct {
     /// changes (60+ Hz across many flows), so opt-in is the safer
     /// default — editors that don't care pay zero cost.
     subscribed_flows: std.StringHashMapUnmanaged(void) = .{},
+    /// Set of flow names the editor wants `pin_value` frames for.
+    /// Mirror of `subscribed_flows` but tracks the (potentially much
+    /// higher-volume) live pin/edge value channel separately so the
+    /// editor can opt into node pulses without paying for per-pin
+    /// payloads (or vice versa). Empty set means **no** emit — same
+    /// opt-in semantics as `subscribed_flows`.
+    subscribed_pin_flows: std.StringHashMapUnmanaged(void) = .{},
     subs_arena: std.heap.ArenaAllocator,
     /// Set of entity IDs the editor wants `component_changed` frames
     /// scoped to. See the field-level doc on `Preview` for the
@@ -214,6 +222,7 @@ pub const Preview = struct {
         self.stream.close();
         self.subscribed_components.deinit(self.subs_arena.allocator());
         self.subscribed_flows.deinit(self.subs_arena.allocator());
+        self.subscribed_pin_flows.deinit(self.subs_arena.allocator());
         self.watched_entities.deinit(self.subs_arena.allocator());
         self.subs_arena.deinit();
         self.inbox.deinit(self.inbox_alloc);
@@ -419,11 +428,77 @@ pub const Preview = struct {
         try self.writeBinaryFrame(.node_entered, buf);
     }
 
+    /// Emit a `pin_value` binary frame. **No-op when the flow name is
+    /// not in `subscribed_pin_flows`** — pin values fire on every
+    /// edge evaluation (potentially many per node per frame), so the
+    /// early-out keeps the engine from doing even a single allocation
+    /// if the editor hasn't asked for this flow's pin stream yet.
+    ///
+    /// Tracked as a separate subscription set from `subscribed_flows`
+    /// (the `node_entered` opt-in) on purpose: the editor will
+    /// typically subscribe to both when a flow tab is opened, but the
+    /// pin channel is by far the higher-volume one and a future
+    /// editor (e.g. minimap) may want node pulses without paying for
+    /// pin payloads. Keeping the sets independent preserves symmetry
+    /// with `node_entered`'s `subscribe_flow` and avoids a flag-bit
+    /// hack inside one control message.
+    ///
+    /// Payload layout (little-endian):
+    ///
+    ///     [u16 flow_name_len] [flow_name bytes (UTF-8)]
+    ///     [u32 node_id]
+    ///     [u16 pin_name_len] [pin_name bytes (UTF-8)]
+    ///     [f64 value]
+    ///
+    /// `flow_name` is the `.flow.zon` file stem (no path, no
+    /// extension); `node_id` is the stable u32 id the flow_io parser
+    /// assigns to each node; `pin_name` is the pin label exactly as
+    /// it appears in the node definition (UTF-8, may contain quotes,
+    /// punctuation, non-ASCII).
+    ///
+    /// **v1 value is `f64`-only.** Covers BinOp results, Literal
+    /// numerics, and `dt`. String / bool / struct payloads are
+    /// deferred — see the follow-up listed in this PR's body.
+    pub fn emitPinValue(
+        self: *Preview,
+        flow_name: []const u8,
+        node_id: u32,
+        pin_name: []const u8,
+        value: f64,
+    ) WriteError!void {
+        if (!self.isPinFlowSubscribed(flow_name)) return;
+        defer _ = self.arena.reset(.retain_capacity);
+        const alloc = self.arena.allocator();
+        const payload_len: usize =
+            @sizeOf(u16) + flow_name.len +
+            @sizeOf(u32) +
+            @sizeOf(u16) + pin_name.len +
+            @sizeOf(f64);
+        const buf = try alloc.alloc(u8, payload_len);
+        var off: usize = 0;
+        std.mem.writeInt(u16, buf[off..][0..2], @intCast(flow_name.len), .little);
+        off += 2;
+        @memcpy(buf[off .. off + flow_name.len], flow_name);
+        off += flow_name.len;
+        std.mem.writeInt(u32, buf[off..][0..4], node_id, .little);
+        off += 4;
+        std.mem.writeInt(u16, buf[off..][0..2], @intCast(pin_name.len), .little);
+        off += 2;
+        @memcpy(buf[off .. off + pin_name.len], pin_name);
+        off += pin_name.len;
+        // f64 bit-pattern as u64, little-endian. Avoids any FP-aware
+        // codec — the editor reverses the bitcast on receive.
+        const bits: u64 = @bitCast(value);
+        std.mem.writeInt(u64, buf[off..][0..8], bits, .little);
+        try self.writeBinaryFrame(.pin_value, buf);
+    }
+
     /// Drain any pending `subscribe` / `unsubscribe` / `subscribe_flow`
-    /// / `unsubscribe_flow` JSON frames sent by the editor and apply
-    /// them to `subscribed_components` / `subscribed_flows`. Non-
-    /// blocking — reads only what's currently available on the
-    /// socket. Safe to call once per tick.
+    /// / `unsubscribe_flow` / `subscribe_pin_values` /
+    /// `unsubscribe_pin_values` JSON frames sent by the editor and
+    /// apply them to `subscribed_components` / `subscribed_flows` /
+    /// `subscribed_pin_flows`. Non-blocking — reads only what's
+    /// currently available on the socket. Safe to call once per tick.
     ///
     /// Wire shapes:
     ///
@@ -431,6 +506,8 @@ pub const Preview = struct {
     ///     {"kind":"unsubscribe","components":["Velocity"]}\n
     ///     {"kind":"subscribe_flow","flow":"player_state_machine"}\n
     ///     {"kind":"unsubscribe_flow","flow":"player_state_machine"}\n
+    ///     {"kind":"subscribe_pin_values","flow":"player_state_machine"}\n
+    ///     {"kind":"unsubscribe_pin_values","flow":"player_state_machine"}\n
     ///
     /// Returns `MalformedSubscription` if a frame parses as JSON but
     /// the shape doesn't match; the caller can choose to log + drop.
@@ -463,6 +540,14 @@ pub const Preview = struct {
     /// flow name string at the call site.
     pub fn isFlowSubscribed(self: *const Preview, flow_name: []const u8) bool {
         return self.subscribed_flows.contains(flow_name);
+    }
+
+    /// Returns `true` if `emitPinValue` would emit a frame for this
+    /// flow's pin stream. Useful as a guard around the cost of
+    /// computing the value (e.g. resolving a wire's source pin) at
+    /// the call site.
+    pub fn isPinFlowSubscribed(self: *const Preview, flow_name: []const u8) bool {
+        return self.subscribed_pin_flows.contains(flow_name);
     }
 
     /// Phase 3 (#534) entity-scope check. Returns `true` when the
@@ -570,6 +655,22 @@ pub const Preview = struct {
                 .ignore_unknown_fields = true,
             }) catch return error.MalformedSubscription;
             _ = self.subscribed_flows.remove(parsed.flow);
+        } else if (std.mem.eql(u8, kind_only.kind, "subscribe_pin_values")) {
+            const Parsed = struct { kind: []const u8, flow: []const u8 };
+            const parsed = std.json.parseFromSliceLeaky(Parsed, alloc, line, .{
+                .ignore_unknown_fields = true,
+            }) catch return error.MalformedSubscription;
+            if (!self.subscribed_pin_flows.contains(parsed.flow)) {
+                const subs_alloc = self.subs_arena.allocator();
+                const owned = try subs_alloc.dupe(u8, parsed.flow);
+                try self.subscribed_pin_flows.put(subs_alloc, owned, {});
+            }
+        } else if (std.mem.eql(u8, kind_only.kind, "unsubscribe_pin_values")) {
+            const Parsed = struct { kind: []const u8, flow: []const u8 };
+            const parsed = std.json.parseFromSliceLeaky(Parsed, alloc, line, .{
+                .ignore_unknown_fields = true,
+            }) catch return error.MalformedSubscription;
+            _ = self.subscribed_pin_flows.remove(parsed.flow);
         } else if (std.mem.eql(u8, kind_only.kind, "watch_entity")) {
             // Phase 3 (#534). Empty `watched_entities` means
             // "watch everything"; once the editor adds an ID we

--- a/test/preview_mode_test.zig
+++ b/test/preview_mode_test.zig
@@ -886,6 +886,348 @@ test "pollSubscription: subscribe_flow / unsubscribe_flow update subscribed_flow
     try std.testing.expect(preview.isFlowSubscribed("not_yet_loaded"));
 }
 
+// ── #57 (labelle-gui) — pin_value binary telemetry ──────────────────
+
+/// Spin until the engine reports the given flow as pin-value
+/// subscribed. Mirror of `waitForFlowSubscription`.
+fn waitForPinFlowSubscription(preview: *Preview, flow_name: []const u8, deadline_ms: u64) !void {
+    const start = std.time.milliTimestamp();
+    while (true) {
+        try preview.pollSubscription();
+        if (preview.isPinFlowSubscribed(flow_name)) return;
+        const now = std.time.milliTimestamp();
+        if (now - start > @as(i64, @intCast(deadline_ms))) return error.SubscriptionDeadlineExceeded;
+        std.Thread.sleep(1 * std.time.ns_per_ms);
+    }
+}
+
+fn waitForPinFlowUnsubscribed(preview: *Preview, flow_name: []const u8, deadline_ms: u64) !void {
+    const start = std.time.milliTimestamp();
+    while (preview.isPinFlowSubscribed(flow_name)) {
+        try preview.pollSubscription();
+        const now = std.time.milliTimestamp();
+        if (now - start > @as(i64, @intCast(deadline_ms))) return error.UnsubscribeDeadlineExceeded;
+        std.Thread.sleep(1 * std.time.ns_per_ms);
+    }
+}
+
+/// Decode the `pin_value` payload into typed fields. Mirrors the
+/// editor-side reader. Returns slices into `payload` — caller must
+/// keep `payload` alive for the lifetime of the result.
+fn decodePinValuePayload(payload: []const u8) !struct {
+    flow_name: []const u8,
+    node_id: u32,
+    pin_name: []const u8,
+    value: f64,
+} {
+    if (payload.len < 2) return error.PayloadTruncated;
+    const flow_name_len = std.mem.readInt(u16, payload[0..2], .little);
+    var off: usize = 2;
+    if (payload.len < off + flow_name_len + 4 + 2 + 8) return error.PayloadTruncated;
+    const flow_name = payload[off .. off + flow_name_len];
+    off += flow_name_len;
+    const node_id = std.mem.readInt(u32, payload[off..][0..4], .little);
+    off += 4;
+    const pin_name_len = std.mem.readInt(u16, payload[off..][0..2], .little);
+    off += 2;
+    if (payload.len < off + pin_name_len + 8) return error.PayloadTruncated;
+    const pin_name = payload[off .. off + pin_name_len];
+    off += pin_name_len;
+    const bits = std.mem.readInt(u64, payload[off..][0..8], .little);
+    const value: f64 = @bitCast(bits);
+    off += 8;
+    if (off != payload.len) return error.TrailingBytes;
+    return .{
+        .flow_name = flow_name,
+        .node_id = node_id,
+        .pin_name = pin_name,
+        .value = value,
+    };
+}
+
+test "emitPinValue: no-op when flow is not pin-subscribed" {
+    // Default empty `subscribed_pin_flows` set → opt-in semantics →
+    // silence. Mirror of `emitNodeEntered: no-op when flow is not
+    // subscribed`.
+    const allocator = std.testing.allocator;
+    var harness = try LoopbackHarness.init();
+    defer harness.deinit();
+
+    var host_port_buf: [32]u8 = undefined;
+    const host_port = try harness.hostPort(&host_port_buf);
+    var preview = try Preview.connect(allocator, host_port);
+    defer preview.deinit();
+    try harness.accept();
+
+    try std.testing.expect(!preview.isPinFlowSubscribed("test_flow"));
+    try preview.emitPinValue("test_flow", 1, "out", 3.14);
+    try preview.emitPinValue("other_flow", 2, "a", 0.0);
+
+    // Probe with a JSON frame so we can prove no binary bytes
+    // preceded it on the wire.
+    try preview.sendHeartbeat(500);
+    var buf: [256]u8 = undefined;
+    try std.testing.expect((try harness.peekByte()) != binary_magic);
+    const f = try harness.readFrame(&buf);
+    try std.testing.expect(std.mem.indexOf(u8, f, "\"kind\":\"heartbeat\"") != null);
+}
+
+test "emitPinValue: subscribed flow emits a frame with the expected layout" {
+    const allocator = std.testing.allocator;
+    var harness = try LoopbackHarness.init();
+    defer harness.deinit();
+
+    var host_port_buf: [32]u8 = undefined;
+    const host_port = try harness.hostPort(&host_port_buf);
+    var preview = try Preview.connect(allocator, host_port);
+    defer preview.deinit();
+    try harness.accept();
+
+    try harness.writeJsonLine("{\"kind\":\"subscribe_pin_values\",\"flow\":\"move\"}");
+    try waitForPinFlowSubscription(&preview, "move", 1000);
+
+    try preview.emitPinValue("move", 42, "speed", 2.5);
+
+    var payload_buf: [256]u8 = undefined;
+    const frame = try harness.readBinaryFrame(&payload_buf);
+    try std.testing.expectEqual(@intFromEnum(BinaryFrameKind.pin_value), frame.kind);
+    const decoded = try decodePinValuePayload(frame.payload);
+    try std.testing.expectEqualStrings("move", decoded.flow_name);
+    try std.testing.expectEqual(@as(u32, 42), decoded.node_id);
+    try std.testing.expectEqualStrings("speed", decoded.pin_name);
+    try std.testing.expectEqual(@as(f64, 2.5), decoded.value);
+    // Payload tightly sized — no trailing bytes (decode helper
+    // asserts this, but assert the expected total too).
+    // flow: 2 + 4 + node: 4 + pin: 2 + 5 + value: 8 = 25
+    try std.testing.expectEqual(@as(usize, 25), frame.payload.len);
+}
+
+test "emitPinValue: unsubscribe_pin_values stops emission" {
+    const allocator = std.testing.allocator;
+    var harness = try LoopbackHarness.init();
+    defer harness.deinit();
+
+    var host_port_buf: [32]u8 = undefined;
+    const host_port = try harness.hostPort(&host_port_buf);
+    var preview = try Preview.connect(allocator, host_port);
+    defer preview.deinit();
+    try harness.accept();
+
+    try harness.writeJsonLine("{\"kind\":\"subscribe_pin_values\",\"flow\":\"move\"}");
+    try waitForPinFlowSubscription(&preview, "move", 1000);
+    try preview.emitPinValue("move", 7, "out", 1.0);
+
+    // Consume the one expected frame.
+    var payload_buf: [256]u8 = undefined;
+    const frame = try harness.readBinaryFrame(&payload_buf);
+    try std.testing.expectEqual(@intFromEnum(BinaryFrameKind.pin_value), frame.kind);
+
+    try harness.writeJsonLine("{\"kind\":\"unsubscribe_pin_values\",\"flow\":\"move\"}");
+    try waitForPinFlowUnsubscribed(&preview, "move", 1000);
+
+    // After unsubscribe the emit must be a no-op. Probe with a
+    // heartbeat so we can prove no binary frame slipped through.
+    try preview.emitPinValue("move", 8, "out", 2.0);
+    try preview.sendHeartbeat(999);
+    try std.testing.expect((try harness.peekByte()) != binary_magic);
+    var buf: [256]u8 = undefined;
+    const f = try harness.readFrame(&buf);
+    try std.testing.expect(std.mem.indexOf(u8, f, "\"kind\":\"heartbeat\"") != null);
+}
+
+test "emitPinValue: subscribing to flow A doesn't enable emission for flow B" {
+    const allocator = std.testing.allocator;
+    var harness = try LoopbackHarness.init();
+    defer harness.deinit();
+
+    var host_port_buf: [32]u8 = undefined;
+    const host_port = try harness.hostPort(&host_port_buf);
+    var preview = try Preview.connect(allocator, host_port);
+    defer preview.deinit();
+    try harness.accept();
+
+    try harness.writeJsonLine("{\"kind\":\"subscribe_pin_values\",\"flow\":\"alpha\"}");
+    try waitForPinFlowSubscription(&preview, "alpha", 1000);
+    try std.testing.expect(!preview.isPinFlowSubscribed("beta"));
+
+    // Emit for B (must be silent), then A (must emit), then a
+    // heartbeat as a wire-position anchor. The reader should see
+    // exactly one binary frame followed by the heartbeat — no B
+    // frame.
+    try preview.emitPinValue("beta", 1, "out", 99.0);
+    try preview.emitPinValue("alpha", 2, "out", 1.5);
+    try preview.sendHeartbeat(500);
+
+    var payload_buf: [256]u8 = undefined;
+    const frame = try harness.readBinaryFrame(&payload_buf);
+    try std.testing.expectEqual(@intFromEnum(BinaryFrameKind.pin_value), frame.kind);
+    const decoded = try decodePinValuePayload(frame.payload);
+    try std.testing.expectEqualStrings("alpha", decoded.flow_name);
+    try std.testing.expectEqual(@as(u32, 2), decoded.node_id);
+    try std.testing.expectEqual(@as(f64, 1.5), decoded.value);
+
+    var buf: [256]u8 = undefined;
+    const f = try harness.readFrame(&buf);
+    try std.testing.expect(std.mem.indexOf(u8, f, "\"kind\":\"heartbeat\"") != null);
+}
+
+test "emitPinValue: pin_name with non-ASCII and quotes round-trips through the wire" {
+    const allocator = std.testing.allocator;
+    var harness = try LoopbackHarness.init();
+    defer harness.deinit();
+
+    var host_port_buf: [32]u8 = undefined;
+    const host_port = try harness.hostPort(&host_port_buf);
+    var preview = try Preview.connect(allocator, host_port);
+    defer preview.deinit();
+    try harness.accept();
+
+    try harness.writeJsonLine("{\"kind\":\"subscribe_pin_values\",\"flow\":\"flow_unicode\"}");
+    try waitForPinFlowSubscription(&preview, "flow_unicode", 1000);
+
+    // The wire treats pin_name as opaque UTF-8 bytes — neither
+    // quoting nor multi-byte sequences should change the length
+    // prefix or the payload contents.
+    const cases = [_]struct { name: []const u8, value: f64 }{
+        .{ .name = "with \"quotes\"", .value = -0.0 },
+        .{ .name = "ünîcödé pîn", .value = 1234.5678 },
+        .{ .name = "日本語ピン", .value = -1e-10 },
+        .{ .name = "tab\there/newline\nhere", .value = 42.0 },
+    };
+
+    var payload_buf: [512]u8 = undefined;
+    for (cases, 0..) |c, i| {
+        try preview.emitPinValue("flow_unicode", @intCast(i), c.name, c.value);
+        const frame = try harness.readBinaryFrame(&payload_buf);
+        try std.testing.expectEqual(@intFromEnum(BinaryFrameKind.pin_value), frame.kind);
+        const decoded = try decodePinValuePayload(frame.payload);
+        try std.testing.expectEqualStrings("flow_unicode", decoded.flow_name);
+        try std.testing.expectEqual(@as(u32, @intCast(i)), decoded.node_id);
+        try std.testing.expectEqualStrings(c.name, decoded.pin_name);
+        try std.testing.expectEqual(c.value, decoded.value);
+    }
+}
+
+test "emitPinValue: f64 value preserves precision through encode/decode" {
+    const allocator = std.testing.allocator;
+    var harness = try LoopbackHarness.init();
+    defer harness.deinit();
+
+    var host_port_buf: [32]u8 = undefined;
+    const host_port = try harness.hostPort(&host_port_buf);
+    var preview = try Preview.connect(allocator, host_port);
+    defer preview.deinit();
+    try harness.accept();
+
+    try harness.writeJsonLine("{\"kind\":\"subscribe_pin_values\",\"flow\":\"precision\"}");
+    try waitForPinFlowSubscription(&preview, "precision", 1000);
+
+    // Pick values that would lose precision under any narrowing
+    // codec (f32, decimal text round-trip, etc.).
+    const values = [_]f64{
+        std.math.pi,
+        std.math.e,
+        -std.math.floatMax(f64),
+        std.math.floatMin(f64),
+        std.math.floatEps(f64),
+        1.0 / 3.0,
+        0.0,
+        -0.0,
+    };
+
+    var payload_buf: [256]u8 = undefined;
+    for (values, 0..) |v, i| {
+        try preview.emitPinValue("precision", @intCast(i), "v", v);
+        const frame = try harness.readBinaryFrame(&payload_buf);
+        const decoded = try decodePinValuePayload(frame.payload);
+        // Bit-exact comparison: f64 → u64 → f64 must round-trip
+        // for every finite value. `expectEqual` on f64 is exact.
+        try std.testing.expectEqual(v, decoded.value);
+        // -0.0 vs 0.0 disambiguation: compare the bit patterns
+        // directly for the signed-zero case.
+        const v_bits: u64 = @bitCast(v);
+        const d_bits: u64 = @bitCast(decoded.value);
+        try std.testing.expectEqual(v_bits, d_bits);
+    }
+}
+
+test "emitPinValue: exact wire-format guard against drift" {
+    // Hand-compose the bytes we expect on the wire for one frame
+    // and diff against `emitPinValue`'s output byte-for-byte.
+    // Mirror of `emitNodeEntered: exact wire-format guard`.
+    const allocator = std.testing.allocator;
+    var harness = try LoopbackHarness.init();
+    defer harness.deinit();
+
+    var host_port_buf: [32]u8 = undefined;
+    const host_port = try harness.hostPort(&host_port_buf);
+    var preview = try Preview.connect(allocator, host_port);
+    defer preview.deinit();
+    try harness.accept();
+
+    try harness.writeJsonLine("{\"kind\":\"subscribe_pin_values\",\"flow\":\"hud\"}");
+    try waitForPinFlowSubscription(&preview, "hud", 1000);
+
+    // Value `1.0` has the well-known bit pattern 0x3FF0000000000000.
+    try preview.emitPinValue("hud", 0x01020304, "x", 1.0);
+
+    // Header: magic(1) + kind(1) + length(4 LE)
+    // Payload:
+    //   u16 flow_name_len LE = 3
+    //   "hud"
+    //   u32 node_id LE       = 0x01020304
+    //   u16 pin_name_len LE  = 1
+    //   "x"
+    //   f64 value LE         = 0x3FF0000000000000
+    // payload_len = 2 + 3 + 4 + 2 + 1 + 8 = 20
+    const expected = [_]u8{
+        binary_magic,
+        @intFromEnum(BinaryFrameKind.pin_value),
+        20, 0, 0, 0, // length LE
+        3,  0, // flow_name_len LE
+        'h', 'u', 'd',
+        0x04, 0x03, 0x02, 0x01, // node_id LE
+        1, 0, // pin_name_len LE
+        'x',
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x3F, // f64 1.0 LE
+    };
+    var actual: [expected.len]u8 = undefined;
+    try harness.readExact(&actual);
+    try std.testing.expectEqualSlices(u8, &expected, &actual);
+}
+
+test "pollSubscription: subscribe_pin_values / unsubscribe_pin_values update subscribed_pin_flows" {
+    const allocator = std.testing.allocator;
+    var harness = try LoopbackHarness.init();
+    defer harness.deinit();
+
+    var host_port_buf: [32]u8 = undefined;
+    const host_port = try harness.hostPort(&host_port_buf);
+    var preview = try Preview.connect(allocator, host_port);
+    defer preview.deinit();
+    try harness.accept();
+
+    // The pin-values subscription set is independent of the
+    // node-entered subscription set: subscribing to one must not
+    // enable the other.
+    try harness.writeJsonLine("{\"kind\":\"subscribe_flow\",\"flow\":\"shared\"}");
+    try waitForFlowSubscription(&preview, "shared", 1000);
+    try std.testing.expect(preview.isFlowSubscribed("shared"));
+    try std.testing.expect(!preview.isPinFlowSubscribed("shared"));
+
+    try harness.writeJsonLine("{\"kind\":\"subscribe_pin_values\",\"flow\":\"shared\"}");
+    try waitForPinFlowSubscription(&preview, "shared", 1000);
+    try std.testing.expect(preview.isFlowSubscribed("shared"));
+    try std.testing.expect(preview.isPinFlowSubscribed("shared"));
+
+    // Unsubscribing from pins must leave the node-entered
+    // subscription untouched.
+    try harness.writeJsonLine("{\"kind\":\"unsubscribe_pin_values\",\"flow\":\"shared\"}");
+    try waitForPinFlowUnsubscribed(&preview, "shared", 1000);
+    try std.testing.expect(preview.isFlowSubscribed("shared"));
+    try std.testing.expect(!preview.isPinFlowSubscribed("shared"));
+}
+
 // ── Phase 3 / #534 — watch_entity protocol + filtered emission ──────
 
 /// Spin until `preview.pollSubscription` reports the given entity is


### PR DESCRIPTION
## Summary

Engine-side primitive for the Flows live pin/edge value preview tracked
in `labelle-toolkit/labelle-gui#57`. Adds the Phase 3 binary telemetry
channel for per-pin runtime values, structured as a literal mirror of
the `node_entered` emitter shipped in #537.

- New `BinaryFrameKind.pin_value = 5` (appended; existing 1-4 wire-stable).
- New `Preview.emitPinValue(flow_name, node_id, pin_name, value: f64)`
  with an opt-in `subscribed_pin_flows` set — empty set = no emit.
- `pollSubscription` decodes `subscribe_pin_values` /
  `unsubscribe_pin_values` JSON control frames.
- Scope is **just the engine primitive**. Editor consumer and codegen
  instrumentation are deferred follow-ups (see below).

## Wire format

Standard binary header followed by the new payload:

```
[u8 magic=0x1B] [u8 kind=5] [u32 length LE]    // header (6 bytes)
[u16 flow_name_len LE] [flow_name bytes]       // payload start
[u32 node_id LE]
[u16 pin_name_len LE]   [pin_name bytes]
[f64 value LE]                                  // bits cast u64 → LE
```

Example: `emitPinValue(\"hud\", 0x01020304, \"x\", 1.0)` produces
20 payload bytes:

```
1B 05  14 00 00 00            // magic, kind=pin_value, len=20 LE
03 00  68 75 64                // flow_name_len=3, \"hud\"
04 03 02 01                    // node_id LE
01 00  78                      // pin_name_len=1, \"x\"
00 00 00 00 00 00 F0 3F        // f64 1.0 LE
```

The `emitPinValue: exact wire-format guard against drift` test
hand-composes this exact byte sequence and diffs the emitter's
output against it — any future drift will fail loud.

**v1 value is `f64`-only.** Covers BinOp results, Literal numerics,
and `dt`. Strings / bools / structs are deferred (see below).

## Subscription protocol

Mirrors `subscribe_flow` / `unsubscribe_flow` but tracks pin-value
emission independently:

```json
{\"kind\":\"subscribe_pin_values\",\"flow\":\"player_state_machine\"}
{\"kind\":\"unsubscribe_pin_values\",\"flow\":\"player_state_machine\"}
```

Why a separate kind (rather than folding pin-values into
`subscribe_flow`): node pulses and pin payloads are very different
volume profiles. A future minimap-style editor may want node pulses
without paying for the high-frequency pin stream; a future debugger
may want pins without the node-pulse channel. Keeping the sets
independent preserves symmetry with `node_entered` and avoids a
flag-bit hack inside one control message. The editor will simply
subscribe to both when opening a flow tab.

Caller-owned strings are duped into the existing `subs_arena` — same
pattern `subscribe_flow` uses, so the editor can churn the set
without leaking into the per-frame arena.

## Tests

8 new tests in `test/preview_mode_test.zig`:

1. `emitPinValue: no-op when flow is not pin-subscribed` — opt-in default.
2. `emitPinValue: subscribed flow emits a frame with the expected layout` —
   decode every field, assert tight payload size.
3. `emitPinValue: unsubscribe_pin_values stops emission`.
4. `emitPinValue: subscribing to flow A doesn't enable emission for flow B`.
5. `emitPinValue: pin_name with non-ASCII and quotes round-trips through
   the wire` — quotes, ümlauts, CJK, tabs/newlines.
6. `emitPinValue: f64 value preserves precision through encode/decode` —
   pi, e, ±floatMax, floatMin, floatEps, 1/3, ±0.0; bit-exact compare.
7. `emitPinValue: exact wire-format guard against drift` — hand-composed
   bytes diffed byte-for-byte.
8. `pollSubscription: subscribe_pin_values / unsubscribe_pin_values
   update subscribed_pin_flows` — and asserts independence from
   `subscribed_flows`.

`zig build` and `zig build test` are both green.

## What's deferred

This PR ships ONE piece of `labelle-gui#57`. Three follow-ups need to
land before the umbrella is done:

- **Non-`f64` value types.** v1 is `f64`-only (BinOp results, Literal
  numerics, `dt`). String / bool / struct payloads need a value-type
  tag in the payload (e.g. `[u8 value_kind] [variable-shape value]`).
  Should be filed as a follow-up issue on this repo before merge —
  the wire format will need a backwards-compat strategy (either a
  new `BinaryFrameKind.pin_value_typed = 6` or a v2 of this kind).
- **Editor consumer.** `labelle-gui` needs to subscribe on flow-tab
  open, decode `pin_value` frames, and render values on edges. Lives
  in `labelle-gui#57` proper.
- **Codegen instrumentation.** `flow_codegen` needs to emit
  `if (game.preview) |*p| p.emitPinValue(...)` calls at edge
  evaluation sites. Likely a new issue on this repo (parallel to the
  `#536` follow-up that wires `emitNodeEntered` into the per-node
  dispatch site).

Part of `labelle-toolkit/labelle-gui#57`.