### PR TITLE
feat(preview): SHM ring handshake protocol + fix variadic-fcntl ABI bug

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -87,17 +87,20 @@ pub fn build(b: *std.Build) void {
         "test/jsonc_bridge_gizmo_visibility_test.zig",
         "test/collect_entities_test.zig",
         "test/set_sprite_flip_test.zig",
-        // preview_mode_test + flows_game_api_test: harnesses migrated to
-        // std.Io.net.Server + libc r/w; basic lifecycle tests (1–11, 16) pass
-        // but 21 subscription-flow tests still fail with a parse/state-update
-        // glitch that the migration didn't unblock. Bytes arrive on the wire
-        // (read() returns the full frame) but applySubscriptionFrame's effect
-        // doesn't land in subscribed_components — needs another debugging pass.
-        // Disabled in CI for now; tests are migrated source-wise so the
-        // re-enable is just flipping these two lines back on once the bug is
-        // pinned.
-        // "test/preview_mode_test.zig",
-        // "test/flows_game_api_test.zig",
+        // PIE viewport handshake (#543) — kept separate from
+        // preview_mode_test.zig so the new coverage isn't gated on
+        // that file's pre-existing 21-test subscription bug.
+        "test/preview_handshake_test.zig",
+        // preview_mode_test + flows_game_api_test: re-enabled after #543
+        // fixed the variadic-`fcntl` ABI bug (declared non-variadic on
+        // a function libc declares variadic — mismatched on
+        // aarch64-darwin where variadic args go on the stack rather
+        // than in registers). With std.c.fcntl (correctly variadic) in
+        // src/preview_mode.zig, O_NONBLOCK actually lands on the FD,
+        // pollSubscription's read can EAGAIN, and the 21 previously-
+        // hanging subscription-flow tests run to completion.
+        "test/preview_mode_test.zig",
+        "test/flows_game_api_test.zig",
     };
 
     for (test_files) |test_file| {

--- a/src/preview_mode.zig
+++ b/src/preview_mode.zig
@@ -434,14 +434,19 @@ pub const Preview = struct {
         return self.frame_state == .accepted;
     }
 
-    /// Pop the pending resize request, if any. Clears the state so a
+    /// Pop the pending resize request, if any. Clears the slot so a
     /// second call returns `null` until the editor sends another
     /// `frame_resize`. Producer responds by tearing down the current
     /// ring and re-issuing `sendFrameOffer` at the new dimensions.
+    ///
+    /// State invalidation (`.accepted → .not_offered`) happens
+    /// *eagerly* in the `frame_resize` parser, not here — so
+    /// producers gating publishes on `isFrameAccepted` see the
+    /// stream go inactive the moment the editor sends the resize
+    /// (#545 review).
     pub fn takeResize(self: *Preview) ?PendingResize {
         const pending = self.pending_resize;
         self.pending_resize = null;
-        if (pending != null) self.frame_state = .not_offered;
         return pending;
     }
 
@@ -759,10 +764,15 @@ pub const Preview = struct {
         // read until EAGAIN, restore flags. The socket stays blocking
         // for writes so partial sends aren't a concern.
         const fd = self.fd;
+        // Both fcntl failures propagate as `InputOutput`. Silently
+        // returning here would leave the socket blocking, and the
+        // first `read` below would stall the entire frame loop — the
+        // exact bug the variadic-fcntl ABI fix uncovered (#545
+        // review).
         const orig_flags = c_fcntl(fd, F_GETFL, @as(c_int, 0));
-        if (orig_flags < 0) return;
+        if (orig_flags < 0) return error.InputOutput;
         const set_rc = c_fcntl(fd, F_SETFL, @as(c_int, orig_flags | O_NONBLOCK));
-        if (set_rc < 0) return;
+        if (set_rc < 0) return error.InputOutput;
         defer _ = c_fcntl(fd, F_SETFL, @as(c_int, orig_flags));
 
         var scratch: [1024]u8 = undefined;
@@ -878,6 +888,13 @@ pub const Preview = struct {
                 .ignore_unknown_fields = true,
             }) catch return error.MalformedSubscription;
             self.pending_resize = .{ .width = parsed.width, .height = parsed.height };
+            // Invalidate the handshake *immediately* — between the
+            // editor's resize request and the backend's
+            // `takeResize`/`beginFrameStream` re-offer cycle, the
+            // current ring is stale. Producers gating publishes on
+            // `isFrameAccepted` must see false in that window
+            // (#545 review).
+            self.frame_state = .not_offered;
         } else {
             return error.MalformedSubscription;
         }

