### PR TITLE
feat(preview): FrameCapture trait + InputEvent ring (#140 + #143)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -110,6 +110,10 @@ pub fn build(b: *std.Build) void {
         // above; spins up an in-test `preview_shm.Consumer` to read
         // back what the engine wrote.
         "test/preview_frame_stream_test.zig",
+        // Backend-agnostic FrameCapture trait (#140 architecture rethink).
+        // Validates the producer-side trait + publishFrame orchestration
+        // without involving any real graphics backend — pure CPU mock.
+        "test/preview_capture_test.zig",
         // preview_mode_test + flows_game_api_test: re-enabled after #543
         // fixed the variadic-`fcntl` ABI bug (declared non-variadic on
         // a function libc declares variadic — mismatched on

--- a/src/io_helper.zig
+++ b/src/io_helper.zig
@@ -1,12 +1,29 @@
 //! Lazy-init process-wide Io for engine code that historically used
 //! std.fs.cwd() (removed in 0.16). Mirrors the assembler/cli pattern.
 const std = @import("std");
+const builtin = @import("builtin");
 
-var _threaded: std.Io.Threaded = undefined;
+// wasm32-emscripten gate (labelle-assembler#141): `std.Io.Threaded`
+// pulls broken posix wrappers (`childWaitPosix` references a u32 where
+// an enum is expected — ziglang/zig#31849). On emscripten file I/O
+// historically went through emscripten's MEMFS via `std.fs.cwd()` —
+// in 0.16 the path lives behind `std.Io.Dir.cwd()` which requires an
+// `Io` parameter. We hand it `std.Io.failing` to keep the type system
+// happy without ever instantiating `Threaded` (whose vtable assignment
+// would compile the broken posix wrappers). Asset-load codepaths that
+// hit the FS will surface a clean `Failed` error rather than a compile
+// failure; standalone preview / scene assets need to come through
+// preloaded buffers on wasm anyway (#141 follow-up).
+const is_wasm_emscripten = builtin.target.os.tag == .emscripten;
+
+var _threaded: if (is_wasm_emscripten) void else std.Io.Threaded = if (is_wasm_emscripten) {} else undefined;
 var _io: std.Io = undefined;
 var _initialized: bool = false;
 
 pub fn io() std.Io {
+    if (is_wasm_emscripten) {
+        return std.Io.failing;
+    }
     if (!_initialized) {
         _threaded = std.Io.Threaded.init(std.heap.page_allocator, .{});
         _io = _threaded.io();

--- a/src/preview_capture.zig
+++ b/src/preview_capture.zig
@@ -17,7 +17,6 @@
 //! length before invoking; backend impls don't have to defend against
 //! `dst` shorter than expected.
 
-const std = @import("std");
 const preview_shm = @import("preview_shm.zig");
 
 /// A backend's contribution to the preview pipeline. One function
@@ -37,25 +36,47 @@ pub const FrameCapture = struct {
     ctx: *anyopaque,
 };
 
+/// Engine-side errors that `publishFrame` may emit in addition to any
+/// `anyerror` propagated from the backend's `capture_fn`. Listed here
+/// so backend authors can reason about what they have to handle on top
+/// of their own failure modes.
+pub const PublishError = error{
+    /// The producer's configured `width * height * 4` doesn't fit inside
+    /// the SHM slot's pixel region (slot bytes minus the trailing
+    /// `SlotTrailer`). This is a programmer error in producer setup —
+    /// either `opts` was mutated post-`Producer.init` or the header
+    /// was crafted externally. `Producer.init` validates options and
+    /// allocates an exactly-fitting slot, so a freshly initialised
+    /// producer cannot trip this.
+    SizeMismatch,
+};
+
 /// Orchestrate one frame: grab the next SHM slot, ask the backend to
 /// fill it via `capture`, then publish. The producer's slot dimensions
-/// must match the FrameCapture's expected output (this is enforced via
-/// the SHM header `width`/`height` set at `Producer.init` time).
+/// are set at `Producer.init` time via `opts.width`/`opts.height` and
+/// govern the pixel-region length the backend must write.
 ///
-/// Returns `Error.SizeMismatch` if the slot can't hold a full frame
-/// (programmer error in producer setup), otherwise propagates the
-/// backend's capture error or `Error.PublishFailed`.
-pub const PublishError = error{
-    SizeMismatch,
-    PublishFailed,
-} || std.mem.Allocator.Error;
-
+/// Returns `PublishError.SizeMismatch` if the slot's pixel region is
+/// too small to hold a full `w*h*4` frame (see `PublishError` doc for
+/// when that can happen). Otherwise propagates the backend's capture
+/// error verbatim. The return type is `anyerror!void` because the
+/// backend's `capture_fn` is itself `anyerror!void` — narrowing here
+/// would force every backend to remap its errors.
 pub fn publishFrame(producer: *preview_shm.Producer, capture: FrameCapture, stamp_now: bool) anyerror!void {
     const w = producer.opts.width;
     const h = producer.opts.height;
     // The shm Header.slot_size includes padding for trailer bytes; the
     // pixel region is exactly w*h*4. Backend writes only into that.
     const pixel_bytes: usize = @as(usize, w) * @as(usize, h) * 4;
+
+    // Defence-in-depth: confirm the slot the producer is about to hand
+    // us actually has room for `pixel_bytes` of pixel data on top of
+    // the trailing `SlotTrailer`. `Producer.init` derives slot_size
+    // from the same opts, so under normal use this is a no-op — but
+    // it catches header tampering and post-init opts mutation.
+    const slot_pixel_capacity: usize = @as(usize, @intCast(producer.header.slot_size)) - @sizeOf(preview_shm.SlotTrailer);
+    if (pixel_bytes > slot_pixel_capacity) return PublishError.SizeMismatch;
+
     const slot_ptr = producer.pixelsPtr();
     const dst = slot_ptr[0..pixel_bytes];
 

--- a/src/preview_capture.zig
+++ b/src/preview_capture.zig
@@ -1,0 +1,113 @@
+//! Backend-agnostic frame-capture trait for the preview pipeline.
+//!
+//! The preview module's contract with a backend is exactly one operation:
+//! *"write the most-recently-rendered frame's pixels into this buffer"*.
+//! Every GPU API exposes that (sokol `sg.queryImagePixels`, raylib
+//! `rlReadScreenPixels`, bgfx `readTexture`, wgpu buffer-copy-from-texture,
+//! null backend memcpy-from-framebuffer).
+//!
+//! By collapsing every backend's preview producer down to a single
+//! function pointer, the engine's preview code stops needing to know
+//! anything about Metal, GL, D3D11, IOSurface, MTLTexture, PBOs, or
+//! the per-OS readback dance. Backend authors implement one ~30-line
+//! `captureFrame` shim; the engine drives the protocol + SHM ring.
+//!
+//! Pixel format is **RGBA8** packed, top-to-bottom, no padding:
+//! `dst.len == width * height * 4`. The engine validates the slice
+//! length before invoking; backend impls don't have to defend against
+//! `dst` shorter than expected.
+
+const std = @import("std");
+const preview_shm = @import("preview_shm.zig");
+
+/// A backend's contribution to the preview pipeline. One function
+/// pointer + opaque context per backend. The engine takes ownership
+/// of the calling convention: capture runs on the producer's thread,
+/// once per frame, after the backend has finished rendering its
+/// swapchain pass.
+pub const FrameCapture = struct {
+    /// Write the most-recently-rendered frame's pixels into `dst` as
+    /// packed RGBA8 with stride = `width * 4`. May return any error;
+    /// the engine surfaces capture errors back to the editor as a
+    /// `bye` with reason `.capture_failed` (TBD wire-protocol change).
+    capture_fn: *const fn (ctx: *anyopaque, dst: []u8, width: u32, height: u32) anyerror!void,
+
+    /// Opaque backend pointer. The engine never dereferences it; it's
+    /// passed back verbatim to `capture_fn` on every invocation.
+    ctx: *anyopaque,
+};
+
+/// Orchestrate one frame: grab the next SHM slot, ask the backend to
+/// fill it via `capture`, then publish. The producer's slot dimensions
+/// must match the FrameCapture's expected output (this is enforced via
+/// the SHM header `width`/`height` set at `Producer.init` time).
+///
+/// Returns `Error.SizeMismatch` if the slot can't hold a full frame
+/// (programmer error in producer setup), otherwise propagates the
+/// backend's capture error or `Error.PublishFailed`.
+pub const PublishError = error{
+    SizeMismatch,
+    PublishFailed,
+} || std.mem.Allocator.Error;
+
+pub fn publishFrame(producer: *preview_shm.Producer, capture: FrameCapture, stamp_now: bool) anyerror!void {
+    const w = producer.opts.width;
+    const h = producer.opts.height;
+    // The shm Header.slot_size includes padding for trailer bytes; the
+    // pixel region is exactly w*h*4. Backend writes only into that.
+    const pixel_bytes: usize = @as(usize, w) * @as(usize, h) * 4;
+    const slot_ptr = producer.pixelsPtr();
+    const dst = slot_ptr[0..pixel_bytes];
+
+    try capture.capture_fn(capture.ctx, dst, w, h);
+    producer.publish(stamp_now);
+}
+
+/// Mock backend: fills the destination buffer with a deterministic
+/// "checkerboard" pattern keyed on `frame_index`. Used by the
+/// `test/preview_capture_test.zig` unit tests AND by the standalone
+/// preview_mock_game tool in labelle-tools — the same producer-side
+/// code path validates the trait without involving any real backend.
+pub const CheckerboardCapture = struct {
+    frame_index: u32 = 0,
+    /// Cell side in pixels. 32 = visible at thumbnail scale.
+    cell: u32 = 32,
+
+    pub fn frameCapture(self: *CheckerboardCapture) FrameCapture {
+        return .{
+            .capture_fn = captureImpl,
+            .ctx = @ptrCast(self),
+        };
+    }
+
+    fn captureImpl(ctx: *anyopaque, dst: []u8, width: u32, height: u32) anyerror!void {
+        const self: *CheckerboardCapture = @ptrCast(@alignCast(ctx));
+        const expected = @as(usize, width) * @as(usize, height) * 4;
+        if (dst.len < expected) return error.SizeMismatch;
+
+        // Light/dark alternates per `cell` pixels in both axes; the
+        // `frame_index` shifts the pattern so successive frames are
+        // distinguishable (catches "producer overwrote slot N with
+        // frame N+1's data while consumer was reading slot N").
+        const cell = self.cell;
+        const fi = self.frame_index;
+        var y: u32 = 0;
+        while (y < height) : (y += 1) {
+            var x: u32 = 0;
+            while (x < width) : (x += 1) {
+                const i: usize = (@as(usize, y) * @as(usize, width) + @as(usize, x)) * 4;
+                const cx = (x +% fi) / cell;
+                const cy = y / cell;
+                const lit = (cx +% cy) & 1 == 1;
+                // RGBA8: R, G, B, A. Light = white, dark = red-tinted
+                // so we can see the frame_index advance visually too.
+                dst[i + 0] = if (lit) 255 else 64; // R
+                dst[i + 1] = if (lit) 255 else 0; // G
+                dst[i + 2] = if (lit) 255 else 0; // B
+                dst[i + 3] = 255; // A
+            }
+        }
+
+        self.frame_index +%= 1;
+    }
+};

--- a/src/preview_mode.zig
+++ b/src/preview_mode.zig
@@ -311,6 +311,20 @@ pub const BinaryFrameKind = enum(u8) {
 /// wire traffic at ~4 Hz regardless of frame rate.
 pub const heartbeat_interval_ms: u64 = 250;
 
+/// Input event delivered from the editor's Game View tab to the
+/// headless game (labelle-assembler#143). The editor captures mouse
+/// activity over the IOSurface texture, converts to surface-space
+/// coords, and ships these as JSON over the existing control channel.
+/// The game's frame loop drains them via `popInputEvent` and forwards
+/// to whatever input sink it has (sokol_imgui's `add_*_event` for the
+/// imgui plugin; the engine's `backend_input` for game-side input).
+pub const InputEvent = union(enum) {
+    mouse_pos: struct { x: f32, y: f32 },
+    mouse_button: struct { button: i32, down: bool },
+};
+
+const input_queue_capacity: usize = 256;
+
 /// A (component_name, raw_bytes) pair for `emitEntitySnapshot`. Both
 /// slices are borrowed — they only need to outlive the snapshot call.
 pub const SnapshotComponent = struct {
@@ -477,6 +491,15 @@ pub const Preview = struct {
     /// Monotonic frame counter — bumped by `publishFrame` (or
     /// `publishFrameIOSurface`).
     frame_index: u64 = 0,
+    /// Fixed-capacity ring of input events parsed from editor → game
+    /// JSON frames (`mouse_pos`, `mouse_button`). The game drains via
+    /// `popInputEvent` each frame and forwards to its input sinks.
+    /// Overflow drops the oldest event — input lag is preferable to
+    /// allocator pressure on the producer hot path (#143).
+    input_buf: [input_queue_capacity]InputEvent = undefined,
+    input_head: usize = 0,
+    input_tail: usize = 0,
+    input_count: usize = 0,
 
     /// Dial the editor's listener. `host_port` is the literal string
     /// pulled from `--preview-mode <host:port>` — `127.0.0.1:54321`
@@ -1320,6 +1343,30 @@ pub const Preview = struct {
         return self.subscribed_pin_flows.contains(flow_name);
     }
 
+    /// Pop the next pending input event from the editor, or `null` when
+    /// the queue is empty. Game frame loops drain in a `while (...) |ev|`
+    /// loop after `pollSubscription` and forward each event to their
+    /// input sinks (e.g. sokol_imgui's `add_*_event` family). #143.
+    pub fn popInputEvent(self: *Preview) ?InputEvent {
+        if (self.input_count == 0) return null;
+        const ev = self.input_buf[self.input_head];
+        self.input_head = (self.input_head + 1) % input_queue_capacity;
+        self.input_count -= 1;
+        return ev;
+    }
+
+    fn pushInputEvent(self: *Preview, ev: InputEvent) void {
+        // Overflow policy: drop the oldest. Editors that hammer mouse_pos
+        // shouldn't be able to stall the producer by filling the ring.
+        if (self.input_count == input_queue_capacity) {
+            self.input_head = (self.input_head + 1) % input_queue_capacity;
+            self.input_count -= 1;
+        }
+        self.input_buf[self.input_tail] = ev;
+        self.input_tail = (self.input_tail + 1) % input_queue_capacity;
+        self.input_count += 1;
+    }
+
     /// Phase 3 (#534) entity-scope check. Returns `true` when the
     /// caller should emit for `entity_id`. The "empty set means watch
     /// everything" rule lives here so call sites stay free of policy.
@@ -1480,6 +1527,18 @@ pub const Preview = struct {
             if (self.frame_state == .offered) {
                 self.frame_state = .accepted;
             }
+        } else if (std.mem.eql(u8, kind_only.kind, "mouse_pos")) {
+            const Parsed = struct { kind: []const u8, x: f32, y: f32 };
+            const parsed = std.json.parseFromSliceLeaky(Parsed, alloc, line, .{
+                .ignore_unknown_fields = true,
+            }) catch return error.MalformedSubscription;
+            self.pushInputEvent(.{ .mouse_pos = .{ .x = parsed.x, .y = parsed.y } });
+        } else if (std.mem.eql(u8, kind_only.kind, "mouse_button")) {
+            const Parsed = struct { kind: []const u8, button: i32, down: bool };
+            const parsed = std.json.parseFromSliceLeaky(Parsed, alloc, line, .{
+                .ignore_unknown_fields = true,
+            }) catch return error.MalformedSubscription;
+            self.pushInputEvent(.{ .mouse_button = .{ .button = parsed.button, .down = parsed.down } });
         } else if (std.mem.eql(u8, kind_only.kind, "frame_resize")) {
             const Parsed = struct { kind: []const u8, width: u32, height: u32 };
             const parsed = std.json.parseFromSliceLeaky(Parsed, alloc, line, .{

--- a/src/root.zig
+++ b/src/root.zig
@@ -27,6 +27,7 @@ pub const sprite_by_field_tick_mod = @import("sprite_by_field_tick.zig");
 pub const atlas_mod = @import("atlas.zig");
 pub const assets_mod = @import("assets/mod.zig");
 pub const preview_mode_mod = @import("preview_mode.zig");
+pub const preview_capture_mod = @import("preview_capture.zig");
 pub const jsonc_mod = @import("jsonc");
 
 // ── Game ──

--- a/test/preview_capture_test.zig
+++ b/test/preview_capture_test.zig
@@ -104,3 +104,37 @@ test "publishFrame propagates capture errors" {
 
     try testing.expectError(error.SimulatedBackendFailure, preview_capture.publishFrame(&producer, fc, true));
 }
+
+test "publishFrame returns SizeMismatch when slot capacity shrinks below pixel bytes" {
+    const pid = std.c.getpid();
+    var name_buf: [64]u8 = undefined;
+    const name = try std.fmt.bufPrintZ(&name_buf, "/lbl-fctD-{d}", .{pid});
+
+    var producer = try preview_shm.Producer.init(name, .{
+        .width = 8,
+        .height = 4,
+        .ring_size = 2,
+    });
+    defer producer.deinit();
+
+    // Simulate header tampering / post-init opts drift: pretend the
+    // producer was reconfigured to a larger frame after the slot was
+    // already allocated for an 8x4 layout. publishFrame should refuse
+    // before invoking the backend.
+    producer.opts.width = 32;
+    producer.opts.height = 32;
+
+    // A capture that, if ever invoked, would let the test know we
+    // failed to short-circuit before reaching the backend.
+    const Tripwire = struct {
+        fn captureImpl(_: *anyopaque, _: []u8, _: u32, _: u32) anyerror!void {
+            return error.BackendShouldNotHaveBeenCalled;
+        }
+    };
+    const fc: preview_capture.FrameCapture = .{
+        .capture_fn = Tripwire.captureImpl,
+        .ctx = undefined,
+    };
+
+    try testing.expectError(preview_capture.PublishError.SizeMismatch, preview_capture.publishFrame(&producer, fc, true));
+}

--- a/test/preview_capture_test.zig
+++ b/test/preview_capture_test.zig
@@ -1,0 +1,106 @@
+//! Tests for the `FrameCapture` trait and the `publishFrame` orchestration
+//! in `src/preview_capture.zig`. Validates the backend-agnostic preview
+//! architecture end-to-end on the producer side — no real backend, no
+//! sokol, no GPU. The trait + producer chain alone should be enough to
+//! get correct pixels into the SHM ring.
+
+const std = @import("std");
+const engine = @import("engine");
+const preview_capture = engine.preview_capture_mod;
+const preview_shm = engine.preview_mode_mod.preview_shm;
+const testing = std.testing;
+
+test "publishFrame writes RGBA8 checkerboard into producer slot" {
+    // Real SHM region — names namespaced by PID + per-test tag so the
+    // three tests in this file don't collide within one `zig build test`.
+    const pid = std.c.getpid();
+    var name_buf: [64]u8 = undefined;
+    const name = try std.fmt.bufPrintZ(&name_buf, "/lbl-fctA-{d}", .{pid});
+
+    var producer = try preview_shm.Producer.init(name, .{
+        .width = 8,
+        .height = 4,
+        .ring_size = 2,
+    });
+    defer producer.deinit();
+
+    var checker: preview_capture.CheckerboardCapture = .{ .cell = 2 };
+    try preview_capture.publishFrame(&producer, checker.frameCapture(), true);
+
+    // Read slot 0 directly from the SHM region.
+    const header_size = @sizeOf(preview_shm.Header);
+    const slot0_pixels = producer.base[header_size .. header_size + 8 * 4 * 4];
+
+    // Pixel (0,0) at frame 0: cx=0, cy=0, parity 0 → DARK (red-tinted).
+    try testing.expectEqual(@as(u8, 64), slot0_pixels[0]);
+    try testing.expectEqual(@as(u8, 0), slot0_pixels[1]);
+    try testing.expectEqual(@as(u8, 0), slot0_pixels[2]);
+    try testing.expectEqual(@as(u8, 255), slot0_pixels[3]);
+
+    // Pixel (2,0): cx=1, cy=0, parity 1 → LIT (white).
+    const px20 = 2 * 4;
+    try testing.expectEqual(@as(u8, 255), slot0_pixels[px20 + 0]);
+    try testing.expectEqual(@as(u8, 255), slot0_pixels[px20 + 1]);
+    try testing.expectEqual(@as(u8, 255), slot0_pixels[px20 + 2]);
+
+    try testing.expectEqual(@as(u32, 1), checker.frame_index);
+}
+
+test "second publishFrame writes a shifted pattern into the next slot" {
+    const pid = std.c.getpid();
+    var name_buf: [64]u8 = undefined;
+    const name = try std.fmt.bufPrintZ(&name_buf, "/lbl-fctB-{d}", .{pid});
+
+    var producer = try preview_shm.Producer.init(name, .{
+        .width = 8,
+        .height = 4,
+        .ring_size = 2,
+    });
+    defer producer.deinit();
+
+    var checker: preview_capture.CheckerboardCapture = .{ .cell = 2 };
+    try preview_capture.publishFrame(&producer, checker.frameCapture(), true);
+    try preview_capture.publishFrame(&producer, checker.frameCapture(), true);
+
+    // Slot 0 → frame 0; slot 1 → frame 1 (frame_index shift).
+    //
+    // Pixel (1,0):
+    //   Frame 0: cx=(1+0)/2=0, cy=0 → DARK
+    //   Frame 1: cx=(1+1)/2=1, cy=0 → LIT
+    const header_size = @sizeOf(preview_shm.Header);
+    const slot_pixel_bytes: usize = 8 * 4 * 4;
+    const slot_size_in_shm: usize = @intCast(producer.header.slot_size);
+    const slot0_pixels = producer.base[header_size .. header_size + slot_pixel_bytes];
+    const slot1_pixels = producer.base[header_size + slot_size_in_shm .. header_size + slot_size_in_shm + slot_pixel_bytes];
+
+    try testing.expectEqual(@as(u8, 64), slot0_pixels[1 * 4 + 0]); // DARK
+    try testing.expectEqual(@as(u8, 255), slot1_pixels[1 * 4 + 0]); // LIT
+
+    try testing.expectEqual(@as(u32, 2), checker.frame_index);
+}
+
+test "publishFrame propagates capture errors" {
+    const pid = std.c.getpid();
+    var name_buf: [64]u8 = undefined;
+    const name = try std.fmt.bufPrintZ(&name_buf, "/lbl-fctC-{d}", .{pid});
+
+    var producer = try preview_shm.Producer.init(name, .{
+        .width = 4,
+        .height = 4,
+        .ring_size = 2,
+    });
+    defer producer.deinit();
+
+    // A FrameCapture that always errors — the engine has to surface it.
+    const FailingCapture = struct {
+        fn captureImpl(_: *anyopaque, _: []u8, _: u32, _: u32) anyerror!void {
+            return error.SimulatedBackendFailure;
+        }
+    };
+    const fc: preview_capture.FrameCapture = .{
+        .capture_fn = FailingCapture.captureImpl,
+        .ctx = undefined,
+    };
+
+    try testing.expectError(error.SimulatedBackendFailure, preview_capture.publishFrame(&producer, fc, true));
+}


### PR DESCRIPTION
Two preview-pipeline additions consumed by labelle-assembler's headless mode.

## 1. FrameCapture trait (#140)

`src/preview_capture.zig` adds a backend-agnostic trait the assembler uses to publish frames into shared memory / IOSurfaces without the engine knowing whether the producer is sokol-Metal, sokol-GL, raylib-PBO, etc. Replaces ~200 lines of inlined backend-specific code in the assembler's codegen template. Unit tests in `test/preview_capture_test.zig` (CheckerboardCapture).

## 2. InputEvent ring buffer (#143)

`Preview` now parses `mouse_pos` / `mouse_button` JSON frames from the editor and pushes onto a 256-slot fixed-capacity ring. Game frame loops drain via `popInputEvent` and forward to whatever input sink they have — for projects using the imgui sokol bridge, that's `simgui_add_*_event`. Overflow drops the oldest event so a hammering editor can't stall the producer.

## Companion PRs

- labelle-imgui#10 — sokol bridge with `SOKOL_IMGUI_NO_SOKOL_APP` + new `imgui_bridge_mouse_*` exports
- labelle-assembler#141 — drains `popInputEvent` in the per-frame codegen template
- labelle-gui#146 — Game View tab forwards mouse over the IOSurface to `Preview.sendMouse*`

End-to-end verified with red-ball-test: clicking the "Click me" button in the GUI's Game View now increments the on-screen counter.