### PR TITLE
feat(preview): macOS IOSurface producer (#547)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -46,6 +46,20 @@ pub fn build(b: *std.Build) void {
     engine_module.addImport("audio_types", audio_types_module);
     engine_module.addImport("font_types", font_types_module);
 
+    // #547: src/preview_iosurface.zig declares `extern "c"` bindings
+    // for IOSurface + CoreFoundation. Even when no caller exercises
+    // those code paths, Zig's analyzer reaches the function bodies
+    // (e.g. `Producer.deinit`) for every test binary that imports
+    // `engine`, and the linker then refuses to leave those symbols
+    // unresolved. Linking the system frameworks at the module level
+    // satisfies every downstream test binary in one place; non-macOS
+    // builds skip them and the macOS-only code is unreachable behind
+    // a `builtin.os.tag == .macos` gate at every entry point.
+    if (target.result.os.tag == .macos) {
+        engine_module.linkFramework("IOSurface", .{});
+        engine_module.linkFramework("CoreFoundation", .{});
+    }
+
     const test_step = b.step("test", "Run engine tests");
 
     // Test files in test/ directory
@@ -123,6 +137,38 @@ pub fn build(b: *std.Build) void {
         });
         test_step.dependOn(&b.addRunArtifact(t).step);
     }
+
+    // PIE viewport macOS IOSurface frame stream (#547). The test
+    // binary itself is cross-platform — on non-macOS hosts every
+    // `test` block early-returns — so we always wire it into the
+    // step. On macOS we additionally link the system frameworks the
+    // test uses to look up surfaces by ID and inspect pixels:
+    //   - IOSurface for `IOSurfaceLookup`/`IOSurfaceLock`/etc.
+    //   - CoreFoundation for `CFRelease` (and the property-dict
+    //     helpers the producer side reaches through the engine module).
+    //   - OpenGL is **not** required by these tests — they read
+    //     pixels via `IOSurfaceGetBaseAddress` rather than going
+    //     through `CGLTexImageIOSurface2D`. It's still listed in the
+    //     ticket's "link these frameworks" callout for completeness
+    //     and so a future test that does want GL interop doesn't
+    //     have to re-touch build.zig.
+    const iosurface_test_module = b.createModule(.{
+        .root_source_file = b.path("test/preview_iosurface_test.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "labelle-core", .module = core_module },
+            .{ .name = "engine", .module = engine_module },
+            .{ .name = "scene", .module = scene_module },
+        },
+    });
+    if (target.result.os.tag == .macos) {
+        iosurface_test_module.linkFramework("IOSurface", .{});
+        iosurface_test_module.linkFramework("CoreFoundation", .{});
+        iosurface_test_module.linkFramework("OpenGL", .{});
+    }
+    const iosurface_test = b.addTest(.{ .root_module = iosurface_test_module });
+    test_step.dependOn(&b.addRunArtifact(iosurface_test).step);
 
     // In-source tests under `src/assets/` (catalog, worker, loader,
     // loaders/*) cannot be dragged into a `test/*` binary through the

--- a/src/preview_iosurface.zig
+++ b/src/preview_iosurface.zig
@@ -48,6 +48,11 @@ pub const Error = error{
     AlreadyLocked,
     NotLocked,
     InvalidFrameSize,
+    /// CoreFoundation allocator returned null — `CFNumberCreate` or
+    /// `CFDictionaryCreateMutable` failed (typically under memory
+    /// pressure). Surfacing as a distinct variant rather than
+    /// OutOfMemory keeps the source of the failure obvious in logs.
+    CFAllocationFailed,
 } || shm.Error;
 
 // ── CoreFoundation / IOSurface externs ─────────────────────────────
@@ -159,10 +164,12 @@ comptime {
 
 // ── BGRA8 property dict (macOS only) ───────────────────────────────
 
-fn cfNumberU32(v: u32) CFNumberRef {
+fn cfNumberU32(v: u32) Error!CFNumberRef {
     if (!macos) unreachable;
     const sv: i32 = @bitCast(v);
-    return CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &sv);
+    const n = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &sv);
+    if (n == null) return error.CFAllocationFailed;
+    return n;
 }
 
 /// Build a BGRA8 property dict with `kIOSurfaceIsGlobal = true`.