--- a/src/preview_mode.zig
+++ b/src/preview_mode.zig
@@ -33,6 +33,11 @@
 ///        {"kind":"unsubscribe","components":["Velocity"]}\n             (editor → engine)
 ///        {"kind":"watch_entity","id":42}\n                               (editor → engine, Phase 3)
 ///        {"kind":"unwatch_entity","id":42}\n                             (editor → engine, Phase 3)
+///        {"kind":"frame_offer","shm_name":"/labelle-preview-<pid>","width":1280,"height":720,
+///                  "format":"rgba8","ring_size":3,"slot_size_bytes":3686464}\n            (engine → editor, viewport)
+///        {"kind":"frame_published","frame_idx":42,"produce_ns":12345}\n                   (engine → editor, viewport)
+///        {"kind":"frame_accept"}\n                                                         (editor → engine, viewport)
+///        {"kind":"frame_resize","width":1920,"height":1080}\n                              (editor → engine, viewport)
 ///
 /// 2. **Binary telemetry plane** (Phase 2) — length-prefixed records
 ///    led by an `ESC` (0x1B) magic byte:
@@ -84,7 +89,14 @@ const std = @import("std");
 extern "c" fn close(fd: c_int) c_int;
 extern "c" fn write(fd: c_int, buf: [*]const u8, len: usize) isize;
 extern "c" fn read(fd: c_int, buf: [*]u8, len: usize) isize;
-extern "c" fn fcntl(fd: c_int, cmd: c_int, arg: c_int) c_int;
+// `fcntl` is variadic in libc (`int fcntl(int, int, ...)`). On
+// aarch64-darwin (and other ABIs that put variadic args on the stack
+// rather than in registers), declaring it as non-variadic with
+// `arg: c_int` is a calling-convention mismatch — F_SETFL receives
+// stack garbage instead of the flag value, O_NONBLOCK never gets set,
+// and the next `read` blocks. Use the stdlib's correctly-declared
+// `std.c.fcntl` instead (see `lib/std/c.zig`).
+const c_fcntl = std.c.fcntl;
 extern "c" fn __error() *c_int; // macOS errno location
 extern "c" fn __errno_location() *c_int; // glibc errno location
 
