### PR TITLE
feat(preview): SHM ring producer + publishFrame API (#544)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -91,6 +91,11 @@ pub fn build(b: *std.Build) void {
         // preview_mode_test.zig so the new coverage isn't gated on
         // that file's pre-existing 21-test subscription bug.
         "test/preview_handshake_test.zig",
+        // PIE viewport frame stream (#544) — producer-side SHM
+        // lifecycle + publishFrame. Companion to the handshake tests
+        // above; spins up an in-test `preview_shm.Consumer` to read
+        // back what the engine wrote.
+        "test/preview_frame_stream_test.zig",
         // preview_mode_test + flows_game_api_test: re-enabled after #543
         // fixed the variadic-`fcntl` ABI bug (declared non-variadic on
         // a function libc declares variadic — mismatched on

--- a/src/preview_mode.zig
+++ b/src/preview_mode.zig
@@ -306,6 +306,13 @@ pub const Preview = struct {
     /// SHM ring writer for #544. `null` until `beginFrameStream` runs;
     /// `endFrameStream` deallocates and resets to `null`.
     frame_producer: ?preview_shm.Producer = null,
+    /// Owned shm_name backing `frame_producer`. Allocated per
+    /// `beginFrameStream` and freed at the start of the next call
+    /// (or in `endFrameStream` / `deinit`). Previously dupe'd into
+    /// `subs_arena`, which is only freed at full `Preview` deinit —
+    /// resize-driven re-offer cycles would otherwise leak names
+    /// proportional to the resize count (#546 review).
+    frame_shm_name: ?[:0]u8 = null,
     /// Monotonic frame counter — bumped by `publishFrame`.
     frame_index: u64 = 0,
 
@@ -344,6 +351,10 @@ pub const Preview = struct {
         if (self.frame_producer) |*p| {
             p.deinit();
             self.frame_producer = null;
+        }
+        if (self.frame_shm_name) |old| {
+            self.inbox_alloc.free(old);
+            self.frame_shm_name = null;
         }
         self.subscribed_components.deinit(self.subs_arena.allocator());
         self.subscribed_flows.deinit(self.subs_arena.allocator());
@@ -519,26 +530,35 @@ pub const Preview = struct {
             p.deinit();
             self.frame_producer = null;
         }
+        if (self.frame_shm_name) |old| {
+            self.inbox_alloc.free(old);
+            self.frame_shm_name = null;
+        }
         self.frame_state = .not_offered;
         self.frame_index = 0;
 
-        // Per-process unique SHM name (PID + counter). Keep it short
-        // for macOS (PSHMNAMLEN ~ 31 chars). Counter increment uses
-        // an atomic RMW so concurrent Preview instances on different
-        // threads (e.g. parallel test fixtures) don't collide on the
-        // shm_open namespace (#546 review).
+        // Per-process unique SHM name (PID + counter). Atomic RMW on
+        // the counter so concurrent Preview instances on different
+        // threads can't collide. **Full** 32-bit PID and counter in
+        // hex — truncating to 16 bits is small enough that two
+        // engine processes whose PIDs share the low 16 bits collide
+        // on the same name and `Producer.init`'s pre-`shm_unlink`
+        // would yank each other's regions (#546 review). Name math:
+        // "/lbl-prv-" (9) + 8 hex + "-" (1) + 8 hex + "\0" = 27 ≤
+        // macOS PSHMNAMLEN (31).
         const pid: i32 = @intCast(std.c.getpid());
         const stream_id = @atomicRmw(u32, &next_stream_id, .Add, 1, .monotonic) +% 1;
         var name_buf: [32]u8 = undefined;
         const name = std.fmt.bufPrintZ(&name_buf, "/lbl-prv-{x}-{x}", .{
-            @as(u32, @bitCast(pid)) & 0xffff,
-            stream_id & 0xffff,
+            @as(u32, @bitCast(pid)),
+            stream_id,
         }) catch return error.OutOfMemory;
-        // Persist the name into the arena so the lifetime outlasts
-        // the local stack buffer for the producer's eventual
-        // shm_unlink at deinit.
-        const name_owned = self.subs_arena.allocator().dupeZ(u8, name) catch
+        // Heap-owned copy so the producer's eventual `shm_unlink`
+        // gets a stable pointer; freed in `endFrameStream` / the
+        // next `beginFrameStream` teardown / `deinit`.
+        const name_owned = self.inbox_alloc.dupeZ(u8, name) catch
             return error.OutOfMemory;
+        errdefer self.inbox_alloc.free(name_owned);
 
         const opts: preview_shm.Options = .{
             .width = width,
@@ -558,6 +578,7 @@ pub const Preview = struct {
         });
 
         self.frame_producer = producer;
+        self.frame_shm_name = name_owned;
     }
 
     /// Publish a CPU-side RGBA8 frame into the SHM ring and emit an
@@ -601,6 +622,10 @@ pub const Preview = struct {
         if (self.frame_producer) |*p| {
             p.deinit();
             self.frame_producer = null;
+        }
+        if (self.frame_shm_name) |old| {
+            self.inbox_alloc.free(old);
+            self.frame_shm_name = null;
         }
         self.frame_state = .not_offered;
         self.frame_index = 0;

--- a/src/preview_mode.zig
+++ b/src/preview_mode.zig
@@ -506,10 +506,20 @@ pub const Preview = struct {
         // Tear down any prior ring so a resize-driven re-offer is
         // idempotent — the protocol allows multiple frame_offer cycles
         // over the same connection.
+        //
+        // Reset `frame_state` *before* allocating the new ring so a
+        // failure in `Producer.init` / `sendFrameOffer` leaves us in a
+        // clean `.not_offered` state, not stuck at `.accepted` with a
+        // null producer. (#546 review: backends gating on
+        // `isFrameAccepted` would otherwise run their expensive PBO
+        // readback only to fail at `publishFrame` with
+        // `StreamNotActive`.) On success, `sendFrameOffer` below
+        // lifts us back to `.offered`.
         if (self.frame_producer) |*p| {
             p.deinit();
             self.frame_producer = null;
         }
+        self.frame_state = .not_offered;
         self.frame_index = 0;
 
         // Per-process unique SHM name (PID + counter). Keep it short

--- a/src/preview_mode.zig
+++ b/src/preview_mode.zig
@@ -79,6 +79,7 @@
 ///    socket. On abnormal exit the OS closes the FD and the editor
 ///    infers the crash from the EOF without a `bye`.
 const std = @import("std");
+pub const preview_shm = @import("preview_shm.zig");
 
 // Raw libc bindings: std.posix in 0.16 dropped top-level `close` and
 // `write` wrappers and routed file IO through `std.Io.File` which
@@ -133,6 +134,13 @@ pub const ByeReason = enum {
 /// `hello` frame. Bump every time the message shapes change in an
 /// incompatible way.
 pub const protocol_version: u32 = 1;
+
+/// Process-wide monotonic suffix for SHM names. Each
+/// `beginFrameStream` call increments this; combined with the PID
+/// it keeps concurrent previews (e.g. test loopback fixtures and a
+/// real game running in parallel) from colliding on the shm_open
+/// namespace.
+var next_stream_id: u32 = 0;
 
 /// Magic byte that flags a binary telemetry frame on the multiplexed
 /// socket. Chosen as `ESC` (0x1B) because no valid JSON document or
@@ -295,6 +303,11 @@ pub const Preview = struct {
     /// Set by the editor's `frame_resize`; cleared by `takeResize`.
     /// `null` means "no resize pending."
     pending_resize: ?PendingResize = null,
+    /// SHM ring writer for #544. `null` until `beginFrameStream` runs;
+    /// `endFrameStream` deallocates and resets to `null`.
+    frame_producer: ?preview_shm.Producer = null,
+    /// Monotonic frame counter — bumped by `publishFrame`.
+    frame_index: u64 = 0,
 
     /// Dial the editor's listener. `host_port` is the literal string
     /// pulled from `--preview-mode <host:port>` — `127.0.0.1:54321`
@@ -326,6 +339,12 @@ pub const Preview = struct {
         // so the caller can still observe write failures; we always
         // close here.
         _ = close(self.fd);
+        // Tear down the SHM ring if a stream was started; safe no-op
+        // when never started.
+        if (self.frame_producer) |*p| {
+            p.deinit();
+            self.frame_producer = null;
+        }
         self.subscribed_components.deinit(self.subs_arena.allocator());
         self.subscribed_flows.deinit(self.subs_arena.allocator());
         self.subscribed_pin_flows.deinit(self.subs_arena.allocator());
@@ -448,6 +467,121 @@ pub const Preview = struct {
         const pending = self.pending_resize;
         self.pending_resize = null;
         return pending;
+    }
+
+    // ── #544: PBO/SHM publish (producer side) ──────────────────────
+
+    /// Errors specific to `beginFrameStream` / `publishFrame`.
+    /// Augments `WriteError` (control-channel write failure) with
+    /// the SHM-allocation failure modes from `preview_shm.Error`.
+    pub const PublishError = WriteError || preview_shm.Error || error{StreamNotActive};
+
+    /// Allocate a SHM ring sized for `width x height` RGBA8 frames and
+    /// emit a `frame_offer` over the control channel.
+    ///
+    /// Caller (typically the backend's render-loop init code) calls
+    /// this once preview is connected and after the first render
+    /// surface dimensions are known. The producer state transitions
+    /// to `.offered`; subsequent `publishFrame` calls are gated on
+    /// the editor's `frame_accept` lifting state to `.accepted` (see
+    /// `isFrameAccepted`).
+    ///
+    /// SHM name is derived from PID and a monotonic counter so concurrent
+    /// previews (e.g. unit-test loopback fixtures) don't collide. The
+    /// name is bounded at ~31 chars to satisfy macOS' PSHMNAMLEN.
+    pub fn beginFrameStream(
+        self: *Preview,
+        width: u32,
+        height: u32,
+    ) PublishError!void {
+        // Tear down any prior ring so a resize-driven re-offer is
+        // idempotent — the protocol allows multiple frame_offer cycles
+        // over the same connection.
+        if (self.frame_producer) |*p| {
+            p.deinit();
+            self.frame_producer = null;
+        }
+        self.frame_index = 0;
+
+        // Per-process unique SHM name (PID + counter). Keep it short
+        // for macOS (PSHMNAMLEN ~ 31 chars).
+        const pid: i32 = @intCast(std.c.getpid());
+        next_stream_id +%= 1;
+        var name_buf: [32]u8 = undefined;
+        const name = std.fmt.bufPrintZ(&name_buf, "/lbl-prv-{x}-{x}", .{
+            @as(u32, @bitCast(pid)) & 0xffff,
+            next_stream_id & 0xffff,
+        }) catch return error.OutOfMemory;
+        // Persist the name into the arena so the lifetime outlasts
+        // the local stack buffer for the producer's eventual
+        // shm_unlink at deinit.
+        const name_owned = self.subs_arena.allocator().dupeZ(u8, name) catch
+            return error.OutOfMemory;
+
+        const opts: preview_shm.Options = .{
+            .width = width,
+            .height = height,
+            .ring_size = 3,
+        };
+        var producer = try preview_shm.Producer.init(name_owned, opts);
+        errdefer producer.deinit();
+
+        try self.sendFrameOffer(.{
+            .shm_name = name_owned,
+            .width = width,
+            .height = height,
+            .format = .rgba8,
+            .ring_size = opts.ring_size,
+            .slot_size_bytes = preview_shm.slotSize(width, height),
+        });
+
+        self.frame_producer = producer;
+    }
+
+    /// Publish a CPU-side RGBA8 frame into the SHM ring and emit an
+    /// optional `frame_published` JSON sidecar.
+    ///
+    /// `pixels` must be exactly `width * height * 4` bytes — the
+    /// dimensions agreed in `beginFrameStream` / the last accepted
+    /// `frame_offer`. Caller (typically the backend) is responsible
+    /// for the GPU → CPU readback (PBO async readback is the
+    /// recommended shape — see `imgui-preview-poc/src/game.zig`).
+    ///
+    /// No-op (returns `error.StreamNotActive`) when the editor hasn't
+    /// yet acknowledged the offer (`frame_state != .accepted`). The
+    /// backend's render loop is expected to early-out via
+    /// `isFrameAccepted` to avoid the readback cost when no editor is
+    /// attached.
+    pub fn publishFrame(self: *Preview, pixels: []const u8) PublishError!void {
+        const producer = if (self.frame_producer != null) &self.frame_producer.? else return error.StreamNotActive;
+        if (!self.isFrameAccepted()) return error.StreamNotActive;
+
+        const expected_len: usize = @intCast(@as(u64, producer.opts.width) * @as(u64, producer.opts.height) * 4);
+        if (pixels.len != expected_len) return error.StreamNotActive;
+
+        // Single memcpy into the next slot; stamp + publish.
+        const slot_pixels = producer.pixelsPtr();
+        @memcpy(slot_pixels[0..expected_len], pixels);
+        producer.publish(true);
+
+        self.frame_index +%= 1;
+        // The control-channel sidecar is optional — emit best-effort
+        // and swallow broken-pipe so an editor that drops mid-stream
+        // doesn't tear down the render loop. The SHM publish above
+        // is the authoritative signal; the editor can poll
+        // `Header.latest` without seeing this frame.
+        self.sendFramePublished(self.frame_index, preview_shm.nowNs()) catch {};
+    }
+
+    /// Tear down the SHM ring. Safe to call when no stream is active.
+    /// Does **not** send a `bye` — caller still owns that lifecycle.
+    pub fn endFrameStream(self: *Preview) void {
+        if (self.frame_producer) |*p| {
+            p.deinit();
+            self.frame_producer = null;
+        }
+        self.frame_state = .not_offered;
+        self.frame_index = 0;
     }
 
     // ── Binary telemetry frames (Phase 2 / #518) ────────────────────

--- a/src/preview_mode.zig
+++ b/src/preview_mode.zig
@@ -474,7 +474,16 @@ pub const Preview = struct {
     /// Errors specific to `beginFrameStream` / `publishFrame`.
     /// Augments `WriteError` (control-channel write failure) with
     /// the SHM-allocation failure modes from `preview_shm.Error`.
-    pub const PublishError = WriteError || preview_shm.Error || error{StreamNotActive};
+    ///
+    /// `StreamNotActive` and `InvalidFrameSize` are split on purpose
+    /// — the former is "no editor attached / not yet accepted /
+    /// stream torn down," the latter is "you handed me the wrong
+    /// number of pixel bytes for the negotiated dims." Conflating
+    /// them was the #546 review feedback.
+    pub const PublishError = WriteError || preview_shm.Error || error{
+        StreamNotActive,
+        InvalidFrameSize,
+    };
 
     /// Allocate a SHM ring sized for `width x height` RGBA8 frames and
     /// emit a `frame_offer` over the control channel.
@@ -504,13 +513,16 @@ pub const Preview = struct {
         self.frame_index = 0;
 
         // Per-process unique SHM name (PID + counter). Keep it short
-        // for macOS (PSHMNAMLEN ~ 31 chars).
+        // for macOS (PSHMNAMLEN ~ 31 chars). Counter increment uses
+        // an atomic RMW so concurrent Preview instances on different
+        // threads (e.g. parallel test fixtures) don't collide on the
+        // shm_open namespace (#546 review).
         const pid: i32 = @intCast(std.c.getpid());
-        next_stream_id +%= 1;
+        const stream_id = @atomicRmw(u32, &next_stream_id, .Add, 1, .monotonic) +% 1;
         var name_buf: [32]u8 = undefined;
         const name = std.fmt.bufPrintZ(&name_buf, "/lbl-prv-{x}-{x}", .{
             @as(u32, @bitCast(pid)) & 0xffff,
-            next_stream_id & 0xffff,
+            stream_id & 0xffff,
         }) catch return error.OutOfMemory;
         // Persist the name into the arena so the lifetime outlasts
         // the local stack buffer for the producer's eventual
@@ -557,7 +569,7 @@ pub const Preview = struct {
         if (!self.isFrameAccepted()) return error.StreamNotActive;
 
         const expected_len: usize = @intCast(@as(u64, producer.opts.width) * @as(u64, producer.opts.height) * 4);
-        if (pixels.len != expected_len) return error.StreamNotActive;
+        if (pixels.len != expected_len) return error.InvalidFrameSize;
 
         // Single memcpy into the next slot; stamp + publish.
         const slot_pixels = producer.pixelsPtr();

--- a/src/preview_shm.zig
+++ b/src/preview_shm.zig
@@ -1,0 +1,448 @@
+//! Cross-process pixel ring backed by POSIX shared memory.
+//!
+//! Layout: a single `shm_open`-d region containing
+//!
+//!     [ Header (cacheline-aligned) ]
+//!     [ Slot 0 pixel bytes (stride * height) ]
+//!     [ Slot 1 pixel bytes ... ]
+//!     [ Slot N-1 pixel bytes ]
+//!
+//! The producer (engine) claims a slot, writes, and publishes the slot
+//! index via `Header.latest`. The consumer (editor in labelle-gui)
+//! reads `latest` (mailbox semantics — always grab the freshest, drop
+//! older).
+//!
+//! Each slot also carries a monotonic `frame_idx` and a producer-stamped
+//! `produce_ns` timestamp so the consumer can compute end-to-end latency.
+//!
+//! Validated end-to-end at 1280x720@60 with raw-IPC p50=5µs / p99=40µs
+//! and zero drops in the matched-FPS bench (see imgui-preview-poc/
+//! experiments/bench/ — both macOS native and aarch64 ubuntu Docker
+//! came within 5% on throughput).
+//!
+//! Pairs with the PIE-viewport handshake (#543) and is driven from
+//! `Preview.beginFrameStream` / `publishFrame` / `endFrameStream`
+//! (this file is the implementation; that file is the protocol API).
+//!
+//! Targets macOS and linux. Windows would use `CreateFileMappingW` —
+//! out of scope; see labelle-gui#110 for the cross-platform follow-up.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+pub const PIXEL_FORMAT_RGBA8: u32 = 0x52474241; // 'RGBA'
+pub const MAGIC: u64 = 0x4C424C5052564653; // 'LBLPRVFS' — labelle preview frame stream
+pub const PROTOCOL_VERSION: u32 = 1;
+
+pub const Error = error{
+    ShmOpenFailed,
+    FtruncateFailed,
+    MmapFailed,
+    FstatFailed,
+    BadMagic,
+    BadVersion,
+    TooSmall,
+};
+
+/// Cacheline-aligned header. Field layout is a stable ABI across the
+/// two processes; do not reorder.
+pub const Header = extern struct {
+    magic: u64,
+    version: u32,
+    pixel_format: u32,
+    width: u32,
+    height: u32,
+    stride: u32,
+    ring_size: u32,
+    /// Slot byte size, including any trailing padding to the next
+    /// cacheline. `slot_offset(i) = header_size + i * slot_size`.
+    slot_size: u64,
+    /// Index of the most-recently published slot. Producer writes,
+    /// consumer reads. Single-writer / single-reader; no atomics
+    /// needed on the surface (writer fences with full memory barrier
+    /// before publishing — see `Producer.publish`).
+    latest: u32,
+    /// Monotonic counter of frames published since the producer
+    /// started. Used by the consumer to detect "new frame available."
+    frame_count: u64,
+    /// Set non-zero by either side when shutting down. The other
+    /// side polls and exits its loop.
+    shutdown: u32,
+    /// Trailing pad so `@sizeOf(Header) == 64`. With the natural
+    /// 8-byte alignment slop between `latest` and `frame_count`, the
+    /// fields above end at byte 60 — so 4 bytes of explicit padding
+    /// brings the struct to one cacheline.
+    _pad: [4]u8,
+};
+
+comptime {
+    std.debug.assert(@sizeOf(Header) % 64 == 0);
+}
+
+/// Per-slot side-band: stamped by the producer when the slot is
+/// published. The PoC stuffs this into the last few bytes of the slot
+/// rather than carrying a separate trailer array, since the slot has
+/// guaranteed padding (rounded up to cacheline).
+pub const SlotTrailer = extern struct {
+    frame_idx: u64,
+    produce_ns: u64, // CLOCK_MONOTONIC nanoseconds at publish
+    _pad: [48]u8,
+};
+
+comptime {
+    std.debug.assert(@sizeOf(SlotTrailer) == 64);
+}
+
+pub const Options = struct {
+    width: u32,
+    height: u32,
+    /// 2 or 3 — 2 is sufficient for single-writer / single-reader at
+    /// 60 Hz; 3 buys a little jitter tolerance.
+    ring_size: u32 = 3,
+};
+
+/// Path used for `shm_open`. On macOS this must start with `/` and be
+/// ≤ `PSHMNAMLEN` (typically 31 chars).
+pub const default_name: [:0]const u8 = "/imgui-preview-poc";
+
+/// Compute the slot size (pixel bytes + trailer, padded to cacheline).
+pub fn slotSize(width: u32, height: u32) u64 {
+    const raw: u64 = @as(u64, width) * @as(u64, height) * 4 + @sizeOf(SlotTrailer);
+    return std.mem.alignForward(u64, raw, 64);
+}
+
+pub fn totalSize(opts: Options) u64 {
+    return @sizeOf(Header) + @as(u64, opts.ring_size) * slotSize(opts.width, opts.height);
+}
+
+/// Wall-clock monotonic nanoseconds — used for the latency stamp.
+pub fn nowNs() u64 {
+    var ts: std.posix.timespec = undefined;
+    _ = std.posix.system.clock_gettime(.MONOTONIC, &ts);
+    const sec: u64 = @intCast(ts.sec);
+    const nsec: u64 = @intCast(ts.nsec);
+    return sec * std.time.ns_per_s + nsec;
+}
+
+/// Cross-platform `fstat`-equivalent that just returns the file size in bytes.
+///
+/// macOS exposes `std.c.fstat` as a real libc binding; on Linux 0.16 the
+/// `std.c.fstat` slot is `void` (the libc binding was removed in favour of
+/// `statx`), so we route through the raw syscall there. The consumer only
+/// needs the byte size to size its mmap, hence this narrow shim rather than
+/// porting the full `Stat` struct.
+fn fdSize(fd: std.c.fd_t) !u64 {
+    if (builtin.os.tag == .linux) {
+        const linux = std.os.linux;
+        var sx: linux.Statx = undefined;
+        const empty: [*:0]const u8 = "";
+        const mask: linux.STATX = .{ .SIZE = true };
+        const rc = linux.statx(@intCast(fd), empty, linux.AT.EMPTY_PATH, mask, &sx);
+        // `usize` syscall return: errors are -4096..-1 (i.e. very large usize).
+        if (@as(isize, @bitCast(rc)) < 0) return Error.FstatFailed;
+        return sx.size;
+    } else {
+        var st: std.c.Stat = undefined;
+        if (std.c.fstat(fd, &st) != 0) return Error.FstatFailed;
+        return @intCast(st.size);
+    }
+}
+
+// ── Producer ───────────────────────────────────────────────────────
+
+pub const Producer = struct {
+    base: [*]u8,
+    total_size: usize,
+    header: *Header,
+    opts: Options,
+    fd: std.c.fd_t,
+    name: [:0]const u8,
+    /// Slot the producer is currently writing into. Rotates 0 → ring-1.
+    next_slot: u32 = 0,
+
+    /// Create + truncate + map the shm region. Sets `Header.magic`,
+    /// dimensions, ring_size, slot_size. Caller can call `pixelsPtr`
+    /// to write into the current slot, then `publish` to advance
+    /// `latest` and bump `frame_count`.
+    pub fn init(name: [:0]const u8, opts: Options) !Producer {
+        const total = totalSize(opts);
+
+        // Best-effort cleanup of any stale region from a previous run.
+        // On macOS, `ftruncate` on a POSIX shm object only succeeds once
+        // (at creation). A leftover from a crashed run will refuse to
+        // resize and we'd fail with `FtruncateFailed`. `shm_unlink` is
+        // the only safe escape hatch; if no stale region exists it's a
+        // no-op (ENOENT) and we proceed to a fresh shm_open below.
+        // On linux this is also harmless: shm_unlink + shm_open(CREAT)
+        // gets us a fresh inode either way, matching prior behaviour.
+        _ = std.c.shm_unlink(name.ptr);
+
+        // O_RDWR | O_CREAT (no O_EXCL — reattach is fine).
+        const flags: std.c.O = .{ .ACCMODE = .RDWR, .CREAT = true };
+        const flags_int: c_int = @bitCast(flags);
+        const fd: std.c.fd_t = @intCast(std.c.shm_open(name.ptr, flags_int, @as(std.c.mode_t, 0o600)));
+        if (fd < 0) return Error.ShmOpenFailed;
+        errdefer _ = std.c.close(fd);
+
+        // ftruncate always — handles both fresh-create and reattach-with-different-size.
+        if (std.c.ftruncate(fd, @intCast(total)) != 0) {
+            return Error.FtruncateFailed;
+        }
+
+        const prot: std.c.PROT = .{ .READ = true, .WRITE = true };
+        const map_flags: std.c.MAP = .{ .TYPE = .SHARED };
+        const raw = std.c.mmap(null, @intCast(total), prot, map_flags, fd, 0);
+        if (raw == std.c.MAP_FAILED) return Error.MmapFailed;
+        const base: [*]u8 = @ptrCast(@alignCast(raw));
+        errdefer _ = std.c.munmap(@ptrCast(@alignCast(base)), @intCast(total));
+
+        const header: *Header = @ptrCast(@alignCast(base));
+        header.* = .{
+            .magic = MAGIC,
+            .version = PROTOCOL_VERSION,
+            .pixel_format = PIXEL_FORMAT_RGBA8,
+            .width = opts.width,
+            .height = opts.height,
+            .stride = opts.width * 4,
+            .ring_size = opts.ring_size,
+            .slot_size = slotSize(opts.width, opts.height),
+            // Sentinel meaning "no slot published yet" — consumers gate on
+            // `latest < ring_size`.
+            .latest = opts.ring_size,
+            .frame_count = 0,
+            .shutdown = 0,
+            ._pad = [_]u8{0} ** 4,
+        };
+
+        return .{
+            .base = base,
+            .total_size = @intCast(total),
+            .header = header,
+            .opts = opts,
+            .fd = fd,
+            .name = name,
+            .next_slot = 0,
+        };
+    }
+
+    pub fn deinit(self: *Producer) void {
+        _ = std.c.munmap(@ptrCast(@alignCast(self.base)), self.total_size);
+        _ = std.c.close(self.fd);
+        // Best-effort: producer owns the lifecycle; remove the name.
+        _ = std.c.shm_unlink(self.name.ptr);
+        self.base = undefined;
+        self.header = undefined;
+    }
+
+    /// Returns the pixel bytes pointer for the *next* slot to fill.
+    /// Producer writes RGBA8 pixels here (width*height*4 bytes), then
+    /// calls `publish`.
+    pub fn pixelsPtr(self: *Producer) [*]u8 {
+        const slot_base = self.base + @sizeOf(Header) + @as(usize, @intCast(self.next_slot)) * @as(usize, @intCast(self.header.slot_size));
+        return slot_base;
+    }
+
+    /// Returns the trailer pointer for the slot returned by the last
+    /// `pixelsPtr` call. Producer may stamp `frame_idx` and
+    /// `produce_ns` directly OR call `publish(stamp_now=true)`.
+    pub fn trailerPtr(self: *Producer) *SlotTrailer {
+        const slot_base = self.base + @sizeOf(Header) + @as(usize, @intCast(self.next_slot)) * @as(usize, @intCast(self.header.slot_size));
+        const trailer_offset: usize = @as(usize, @intCast(self.header.slot_size)) - @sizeOf(SlotTrailer);
+        return @ptrCast(@alignCast(slot_base + trailer_offset));
+    }
+
+    /// Publish the current slot. With `stamp_now=true` (the default)
+    /// the trailer is written here with the current `nowNs()`; if the
+    /// producer wants to stamp earlier (e.g. before GPU sync), pass
+    /// `stamp_now=false` and write the trailer manually.
+    pub fn publish(self: *Producer, stamp_now: bool) void {
+        const new_frame_idx = self.header.frame_count + 1;
+        if (stamp_now) {
+            const trailer = self.trailerPtr();
+            trailer.frame_idx = new_frame_idx;
+            trailer.produce_ns = nowNs();
+        }
+
+        // Release-store `latest` first so any consumer that reads it has a
+        // happens-before on the pixel writes + trailer. Then release-store
+        // `frame_count` — consumer acquire-loads frame_count first, so the
+        // ordering is: consumer sees new frame_count → acquire-load latest
+        // → guaranteed to see the slot writes.
+        @atomicStore(u32, &self.header.latest, self.next_slot, .release);
+        @atomicStore(u64, &self.header.frame_count, new_frame_idx, .release);
+
+        self.next_slot = (self.next_slot + 1) % self.header.ring_size;
+    }
+};
+
+// ── Consumer ───────────────────────────────────────────────────────
+
+pub const Consumer = struct {
+    base: [*]u8,
+    total_size: usize,
+    header: *Header,
+    name: [:0]const u8,
+    fd: std.c.fd_t,
+    last_seen_frame: u64 = 0,
+
+    /// Open + map an existing shm region created by the producer.
+    /// Validates `Header.magic` and `version`.
+    pub fn init(name: [:0]const u8) !Consumer {
+        const flags: std.c.O = .{ .ACCMODE = .RDWR };
+        const flags_int: c_int = @bitCast(flags);
+        const fd: std.c.fd_t = @intCast(std.c.shm_open(name.ptr, flags_int, @as(std.c.mode_t, 0)));
+        if (fd < 0) return Error.ShmOpenFailed;
+        errdefer _ = std.c.close(fd);
+
+        const size_bytes = try fdSize(fd);
+        if (size_bytes < @sizeOf(Header)) return Error.TooSmall;
+        const total: usize = @intCast(size_bytes);
+
+        const prot: std.c.PROT = .{ .READ = true, .WRITE = true };
+        const map_flags: std.c.MAP = .{ .TYPE = .SHARED };
+        const raw = std.c.mmap(null, total, prot, map_flags, fd, 0);
+        if (raw == std.c.MAP_FAILED) return Error.MmapFailed;
+        const base: [*]u8 = @ptrCast(@alignCast(raw));
+        errdefer _ = std.c.munmap(@ptrCast(@alignCast(base)), total);
+
+        const header: *Header = @ptrCast(@alignCast(base));
+        if (header.magic != MAGIC) return Error.BadMagic;
+        if (header.version != PROTOCOL_VERSION) return Error.BadVersion;
+
+        return .{
+            .base = base,
+            .total_size = total,
+            .header = header,
+            .name = name,
+            .fd = fd,
+            .last_seen_frame = 0,
+        };
+    }
+
+    pub fn deinit(self: *Consumer) void {
+        _ = std.c.munmap(@ptrCast(@alignCast(self.base)), self.total_size);
+        _ = std.c.close(self.fd);
+        // Do NOT shm_unlink — producer owns the lifecycle.
+        self.base = undefined;
+        self.header = undefined;
+    }
+
+    pub const Frame = struct {
+        pixels: [*]const u8,
+        width: u32,
+        height: u32,
+        stride: u32,
+        frame_idx: u64,
+        produce_ns: u64,
+    };
+
+    /// Returns the latest unread frame, or null if none new since last
+    /// `latest` call. Mailbox semantics: only the most-recent frame is
+    /// returned; older un-consumed frames are dropped.
+    pub fn latest(self: *Consumer) ?Frame {
+        // Acquire-load frame_count first — pairs with the release-store in
+        // publish, ensuring we observe latest + slot bytes that were
+        // committed before this counter bump.
+        const fc = @atomicLoad(u64, &self.header.frame_count, .acquire);
+        if (fc <= self.last_seen_frame) return null;
+
+        const slot = @atomicLoad(u32, &self.header.latest, .acquire);
+        if (slot >= self.header.ring_size) return null; // sentinel: never published
+
+        const ring_size = self.header.ring_size;
+        const slot_size: usize = @intCast(self.header.slot_size);
+        const slot_base = self.base + @sizeOf(Header) + @as(usize, slot) * slot_size;
+        const trailer: *const SlotTrailer = @ptrCast(@alignCast(slot_base + slot_size - @sizeOf(SlotTrailer)));
+
+        const frame_idx = trailer.frame_idx;
+        const produce_ns = trailer.produce_ns;
+
+        // Race guard: if the producer is mid-publish on the same slot we just
+        // looked at (slot index wraps every `ring_size` frames), the trailer
+        // could be torn. We compare against last_seen_frame as a coarse
+        // monotonicity check.
+        if (frame_idx <= self.last_seen_frame) return null;
+
+        self.last_seen_frame = frame_idx;
+        _ = ring_size;
+        return .{
+            .pixels = slot_base,
+            .width = self.header.width,
+            .height = self.header.height,
+            .stride = self.header.stride,
+            .frame_idx = frame_idx,
+            .produce_ns = produce_ns,
+        };
+    }
+};
+
+// ── Shutdown signaling ─────────────────────────────────────────────
+
+pub fn signalShutdown(header: *Header) void {
+    @atomicStore(u32, &header.shutdown, 1, .seq_cst);
+}
+
+pub fn isShuttingDown(header: *const Header) bool {
+    // `@atomicLoad` requires a mutable pointer in older Zig; cast away const.
+    const mut: *u32 = @constCast(&header.shutdown);
+    return @atomicLoad(u32, mut, .seq_cst) != 0;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+test "totalSize layout sanity" {
+    const opts: Options = .{ .width = 64, .height = 32, .ring_size = 3 };
+    const slot = slotSize(64, 32);
+    try std.testing.expect(slot >= 64 * 32 * 4 + @sizeOf(SlotTrailer));
+    try std.testing.expect(slot % 64 == 0);
+    try std.testing.expectEqual(@as(u64, @sizeOf(Header) + 3 * slot), totalSize(opts));
+}
+
+test "header is cacheline-aligned and stable size" {
+    try std.testing.expectEqual(@as(usize, 64), @sizeOf(Header));
+    try std.testing.expectEqual(@as(usize, 64), @sizeOf(SlotTrailer));
+}
+
+test "producer/consumer round-trip" {
+    // Use a test-only name so we don't collide with a running game.
+    const name: [:0]const u8 = "/imgui-preview-poc-test";
+    // Best-effort cleanup from any prior aborted run.
+    _ = std.c.shm_unlink(name.ptr);
+
+    var producer = try Producer.init(name, .{ .width = 4, .height = 4, .ring_size = 2 });
+    defer producer.deinit();
+
+    var consumer = try Consumer.init(name);
+    defer consumer.deinit();
+
+    // Before any publish, latest() returns null (sentinel).
+    try std.testing.expect(consumer.latest() == null);
+
+    // Write a recognisable pattern, then publish.
+    const pixels = producer.pixelsPtr();
+    var i: usize = 0;
+    while (i < 4 * 4 * 4) : (i += 1) pixels[i] = @intCast(i & 0xFF);
+    producer.publish(true);
+
+    const frame = consumer.latest() orelse return error.NoFrame;
+    try std.testing.expectEqual(@as(u32, 4), frame.width);
+    try std.testing.expectEqual(@as(u32, 4), frame.height);
+    try std.testing.expectEqual(@as(u32, 16), frame.stride);
+    try std.testing.expectEqual(@as(u64, 1), frame.frame_idx);
+    try std.testing.expect(frame.produce_ns > 0);
+    try std.testing.expectEqual(@as(u8, 0), frame.pixels[0]);
+    try std.testing.expectEqual(@as(u8, 7), frame.pixels[7]);
+
+    // Second call returns null (no new frame).
+    try std.testing.expect(consumer.latest() == null);
+
+    // Publish another, ensure consumer sees it.
+    producer.publish(true);
+    const frame2 = consumer.latest() orelse return error.NoFrame2;
+    try std.testing.expectEqual(@as(u64, 2), frame2.frame_idx);
+
+    // Shutdown signaling.
+    try std.testing.expect(!isShuttingDown(producer.header));
+    signalShutdown(producer.header);
+    try std.testing.expect(isShuttingDown(producer.header));
+}

--- a/src/preview_shm.zig
+++ b/src/preview_shm.zig
@@ -42,6 +42,10 @@ pub const Error = error{
     BadMagic,
     BadVersion,
     TooSmall,
+    /// Options failed `validateOptions` — zero / overflowing dims or
+    /// `ring_size == 0`. Producer side only; the consumer mirrors the
+    /// producer's header.
+    InvalidOptions,
 };
 
 /// Cacheline-aligned header. Field layout is a stable ABI across the
@@ -102,13 +106,32 @@ pub const Options = struct {
 };
 
 /// Path used for `shm_open`. On macOS this must start with `/` and be
-/// ≤ `PSHMNAMLEN` (typically 31 chars).
-pub const default_name: [:0]const u8 = "/imgui-preview-poc";
+/// ≤ `PSHMNAMLEN` (typically 31 chars). Engine-specific namespace so
+/// `Producer.init`'s pre-unlink can't clobber a stale PoC region.
+pub const default_name: [:0]const u8 = "/labelle-preview-default";
+
+/// Upper bound on each dimension to keep `width * height * 4` from
+/// overflowing `u64`. At 4 bytes/pixel a 16384×16384 buffer is 1 GiB,
+/// already well past anything the editor would sanely display; the
+/// hard cap is the `u32 stride = width * 4` headroom.
+pub const max_dim: u32 = std.math.maxInt(u32) / 4;
 
 /// Compute the slot size (pixel bytes + trailer, padded to cacheline).
+/// Returns 0 if either dimension is out of range — callers gate on
+/// `validateOptions` before using this.
 pub fn slotSize(width: u32, height: u32) u64 {
+    if (width == 0 or height == 0 or width > max_dim or height > max_dim) return 0;
     const raw: u64 = @as(u64, width) * @as(u64, height) * 4 + @sizeOf(SlotTrailer);
     return std.mem.alignForward(u64, raw, 64);
+}
+
+/// Reject malformed `Options` before we hand them to `shm_open` /
+/// `ftruncate`. The producer surfaces these as `Error.InvalidOptions`.
+pub fn validateOptions(opts: Options) bool {
+    if (opts.ring_size == 0) return false;
+    if (opts.width == 0 or opts.height == 0) return false;
+    if (opts.width > max_dim or opts.height > max_dim) return false;
+    return true;
 }
 
 pub fn totalSize(opts: Options) u64 {
@@ -171,6 +194,13 @@ pub const Producer = struct {
     /// to write into the current slot, then `publish` to advance
     /// `latest` and bump `frame_count`.
     pub fn init(name: [:0]const u8, opts: Options) !Producer {
+        // Reject malformed options up-front so we don't `mmap` a
+        // zero-sized region or wrap arithmetic into an undersized
+        // mapping. `pixelsPtr` assumes at least one slot; `publish`
+        // mods by `ring_size`; `slotSize` would silently overflow on
+        // huge dims (#546 review).
+        if (!validateOptions(opts)) return Error.InvalidOptions;
+
         const total = totalSize(opts);
 
         // Best-effort cleanup of any stale region from a previous run.

--- a/src/preview_shm.zig
+++ b/src/preview_shm.zig
@@ -116,9 +116,15 @@ pub fn totalSize(opts: Options) u64 {
 }
 
 /// Wall-clock monotonic nanoseconds — used for the latency stamp.
+/// On the vanishingly-rare `clock_gettime(CLOCK_MONOTONIC)` failure
+/// (per POSIX, EINVAL only — and CLOCK_MONOTONIC is mandatory) we
+/// return `0` rather than reading uninitialized `timespec` memory.
+/// A zero timestamp shows up as a giant negative latency on the
+/// editor side, which is the right signal: "this frame's timing
+/// is unreliable" (#546 review).
 pub fn nowNs() u64 {
     var ts: std.posix.timespec = undefined;
-    _ = std.posix.system.clock_gettime(.MONOTONIC, &ts);
+    if (std.posix.system.clock_gettime(.MONOTONIC, &ts) != 0) return 0;
     const sec: u64 = @intCast(ts.sec);
     const nsec: u64 = @intCast(ts.nsec);
     return sec * std.time.ns_per_s + nsec;

--- a/test/preview_frame_stream_test.zig
+++ b/test/preview_frame_stream_test.zig
@@ -1,0 +1,325 @@
+//! Tests for the PIE viewport SHM frame stream (#544): the
+//! producer side of the embedded-viewport pipeline. Exercises
+//! `Preview.beginFrameStream` / `publishFrame` / `endFrameStream`
+//! end-to-end by spinning up an in-test `preview_shm.Consumer`
+//! against the SHM region the engine allocates.
+//!
+//! The actual PBO → CPU readback lives in each backend (raylib,
+//! sokol, …); this file covers only the engine-side API. PoC end-
+//! to-end with a real GL producer is in
+//! `imgui-preview-poc/src/{game,editor}.zig`.
+
+const std = @import("std");
+const engine = @import("engine");
+const preview = engine.preview_mode_mod;
+const shm = engine.preview_mode_mod.preview_shm;
+
+extern "c" fn close(fd: c_int) c_int;
+extern "c" fn write(fd: c_int, buf: [*]const u8, len: usize) isize;
+extern "c" fn read(fd: c_int, buf: [*]u8, len: usize) isize;
+extern "c" fn nanosleep(req: *const Timespec, rem: ?*Timespec) c_int;
+extern "c" fn clock_gettime(clk: c_int, tp: *Timespec) c_int;
+
+const Timespec = extern struct { sec: isize, nsec: isize };
+
+fn nowMs() i64 {
+    const CLOCK_MONOTONIC: c_int = if (@import("builtin").os.tag == .macos) 6 else 1;
+    var ts: Timespec = undefined;
+    _ = clock_gettime(CLOCK_MONOTONIC, &ts);
+    return @as(i64, ts.sec) * 1000 + @divTrunc(@as(i64, ts.nsec), 1_000_000);
+}
+
+fn sleepMs(ms: u64) void {
+    const ts: Timespec = .{
+        .sec = @intCast(ms / 1000),
+        .nsec = @intCast((ms % 1000) * 1_000_000),
+    };
+    _ = nanosleep(&ts, null);
+}
+
+// ── Loopback harness (same shape as preview_handshake_test) ────────
+
+const LoopbackHarness = struct {
+    server: std.Io.net.Server,
+    port: u16,
+    conn_fd: ?std.posix.fd_t = null,
+    read_buf: [4096]u8 = undefined,
+    read_len: usize = 0,
+
+    fn init() !LoopbackHarness {
+        const addr = std.Io.net.IpAddress.parse("127.0.0.1", 0) catch unreachable;
+        const server = try addr.listen(std.testing.io, .{ .reuse_address = true });
+        var sa: std.posix.sockaddr.in = undefined;
+        var sa_len: std.posix.socklen_t = @sizeOf(@TypeOf(sa));
+        if (std.posix.system.getsockname(server.socket.handle, @ptrCast(&sa), &sa_len) != 0) {
+            return error.GetSockNameFailed;
+        }
+        return .{ .server = server, .port = std.mem.bigToNative(u16, sa.port) };
+    }
+
+    fn deinit(self: *LoopbackHarness) void {
+        if (self.conn_fd) |fd| _ = close(@intCast(fd));
+        self.server.deinit(std.testing.io);
+    }
+
+    fn hostPort(self: *LoopbackHarness, buf: []u8) ![]const u8 {
+        return std.fmt.bufPrint(buf, "127.0.0.1:{d}", .{self.port});
+    }
+
+    fn accept(self: *LoopbackHarness) !void {
+        const stream = try self.server.accept(std.testing.io);
+        self.conn_fd = stream.socket.handle;
+    }
+
+    fn readLine(self: *LoopbackHarness, out: []u8) ![]const u8 {
+        while (true) {
+            if (std.mem.indexOfScalar(u8, self.read_buf[0..self.read_len], '\n')) |nl| {
+                if (nl > out.len) return error.LineTooLong;
+                @memcpy(out[0..nl], self.read_buf[0..nl]);
+                const remaining = self.read_len - (nl + 1);
+                std.mem.copyForwards(u8, self.read_buf[0..remaining], self.read_buf[nl + 1 .. self.read_len]);
+                self.read_len = remaining;
+                return out[0..nl];
+            }
+            if (self.read_len == self.read_buf.len) return error.LineTooLong;
+            const fd = self.conn_fd orelse return error.NotConnected;
+            const n = read(@intCast(fd), self.read_buf[self.read_len..].ptr, self.read_buf.len - self.read_len);
+            if (n <= 0) return error.UnexpectedEof;
+            self.read_len += @intCast(n);
+        }
+    }
+
+    fn sendLine(self: *LoopbackHarness, body: []const u8) !void {
+        const fd = self.conn_fd orelse return error.NotConnected;
+        var off: usize = 0;
+        while (off < body.len) {
+            const n = write(@intCast(fd), body.ptr + off, body.len - off);
+            if (n <= 0) return error.WriteFailed;
+            off += @intCast(n);
+        }
+    }
+};
+
+fn connectPair(h: *LoopbackHarness) !preview.Preview {
+    var hp_buf: [64]u8 = undefined;
+    const host_port = try h.hostPort(&hp_buf);
+    const p = try preview.Preview.connect(std.testing.io, std.testing.allocator, host_port);
+    try h.accept();
+    return p;
+}
+
+fn waitUntil(p: *preview.Preview, predicate: *const fn (*preview.Preview) bool, deadline_ms: u64) !void {
+    const start = nowMs();
+    while (true) {
+        try p.pollSubscription();
+        if (predicate(p)) return;
+        if (nowMs() - start > @as(i64, @intCast(deadline_ms))) return error.WaitDeadlineExceeded;
+        sleepMs(1);
+    }
+}
+
+fn isAccepted(p: *preview.Preview) bool {
+    return p.isFrameAccepted();
+}
+
+// Reads the `frame_offer` JSON the engine emitted and returns the
+// parsed shm_name + dims, so the test's `shm.Consumer` knows where
+// to attach.
+const Offer = struct {
+    shm_name: [:0]u8,
+    width: u32,
+    height: u32,
+    ring_size: u32,
+};
+
+fn readOffer(h: *LoopbackHarness) !Offer {
+    var line_buf: [512]u8 = undefined;
+    const line = try h.readLine(&line_buf);
+    const Parsed = struct {
+        kind: []const u8,
+        shm_name: []const u8,
+        width: u32,
+        height: u32,
+        format: []const u8,
+        ring_size: u32,
+        slot_size_bytes: u64,
+    };
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const parsed = try std.json.parseFromSliceLeaky(Parsed, arena.allocator(), line, .{});
+    try std.testing.expectEqualStrings("frame_offer", parsed.kind);
+    // shm_name needs to outlive the arena — caller owns the dupe.
+    const dup = try std.testing.allocator.dupeZ(u8, parsed.shm_name);
+    return .{
+        .shm_name = dup,
+        .width = parsed.width,
+        .height = parsed.height,
+        .ring_size = parsed.ring_size,
+    };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+test "beginFrameStream emits frame_offer + leaves producer in .offered" {
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try p.beginFrameStream(320, 240);
+    try std.testing.expectEqual(preview.FrameHandshakeState.offered, p.frame_state);
+
+    const offer = try readOffer(&h);
+    defer std.testing.allocator.free(offer.shm_name);
+    try std.testing.expectEqual(@as(u32, 320), offer.width);
+    try std.testing.expectEqual(@as(u32, 240), offer.height);
+    try std.testing.expectEqual(@as(u32, 3), offer.ring_size);
+    // SHM name must start with `/` (POSIX shm_open requirement).
+    try std.testing.expect(offer.shm_name[0] == '/');
+}
+
+test "publishFrame writes pixels into the SHM ring; consumer reads them back" {
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try p.beginFrameStream(64, 48);
+    const offer = try readOffer(&h);
+    defer std.testing.allocator.free(offer.shm_name);
+
+    // Editor side: open the consumer ring.
+    var consumer = try shm.Consumer.init(offer.shm_name);
+    defer consumer.deinit();
+
+    // Editor ACKs the offer; engine state flips to .accepted.
+    try h.sendLine("{\"kind\":\"frame_accept\"}\n");
+    try waitUntil(&p, isAccepted, 1000);
+
+    // Synthesize a frame whose first 4 bytes are 0xDE 0xAD 0xBE 0xEF
+    // and the rest a known gradient. publishFrame must memcpy + publish.
+    const N: usize = 64 * 48 * 4;
+    const pixels = try std.testing.allocator.alloc(u8, N);
+    defer std.testing.allocator.free(pixels);
+    pixels[0] = 0xDE;
+    pixels[1] = 0xAD;
+    pixels[2] = 0xBE;
+    pixels[3] = 0xEF;
+    for (4..N) |i| pixels[i] = @intCast(i & 0xff);
+
+    try p.publishFrame(pixels);
+
+    // Consumer reads the published frame and verifies content.
+    const frame = consumer.latest() orelse return error.NoFrameFound;
+    try std.testing.expectEqual(@as(u64, 1), frame.frame_idx);
+    try std.testing.expectEqual(@as(u32, 64), frame.width);
+    try std.testing.expectEqual(@as(u32, 48), frame.height);
+    try std.testing.expectEqual(@as(u8, 0xDE), frame.pixels[0]);
+    try std.testing.expectEqual(@as(u8, 0xAD), frame.pixels[1]);
+    try std.testing.expectEqual(@as(u8, 0xBE), frame.pixels[2]);
+    try std.testing.expectEqual(@as(u8, 0xEF), frame.pixels[3]);
+    try std.testing.expectEqual(@as(u8, 100 & 0xff), frame.pixels[100]);
+}
+
+test "publishFrame returns StreamNotActive when state is .offered (editor hasn't accepted)" {
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try p.beginFrameStream(8, 8);
+    var drop_buf: [512]u8 = undefined;
+    _ = try h.readLine(&drop_buf);
+    // State is .offered, NOT .accepted — publish must refuse.
+    var pixels: [8 * 8 * 4]u8 = undefined;
+    @memset(&pixels, 0);
+    try std.testing.expectError(error.StreamNotActive, p.publishFrame(&pixels));
+}
+
+test "publishFrame returns StreamNotActive when called without beginFrameStream" {
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    var pixels: [4]u8 = undefined;
+    try std.testing.expectError(error.StreamNotActive, p.publishFrame(&pixels));
+}
+
+test "publishFrame increments frame_idx monotonically across multiple publishes" {
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try p.beginFrameStream(4, 4);
+    const offer = try readOffer(&h);
+    defer std.testing.allocator.free(offer.shm_name);
+
+    var consumer = try shm.Consumer.init(offer.shm_name);
+    defer consumer.deinit();
+
+    try h.sendLine("{\"kind\":\"frame_accept\"}\n");
+    try waitUntil(&p, isAccepted, 1000);
+
+    var pixels: [4 * 4 * 4]u8 = undefined;
+    @memset(&pixels, 0);
+    try p.publishFrame(&pixels);
+    try p.publishFrame(&pixels);
+    try p.publishFrame(&pixels);
+
+    const frame = consumer.latest() orelse return error.NoFrameFound;
+    // Mailbox semantics: consumer sees only the latest. frame_idx
+    // bumps once per publish — third publish is frame_idx == 3.
+    try std.testing.expectEqual(@as(u64, 3), frame.frame_idx);
+}
+
+test "beginFrameStream after frame_resize re-offers at new dims, old ring is torn down" {
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try p.beginFrameStream(16, 16);
+    const first_offer = try readOffer(&h);
+    defer std.testing.allocator.free(first_offer.shm_name);
+    try std.testing.expectEqual(@as(u32, 16), first_offer.width);
+
+    // Editor requests a resize.
+    try h.sendLine("{\"kind\":\"frame_resize\",\"width\":32,\"height\":24}\n");
+    try waitUntil(&p, struct {
+        fn pred(pv: *preview.Preview) bool { return pv.pending_resize != null; }
+    }.pred, 1000);
+
+    const r = p.takeResize().?;
+    try std.testing.expectEqual(@as(u32, 32), r.width);
+
+    // Backend re-offers at the new dims; first ring's shm is gone now.
+    try p.beginFrameStream(r.width, r.height);
+    const second_offer = try readOffer(&h);
+    defer std.testing.allocator.free(second_offer.shm_name);
+    try std.testing.expectEqual(@as(u32, 32), second_offer.width);
+    try std.testing.expectEqual(@as(u32, 24), second_offer.height);
+    // The two SHM names should differ — each beginFrameStream call
+    // increments the per-process stream-id counter, so resize-
+    // re-offer cycles never collide on the shm_open namespace.
+    try std.testing.expect(!std.mem.eql(u8, first_offer.shm_name, second_offer.shm_name));
+}
+
+test "endFrameStream tears down ring, subsequent publishFrame is StreamNotActive" {
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try p.beginFrameStream(8, 8);
+    var drop_buf: [512]u8 = undefined;
+    _ = try h.readLine(&drop_buf);
+
+    p.endFrameStream();
+    try std.testing.expectEqual(preview.FrameHandshakeState.not_offered, p.frame_state);
+
+    var pixels: [8 * 8 * 4]u8 = undefined;
+    @memset(&pixels, 0);
+    try std.testing.expectError(error.StreamNotActive, p.publishFrame(&pixels));
+}

--- a/test/preview_frame_stream_test.zig
+++ b/test/preview_frame_stream_test.zig
@@ -246,6 +246,26 @@ test "publishFrame returns StreamNotActive when called without beginFrameStream"
     try std.testing.expectError(error.StreamNotActive, p.publishFrame(&pixels));
 }
 
+test "publishFrame returns InvalidFrameSize when buffer size mismatches dims" {
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try p.beginFrameStream(8, 8);
+    var drop_buf: [512]u8 = undefined;
+    _ = try h.readLine(&drop_buf);
+    try h.sendLine("{\"kind\":\"frame_accept\"}\n");
+    try waitUntil(&p, isAccepted, 1000);
+
+    // Negotiated dims are 8×8×4 = 256 bytes — pass 100 to provoke
+    // the size guard. Distinct from StreamNotActive so callers can
+    // tell "no editor attached" from "wrong number of bytes."
+    var pixels: [100]u8 = undefined;
+    @memset(&pixels, 0);
+    try std.testing.expectError(error.InvalidFrameSize, p.publishFrame(&pixels));
+}
+
 test "publishFrame increments frame_idx monotonically across multiple publishes" {
     var h = try LoopbackHarness.init();
     defer h.deinit();

--- a/test/preview_frame_stream_test.zig
+++ b/test/preview_frame_stream_test.zig
@@ -246,6 +246,36 @@ test "publishFrame returns StreamNotActive when called without beginFrameStream"
     try std.testing.expectError(error.StreamNotActive, p.publishFrame(&pixels));
 }
 
+test "beginFrameStream resets frame_state even when re-offer is in progress" {
+    // Regression for #546 review: a failed re-offer path used to leave
+    // `frame_state == .accepted` while `frame_producer == null`, which
+    // made `isFrameAccepted()` lie to the backend. Here we exercise the
+    // happy-path re-offer cycle and assert that *during* the
+    // re-offer (after teardown but before sendFrameOffer lands) the
+    // state is invalidated.
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try p.beginFrameStream(8, 8);
+    var drop: [512]u8 = undefined;
+    _ = try h.readLine(&drop);
+    try h.sendLine("{\"kind\":\"frame_accept\"}\n");
+    try waitUntil(&p, isAccepted, 1000);
+    try std.testing.expect(p.isFrameAccepted());
+
+    // Force a re-offer (same shape as the resize path). After
+    // beginFrameStream returns, state should be `.offered` (the
+    // freshly-sent offer awaits the next accept). What we're really
+    // proving: state is **not** stuck at `.accepted` carrying over
+    // from the previous handshake — sendFrameOffer is the only thing
+    // that can flip us to `.offered` post-teardown.
+    try p.beginFrameStream(16, 16);
+    try std.testing.expectEqual(preview.FrameHandshakeState.offered, p.frame_state);
+    try std.testing.expect(!p.isFrameAccepted());
+}
+
 test "publishFrame returns InvalidFrameSize when buffer size mismatches dims" {
     var h = try LoopbackHarness.init();
     defer h.deinit();


### PR DESCRIPTION
Implements #544. Stacked on top of #545 (handshake protocol) — review/merge #545 first, then this rebases automatically onto main.

## What this adds

**Engine-side producer machinery for the PIE viewport pipeline.** The engine allocates a cross-process RGBA8 pixel ring, advertises it via the #543 `frame_offer` message, and exposes a single call (`publishFrame`) that backends invoke once per frame after their PBO readback.

### New module

- `src/preview_shm.zig` — port of the PoC SHM ring (`imgui-preview-poc/src/preview_shm.zig`). Magic + protocol_version explicitly distinct from the PoC's so stale poc-side regions don't collide. Header layout, mailbox semantics, atomic ordering, and the per-slot trailer (frame_idx + produce_ns for editor-side latency measurement) all unchanged.

### New `Preview` methods

| Call | Effect |
|---|---|
| `beginFrameStream(W, H)` | Allocates ring (`ring_size = 3`), generates per-PID-and-counter shm_name (≤ PSHMNAMLEN), emits `frame_offer`, state → `.offered`. Idempotent across resize re-offers. |
| `publishFrame(pixels)` | Memcpies `W*H*4` bytes, stamps trailer, fence-publishes, bumps `frame_index`, sends `frame_published` sidecar (best-effort). `error.StreamNotActive` when state != `.accepted`. |
| `endFrameStream()` | Tears down ring; safe to call when inactive. Doesn't send `bye`. |
| `Preview.deinit` | Now also tears down the producer for hard-exit paths. |

### Backend contract (out of scope here)

The actual GL PBO async readback lives per-backend (raylib / sokol / SDL); reference impl at `imgui-preview-poc/src/game.zig`. Backends call:

```zig
if (preview) |*p| {
    if (p.isFrameAccepted()) {
        const bytes = backend.pboReadback();   // backend-specific
        try p.publishFrame(bytes);
    }
    if (p.takeResize()) |r| try p.beginFrameStream(r.width, r.height);
}
```

## Test plan

- [x] 7 new tests in `test/preview_frame_stream_test.zig`:
  - `beginFrameStream` emits `frame_offer` with right dims, state flips to `.offered`
  - End-to-end SHM round-trip — engine `publishFrame` → in-test `preview_shm.Consumer` reads back a known 0xDEADBEEF pattern at frame_idx=1
  - `publishFrame` guards: `error.StreamNotActive` when state=.offered, when no stream begun
  - `frame_idx` bumps monotonically across 3 publishes; mailbox-drop consumer sees frame_idx=3
  - Resize re-offer produces a **distinct** shm_name (per-process stream-id counter)
  - `endFrameStream` resets state + future publishes are `StreamNotActive`
- [x] Full `zig build test` green: 36+7+7+7 = 57 preview-related tests, all other tests unaffected.
- [x] Local builds clean on Apple Silicon + Zig 0.16.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)