### PR TITLE
feat(preview): getIOSurfaceAt + signalSlotReady for Path-A producers (#553)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xe8a81a8dc7f48c87,
     .name = .engine,
-    .version = "1.37.3",
+    .version = "1.37.4",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{

--- a/src/preview_mode.zig
+++ b/src/preview_mode.zig
@@ -800,6 +800,79 @@ pub const Preview = struct {
         self.sendFramePublished(self.frame_index, preview_shm.nowNs()) catch {};
     }
 
+    /// Borrow the underlying `IOSurfaceRef` for slot N. Caller wraps
+    /// the surface as an `MTLTexture` (via
+    /// `MTLDevice.newTextureWithDescriptor:iosurface:plane:`), an
+    /// `IOSurface`-backed `CVPixelBuffer`, or any other API that
+    /// consumes IOSurfaces, then renders directly into it. The
+    /// returned ref is borrowed — do NOT `CFRelease` it; the producer
+    /// owns lifetime for the duration of the stream.
+    ///
+    /// Slot indexing matches the `ControlBlock.ids[]` layout the
+    /// consumer side reads (so a producer that picks slot N here and
+    /// then calls `signalSlotReady(N)` lines up with the consumer's
+    /// `surfaces[N]` lookup verbatim). Stable for the lifetime of
+    /// `beginFrameStreamIOSurface` — `endFrameStreamIOSurface` /
+    /// `deinit` invalidate every slot's surface.
+    ///
+    /// Returns `null` for an out-of-range slot, when the iosurface
+    /// stream is not active, or on non-macOS platforms (the producer
+    /// is macOS-only by construction). Pair with
+    /// `signalSlotReady` to publish a slot the caller rendered into.
+    pub fn getIOSurfaceAt(self: *const Preview, slot: u32) ?preview_iosurface.IOSurfaceRef {
+        if (builtin.os.tag != .macos) return null;
+        const p = if (self.frame_iosurface_producer) |*pp| pp else return null;
+        // `surfaceAt` already returns null (the inner `?*opaque` null)
+        // for out-of-range slots; collapse that into the outer
+        // optional so callers get a single `null` regardless of the
+        // failure shape (slot OOB vs. stream-not-active vs. wrong
+        // platform). The `?IOSurfaceRef` ergonomics is purely for the
+        // caller — `surfaceAt`'s `IOSurfaceRef` is already itself
+        // optional and we'd otherwise force two layers of `if (… |s| …)`
+        // at every Path-A call site.
+        if (slot >= p.ring_size) return null;
+        return p.surfaceAt(slot);
+    }
+
+    /// Signal the editor that slot N's IOSurface has freshly-rendered
+    /// content. This is the Path-A counterpart to `publishFrameIOSurface`:
+    /// the caller has already rendered into the IOSurface itself
+    /// (typically via an `MTLTexture` wrapper that uses the surface as
+    /// a render-target backing store), so we don't touch pixel memory.
+    /// We just stamp the shm slot's trailer + bump `header.latest` to
+    /// `slot`, advance `frame_index`, and emit a best-effort
+    /// `frame_published` JSON sidecar.
+    ///
+    /// Equivalent to the publish half of `publishFrameIOSurface` minus
+    /// the lock / row-by-row swizzle copy. Same handshake gating —
+    /// returns `error.StreamNotActive` when the editor hasn't ACKed
+    /// the offer yet — and the same slot-bounds check as the SHM
+    /// publish path (`error.InvalidFrameSize` when
+    /// `slot >= ring_size`; the name keeps parity with the existing
+    /// `publishFrame` error vocabulary, even though no pixel
+    /// dimensions are involved).
+    pub fn signalSlotReady(self: *Preview, slot: u32) PublishError!void {
+        if (builtin.os.tag != .macos) return error.PlatformUnsupported;
+        const p = if (self.frame_iosurface_producer != null)
+            &self.frame_iosurface_producer.?
+        else
+            return error.StreamNotActive;
+        if (!self.isFrameAccepted()) return error.StreamNotActive;
+        if (slot >= p.ring_size) return error.InvalidFrameSize;
+
+        // Mirror the publish dance from `publishFrameIOSurface` without
+        // the lock + swizzle copy. The IOSurface contents are already
+        // current (the caller rendered into them via Metal); all we
+        // owe the consumer is the slot-pointer bump + the trailer
+        // stamp the shm-side reader expects to find.
+        p.shm_producer.next_slot = slot;
+        p.shm_producer.publish(true);
+        p.next_slot = (slot + 1) % p.ring_size;
+
+        self.frame_index +%= 1;
+        self.sendFramePublished(self.frame_index, preview_shm.nowNs()) catch {};
+    }
+
     /// Tear down the IOSurface ring + control-plane shm region.
     /// Safe to call when no iosurface stream is active — no-ops in
     /// that case. Critically, also a no-op when an SHM-mode stream

--- a/test/preview_iosurface_test.zig
+++ b/test/preview_iosurface_test.zig
@@ -456,6 +456,169 @@ test "endFrameStreamIOSurface tears down ring; subsequent publish is StreamNotAc
     try std.testing.expectError(error.StreamNotActive, p.publishFrameIOSurface(&pixels));
 }
 
+// ── Path-A producer API (#553) ─────────────────────────────────────
+
+test "getIOSurfaceAt returns non-null for valid slots and null for out-of-range" {
+    if (builtin.os.tag != .macos) return;
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try p.beginFrameStreamIOSurface(16, 16);
+    var drop: [512]u8 = undefined;
+    _ = try h.readLine(&drop);
+
+    // Default ring_size is 3 — slots 0..2 must yield non-null refs;
+    // slot 3 (== ring_size) and beyond must yield null.
+    try std.testing.expect(p.getIOSurfaceAt(0) != null);
+    try std.testing.expect(p.getIOSurfaceAt(1) != null);
+    try std.testing.expect(p.getIOSurfaceAt(2) != null);
+    try std.testing.expectEqual(@as(?iosurface.IOSurfaceRef, null), p.getIOSurfaceAt(3));
+    try std.testing.expectEqual(@as(?iosurface.IOSurfaceRef, null), p.getIOSurfaceAt(99));
+}
+
+test "getIOSurfaceAt returns null when no iosurface stream is active" {
+    if (builtin.os.tag != .macos) return;
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    // No `beginFrameStreamIOSurface` call — producer is nil.
+    try std.testing.expectEqual(@as(?iosurface.IOSurfaceRef, null), p.getIOSurfaceAt(0));
+}
+
+test "signalSlotReady advances frame_index and bumps header.latest to the slot" {
+    if (builtin.os.tag != .macos) return;
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try p.beginFrameStreamIOSurface(8, 8);
+    const offer = try readOffer(&h);
+    defer freeOffer(offer);
+    var consumer = try TestConsumer.init(offer.shm_name);
+    defer consumer.deinit();
+    try h.sendLine("{\"kind\":\"frame_accept\"}\n");
+    try waitUntil(&p, isAccepted, 1000);
+
+    // Signal slot 2 ready. No pixel writes — the IOSurface bytes are
+    // whatever IOSurfaceCreate left there (zero-filled in practice).
+    // Editor side just sees `header.latest = 2`, `frame_count = 1`.
+    try p.signalSlotReady(2);
+    try std.testing.expectEqual(@as(u64, 1), p.frame_index);
+    const frame = consumer.latest() orelse return error.NoFrameFound;
+    try std.testing.expectEqual(@as(u32, 2), frame.slot);
+    try std.testing.expectEqual(@as(u64, 1), frame.frame_idx);
+
+    // Second signal at slot 0 — index advances, latest follows.
+    try p.signalSlotReady(0);
+    try std.testing.expectEqual(@as(u64, 2), p.frame_index);
+    const frame2 = consumer.latest() orelse return error.NoFrameFound;
+    try std.testing.expectEqual(@as(u32, 0), frame2.slot);
+    try std.testing.expectEqual(@as(u64, 2), frame2.frame_idx);
+}
+
+test "signalSlotReady returns StreamNotActive without an active iosurface stream" {
+    if (builtin.os.tag != .macos) return;
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    // No `beginFrameStreamIOSurface` — `frame_iosurface_producer` is
+    // nil; signalSlotReady must reject before touching anything.
+    try std.testing.expectError(error.StreamNotActive, p.signalSlotReady(0));
+}
+
+test "signalSlotReady returns StreamNotActive before the editor accepts" {
+    if (builtin.os.tag != .macos) return;
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try p.beginFrameStreamIOSurface(8, 8);
+    var drop: [512]u8 = undefined;
+    _ = try h.readLine(&drop);
+
+    // Offer was sent but editor hasn't ACKed yet — state == .offered.
+    try std.testing.expectError(error.StreamNotActive, p.signalSlotReady(0));
+}
+
+test "signalSlotReady returns InvalidFrameSize for slot >= ring_size" {
+    if (builtin.os.tag != .macos) return;
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try p.beginFrameStreamIOSurface(8, 8);
+    var drop: [512]u8 = undefined;
+    _ = try h.readLine(&drop);
+    try h.sendLine("{\"kind\":\"frame_accept\"}\n");
+    try waitUntil(&p, isAccepted, 1000);
+
+    // ring_size defaults to 3 — slot 3 and beyond are out of range.
+    try std.testing.expectError(error.InvalidFrameSize, p.signalSlotReady(3));
+    try std.testing.expectError(error.InvalidFrameSize, p.signalSlotReady(99));
+}
+
+test "signalSlotReady: consumer reads back content pre-populated via getIOSurfaceAt (no-copy round-trip)" {
+    if (builtin.os.tag != .macos) return;
+    var h = try LoopbackHarness.init();
+    defer h.deinit();
+    var p = try connectPair(&h);
+    defer p.deinit();
+
+    try p.beginFrameStreamIOSurface(8, 8);
+    const offer = try readOffer(&h);
+    defer freeOffer(offer);
+    var consumer = try TestConsumer.init(offer.shm_name);
+    defer consumer.deinit();
+    try h.sendLine("{\"kind\":\"frame_accept\"}\n");
+    try waitUntil(&p, isAccepted, 1000);
+
+    // Pre-populate slot 1 directly through the borrowed IOSurfaceRef —
+    // simulates what a Metal render target would write into the
+    // surface. The producer never touches the pixels in this path.
+    const slot: u32 = 1;
+    const surf = p.getIOSurfaceAt(slot) orelse return error.NoSurface;
+    const lr = IOSurfaceLock(surf, 0, null);
+    try std.testing.expectEqual(@as(c_int, 0), lr);
+    {
+        const base_opt = IOSurfaceGetBaseAddress(surf);
+        const base: [*]u8 = @ptrCast(base_opt orelse return error.BaseAddressNull);
+        // First pixel BGRA = (0x11, 0x22, 0x33, 0x44).
+        base[0] = 0x11;
+        base[1] = 0x22;
+        base[2] = 0x33;
+        base[3] = 0x44;
+    }
+    const ul = IOSurfaceUnlock(surf, 0, null);
+    try std.testing.expectEqual(@as(c_int, 0), ul);
+
+    // Signal — no pixel copy happens producer-side.
+    try p.signalSlotReady(slot);
+
+    // Consumer attaches to the same IOSurface (looked up by ID) and
+    // sees the exact bytes we wrote above — proof of the zero-copy
+    // round-trip.
+    const frame = consumer.latest() orelse return error.NoFrameFound;
+    try std.testing.expectEqual(slot, frame.slot);
+    const lr2 = IOSurfaceLock(frame.surface, 0x1, null);
+    try std.testing.expectEqual(@as(c_int, 0), lr2);
+    defer _ = IOSurfaceUnlock(frame.surface, 0x1, null);
+    const base_opt = IOSurfaceGetBaseAddress(frame.surface);
+    const base: [*]const u8 = @ptrCast(base_opt orelse return error.BaseAddressNull);
+    try std.testing.expectEqual(@as(u8, 0x11), base[0]);
+    try std.testing.expectEqual(@as(u8, 0x22), base[1]);
+    try std.testing.expectEqual(@as(u8, 0x33), base[2]);
+    try std.testing.expectEqual(@as(u8, 0x44), base[3]);
+}
+
 test "SHM and IOSurface modes are mutually exclusive on the same Preview" {
     if (builtin.os.tag != .macos) return;
 


### PR DESCRIPTION
## Summary

Two thin `Preview`-side helpers needed by the sokol Metal Path-A rework (floooh/sokol#1510 — render-to-IOSurface offscreen, not post-frame blit):

- `getIOSurfaceAt(slot) -> ?IOSurfaceRef` — borrow the underlying surface so the backend can wrap it as an `MTLTexture` and render straight into it. Returns the outer `null` for OOB slot / inactive stream / non-macOS; ref is borrowed (do NOT `CFRelease`).
- `signalSlotReady(slot) -> PublishError!void` — publish half of `publishFrameIOSurface` minus the lock + RGBA→BGRA copy. Caller has already rendered into the IOSurface; we just stamp the trailer + bump `header.latest`. Same handshake gating (`error.StreamNotActive` until the editor ACKs) and slot-bounds check (`error.InvalidFrameSize` when `slot >= ring_size`) as the existing publish path.

Mechanics piggyback on `preview_iosurface.Producer.surfaceAt` (already private) and the existing `shm_producer.publish` dance. No protocol change — wire format / `ControlBlock` shape / consumer side all unchanged.

Bumps to `1.37.4` (tag cut separately).

Path-A means the assembler will allocate an IOSurface ring up front, hand each surface to sokol-gfx as an `MTLTexture` render target via `sg_make_image` + `sg_make_attachments`, render the game directly into it, then `signalSlotReady(slot)`. No drawable plumbing, no post-frame blit — we own the lifetime end-to-end.

## Test plan

- [x] `zig build test` — full engine suite (430/430 tests pass)
- [x] `getIOSurfaceAt` returns non-null for slots 0..ring_size-1, outer-null for `>= ring_size` / inactive stream
- [x] `signalSlotReady` advances `frame_index`, bumps `header.latest` to the requested slot, in-test consumer reads it back
- [x] `signalSlotReady` rejects with `StreamNotActive` when no iosurface stream / before editor ACKs the offer
- [x] `signalSlotReady` rejects with `InvalidFrameSize` for `slot >= ring_size`
- [x] Round-trip: caller pre-populates IOSurface via `getIOSurfaceAt`, calls `signalSlotReady`, in-test consumer reads back the exact bytes (proves the no-copy publish)
- [x] Mutual-exclusion guards with SHM mode unchanged

## Notes for the reviewer

- Test file is gated on macOS — every test early-returns on Linux/Windows so `zig build test` stays green on every host.
- `IOSurfaceRef` is already `?*opaque{}` so `?IOSurfaceRef` is two layers of optional. Decision: collapse "OOB slot" into the outer `null` rather than returning `Some(null)` — keeps the call-site ergonomics to a single `orelse break :_readback` per slot lookup. Documented inline.
- No re-export added in `root.zig` — methods land on `Preview` directly, `IOSurfaceRef` is already reachable via `engine.preview_iosurface_mod.IOSurfaceRef`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)