@@ -150,6 +162,57 @@ pub const heartbeat_interval_ms: u64 = 250;
 pub const SnapshotComponent = struct {
     name: []const u8,
     bytes: []const u8,
+};
+
+// ── PIE viewport handshake (#543) ───────────────────────────────────
+
+/// Pixel format identifiers carried over the wire. Plain enum to keep
+/// the JSON-serializer side trivial. Add new entries when the producer
+/// gains support; consumers compare by string.
+pub const FramePixelFormat = enum {
+    rgba8,
+
+    pub fn asString(self: FramePixelFormat) []const u8 {
+        return switch (self) {
+            .rgba8 => "rgba8",
+        };
+    }
+};
+
+/// `frame_offer` payload. `shm_name` is the POSIX shm name (`/labelle-…`)
+/// the engine has bound; the editor will `shm_open` it and map
+/// `header_bytes + ring_size * slot_size_bytes`. All fields borrowed —
+/// only need to outlive the `sendFrameOffer` call.
+pub const FrameOffer = struct {
+    shm_name: []const u8,
+    width: u32,
+    height: u32,
+    format: FramePixelFormat = .rgba8,
+    ring_size: u32 = 3,
+    slot_size_bytes: u64,
+};
+
+/// Three-state handshake. Producer transitions:
+///
+///   not_offered  ── sendFrameOffer ──▶  offered
+///   offered      ── (editor sends frame_accept) ──▶  accepted
+///
+/// A `frame_resize` from the editor does **not** kick us out of
+/// `.accepted`; it just sets `pending_resize`. The caller decides
+/// whether/when to honour it (typically: tear down the current ring,
+/// send a new `frame_offer`, wait for `frame_accept` again).
+pub const FrameHandshakeState = enum {
+    not_offered,
+    offered,
+    accepted,
+};
+
+/// Pending resize requested by the editor. Producer polls
+/// `Preview.takeResize` once per frame; nil result means no resize
+/// requested since last poll.
+pub const PendingResize = struct {
+    width: u32,
+    height: u32,
 };
 
 pub const ParseError = error{
@@ -225,6 +288,13 @@ pub const Preview = struct {
     /// initial capacity if a very long subscribe list arrives.
     inbox: std.ArrayListUnmanaged(u8) = .empty,
     inbox_alloc: std.mem.Allocator,
+    /// PIE viewport handshake state (#543). The producer-side render
+    /// loop is expected to gate `frame_published` on
+    /// `frame_state == .accepted`.
+    frame_state: FrameHandshakeState = .not_offered,
+    /// Set by the editor's `frame_resize`; cleared by `takeResize`.
+    /// `null` means "no resize pending."
+    pending_resize: ?PendingResize = null,
 
     /// Dial the editor's listener. `host_port` is the literal string
     /// pulled from `--preview-mode <host:port>` — `127.0.0.1:54321`
@@ -313,6 +383,66 @@ pub const Preview = struct {
             reason: []const u8,
         };
         try self.writeFrame(Msg{ .reason = reason.asString() });
+    }
+
+    // ── PIE viewport handshake (#543) ──────────────────────────────
+
+    /// Offer the editor a SHM pixel ring. Call once the producer has
+    /// bound the region; transitions `frame_state` to `.offered`.
+    /// The producer should withhold any `frame_published` notifications
+    /// until the editor responds with `frame_accept`.
+    pub fn sendFrameOffer(self: *Preview, offer: FrameOffer) WriteError!void {
+        const Msg = struct {
+            kind: []const u8 = "frame_offer",
+            shm_name: []const u8,
+            width: u32,
+            height: u32,
+            format: []const u8,
+            ring_size: u32,
+            slot_size_bytes: u64,
+        };
+        try self.writeFrame(Msg{
+            .shm_name = offer.shm_name,
+            .width = offer.width,
+            .height = offer.height,
+            .format = offer.format.asString(),
+            .ring_size = offer.ring_size,
+            .slot_size_bytes = offer.slot_size_bytes,
+        });
+        self.frame_state = .offered;
+    }
+
+    /// Optional sidecar to wake the editor on a new frame. The wire
+    /// contract is "editor polls `Header.latest` to find the freshest
+    /// slot" — this frame is informational (and useful for editors that
+    /// want to throttle frame uploads to actual publishes rather than
+    /// every render tick). Cheap when the editor doesn't care: a
+    /// roughly 60-byte JSON line per produced frame.
+    pub fn sendFramePublished(self: *Preview, frame_idx: u64, produce_ns: u64) WriteError!void {
+        const Msg = struct {
+            kind: []const u8 = "frame_published",
+            frame_idx: u64,
+            produce_ns: u64,
+        };
+        try self.writeFrame(Msg{ .frame_idx = frame_idx, .produce_ns = produce_ns });
+    }
+
+    /// True once the editor has acknowledged the offer. Producer uses
+    /// this as the gate on writing pixels into the SHM ring (no point
+    /// rendering into a region nobody is reading from).
+    pub fn isFrameAccepted(self: *const Preview) bool {
+        return self.frame_state == .accepted;
+    }
+
+    /// Pop the pending resize request, if any. Clears the state so a
+    /// second call returns `null` until the editor sends another
+    /// `frame_resize`. Producer responds by tearing down the current
+    /// ring and re-issuing `sendFrameOffer` at the new dimensions.
+    pub fn takeResize(self: *Preview) ?PendingResize {
+        const pending = self.pending_resize;
+        self.pending_resize = null;
+        if (pending != null) self.frame_state = .not_offered;
+        return pending;
     }
 
     // ── Binary telemetry frames (Phase 2 / #518) ────────────────────
@@ -629,18 +759,22 @@ pub const Preview = struct {
         // read until EAGAIN, restore flags. The socket stays blocking
         // for writes so partial sends aren't a concern.
         const fd = self.fd;
-        const orig_flags = fcntl(fd, F_GETFL, 0);        if (orig_flags < 0) return;
-        const set_rc = fcntl(fd, F_SETFL, orig_flags | O_NONBLOCK);        if (set_rc < 0) return;
-        defer _ = fcntl(fd, F_SETFL, orig_flags);
+        const orig_flags = c_fcntl(fd, F_GETFL, @as(c_int, 0));
+        if (orig_flags < 0) return;
+        const set_rc = c_fcntl(fd, F_SETFL, @as(c_int, orig_flags | O_NONBLOCK));
+        if (set_rc < 0) return;
+        defer _ = c_fcntl(fd, F_SETFL, @as(c_int, orig_flags));
 
         var scratch: [1024]u8 = undefined;
         while (true) {
-            const n = read(fd, @ptrCast(&scratch[0]), scratch.len);            if (n < 0) {
+            const n = read(fd, @ptrCast(&scratch[0]), scratch.len);
+            if (n < 0) {
                 if (libcErrno() == EAGAIN) return;
                 return error.InputOutput;
             }
             if (n == 0) return; // EOF — caller infers from subsequent write failures.
-            try self.inbox.appendSlice(self.inbox_alloc, scratch[0..@intCast(n)]);        }
+            try self.inbox.appendSlice(self.inbox_alloc, scratch[0..@intCast(n)]);
+        }
     }
 
     fn applySubscriptionFrame(self: *Preview, line: []const u8) error{ OutOfMemory, MalformedSubscription }!void {
@@ -730,6 +864,20 @@ pub const Preview = struct {
                 .ignore_unknown_fields = true,
             }) catch return error.MalformedSubscription;
             _ = self.watched_entities.remove(parsed.id);
+        } else if (std.mem.eql(u8, kind_only.kind, "frame_accept")) {
+            // Editor acknowledges a prior `frame_offer`. The transition
+            // is `.offered → .accepted`; from any other state we ignore
+            // (an editor that ACKs a stale offer after a resize won't
+            // tip us back into the wrong state).
+            if (self.frame_state == .offered) {
+                self.frame_state = .accepted;
+            }
+        } else if (std.mem.eql(u8, kind_only.kind, "frame_resize")) {
+            const Parsed = struct { kind: []const u8, width: u32, height: u32 };
+            const parsed = std.json.parseFromSliceLeaky(Parsed, alloc, line, .{
+                .ignore_unknown_fields = true,
+            }) catch return error.MalformedSubscription;
+            self.pending_resize = .{ .width = parsed.width, .height = parsed.height };
         } else {
             return error.MalformedSubscription;
         }