@@ -172,7 +179,7 @@ fn cfNumberU32(v: u32) CFNumberRef {
 /// but the kernel may pad up for alignment — always query
 /// `IOSurfaceGetBytesPerRow` after creation rather than assuming
 /// `width * 4` (PoC bit us with this; see ticket macOS specifics).
-pub fn makeBGRA8Properties(width: u32, height: u32) CFDictionaryRef {
+pub fn makeBGRA8Properties(width: u32, height: u32) Error!CFDictionaryRef {
     if (!macos) unreachable;
     const dict = CFDictionaryCreateMutable(
         kCFAllocatorDefault,
@@ -180,11 +187,24 @@ pub fn makeBGRA8Properties(width: u32, height: u32) CFDictionaryRef {
         kCFTypeDictionaryKeyCallBacks,
         kCFTypeDictionaryValueCallBacks,
     );
-    const w = cfNumberU32(width);
-    const h = cfNumberU32(height);
-    const bpe = cfNumberU32(4);
-    const bpr = cfNumberU32(width * 4);
-    const fmt = cfNumberU32(kPixelFormat_BGRA8);
+    if (dict == null) return error.CFAllocationFailed;
+    errdefer CFRelease(dict);
+
+    // Build each CFNumber with its own errdefer so a partial failure
+    // mid-list doesn't leak earlier ones. errdefers run LIFO so we
+    // release the most-recent first — matching the manual CFRelease
+    // chain at the end of the happy path.
+    const w = try cfNumberU32(width);
+    errdefer CFRelease(w);
+    const h = try cfNumberU32(height);
+    errdefer CFRelease(h);
+    const bpe = try cfNumberU32(4);
+    errdefer CFRelease(bpe);
+    const bpr = try cfNumberU32(width * 4);
+    errdefer CFRelease(bpr);
+    const fmt = try cfNumberU32(kPixelFormat_BGRA8);
+    errdefer CFRelease(fmt);
+
     CFDictionarySetValue(dict, kIOSurfaceWidth, w);
     CFDictionarySetValue(dict, kIOSurfaceHeight, h);
     CFDictionarySetValue(dict, kIOSurfaceBytesPerElement, bpe);
@@ -302,7 +322,7 @@ pub const Producer = struct {
 
         // One property dict reused for every surface — all N share
         // dims/format.
-        const props = makeBGRA8Properties(opts.width, opts.height);
+        const props = try makeBGRA8Properties(opts.width, opts.height);
         defer CFRelease(props);
 
         while (created < opts.ring_size) : (created += 1) {

--- a/src/preview_iosurface.zig
+++ b/src/preview_iosurface.zig
@@ -1,0 +1,474 @@
+//! macOS IOSurface-backed pixel ring producer for the PIE viewport
+//! (#547 — Phase 2 zero-copy fast path, engine side).
+//!
+//! Pair to the consumer that already shipped in labelle-gui#115 (see
+//! `labelle-gui/src/iosurface.zig` for the canonical protocol). The
+//! engine allocates N `IOSurfaceRef` objects up front, stamps their
+//! `IOSurfaceID`s into a `ControlBlock` written into slot 0 of the
+//! existing `preview_shm.Producer` ring, and per frame just locks the
+//! next surface, writes BGRA8 pixels, unlocks, and bumps the
+//! shm header's `latest` slot pointer.
+//!
+//! Producer surface mirrors `preview_shm.Producer`:
+//!
+//!     init(name, opts) → Producer
+//!     deinit()
+//!     pixelsPtr() → Locked          // pointer + bytes_per_row + slot
+//!     publish(stamp_now)
+//!
+//! Cross-process visibility:
+//!   We set `kIOSurfaceIsGlobal = true` so the editor side can call
+//!   `IOSurfaceLookup(id)` directly. Deprecated since 10.11 but still
+//!   functional and what the labelle-gui consumer expects. Mach-port
+//!   hand-off is the production path (separate ticket) — SCM_RIGHTS
+//!   won't carry mach ports.
+//!
+//! Pixel format: BGRA8. The producer writes BGRA (the GL readback is
+//! RGBA so a per-pixel swizzle happens inside `publish`). The eventual
+//! render-to-IOSurface FBO path would dodge the swizzle entirely;
+//! it's called out as a stretch goal in the ticket and deferred here.
+//!
+//! macOS-only by construction. Every entry point gates on
+//! `builtin.os.tag == .macos`; on other platforms the public APIs
+//! surface `error.PlatformUnsupported`. The control plane reuses
+//! `preview_shm.Producer` verbatim so the editor-side polling /
+//! shutdown signalling stay identical.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const shm = @import("preview_shm.zig");
+
+pub const Error = error{
+    PlatformUnsupported,
+    RingSizeOutOfRange,
+    IOSurfaceCreateFailed,
+    IOSurfaceLockFailed,
+    IOSurfaceUnlockFailed,
+    IOSurfaceBaseAddressNull,
+    AlreadyLocked,
+    NotLocked,
+    InvalidFrameSize,
+} || shm.Error;
+
+// ── CoreFoundation / IOSurface externs ─────────────────────────────
+//
+// These are macOS-only. The non-macOS build path never references
+// them at link time because every public entry point returns
+// `error.PlatformUnsupported` before reaching them.
+
+pub const IOSurfaceRef = ?*opaque {};
+pub const CFTypeRef = ?*anyopaque;
+pub const CFStringRef = ?*anyopaque;
+pub const CFNumberRef = ?*anyopaque;
+pub const CFDictionaryRef = ?*anyopaque;
+pub const CFMutableDictionaryRef = ?*anyopaque;
+pub const CFAllocatorRef = ?*anyopaque;
+
+pub const IOSurfaceID = u32;
+pub const IOReturn = c_int;
+pub const MachPort = u32;
+
+/// 'BGRA' four-CC — matches the consumer's `kPixelFormat_BGRA8` in
+/// `labelle-gui/src/iosurface.zig`. MUST match exactly; bumping is a
+/// protocol break.
+pub const kPixelFormat_BGRA8: u32 = 0x42475241;
+
+pub const kIOSurfaceLockReadOnly: u32 = 0x1;
+pub const kIOSurfaceLockAvoidSync: u32 = 0x2;
+
+pub const kCFNumberSInt32Type: c_int = 3;
+
+/// Maximum ring size — matches consumer's `MAX_RING`. Bumping is a
+/// protocol break with the editor.
+pub const MAX_RING: u32 = 8;
+
+// macOS-only externs. Linking these on Linux/Windows would fail; the
+// gate is at every call site.
+const macos = builtin.os.tag == .macos;
+
+pub extern "c" fn IOSurfaceCreate(properties: CFDictionaryRef) IOSurfaceRef;
+pub extern "c" fn IOSurfaceGetID(buffer: IOSurfaceRef) IOSurfaceID;
+pub extern "c" fn IOSurfaceLock(buffer: IOSurfaceRef, options: u32, seed: ?*u32) IOReturn;
+pub extern "c" fn IOSurfaceUnlock(buffer: IOSurfaceRef, options: u32, seed: ?*u32) IOReturn;
+pub extern "c" fn IOSurfaceGetBaseAddress(buffer: IOSurfaceRef) ?*anyopaque;
+pub extern "c" fn IOSurfaceGetWidth(buffer: IOSurfaceRef) usize;
+pub extern "c" fn IOSurfaceGetHeight(buffer: IOSurfaceRef) usize;
+pub extern "c" fn IOSurfaceGetBytesPerRow(buffer: IOSurfaceRef) usize;
+pub extern "c" fn IOSurfaceGetAllocSize(buffer: IOSurfaceRef) usize;
+pub extern "c" fn IOSurfaceGetSeed(buffer: IOSurfaceRef) u32;
+
+pub extern "c" const kIOSurfaceWidth: CFStringRef;
+pub extern "c" const kIOSurfaceHeight: CFStringRef;
+pub extern "c" const kIOSurfaceBytesPerElement: CFStringRef;
+pub extern "c" const kIOSurfaceBytesPerRow: CFStringRef;
+pub extern "c" const kIOSurfacePixelFormat: CFStringRef;
+/// Deprecated since 10.11 but functional. Required for the shortcut
+/// where the consumer calls `IOSurfaceLookup(id)` directly across
+/// processes. Drop once the mach-port path lands (separate ticket).
+pub extern "c" const kIOSurfaceIsGlobal: CFStringRef;
+
+pub extern "c" const kCFAllocatorDefault: CFAllocatorRef;
+pub extern "c" const kCFTypeDictionaryKeyCallBacks: *const anyopaque;
+pub extern "c" const kCFTypeDictionaryValueCallBacks: *const anyopaque;
+pub extern "c" const kCFBooleanTrue: CFTypeRef;
+pub extern "c" const kCFBooleanFalse: CFTypeRef;
+
+pub extern "c" fn CFNumberCreate(
+    allocator: CFAllocatorRef,
+    the_type: c_int,
+    value_ptr: *const anyopaque,
+) CFNumberRef;
+pub extern "c" fn CFDictionaryCreateMutable(
+    allocator: CFAllocatorRef,
+    capacity: isize,
+    key_callbacks: *const anyopaque,
+    value_callbacks: *const anyopaque,
+) CFMutableDictionaryRef;
+pub extern "c" fn CFDictionarySetValue(
+    dict: CFMutableDictionaryRef,
+    key: ?*const anyopaque,
+    value: ?*const anyopaque,
+) void;
+pub extern "c" fn CFRelease(cf: CFTypeRef) void;
+
+// ── Control-plane payload (rides inside slot 0 of the shm region) ──
+
+/// Header written into the *first* shm slot's pixel area. The producer
+/// initialises it exactly once at startup; the consumer reads it once
+/// at startup; from then on only `Header.latest` is touched per frame.
+///
+/// Layout MUST match `labelle-gui/src/iosurface.zig:ControlBlock`. The
+/// `MAGIC` constant ('IOSRFCL1') is shared verbatim.
+pub const ControlBlock = extern struct {
+    magic: u64,
+    ring_size: u32,
+    pixel_format: u32,
+    width: u32,
+    height: u32,
+    ids: [MAX_RING]IOSurfaceID,
+    _pad: [16]u8 = [_]u8{0} ** 16,
+
+    /// 'IOSRFCL1' — same value as the consumer (`labelle-gui#115`).
+    /// Bumping is a protocol break; coordinate with labelle-gui.
+    pub const MAGIC: u64 = 0x494F535246434C31;
+};
+
+comptime {
+    std.debug.assert(@sizeOf(ControlBlock) == 24 + MAX_RING * 4 + 16);
+}
+
+// ── BGRA8 property dict (macOS only) ───────────────────────────────
+
+fn cfNumberU32(v: u32) CFNumberRef {
+    const sv: i32 = @bitCast(v);
+    return CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &sv);
+}
+
+/// Build a BGRA8 property dict with `kIOSurfaceIsGlobal = true`.
+/// Returned dict is retained; caller must `CFRelease`.
+///
+/// Note: we pass `width*4` as the requested `kIOSurfaceBytesPerRow`
+/// but the kernel may pad up for alignment — always query
+/// `IOSurfaceGetBytesPerRow` after creation rather than assuming
+/// `width * 4` (PoC bit us with this; see ticket macOS specifics).
+pub fn makeBGRA8Properties(width: u32, height: u32) CFDictionaryRef {
+    const dict = CFDictionaryCreateMutable(
+        kCFAllocatorDefault,
+        0,
+        kCFTypeDictionaryKeyCallBacks,
+        kCFTypeDictionaryValueCallBacks,
+    );
+    const w = cfNumberU32(width);
+    const h = cfNumberU32(height);
+    const bpe = cfNumberU32(4);
+    const bpr = cfNumberU32(width * 4);
+    const fmt = cfNumberU32(kPixelFormat_BGRA8);
+    CFDictionarySetValue(dict, kIOSurfaceWidth, w);
+    CFDictionarySetValue(dict, kIOSurfaceHeight, h);
+    CFDictionarySetValue(dict, kIOSurfaceBytesPerElement, bpe);
+    CFDictionarySetValue(dict, kIOSurfaceBytesPerRow, bpr);
+    CFDictionarySetValue(dict, kIOSurfacePixelFormat, fmt);
+    // Required for cross-process IOSurfaceLookup without a mach-port
+    // hand-off. Deprecated, still functional. TODO: replace with
+    // mach-port path (separate ticket).
+    CFDictionarySetValue(dict, kIOSurfaceIsGlobal, kCFBooleanTrue);
+    CFRelease(w);
+    CFRelease(h);
+    CFRelease(bpe);
+    CFRelease(bpr);
+    CFRelease(fmt);
+    return dict;
+}
+
+// ── RGBA → BGRA swizzle (producer side) ────────────────────────────
+
+/// Swizzle a buffer in place from RGBA8 (GL readback order) to BGRA8
+/// (what `CGLTexImageIOSurface2D` and `kPixelFormat_BGRA8` want).
+/// The slice length must be a multiple of 4 — caller already validates
+/// against the negotiated width*height*4.
+///
+/// In-place is intentional: the caller hands us a buffer it owns; we
+/// rewrite it before the memcpy into the IOSurface. The eventual
+/// render-to-IOSurface FBO path (stretch goal, deferred) would skip
+/// this entirely.
+pub fn swizzleRgbaToBgraInPlace(buf: []u8) void {
+    var i: usize = 0;
+    while (i + 4 <= buf.len) : (i += 4) {
+        const r = buf[i];
+        const b = buf[i + 2];
+        buf[i] = b;
+        buf[i + 2] = r;
+        // G (i+1) and A (i+3) stay.
+    }
+}
+
+/// Same swizzle, but copies from `src` into `dst` while reordering.
+/// Used when the producer can't mutate the caller's buffer (e.g. it
+/// belongs to a backend's PBO mapping). `dst.len == src.len` and both
+/// must be a multiple of 4.
+pub fn copySwizzleRgbaToBgra(dst: []u8, src: []const u8) void {
+    std.debug.assert(dst.len == src.len);
+    var i: usize = 0;
+    while (i + 4 <= src.len) : (i += 4) {
+        dst[i] = src[i + 2]; // B
+        dst[i + 1] = src[i + 1]; // G
+        dst[i + 2] = src[i]; // R
+        dst[i + 3] = src[i + 3]; // A
+    }
+}
+
+// ── Producer ───────────────────────────────────────────────────────
+
+pub const Options = struct {
+    width: u32,
+    height: u32,
+    /// 2 or 3 typically — 3 buys jitter tolerance for the editor's
+    /// upload cadence. Bounded by `MAX_RING`.
+    ring_size: u32 = 3,
+};
+
+pub const Locked = struct {
+    /// BGRA8 base pointer for the locked slot. Writers MUST honour
+    /// `bytes_per_row` (the kernel may pad past `width * 4`).
+    base: [*]u8,
+    bytes_per_row: u32,
+    slot: u32,
+};
+
+pub const Producer = struct {
+    /// Control-plane shm ring. We hold a full `preview_shm.Producer`
+    /// because we still use `header.latest`, `header.frame_count`,
+    /// and the per-slot trailer (for the produce_ns stamp).
+    shm_producer: shm.Producer,
+    /// Ring of IOSurface refs we own. Held for the session — if we
+    /// drop these the consumer's `IOSurfaceLookup` would start
+    /// returning null.
+    surfaces: [MAX_RING]IOSurfaceRef = [_]IOSurfaceRef{null} ** MAX_RING,
+    ring_size: u32,
+    width: u32,
+    height: u32,
+    /// Query-cached at init — IOSurface row stride is platform-
+    /// controlled, NOT `width * 4`. Same value across all surfaces in
+    /// the ring (they share dims/format).
+    bytes_per_row: u32,
+    /// Slot index the next `pixelsPtr`/`publish` pair will touch.
+    /// Rotates 0..ring_size-1.
+    next_slot: u32 = 0,
+    /// Lock held between `pixelsPtr` and `publish` so the caller can
+    /// write straight into `IOSurfaceGetBaseAddress`. `null` between
+    /// publish cycles.
+    locked_slot: ?u32 = null,
+
+    /// Create the IOSurface ring, allocate the control-plane shm
+    /// region, and stamp the `ControlBlock` into slot 0. Caller then
+    /// calls `pixelsPtr` to lock a slot, writes BGRA8 pixels, and
+    /// `publish` to advance `latest` + bump `frame_count`.
+    pub fn init(name: [:0]const u8, opts: Options) Error!Producer {
+        if (!macos) return error.PlatformUnsupported;
+        if (opts.ring_size == 0 or opts.ring_size > MAX_RING) {
+            return error.RingSizeOutOfRange;
+        }
+
+        var surfaces: [MAX_RING]IOSurfaceRef = [_]IOSurfaceRef{null} ** MAX_RING;
+        var created: u32 = 0;
+        errdefer {
+            var i: u32 = 0;
+            while (i < created) : (i += 1) {
+                if (surfaces[i]) |s| CFRelease(@ptrCast(s));
+            }
+        }
+
+        // One property dict reused for every surface — all N share
+        // dims/format.
+        const props = makeBGRA8Properties(opts.width, opts.height);
+        defer CFRelease(props);
+
+        while (created < opts.ring_size) : (created += 1) {
+            const ref = IOSurfaceCreate(props) orelse return error.IOSurfaceCreateFailed;
+            surfaces[created] = ref;
+        }
+
+        // Initialise the control-plane shm region. We reuse
+        // `preview_shm.Producer` verbatim — slot 0's pixel area is
+        // where we stash the ControlBlock.
+        var sp = try shm.Producer.init(name, .{
+            .width = opts.width,
+            .height = opts.height,
+            .ring_size = opts.ring_size,
+        });
+        errdefer sp.deinit();
+
+        // Stamp the ControlBlock into slot 0's pixel area. Written
+        // exactly once; the consumer reads it exactly once.
+        const ctrl: *ControlBlock = @ptrCast(@alignCast(sp.base + @sizeOf(shm.Header)));
+        ctrl.* = .{
+            .magic = 0,
+            .ring_size = opts.ring_size,
+            .pixel_format = kPixelFormat_BGRA8,
+            .width = opts.width,
+            .height = opts.height,
+            .ids = [_]IOSurfaceID{0} ** MAX_RING,
+        };
+        var i: u32 = 0;
+        while (i < opts.ring_size) : (i += 1) {
+            ctrl.ids[i] = IOSurfaceGetID(surfaces[i]);
+        }
+        // Release-store the magic last so the consumer's acquire-load
+        // sees a fully-populated ControlBlock (matches the PoC and
+        // labelle-gui consumer expectations).
+        @atomicStore(u64, &ctrl.magic, ControlBlock.MAGIC, .release);
+
+        // Query bytes_per_row from the first surface — Apple may pad
+        // past `width * 4` for alignment (ticket gotcha).
+        const bpr: u32 = @intCast(IOSurfaceGetBytesPerRow(surfaces[0]));
+
+        return .{
+            .shm_producer = sp,
+            .surfaces = surfaces,
+            .ring_size = opts.ring_size,
+            .width = opts.width,
+            .height = opts.height,
+            .bytes_per_row = bpr,
+        };
+    }
+
+    pub fn deinit(self: *Producer) void {
+        // Best-effort unlock if caller bailed mid-write.
+        if (self.locked_slot) |slot| {
+            if (self.surfaces[slot]) |s| {
+                _ = IOSurfaceUnlock(s, 0, null);
+            }
+            self.locked_slot = null;
+        }
+        var i: u32 = 0;
+        while (i < self.ring_size) : (i += 1) {
+            if (self.surfaces[i]) |s| CFRelease(@ptrCast(s));
+            self.surfaces[i] = null;
+        }
+        self.shm_producer.deinit();
+    }
+
+    /// Lock the next slot for write. Caller writes BGRA8 pixels into
+    /// `Locked.base` honouring `Locked.bytes_per_row`, then calls
+    /// `publish`.
+    pub fn pixelsPtr(self: *Producer) Error!Locked {
+        if (self.locked_slot != null) return error.AlreadyLocked;
+        const slot = self.next_slot;
+        const surf = self.surfaces[slot];
+        const lr = IOSurfaceLock(surf, 0, null);
+        if (lr != 0) return error.IOSurfaceLockFailed;
+        const base_opt = IOSurfaceGetBaseAddress(surf);
+        const base: [*]u8 = @ptrCast(base_opt orelse {
+            _ = IOSurfaceUnlock(surf, 0, null);
+            return error.IOSurfaceBaseAddressNull;
+        });
+        self.locked_slot = slot;
+        return .{ .base = base, .bytes_per_row = self.bytes_per_row, .slot = slot };
+    }
+
+    /// Unlock the current slot and publish its index via the shm
+    /// header. Mirrors `preview_shm.Producer.publish` for the
+    /// timestamp + frame-count release-store dance.
+    pub fn publish(self: *Producer, stamp_now: bool) Error!void {
+        const slot = self.locked_slot orelse return error.NotLocked;
+        const ul = IOSurfaceUnlock(self.surfaces[slot], 0, null);
+        if (ul != 0) return error.IOSurfaceUnlockFailed;
+        self.locked_slot = null;
+
+        // Stamp the trailer in the matching shm slot — purely
+        // metadata (frame_idx, produce_ns); pixel bytes in the shm
+        // slot are unused in iosurface mode (they hold the
+        // ControlBlock in slot 0 and are scratch in the others).
+        self.shm_producer.next_slot = slot;
+        self.shm_producer.publish(stamp_now);
+        self.next_slot = (slot + 1) % self.ring_size;
+    }
+
+    /// Direct accessor for the IOSurface refs (intentional for
+    /// future render-to-IOSurface FBO paths — defer for now). The
+    /// returned ref is borrowed; do NOT `CFRelease` it.
+    pub fn surfaceAt(self: *const Producer, slot: u32) IOSurfaceRef {
+        if (slot >= self.ring_size) return null;
+        return self.surfaces[slot];
+    }
+
+    /// Pass-through to the embedded shm header for shutdown signalling.
+    pub fn header(self: *Producer) *shm.Header {
+        return self.shm_producer.header;
+    }
+};
+
+// ── Tests ──────────────────────────────────────────────────────────
+//
+// Most coverage lives in `test/preview_iosurface_test.zig` (per the
+// engine's `test/*.zig is its own binary` convention). Keep only
+// platform-agnostic, allocation-free static checks here.
+
+test "ControlBlock layout matches consumer canonical" {
+    // Mirrors `labelle-gui/src/iosurface.zig`'s compile-time assertion.
+    // Drift in either file is a protocol break.
+    try std.testing.expectEqual(@as(usize, 24 + MAX_RING * 4 + 16), @sizeOf(ControlBlock));
+}
+
+test "MAX_RING matches consumer" {
+    // If this fails, labelle-gui#115's `MAX_RING` has drifted out of
+    // sync with ours — coordinate before merging.
+    try std.testing.expectEqual(@as(u32, 8), MAX_RING);
+}
+
+test "kPixelFormat_BGRA8 matches consumer four-CC" {
+    // 'BGRA' as bytes in memory.
+    try std.testing.expectEqual(@as(u32, 0x42475241), kPixelFormat_BGRA8);
+}
+
+test "ControlBlock.MAGIC matches consumer ('IOSRFCL1')" {
+    try std.testing.expectEqual(@as(u64, 0x494F535246434C31), ControlBlock.MAGIC);
+}
+
+test "swizzleRgbaToBgraInPlace reorders channels correctly" {
+    var buf: [8]u8 = .{
+        0xAA, 0xBB, 0xCC, 0xDD,
+        0x11, 0x22, 0x33, 0x44,
+    };
+    swizzleRgbaToBgraInPlace(&buf);
+    // First pixel: R=AA G=BB B=CC A=DD → B=CC G=BB R=AA A=DD
+    try std.testing.expectEqual(@as(u8, 0xCC), buf[0]);
+    try std.testing.expectEqual(@as(u8, 0xBB), buf[1]);
+    try std.testing.expectEqual(@as(u8, 0xAA), buf[2]);
+    try std.testing.expectEqual(@as(u8, 0xDD), buf[3]);
+    // Second pixel.
+    try std.testing.expectEqual(@as(u8, 0x33), buf[4]);
+    try std.testing.expectEqual(@as(u8, 0x22), buf[5]);
+    try std.testing.expectEqual(@as(u8, 0x11), buf[6]);
+    try std.testing.expectEqual(@as(u8, 0x44), buf[7]);
+}
+
+test "copySwizzleRgbaToBgra reorders channels correctly" {
+    const src: [4]u8 = .{ 0x10, 0x20, 0x30, 0x40 };
+    var dst: [4]u8 = undefined;
+    copySwizzleRgbaToBgra(&dst, &src);
+    try std.testing.expectEqual(@as(u8, 0x30), dst[0]); // B
+    try std.testing.expectEqual(@as(u8, 0x20), dst[1]); // G
+    try std.testing.expectEqual(@as(u8, 0x10), dst[2]); // R
+    try std.testing.expectEqual(@as(u8, 0x40), dst[3]); // A
+}

--- a/src/preview_iosurface.zig
+++ b/src/preview_iosurface.zig
@@ -160,6 +160,7 @@ comptime {
 // ── BGRA8 property dict (macOS only) ───────────────────────────────
 
 fn cfNumberU32(v: u32) CFNumberRef {
+    if (!macos) unreachable;
     const sv: i32 = @bitCast(v);
     return CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &sv);
 }
@@ -172,6 +173,7 @@ fn cfNumberU32(v: u32) CFNumberRef {
 /// `IOSurfaceGetBytesPerRow` after creation rather than assuming
 /// `width * 4` (PoC bit us with this; see ticket macOS specifics).
 pub fn makeBGRA8Properties(width: u32, height: u32) CFDictionaryRef {
+    if (!macos) unreachable;
     const dict = CFDictionaryCreateMutable(
         kCFAllocatorDefault,
         0,
@@ -353,6 +355,7 @@ pub const Producer = struct {
     }
 
     pub fn deinit(self: *Producer) void {
+        if (!macos) return;
         // Best-effort unlock if caller bailed mid-write.
         if (self.locked_slot) |slot| {
             if (self.surfaces[slot]) |s| {
@@ -372,6 +375,7 @@ pub const Producer = struct {
     /// `Locked.base` honouring `Locked.bytes_per_row`, then calls
     /// `publish`.
     pub fn pixelsPtr(self: *Producer) Error!Locked {
+        if (!macos) return error.PlatformUnsupported;
         if (self.locked_slot != null) return error.AlreadyLocked;
         const slot = self.next_slot;
         const surf = self.surfaces[slot];
@@ -390,6 +394,7 @@ pub const Producer = struct {
     /// header. Mirrors `preview_shm.Producer.publish` for the
     /// timestamp + frame-count release-store dance.
     pub fn publish(self: *Producer, stamp_now: bool) Error!void {
+        if (!macos) return error.PlatformUnsupported;
         const slot = self.locked_slot orelse return error.NotLocked;
         const ul = IOSurfaceUnlock(self.surfaces[slot], 0, null);
         if (ul != 0) return error.IOSurfaceUnlockFailed;

--- a/src/preview_mode.zig
+++ b/src/preview_mode.zig
@@ -802,13 +802,19 @@ pub const Preview = struct {
     }
 
     /// Tear down the IOSurface ring + control-plane shm region.
-    /// Safe to call when no iosurface stream is active. Does NOT
-    /// send a `bye` — caller owns the connection lifecycle.
+    /// Safe to call when no iosurface stream is active — no-ops in
+    /// that case. Critically, also a no-op when an SHM-mode stream
+    /// is active: that path's `frame_shm_name` is owned in parallel
+    /// by `beginFrameStream`'s producer (which holds a reference to
+    /// the same `[:0]u8`), so freeing it here would land a
+    /// use-after-free at the SHM producer's later `shm_unlink`.
+    /// Caller owns mode selection. Does NOT send a `bye` — caller
+    /// owns the connection lifecycle.
     pub fn endFrameStreamIOSurface(self: *Preview) void {
-        if (self.frame_iosurface_producer) |*p| {
-            p.deinit();
-            self.frame_iosurface_producer = null;
-        }
+        if (self.frame_iosurface_producer == null) return;
+        var p = self.frame_iosurface_producer.?;
+        p.deinit();
+        self.frame_iosurface_producer = null;
         if (self.frame_shm_name) |old| {
             self.inbox_alloc.free(old);
             self.frame_shm_name = null;

--- a/src/preview_mode.zig
+++ b/src/preview_mode.zig
@@ -80,6 +80,7 @@
 ///    infers the crash from the EOF without a `bye`.
 const std = @import("std");
 pub const preview_shm = @import("preview_shm.zig");
+pub const preview_iosurface = @import("preview_iosurface.zig");
 
 // Raw libc bindings: std.posix in 0.16 dropped top-level `close` and
 // `write` wrappers and routed file IO through `std.Io.File` which
@@ -177,12 +178,20 @@ pub const SnapshotComponent = struct {
 /// Pixel format identifiers carried over the wire. Plain enum to keep
 /// the JSON-serializer side trivial. Add new entries when the producer
 /// gains support; consumers compare by string.
+///
+/// `iosurface_bgra8` is the macOS zero-copy path (#547): the shm
+/// region carries only a `ControlBlock` + `Header.latest` slot
+/// pointer; the pixel bytes live in `IOSurfaceRef` objects whose IDs
+/// the editor looks up via `IOSurfaceLookup`. The consumer side of
+/// this lives in `labelle-gui/src/iosurface.zig`.
 pub const FramePixelFormat = enum {
     rgba8,
+    iosurface_bgra8,
 
     pub fn asString(self: FramePixelFormat) []const u8 {
         return switch (self) {
             .rgba8 => "rgba8",
+            .iosurface_bgra8 => "iosurface_bgra8",
         };
     }
 };
@@ -306,6 +315,13 @@ pub const Preview = struct {
     /// SHM ring writer for #544. `null` until `beginFrameStream` runs;
     /// `endFrameStream` deallocates and resets to `null`.
     frame_producer: ?preview_shm.Producer = null,
+    /// macOS IOSurface ring writer for #547. `null` until
+    /// `beginFrameStreamIOSurface` runs; `endFrameStreamIOSurface`
+    /// deallocates and resets to `null`. Mutually exclusive with
+    /// `frame_producer` on the same `Preview` instance — the two
+    /// `begin*` entry points reject if the other mode is already
+    /// active.
+    frame_iosurface_producer: ?preview_iosurface.Producer = null,
     /// Owned shm_name backing `frame_producer`. Allocated per
     /// `beginFrameStream` and freed at the start of the next call
     /// (or in `endFrameStream` / `deinit`). Previously dupe'd into
@@ -313,7 +329,8 @@ pub const Preview = struct {
     /// resize-driven re-offer cycles would otherwise leak names
     /// proportional to the resize count (#546 review).
     frame_shm_name: ?[:0]u8 = null,
-    /// Monotonic frame counter — bumped by `publishFrame`.
+    /// Monotonic frame counter — bumped by `publishFrame` (or
+    /// `publishFrameIOSurface`).
     frame_index: u64 = 0,
 
     /// Dial the editor's listener. `host_port` is the literal string
@@ -351,6 +368,14 @@ pub const Preview = struct {
         if (self.frame_producer) |*p| {
             p.deinit();
             self.frame_producer = null;
+        }
+        // Same for the IOSurface ring (mutually exclusive with the
+        // SHM ring at runtime — only one of the two should be non-
+        // null at any point — but `deinit` defensively cleans both
+        // so a half-initialised state can't leak).
+        if (self.frame_iosurface_producer) |*p| {
+            p.deinit();
+            self.frame_iosurface_producer = null;
         }
         if (self.frame_shm_name) |old| {
             self.inbox_alloc.free(old);
@@ -491,9 +516,17 @@ pub const Preview = struct {
     /// stream torn down," the latter is "you handed me the wrong
     /// number of pixel bytes for the negotiated dims." Conflating
     /// them was the #546 review feedback.
-    pub const PublishError = WriteError || preview_shm.Error || error{
+    ///
+    /// `WrongFrameMode` (#547) is raised by `beginFrameStream` when
+    /// the iosurface mode is already active on the same `Preview`
+    /// (and vice versa). The two modes are mutually exclusive on a
+    /// single instance — the editor offer carries the format once
+    /// and the producer doesn't try to multiplex.
+    pub const PublishError = WriteError || preview_shm.Error ||
+        preview_iosurface.Error || error{
         StreamNotActive,
         InvalidFrameSize,
+        WrongFrameMode,
     };
 
     /// Allocate a SHM ring sized for `width x height` RGBA8 frames and
@@ -514,6 +547,14 @@ pub const Preview = struct {
         width: u32,
         height: u32,
     ) PublishError!void {
+        // Reject if the iosurface mode is already active on this
+        // `Preview`. The two modes are mutually exclusive — the
+        // editor's `frame_offer` carries a single format, and
+        // multiplexing them would force the editor's consumer to
+        // pick a side mid-stream. The caller is expected to call
+        // `endFrameStreamIOSurface` before switching modes (#547).
+        if (self.frame_iosurface_producer != null) return error.WrongFrameMode;
+
         // Tear down any prior ring so a resize-driven re-offer is
         // idempotent — the protocol allows multiple frame_offer cycles
         // over the same connection.
@@ -622,6 +663,151 @@ pub const Preview = struct {
         if (self.frame_producer) |*p| {
             p.deinit();
             self.frame_producer = null;
+        }
+        if (self.frame_shm_name) |old| {
+            self.inbox_alloc.free(old);
+            self.frame_shm_name = null;
+        }
+        self.frame_state = .not_offered;
+        self.frame_index = 0;
+    }
+
+    // ── #547: macOS IOSurface publish (producer side) ──────────────
+
+    /// Allocate an IOSurface ring sized for `width x height` BGRA8
+    /// frames + the control-plane shm region, then emit a
+    /// `frame_offer` with `format = "iosurface_bgra8"`.
+    ///
+    /// Mutually exclusive with `beginFrameStream` (SHM mode) on the
+    /// same `Preview` instance — see `PublishError.WrongFrameMode`.
+    ///
+    /// macOS-only. On other platforms returns
+    /// `error.PlatformUnsupported` before allocating anything; the
+    /// caller (typically a backend's macOS-gated init path) is
+    /// expected to fall back to `beginFrameStream` everywhere else.
+    pub fn beginFrameStreamIOSurface(
+        self: *Preview,
+        width: u32,
+        height: u32,
+    ) PublishError!void {
+        if (builtin.os.tag != .macos) return error.PlatformUnsupported;
+        // Reject if SHM mode is already active. See the mirror guard
+        // in `beginFrameStream`.
+        if (self.frame_producer != null) return error.WrongFrameMode;
+
+        // Tear down any prior iosurface ring so a resize-driven
+        // re-offer cycle is idempotent. Reset state pre-allocation
+        // so a failure in `Producer.init` / `sendFrameOffer` leaves
+        // us cleanly at `.not_offered` (#546 review carries over to
+        // this path verbatim).
+        if (self.frame_iosurface_producer) |*p| {
+            p.deinit();
+            self.frame_iosurface_producer = null;
+        }
+        if (self.frame_shm_name) |old| {
+            self.inbox_alloc.free(old);
+            self.frame_shm_name = null;
+        }
+        self.frame_state = .not_offered;
+        self.frame_index = 0;
+
+        // Same per-process unique name shape as the SHM path —
+        // PID + monotonic counter, hex-formatted, ≤ macOS
+        // PSHMNAMLEN (31). Reuses `next_stream_id` so SHM and
+        // iosurface mode allocations within the same process don't
+        // collide on the name space (each begin* bumps it).
+        const pid: i32 = @intCast(std.c.getpid());
+        const stream_id = @atomicRmw(u32, &next_stream_id, .Add, 1, .monotonic) +% 1;
+        var name_buf: [32]u8 = undefined;
+        const name = std.fmt.bufPrintZ(&name_buf, "/lbl-prv-{x}-{x}", .{
+            @as(u32, @bitCast(pid)),
+            stream_id,
+        }) catch return error.OutOfMemory;
+        const name_owned = self.inbox_alloc.dupeZ(u8, name) catch
+            return error.OutOfMemory;
+        errdefer self.inbox_alloc.free(name_owned);
+
+        const opts: preview_iosurface.Options = .{
+            .width = width,
+            .height = height,
+            .ring_size = 3,
+        };
+        var producer = try preview_iosurface.Producer.init(name_owned, opts);
+        errdefer producer.deinit();
+
+        try self.sendFrameOffer(.{
+            .shm_name = name_owned,
+            .width = width,
+            .height = height,
+            .format = .iosurface_bgra8,
+            .ring_size = opts.ring_size,
+            // `slot_size_bytes` describes the underlying shm slot
+            // layout (the consumer uses it to walk to the trailer
+            // for the produce_ns timestamp). The IOSurface pixel
+            // bytes live elsewhere — the editor side already knows
+            // to ignore the shm pixel area when format ==
+            // `iosurface_bgra8` (see labelle-gui#115).
+            .slot_size_bytes = preview_shm.slotSize(width, height),
+        });
+
+        self.frame_iosurface_producer = producer;
+        self.frame_shm_name = name_owned;
+    }
+
+    /// Publish a CPU-side RGBA8 frame into the next IOSurface slot.
+    /// The producer-side swizzles into BGRA8 (the IOSurface pixel
+    /// format) while copying; the editor samples BGRA8 directly via
+    /// `CGLTexImageIOSurface2D` on a `GL_TEXTURE_RECTANGLE` (the
+    /// consumer side).
+    ///
+    /// `pixels` is RGBA8 because that's what GL readback produces;
+    /// asking the caller to pre-swizzle would just push the same
+    /// per-byte work up the stack. The eventual render-to-IOSurface
+    /// FBO path would skip this and is the documented stretch goal
+    /// (deferred — separate ticket).
+    ///
+    /// Length MUST be exactly `width * height * 4` — same shape as
+    /// `publishFrame`. The IOSurface's `bytes_per_row` may be padded
+    /// past `width * 4` (Apple alignment), so we copy row-by-row
+    /// rather than a single memcpy.
+    pub fn publishFrameIOSurface(self: *Preview, pixels: []const u8) PublishError!void {
+        if (builtin.os.tag != .macos) return error.PlatformUnsupported;
+        const producer = if (self.frame_iosurface_producer != null)
+            &self.frame_iosurface_producer.?
+        else
+            return error.StreamNotActive;
+        if (!self.isFrameAccepted()) return error.StreamNotActive;
+
+        const expected_len: usize = @intCast(@as(u64, producer.width) * @as(u64, producer.height) * 4);
+        if (pixels.len != expected_len) return error.InvalidFrameSize;
+
+        const locked = try producer.pixelsPtr();
+        // Row-by-row swizzle copy — `bytes_per_row` may exceed
+        // `width * 4` on macOS due to alignment padding. The kernel
+        // owns the per-row stride; we honour whatever it reported.
+        const row_bytes: usize = producer.width * 4;
+        var y: u32 = 0;
+        while (y < producer.height) : (y += 1) {
+            const src_row = pixels[y * row_bytes ..][0..row_bytes];
+            const dst_row = locked.base[y * locked.bytes_per_row ..][0..row_bytes];
+            preview_iosurface.copySwizzleRgbaToBgra(dst_row, src_row);
+        }
+        try producer.publish(true);
+
+        self.frame_index +%= 1;
+        // Optional sidecar — best-effort, same shape as the SHM
+        // `publishFrame`. The IOSurface publish above is the
+        // authoritative signal.
+        self.sendFramePublished(self.frame_index, preview_shm.nowNs()) catch {};
+    }
+
+    /// Tear down the IOSurface ring + control-plane shm region.
+    /// Safe to call when no iosurface stream is active. Does NOT
+    /// send a `bye` — caller owns the connection lifecycle.
+    pub fn endFrameStreamIOSurface(self: *Preview) void {
+        if (self.frame_iosurface_producer) |*p| {
+            p.deinit();
+            self.frame_iosurface_producer = null;
         }
         if (self.frame_shm_name) |old| {
             self.inbox_alloc.free(old);

--- a/src/root.zig
+++ b/src/root.zig
@@ -205,6 +205,12 @@ pub const parsePreviewArgs = preview_mode_mod.parseArgs;
 // Phase 2 / #518 — binary state telemetry frame types.
 pub const PreviewBinaryFrameKind = preview_mode_mod.BinaryFrameKind;
 pub const preview_binary_magic = preview_mode_mod.binary_magic;
+// #547 — macOS IOSurface producer module. Surfaced for tests +
+// downstream code that wants the `ControlBlock` shape; the runtime
+// API the assembler-generated `main.zig` cares about is the
+// `Preview.beginFrameStreamIOSurface` / `publishFrameIOSurface` /
+// `endFrameStreamIOSurface` triple.
+pub const preview_iosurface_mod = preview_mode_mod.preview_iosurface;
 
 // ── JSONC Scene Bridge ──
 pub const JsoncSceneBridge = @import("jsonc_scene_bridge.zig").JsoncSceneBridge;

--- a/test/preview_frame_stream_test.zig
+++ b/test/preview_frame_stream_test.zig
@@ -373,3 +373,32 @@ test "endFrameStream tears down ring, subsequent publishFrame is StreamNotActive
     @memset(&pixels, 0);
     try std.testing.expectError(error.StreamNotActive, p.publishFrame(&pixels));
 }
+
+// Regression: PR #548 review (cursor "endFrameStreamIOSurface
+// unconditionally corrupts shared state"). The IOSurface tear-down
+// must no-op when no IOSurface stream is active. Previously it freed
+// `frame_shm_name` from under an active SHM-mode stream, landing a
+// use-after-free at the SHM producer's later `shm_unlink`. Caller
+// owns mode selection.
+test "endFrameStreamIOSurface is a no-op when SHM mode is active" {
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try p.beginFrameStream(8, 8);
+    var drop_buf: [512]u8 = undefined;
+    _ = try h.readLine(&drop_buf);
+
+    // Snapshot the SHM name pointer so we can verify it survives
+    // intact across the cross-mode end call.
+    const name_before = p.frame_shm_name.?;
+
+    p.endFrameStreamIOSurface();
+
+    // SHM stream still active; cross-mode end was a no-op.
+    try std.testing.expect(p.frame_producer != null);
+    try std.testing.expect(p.frame_shm_name != null);
+    try std.testing.expectEqual(name_before.ptr, p.frame_shm_name.?.ptr);
+    try std.testing.expect(p.frame_state != .not_offered);
+}

--- a/test/preview_iosurface_test.zig
+++ b/test/preview_iosurface_test.zig
@@ -1,0 +1,487 @@
+//! Tests for the PIE viewport macOS IOSurface frame stream (#547).
+//! Producer is the engine side under test; the consumer half ships
+//! in `labelle-gui/src/iosurface.zig`. To avoid a cross-repo build
+//! dependency we port a scope-internal consumer in this file (lean
+//! version of the labelle-gui code — just enough to look up surfaces
+//! by ID, read the ControlBlock back, and inspect pixel bytes via
+//! `IOSurfaceGetBaseAddress`).
+//!
+//! Gated on macOS. On Linux/Windows every test in this file early-
+//! returns so the engine's `zig build test` step stays green on every
+//! supported host (per ticket: macOS-only test target, cross-platform
+//! stub).
+
+const std = @import("std");
+const builtin = @import("builtin");
+const engine = @import("engine");
+
+const preview = engine.preview_mode_mod;
+const shm = engine.preview_mode_mod.preview_shm;
+const iosurface = engine.preview_iosurface_mod;
+
+// ── macOS-only IOSurface externs (only called on macOS — guarded at
+// every callsite by `builtin.os.tag == .macos` early returns). Linker
+// resolves these via the engine module's frameworks linkage (see
+// `build.zig`).
+
+extern "c" fn IOSurfaceLookup(csid: iosurface.IOSurfaceID) iosurface.IOSurfaceRef;
+extern "c" fn IOSurfaceGetBaseAddress(buffer: iosurface.IOSurfaceRef) ?*anyopaque;
+extern "c" fn IOSurfaceGetWidth(buffer: iosurface.IOSurfaceRef) usize;
+extern "c" fn IOSurfaceGetHeight(buffer: iosurface.IOSurfaceRef) usize;
+extern "c" fn IOSurfaceGetBytesPerRow(buffer: iosurface.IOSurfaceRef) usize;
+extern "c" fn IOSurfaceLock(buffer: iosurface.IOSurfaceRef, options: u32, seed: ?*u32) c_int;
+extern "c" fn IOSurfaceUnlock(buffer: iosurface.IOSurfaceRef, options: u32, seed: ?*u32) c_int;
+extern "c" fn CFRelease(cf: ?*anyopaque) void;
+extern "c" fn close(fd: c_int) c_int;
+extern "c" fn write(fd: c_int, buf: [*]const u8, len: usize) isize;
+extern "c" fn read(fd: c_int, buf: [*]u8, len: usize) isize;
+extern "c" fn nanosleep(req: *const Timespec, rem: ?*Timespec) c_int;
+extern "c" fn clock_gettime(clk: c_int, tp: *Timespec) c_int;
+
+const Timespec = extern struct { sec: isize, nsec: isize };
+
+fn nowMs() i64 {
+    // CLOCK_MONOTONIC == 6 on macOS, 1 on Linux. Both branches valid
+    // because the routine is only used inside macOS-gated tests; the
+    // Linux value is here purely so the file compiles cross-platform.
+    const CLOCK_MONOTONIC: c_int = if (builtin.os.tag == .macos) 6 else 1;
+    var ts: Timespec = undefined;
+    _ = clock_gettime(CLOCK_MONOTONIC, &ts);
+    return @as(i64, ts.sec) * 1000 + @divTrunc(@as(i64, ts.nsec), 1_000_000);
+}
+
+fn sleepMs(ms: u64) void {
+    const ts: Timespec = .{
+        .sec = @intCast(ms / 1000),
+        .nsec = @intCast((ms % 1000) * 1_000_000),
+    };
+    _ = nanosleep(&ts, null);
+}
+
+// ── In-test consumer (a slim port of labelle-gui's consumer). Lives
+// here on purpose — we don't want to widen the engine's public
+// surface with a consumer half; that's the editor's job.
+
+const TestConsumer = struct {
+    shm_consumer: shm.Consumer,
+    surfaces: [iosurface.MAX_RING]iosurface.IOSurfaceRef = [_]iosurface.IOSurfaceRef{null} ** iosurface.MAX_RING,
+    ring_size: u32 = 0,
+    width: u32 = 0,
+    height: u32 = 0,
+    bytes_per_row: u32 = 0,
+    slot_size: usize = 0,
+    last_seen_frame: u64 = 0,
+
+    fn init(shm_name: [:0]const u8) !TestConsumer {
+        var sc = try shm.Consumer.init(shm_name);
+        errdefer sc.deinit();
+
+        const ctrl: *const iosurface.ControlBlock =
+            @ptrCast(@alignCast(sc.base + @sizeOf(shm.Header)));
+        if (@atomicLoad(u64, @constCast(&ctrl.magic), .acquire) != iosurface.ControlBlock.MAGIC) {
+            return error.ControlBlockMissing;
+        }
+        const ring_size = ctrl.ring_size;
+        const width = ctrl.width;
+        const height = ctrl.height;
+        const pixel_format = ctrl.pixel_format;
+        if (ring_size == 0 or ring_size > iosurface.MAX_RING) return error.RingSizeOutOfRange;
+        if (pixel_format != iosurface.kPixelFormat_BGRA8) return error.PixelFormatMismatch;
+
+        var surfaces: [iosurface.MAX_RING]iosurface.IOSurfaceRef =
+            [_]iosurface.IOSurfaceRef{null} ** iosurface.MAX_RING;
+        var looked_up: u32 = 0;
+        errdefer {
+            var i: u32 = 0;
+            while (i < looked_up) : (i += 1) {
+                if (surfaces[i]) |s| CFRelease(@ptrCast(s));
+            }
+        }
+        while (looked_up < ring_size) : (looked_up += 1) {
+            const id = ctrl.ids[looked_up];
+            const ref = IOSurfaceLookup(id) orelse return error.IOSurfaceLookupFailed;
+            surfaces[looked_up] = ref;
+        }
+        const bpr: u32 = @intCast(IOSurfaceGetBytesPerRow(surfaces[0].?));
+        const slot_size: usize = @intCast(sc.header.slot_size);
+        return .{
+            .shm_consumer = sc,
+            .surfaces = surfaces,
+            .ring_size = ring_size,
+            .width = width,
+            .height = height,
+            .bytes_per_row = bpr,
+            .slot_size = slot_size,
+        };
+    }
+
+    fn deinit(self: *TestConsumer) void {
+        var i: u32 = 0;
+        while (i < self.ring_size) : (i += 1) {
+            if (self.surfaces[i]) |s| CFRelease(@ptrCast(s));
+            self.surfaces[i] = null;
+        }
+        self.shm_consumer.deinit();
+    }
+
+    const Frame = struct {
+        surface: iosurface.IOSurfaceRef,
+        slot: u32,
+        frame_idx: u64,
+    };
+
+    fn latest(self: *TestConsumer) ?Frame {
+        const fc = @atomicLoad(u64, &self.shm_consumer.header.frame_count, .acquire);
+        if (fc <= self.last_seen_frame) return null;
+        const slot = @atomicLoad(u32, &self.shm_consumer.header.latest, .acquire);
+        if (slot >= self.ring_size) return null;
+        const slot_base = self.shm_consumer.base + @sizeOf(shm.Header) +
+            @as(usize, slot) * self.slot_size;
+        const trailer: *const shm.SlotTrailer =
+            @ptrCast(@alignCast(slot_base + self.slot_size - @sizeOf(shm.SlotTrailer)));
+        const frame_idx = trailer.frame_idx;
+        if (frame_idx <= self.last_seen_frame) return null;
+        self.last_seen_frame = frame_idx;
+        return .{
+            .surface = self.surfaces[slot],
+            .slot = slot,
+            .frame_idx = frame_idx,
+        };
+    }
+};
+
+// ── Loopback harness (same shape as preview_frame_stream_test) ─────
+
+const LoopbackHarness = struct {
+    server: std.Io.net.Server,
+    port: u16,
+    conn_fd: ?std.posix.fd_t = null,
+    read_buf: [4096]u8 = undefined,
+    read_len: usize = 0,
+
+    fn init() !LoopbackHarness {
+        const addr = std.Io.net.IpAddress.parse("127.0.0.1", 0) catch unreachable;
+        const server = try addr.listen(std.testing.io, .{ .reuse_address = true });
+        var sa: std.posix.sockaddr.in = undefined;
+        var sa_len: std.posix.socklen_t = @sizeOf(@TypeOf(sa));
+        if (std.posix.system.getsockname(server.socket.handle, @ptrCast(&sa), &sa_len) != 0) {
+            return error.GetSockNameFailed;
+        }
+        return .{ .server = server, .port = std.mem.bigToNative(u16, sa.port) };
+    }
+
+    fn deinit(self: *LoopbackHarness) void {
+        if (self.conn_fd) |fd| _ = close(@intCast(fd));
+        self.server.deinit(std.testing.io);
+    }
+
+    fn hostPort(self: *LoopbackHarness, buf: []u8) ![]const u8 {
+        return std.fmt.bufPrint(buf, "127.0.0.1:{d}", .{self.port});
+    }
+
+    fn accept(self: *LoopbackHarness) !void {
+        const stream = try self.server.accept(std.testing.io);
+        self.conn_fd = stream.socket.handle;
+    }
+
+    fn readLine(self: *LoopbackHarness, out: []u8) ![]const u8 {
+        while (true) {
+            if (std.mem.indexOfScalar(u8, self.read_buf[0..self.read_len], '\n')) |nl| {
+                if (nl > out.len) return error.LineTooLong;
+                @memcpy(out[0..nl], self.read_buf[0..nl]);
+                const remaining = self.read_len - (nl + 1);
+                std.mem.copyForwards(u8, self.read_buf[0..remaining], self.read_buf[nl + 1 .. self.read_len]);
+                self.read_len = remaining;
+                return out[0..nl];
+            }
+            if (self.read_len == self.read_buf.len) return error.LineTooLong;
+            const fd = self.conn_fd orelse return error.NotConnected;
+            const n = read(@intCast(fd), self.read_buf[self.read_len..].ptr, self.read_buf.len - self.read_len);
+            if (n <= 0) return error.UnexpectedEof;
+            self.read_len += @intCast(n);
+        }
+    }
+
+    fn sendLine(self: *LoopbackHarness, body: []const u8) !void {
+        const fd = self.conn_fd orelse return error.NotConnected;
+        var off: usize = 0;
+        while (off < body.len) {
+            const n = write(@intCast(fd), body.ptr + off, body.len - off);
+            if (n <= 0) return error.WriteFailed;
+            off += @intCast(n);
+        }
+    }
+};
+
+fn connectPair(h: *LoopbackHarness) !preview.Preview {
+    var hp_buf: [64]u8 = undefined;
+    const host_port = try h.hostPort(&hp_buf);
+    const p = try preview.Preview.connect(std.testing.io, std.testing.allocator, host_port);
+    try h.accept();
+    return p;
+}
+
+fn waitUntil(p: *preview.Preview, predicate: *const fn (*preview.Preview) bool, deadline_ms: u64) !void {
+    const start = nowMs();
+    while (true) {
+        try p.pollSubscription();
+        if (predicate(p)) return;
+        if (nowMs() - start > @as(i64, @intCast(deadline_ms))) return error.WaitDeadlineExceeded;
+        sleepMs(1);
+    }
+}
+
+fn isAccepted(p: *preview.Preview) bool {
+    return p.isFrameAccepted();
+}
+
+const Offer = struct {
+    shm_name: [:0]u8,
+    width: u32,
+    height: u32,
+    format: []u8, // owned
+    ring_size: u32,
+};
+
+fn readOffer(h: *LoopbackHarness) !Offer {
+    var line_buf: [512]u8 = undefined;
+    const line = try h.readLine(&line_buf);
+    const Parsed = struct {
+        kind: []const u8,
+        shm_name: []const u8,
+        width: u32,
+        height: u32,
+        format: []const u8,
+        ring_size: u32,
+        slot_size_bytes: u64,
+    };
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const parsed = try std.json.parseFromSliceLeaky(Parsed, arena.allocator(), line, .{});
+    try std.testing.expectEqualStrings("frame_offer", parsed.kind);
+    return .{
+        .shm_name = try std.testing.allocator.dupeZ(u8, parsed.shm_name),
+        .width = parsed.width,
+        .height = parsed.height,
+        .format = try std.testing.allocator.dupe(u8, parsed.format),
+        .ring_size = parsed.ring_size,
+    };
+}
+
+fn freeOffer(o: Offer) void {
+    std.testing.allocator.free(o.shm_name);
+    std.testing.allocator.free(o.format);
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+test "beginFrameStreamIOSurface emits frame_offer with iosurface_bgra8 format" {
+    if (builtin.os.tag != .macos) return;
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try p.beginFrameStreamIOSurface(64, 48);
+    try std.testing.expectEqual(preview.FrameHandshakeState.offered, p.frame_state);
+
+    const offer = try readOffer(&h);
+    defer freeOffer(offer);
+    try std.testing.expectEqual(@as(u32, 64), offer.width);
+    try std.testing.expectEqual(@as(u32, 48), offer.height);
+    try std.testing.expectEqual(@as(u32, 3), offer.ring_size);
+    try std.testing.expectEqualStrings("iosurface_bgra8", offer.format);
+    try std.testing.expect(offer.shm_name[0] == '/');
+}
+
+test "in-test Consumer attaches, sees ControlBlock, looks up every surface" {
+    if (builtin.os.tag != .macos) return;
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try p.beginFrameStreamIOSurface(32, 32);
+    const offer = try readOffer(&h);
+    defer freeOffer(offer);
+
+    var consumer = try TestConsumer.init(offer.shm_name);
+    defer consumer.deinit();
+    try std.testing.expectEqual(@as(u32, 3), consumer.ring_size);
+    try std.testing.expectEqual(@as(u32, 32), consumer.width);
+    try std.testing.expectEqual(@as(u32, 32), consumer.height);
+    // Every surface in the ring must have looked up successfully —
+    // `init` would have errored if any slot was null.
+    var i: u32 = 0;
+    while (i < consumer.ring_size) : (i += 1) {
+        try std.testing.expect(consumer.surfaces[i] != null);
+    }
+    // bytes_per_row may be > width * 4 due to kernel-imposed
+    // alignment; equality isn't promised, but it must be at least
+    // width * 4.
+    try std.testing.expect(consumer.bytes_per_row >= 32 * 4);
+}
+
+test "publishFrameIOSurface writes pixels (RGBA→BGRA swizzle); consumer reads them back" {
+    if (builtin.os.tag != .macos) return;
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try p.beginFrameStreamIOSurface(16, 16);
+    const offer = try readOffer(&h);
+    defer freeOffer(offer);
+
+    var consumer = try TestConsumer.init(offer.shm_name);
+    defer consumer.deinit();
+
+    // Editor ACKs the offer; engine state flips to .accepted.
+    try h.sendLine("{\"kind\":\"frame_accept\"}\n");
+    try waitUntil(&p, isAccepted, 1000);
+
+    // Build an RGBA8 buffer with a recognisable first pixel
+    // (R=0xDE G=0xAD B=0xBE A=0xEF); the producer swizzles to BGRA8.
+    const W: u32 = 16;
+    const H: u32 = 16;
+    const N: usize = W * H * 4;
+    const pixels = try std.testing.allocator.alloc(u8, N);
+    defer std.testing.allocator.free(pixels);
+    pixels[0] = 0xDE;
+    pixels[1] = 0xAD;
+    pixels[2] = 0xBE;
+    pixels[3] = 0xEF;
+    for (4..N) |i| pixels[i] = @intCast(i & 0xff);
+
+    try p.publishFrameIOSurface(pixels);
+
+    const frame = consumer.latest() orelse return error.NoFrameFound;
+    try std.testing.expectEqual(@as(u64, 1), frame.frame_idx);
+
+    // Lock the surface read-only to inspect the bytes. After the
+    // swizzle, byte[0] = B = 0xBE, byte[1] = G = 0xAD, byte[2] = R = 0xDE,
+    // byte[3] = A = 0xEF.
+    const lr = IOSurfaceLock(frame.surface, 0x1, null);
+    try std.testing.expectEqual(@as(c_int, 0), lr);
+    defer _ = IOSurfaceUnlock(frame.surface, 0x1, null);
+    const base_opt = IOSurfaceGetBaseAddress(frame.surface);
+    const base: [*]const u8 = @ptrCast(base_opt orelse return error.BaseAddressNull);
+    try std.testing.expectEqual(@as(u8, 0xBE), base[0]);
+    try std.testing.expectEqual(@as(u8, 0xAD), base[1]);
+    try std.testing.expectEqual(@as(u8, 0xDE), base[2]);
+    try std.testing.expectEqual(@as(u8, 0xEF), base[3]);
+
+    // Check the swizzle for a second pixel too (offset 4..7).
+    // pixels[4]=4 (R), pixels[5]=5 (G), pixels[6]=6 (B), pixels[7]=7 (A)
+    // → base[4]=6 (B), base[5]=5 (G), base[6]=4 (R), base[7]=7 (A)
+    try std.testing.expectEqual(@as(u8, 6), base[4]);
+    try std.testing.expectEqual(@as(u8, 5), base[5]);
+    try std.testing.expectEqual(@as(u8, 4), base[6]);
+    try std.testing.expectEqual(@as(u8, 7), base[7]);
+}
+
+test "publishFrameIOSurface returns StreamNotActive when editor hasn't accepted" {
+    if (builtin.os.tag != .macos) return;
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try p.beginFrameStreamIOSurface(8, 8);
+    var drop: [512]u8 = undefined;
+    _ = try h.readLine(&drop);
+    var pixels: [8 * 8 * 4]u8 = undefined;
+    @memset(&pixels, 0);
+    try std.testing.expectError(error.StreamNotActive, p.publishFrameIOSurface(&pixels));
+}
+
+test "publishFrameIOSurface returns InvalidFrameSize on wrong buffer size" {
+    if (builtin.os.tag != .macos) return;
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try p.beginFrameStreamIOSurface(8, 8);
+    var drop: [512]u8 = undefined;
+    _ = try h.readLine(&drop);
+    try h.sendLine("{\"kind\":\"frame_accept\"}\n");
+    try waitUntil(&p, isAccepted, 1000);
+
+    var pixels: [100]u8 = undefined;
+    @memset(&pixels, 0);
+    try std.testing.expectError(error.InvalidFrameSize, p.publishFrameIOSurface(&pixels));
+}
+
+test "publishFrameIOSurface increments frame_idx monotonically" {
+    if (builtin.os.tag != .macos) return;
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try p.beginFrameStreamIOSurface(4, 4);
+    const offer = try readOffer(&h);
+    defer freeOffer(offer);
+    var consumer = try TestConsumer.init(offer.shm_name);
+    defer consumer.deinit();
+    try h.sendLine("{\"kind\":\"frame_accept\"}\n");
+    try waitUntil(&p, isAccepted, 1000);
+
+    var pixels: [4 * 4 * 4]u8 = undefined;
+    @memset(&pixels, 0);
+    try p.publishFrameIOSurface(&pixels);
+    try p.publishFrameIOSurface(&pixels);
+    try p.publishFrameIOSurface(&pixels);
+
+    const frame = consumer.latest() orelse return error.NoFrameFound;
+    try std.testing.expectEqual(@as(u64, 3), frame.frame_idx);
+}
+
+test "endFrameStreamIOSurface tears down ring; subsequent publish is StreamNotActive" {
+    if (builtin.os.tag != .macos) return;
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try p.beginFrameStreamIOSurface(8, 8);
+    var drop: [512]u8 = undefined;
+    _ = try h.readLine(&drop);
+    p.endFrameStreamIOSurface();
+    try std.testing.expectEqual(preview.FrameHandshakeState.not_offered, p.frame_state);
+
+    var pixels: [8 * 8 * 4]u8 = undefined;
+    @memset(&pixels, 0);
+    try std.testing.expectError(error.StreamNotActive, p.publishFrameIOSurface(&pixels));
+}
+
+test "SHM and IOSurface modes are mutually exclusive on the same Preview" {
+    if (builtin.os.tag != .macos) return;
+
+    // SHM first, then IOSurface — must reject.
+    {
+        var h = try LoopbackHarness.init();
+        defer h.deinit();
+        var p = try connectPair(&h);
+        defer p.deinit();
+
+        try p.beginFrameStream(8, 8);
+        var drop: [512]u8 = undefined;
+        _ = try h.readLine(&drop);
+        try std.testing.expectError(error.WrongFrameMode, p.beginFrameStreamIOSurface(8, 8));
+    }
+
+    // IOSurface first, then SHM — must also reject.
+    {
+        var h = try LoopbackHarness.init();
+        defer h.deinit();
+        var p = try connectPair(&h);
+        defer p.deinit();
+
+        try p.beginFrameStreamIOSurface(8, 8);
+        var drop: [512]u8 = undefined;
+        _ = try h.readLine(&drop);
+        try std.testing.expectError(error.WrongFrameMode, p.beginFrameStream(8, 8));
+    }
+}


### PR DESCRIPTION
## Summary

Engine-side producer half of the macOS IOSurface zero-copy PIE viewport pipeline. Pairs with the consumer that already shipped in **labelle-gui#115** — protocol (`ControlBlock`, `MAGIC = 'IOSRFCL1'`, `MAX_RING = 8`, `kPixelFormat_BGRA8 = 0x42475241`) is canonical there and matched verbatim here.

- New `src/preview_iosurface.zig` — `Producer` mirrors the shape of `preview_shm.Producer` (`init`/`deinit`/`pixelsPtr`/`publish`) but pixel bytes live in `IOSurfaceRef`s. Control plane reuses `preview_shm.Producer`; slot 0 carries the `ControlBlock` + `IOSurfaceID` list.
- New `Preview` API trio: `beginFrameStreamIOSurface(w, h)` / `publishFrameIOSurface(pixels)` / `endFrameStreamIOSurface()`. Emits `frame_offer` with `format = "iosurface_bgra8"` (new enum variant).
- SHM and IOSurface modes are mutually exclusive on the same `Preview` — second `begin*` errors with `PublishError.WrongFrameMode`.
- Producer-side RGBA→BGRA swizzle (GL readback is RGBA; IOSurface format is BGRA). Render-to-IOSurface FBO path is the documented stretch goal and **deferred**.

## What's deferred (per ticket)
- Render-to-IOSurface FBO optimization (stretch goal).
- Mach-port handoff replacing the deprecated `kIOSurfaceIsGlobal` shortcut (separate ticket).
- Linux / Windows equivalents (out of scope).

## macOS gotchas documented in source
- `IOSurfaceLookup` cross-process requires `kIOSurfaceIsGlobal = true` (deprecated since 10.11 but functional) OR a mach port — SCM_RIGHTS can't carry mach ports.
- Pixel format MUST be BGRA8 (`0x42475241`).
- Row alignment is kernel-controlled — always query `IOSurfaceGetBytesPerRow` rather than computing `width * 4`. We cache the result at producer init and the `publishFrameIOSurface` swizzle-copy honours it row by row.

## Build

`build.zig` now links `IOSurface` + `CoreFoundation` frameworks on the `engine_module` for macOS targets (Zig's analyzer reaches `Producer.deinit` from every test binary that imports `engine`; non-macOS builds skip the link and the macOS-only code stays unreachable behind `builtin.os.tag == .macos` gates). The new test binary additionally pulls `OpenGL` for the ticket's framework callout.

## Test plan

`test/preview_iosurface_test.zig` (8 tests, macOS-only — every block early-returns on Linux/Windows so `zig build test` stays green everywhere):

- [x] `frame_offer` emission + state + `iosurface_bgra8` format string match
- [x] In-test `TestConsumer` (a slim port of labelle-gui's consumer, scoped to the test file so the engine's public surface doesn't grow a consumer half) attaches, sees the `ControlBlock`, looks up every surface
- [x] End-to-end: producer publishes known RGBA pattern, consumer reads back via `IOSurfaceGetBaseAddress` and asserts the BGRA swizzle landed
- [x] `publishFrameIOSurface` returns `StreamNotActive` when not accepted; `InvalidFrameSize` on wrong-sized buffer
- [x] Monotonic `frame_idx` across multiple publishes
- [x] `endFrameStreamIOSurface` tears down; subsequent publish errors with `StreamNotActive`
- [x] SHM ↔ IOSurface mode mutual exclusion in both orderings (`WrongFrameMode`)

Ran locally on macOS 25.3 (darwin arm64) with Zig 0.16.0 — `zig build test --summary all` → **422/422 tests pass** (was 414 before adding 8 new iosurface tests).

Refs #547, #59 (PIE umbrella). Pairs with **labelle-gui#115** (consumer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)