--- a/test/preview_handshake_test.zig
+++ b/test/preview_handshake_test.zig
@@ -2,9 +2,12 @@
 //! `frame_accept`, `frame_resize`, `frame_published` shape +
 //! state-machine transitions on the `Preview` struct.
 //!
-//! Lives in its own file (separate from `preview_mode_test.zig`,
-//! which is parked while the subscription-flow tests are debugged)
-//! so the handshake coverage isn't gated on that work.
+//! Lives in its own file (separate from `preview_mode_test.zig`)
+//! to keep handshake coverage cohesive. preview_mode_test.zig is
+//! re-enabled in this PR — the same variadic-fcntl ABI fix that
+//! unblocked the handshake tests also unblocked its 21 previously-
+//! disabled subscription-flow tests, so the split is now purely
+//! organisational, not a gate.
 
 const std = @import("std");
 const engine = @import("engine");
@@ -229,13 +232,16 @@ test "frame_accept from not_offered is ignored (no spurious transition)" {
     defer p.deinit();
 
     try h.sendLine("{\"kind\":\"frame_accept\"}\n");
-    // Drain the inbox — but state must still be .not_offered.
-    var i: u32 = 0;
-    while (i < 50) : (i += 1) {
+    // Drain the inbox: poll until the bytes have been consumed (the
+    // frame_accept handler is a no-op in this state, so we can't
+    // observe a state change — wait for the inbox to drain instead).
+    const start = nowMs();
+    while (nowMs() - start <= 200) {
         try p.pollSubscription();
-        if (p.inbox.items.len == 0 and p.frame_state != .not_offered) break;
+        if (p.inbox.items.len == 0) break;
         sleepMs(1);
     }
+    try std.testing.expectEqual(@as(usize, 0), p.inbox.items.len);
     try std.testing.expectEqual(preview.FrameHandshakeState.not_offered, p.frame_state);
 }
 

--- a/test/preview_handshake_test.zig
+++ b/test/preview_handshake_test.zig
@@ -1,0 +1,308 @@
+//! Tests for the PIE viewport handshake (#543): `frame_offer`,
+//! `frame_accept`, `frame_resize`, `frame_published` shape +
+//! state-machine transitions on the `Preview` struct.
+//!
+//! Lives in its own file (separate from `preview_mode_test.zig`,
+//! which is parked while the subscription-flow tests are debugged)
+//! so the handshake coverage isn't gated on that work.
+
+const std = @import("std");
+const engine = @import("engine");
+const preview = engine.preview_mode_mod;
+
+extern "c" fn close(fd: c_int) c_int;
+extern "c" fn write(fd: c_int, buf: [*]const u8, len: usize) isize;
+extern "c" fn read(fd: c_int, buf: [*]u8, len: usize) isize;
+
+// ── Loopback harness ───────────────────────────────────────────────
+//
+// Mirrors the (currently-disabled) harness in preview_mode_test.zig.
+// Bound to 127.0.0.1:0, port discovered via getsockname.
+
+const LoopbackHarness = struct {
+    server: std.Io.net.Server,
+    port: u16,
+    conn_fd: ?std.posix.fd_t = null,
+    read_buf: [4096]u8 = undefined,
+    read_len: usize = 0,
+
+    fn init() !LoopbackHarness {
+        const addr = std.Io.net.IpAddress.parse("127.0.0.1", 0) catch unreachable;
+        const server = try addr.listen(std.testing.io, .{ .reuse_address = true });
+        var sa: std.posix.sockaddr.in = undefined;
+        var sa_len: std.posix.socklen_t = @sizeOf(@TypeOf(sa));
+        if (std.posix.system.getsockname(server.socket.handle, @ptrCast(&sa), &sa_len) != 0) {
+            return error.GetSockNameFailed;
+        }
+        const port = std.mem.bigToNative(u16, sa.port);
+        return .{ .server = server, .port = port };
+    }
+
+    fn deinit(self: *LoopbackHarness) void {
+        if (self.conn_fd) |fd| _ = close(@intCast(fd));
+        self.server.deinit(std.testing.io);
+    }
+
+    fn hostPort(self: *LoopbackHarness, buf: []u8) ![]const u8 {
+        return std.fmt.bufPrint(buf, "127.0.0.1:{d}", .{self.port});
+    }
+
+    fn accept(self: *LoopbackHarness) !void {
+        const stream = try self.server.accept(std.testing.io);
+        self.conn_fd = stream.socket.handle;
+    }
+
+    /// Read a newline-terminated JSON line (the engine → editor frame).
+    /// Returns the body without the trailing `\n`.
+    fn readLine(self: *LoopbackHarness, out: []u8) ![]const u8 {
+        while (true) {
+            // Look for an existing newline in the buffered bytes.
+            if (std.mem.indexOfScalar(u8, self.read_buf[0..self.read_len], '\n')) |nl| {
+                if (nl > out.len) return error.LineTooLong;
+                @memcpy(out[0..nl], self.read_buf[0..nl]);
+                const remaining = self.read_len - (nl + 1);
+                std.mem.copyForwards(u8, self.read_buf[0..remaining], self.read_buf[nl + 1 .. self.read_len]);
+                self.read_len = remaining;
+                return out[0..nl];
+            }
+            if (self.read_len == self.read_buf.len) return error.LineTooLong;
+            const fd = self.conn_fd orelse return error.NotConnected;
+            const n = read(@intCast(fd), self.read_buf[self.read_len..].ptr, self.read_buf.len - self.read_len);
+            if (n <= 0) return error.UnexpectedEof;
+            self.read_len += @intCast(n);
+        }
+    }
+
+    /// Push a complete editor → engine frame (caller supplies the `\n`).
+    fn sendLine(self: *LoopbackHarness, body: []const u8) !void {
+        const fd = self.conn_fd orelse return error.NotConnected;
+        var off: usize = 0;
+        while (off < body.len) {
+            const n = write(@intCast(fd), body.ptr + off, body.len - off);
+            if (n <= 0) return error.WriteFailed;
+            off += @intCast(n);
+        }
+    }
+};
+
+fn connectPair(h: *LoopbackHarness) !preview.Preview {
+    var hp_buf: [64]u8 = undefined;
+    const host_port = try h.hostPort(&hp_buf);
+    const p = try preview.Preview.connect(std.testing.io, std.testing.allocator, host_port);
+    try h.accept();
+    return p;
+}
+
+const Timespec = extern struct { sec: isize, nsec: isize };
+extern "c" fn nanosleep(req: *const Timespec, rem: ?*Timespec) c_int;
+extern "c" fn clock_gettime(clk: c_int, tp: *Timespec) c_int;
+
+fn nowMs() i64 {
+    const CLOCK_MONOTONIC: c_int = if (@import("builtin").os.tag == .macos) 6 else 1;
+    var ts: Timespec = undefined;
+    _ = clock_gettime(CLOCK_MONOTONIC, &ts);
+    return @as(i64, ts.sec) * 1000 + @divTrunc(@as(i64, ts.nsec), 1_000_000);
+}
+
+fn sleepMs(ms: u64) void {
+    const ts: Timespec = .{
+        .sec = @intCast(ms / 1000),
+        .nsec = @intCast((ms % 1000) * 1_000_000),
+    };
+    _ = nanosleep(&ts, null);
+}
+
+/// Polls `Preview.pollSubscription` in a tight loop until `predicate`
+/// returns true or `deadline_ms` elapses. Mirrors the
+/// `waitForSubscription` pattern in the disabled preview_mode_test
+/// — TCP loopback delivery isn't synchronous, so a single poll right
+/// after the harness `write` won't always see the bytes.
+fn waitFor(p: *preview.Preview, predicate: *const fn (*preview.Preview) bool, deadline_ms: u64) !void {
+    const start = nowMs();
+    while (true) {
+        try p.pollSubscription();
+        if (predicate(p)) return;
+        if (nowMs() - start > @as(i64, @intCast(deadline_ms))) return error.WaitForDeadlineExceeded;
+        sleepMs(1);
+    }
+}
+
+fn isAccepted(p: *preview.Preview) bool {
+    return p.isFrameAccepted();
+}
+
+fn hasResize(p: *preview.Preview) bool {
+    return p.pending_resize != null;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+test "sendFrameOffer serializes expected JSON and flips state to offered" {
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try std.testing.expectEqual(preview.FrameHandshakeState.not_offered, p.frame_state);
+
+    try p.sendFrameOffer(.{
+        .shm_name = "/labelle-preview-42",
+        .width = 1280,
+        .height = 720,
+        .format = .rgba8,
+        .ring_size = 3,
+        .slot_size_bytes = 3_686_464,
+    });
+
+    try std.testing.expectEqual(preview.FrameHandshakeState.offered, p.frame_state);
+
+    var line_buf: [512]u8 = undefined;
+    const line = try h.readLine(&line_buf);
+    // Sanity: round-trip parse + spot-check fields. The exact key
+    // ordering is Zig std.json's choice; assert by parse, not by
+    // byte-equal compare.
+    const Parsed = struct {
+        kind: []const u8,
+        shm_name: []const u8,
+        width: u32,
+        height: u32,
+        format: []const u8,
+        ring_size: u32,
+        slot_size_bytes: u64,
+    };
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const parsed = try std.json.parseFromSliceLeaky(Parsed, arena.allocator(), line, .{});
+    try std.testing.expectEqualStrings("frame_offer", parsed.kind);
+    try std.testing.expectEqualStrings("/labelle-preview-42", parsed.shm_name);
+    try std.testing.expectEqual(@as(u32, 1280), parsed.width);
+    try std.testing.expectEqual(@as(u32, 720), parsed.height);
+    try std.testing.expectEqualStrings("rgba8", parsed.format);
+    try std.testing.expectEqual(@as(u32, 3), parsed.ring_size);
+    try std.testing.expectEqual(@as(u64, 3_686_464), parsed.slot_size_bytes);
+}
+
+test "sendFramePublished carries frame_idx and produce_ns" {
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try p.sendFramePublished(42, 1_234_567_890);
+
+    var buf: [256]u8 = undefined;
+    const line = try h.readLine(&buf);
+    const Parsed = struct { kind: []const u8, frame_idx: u64, produce_ns: u64 };
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const parsed = try std.json.parseFromSliceLeaky(Parsed, arena.allocator(), line, .{});
+    try std.testing.expectEqualStrings("frame_published", parsed.kind);
+    try std.testing.expectEqual(@as(u64, 42), parsed.frame_idx);
+    try std.testing.expectEqual(@as(u64, 1_234_567_890), parsed.produce_ns);
+}
+
+test "frame_accept transitions offered → accepted; isFrameAccepted reports it" {
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try p.sendFrameOffer(.{
+        .shm_name = "/labelle-preview-test",
+        .width = 320,
+        .height = 240,
+        .slot_size_bytes = 320 * 240 * 4 + 64,
+    });
+    var drop: [512]u8 = undefined;
+    _ = try h.readLine(&drop);
+
+    try std.testing.expect(!p.isFrameAccepted());
+    try h.sendLine("{\"kind\":\"frame_accept\"}\n");
+    try waitFor(&p, isAccepted, 1000);
+    try std.testing.expectEqual(preview.FrameHandshakeState.accepted, p.frame_state);
+}
+
+test "frame_accept from not_offered is ignored (no spurious transition)" {
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try h.sendLine("{\"kind\":\"frame_accept\"}\n");
+    // Drain the inbox — but state must still be .not_offered.
+    var i: u32 = 0;
+    while (i < 50) : (i += 1) {
+        try p.pollSubscription();
+        if (p.inbox.items.len == 0 and p.frame_state != .not_offered) break;
+        sleepMs(1);
+    }
+    try std.testing.expectEqual(preview.FrameHandshakeState.not_offered, p.frame_state);
+}
+
+test "frame_resize sets pending_resize, takeResize pops it once and resets state" {
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try p.sendFrameOffer(.{
+        .shm_name = "/labelle-preview-resize",
+        .width = 640,
+        .height = 360,
+        .slot_size_bytes = 640 * 360 * 4 + 64,
+    });
+    var drop: [512]u8 = undefined;
+    _ = try h.readLine(&drop);
+    try h.sendLine("{\"kind\":\"frame_accept\"}\n");
+    try waitFor(&p, isAccepted, 1000);
+
+    try std.testing.expect(p.takeResize() == null);
+
+    try h.sendLine("{\"kind\":\"frame_resize\",\"width\":1920,\"height\":1080}\n");
+    try waitFor(&p, hasResize, 1000);
+
+    const first = p.takeResize();
+    try std.testing.expect(first != null);
+    try std.testing.expectEqual(@as(u32, 1920), first.?.width);
+    try std.testing.expectEqual(@as(u32, 1080), first.?.height);
+    try std.testing.expectEqual(preview.FrameHandshakeState.not_offered, p.frame_state);
+    try std.testing.expect(p.takeResize() == null);
+}
+
+// Helper that polls until pollSubscription returns the expected error
+// or the deadline expires (in which case we propagate "we never saw
+// the bytes" as a test failure).
+fn expectPollErrorWithin(p: *preview.Preview, expected: anyerror, deadline_ms: u64) !void {
+    const start = nowMs();
+    while (true) {
+        const r = p.pollSubscription();
+        if (r) |_| {
+            if (nowMs() - start > @as(i64, @intCast(deadline_ms))) return error.DidNotErrorBeforeDeadline;
+            sleepMs(1);
+            continue;
+        } else |err| {
+            if (err == expected) return;
+            return err;
+        }
+    }
+}
+
+test "frame_resize with missing dim fields surfaces MalformedSubscription" {
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try h.sendLine("{\"kind\":\"frame_resize\"}\n");
+    try expectPollErrorWithin(&p, error.MalformedSubscription, 1000);
+}
+
+test "unknown control frame is still rejected (regression guard)" {
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try h.sendLine("{\"kind\":\"frame_who_knows\"}\n");
+    try expectPollErrorWithin(&p, error.MalformedSubscription, 1000);
+}


### PR DESCRIPTION
Implements #543 — extends the Preview JSON control plane with the four messages needed to negotiate a shared-memory pixel ring between the engine and the editor. Plus a drive-by fix for a variadic-`fcntl` ABI bug that turned out to be the root cause of #543's first failing test AND the 21 disabled subscription tests AND the 7 disabled `flows_game_api_test` tests.

## #543 — handshake protocol

| Message | Direction | Effect |
|---|---|---|
| `frame_offer` | engine → editor | shm_name, dims, format, ring_size, slot_size. Producer state → `.offered`. |
| `frame_published` | engine → editor | Optional sidecar: frame_idx + produce_ns. Editor's primary cue is still `header.latest`. |
| `frame_accept` | editor → engine | ACKs an offer. Producer state → `.accepted`. Render loop is expected to gate publishes on `isFrameAccepted()`. |
| `frame_resize` | editor → engine | Requests new dims. Sets `pending_resize`, drops state back to `.not_offered`. Producer pops via `takeResize`, re-offers. |

New types: `FramePixelFormat`, `FrameOffer`, `FrameHandshakeState`, `PendingResize`. New `Preview` methods: `sendFrameOffer`, `sendFramePublished`, `isFrameAccepted`, `takeResize`. New parser branches in `applySubscriptionFrame` for `frame_accept` and `frame_resize`.

7 new tests in `test/preview_handshake_test.zig`, all green:
1. `sendFrameOffer` serializes the expected JSON + flips state to `.offered`
2. `sendFramePublished` carries `frame_idx` and `produce_ns`
3. `frame_accept` transitions `.offered` → `.accepted`; `isFrameAccepted` reports it
4. `frame_accept` from `.not_offered` is ignored (no spurious transition)
5. `frame_resize` sets `pending_resize`, `takeResize` pops it once and resets state to `.not_offered`
6. `frame_resize` with missing dim fields surfaces `MalformedSubscription`
7. Unknown control frame is still rejected (regression guard)

## Drive-by: variadic-`fcntl` ABI fix

`src/preview_mode.zig` declared

```zig
extern "c" fn fcntl(fd: c_int, cmd: c_int, arg: c_int) c_int;
```

— non-variadic. libc's actual `fcntl` is variadic: `int fcntl(int, int, ...)`. On aarch64-darwin the calling convention differs for variadic vs non-variadic functions (variadic args go on the stack, non-variadic stays in registers), so `F_SETFL`'s third argument never reached the kernel. The kernel applied a stack-garbage flag set instead of `orig_flags | O_NONBLOCK`, the FD stayed blocking, and the second `read` in `fillInboxNonBlocking` blocked indefinitely.

Bisected with diagnostic prints — `F_GETFL` reported `current_flags=65666 (O_NONBLOCK_set=false)` immediately after a "successful" `F_SETFL(orig | O_NONBLOCK)`. Fix: use `std.c.fcntl` which the stdlib declares correctly as `pub extern "c" fn fcntl(fd: fd_t, cmd: c_int, ...) c_int`.

This is **also** the root cause of:

- The 21 disabled subscription-flow tests in `test/preview_mode_test.zig` (re-enabled in this PR).
- The 7 disabled `test/flows_game_api_test.zig` tests (re-enabled in this PR).

Yesterday's PoC investigation described them as "bytes arrive on the wire (read() returns the full frame) but applySubscriptionFrame's effect doesn't land in subscribed_components". The bytes did arrive — read 1 succeeded. Then read 2 hung; the test runner saw the hang and the deadline expired, with the test framework reporting "didn't observe state update" because the deadline-loop never got back around.

## Test plan

- [x] 7/7 new handshake tests pass locally (Apple Silicon, Zig 0.16.0).
- [x] All 36 previously-disabled `preview_mode_test.zig` tests pass (was 15/36, now 36/36).
- [x] All 7 previously-disabled `flows_game_api_test.zig` tests pass.
- [x] Full `zig build test` green — no regression in any other test file.
- [x] `zig build` clean (no warnings).
- [ ] CI confirmation on next push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)