### PR TITLE
fix(android): drop POSIX shm + glibc errno refs Bionic doesn't ship

### DIFF
--- a/src/preview_mode.zig
+++ b/src/preview_mode.zig
@@ -142,8 +142,14 @@ const socket_io = if (builtin.os.tag == .windows) struct {
     pub const c_fcntl = std.c.fcntl;
     extern "c" fn __error() *c_int; // macOS errno location
     extern "c" fn __errno_location() *c_int; // glibc errno location
+    extern "c" fn __errno() *c_int; // Bionic errno location (Android)
 
     pub fn errno() c_int {
+        // Bionic (Android) ships `__errno`, not `__errno_location`.
+        // Compile-time pick by ABI so the dead branch's extern ref is
+        // dropped by Zig's linker on each target.
+        const is_android = builtin.target.abi == .android or builtin.target.abi == .androideabi;
+        if (comptime is_android) return __errno().*;
         return if (builtin.os.tag == .macos) __error().* else __errno_location().*;
     }
 

--- a/src/preview_shm.zig
+++ b/src/preview_shm.zig
@@ -47,6 +47,16 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
+/// Bionic doesn't ship `shm_open` / `shm_unlink` — Android uses ashmem
+/// instead. `libgame.so` would otherwise fail to `dlopen` at runtime
+/// with `cannot locate symbol "shm_unlink"` on `NativeActivity.onCreate`.
+/// The preview pipeline (POSIX shm producer/consumer) is editor-side
+/// only — there is no in-process preview consumer on-device — so on
+/// Android we return `error.ShmOpenFailed` from every entry point and
+/// rely on Zig's comptime dead-code elimination to drop the linker
+/// references to `std.c.shm_*` entirely.
+const is_android_abi = builtin.target.abi == .android or builtin.target.abi == .androideabi;
+
 pub const PIXEL_FORMAT_RGBA8: u32 = 0x52474241; // 'RGBA'
 pub const MAGIC: u64 = 0x4C424C5052564653; // 'LBLPRVFS' — labelle preview frame stream
 pub const PROTOCOL_VERSION: u32 = 1;
@@ -282,7 +292,10 @@ const MappedRegion = struct {
 /// Create a new mapping (or open + resize an existing one on POSIX —
 /// the producer's create-or-reattach idiom).
 fn createMapping(name: [:0]const u8, total: u64) Error!MappedRegion {
-    if (builtin.os.tag == .windows) {
+    if (is_android_abi) {
+        // See top-of-file note on Bionic. Preview pipeline isn't reachable on-device.
+        return Error.ShmOpenFailed;
+    } else if (builtin.os.tag == .windows) {
         // The producer side. CreateFileMappingW with hFile=INVALID_HANDLE_VALUE
         // creates a section backed by the system paging file (i.e. shared
         // memory). Same name → existing section is reopened with the same
@@ -363,7 +376,9 @@ fn createMapping(name: [:0]const u8, total: u64) Error!MappedRegion {
 
 /// Open an existing mapping (consumer side).
 fn openMapping(name: [:0]const u8) Error!MappedRegion {
-    if (builtin.os.tag == .windows) {
+    if (is_android_abi) {
+        return Error.ShmOpenFailed;
+    } else if (builtin.os.tag == .windows) {
         const wname = windows.mappingNameFromPosix(std.heap.page_allocator, name) catch
             return Error.ShmOpenFailed;
         defer std.heap.page_allocator.free(wname);
@@ -452,6 +467,7 @@ fn unmapRegion(region: *const MappedRegion) void {
 /// Best-effort unlink (POSIX only — `shm_unlink` doesn't exist on
 /// Windows where section objects are reference-counted on the handle).
 fn unlinkName(name: [:0]const u8) void {
+    if (is_android_abi) return;
     if (builtin.os.tag == .windows) return;
     _ = std.c.shm_unlink(name.ptr);
 }


### PR DESCRIPTION
## Summary

`libgame.so` failed to `dlopen` on a connected Samsung Tab device with two sequential `cannot locate symbol` failures from Bionic's loader:

1. `dlopen failed: cannot locate symbol "shm_unlink" referenced by libgame.so` — `src/preview_shm.zig` uses POSIX `shm_open`/`shm_unlink` for the editor's Play-in-Editor pipeline. Bionic doesn't ship those (Android uses ashmem). The PIE consumer never runs on-device, so the right answer is to never link them.
2. `dlopen failed: cannot locate symbol "__errno_location" referenced by libgame.so` — `src/preview_mode.zig` declared its own `extern "c" fn __errno_location()` for the glibc errno thunk and called it for any non-macOS target. Bionic uses `__errno`. The stdlib already gets this right in `std.c._errno`'s switch (`.android, .androideabi => private.__errno`); only this local extern bypassed it.

## Fix

`preview_shm.zig`: add `is_android_abi` comptime guard at the top of `createMapping` / `openMapping` / `unlinkName`. Each entry point returns `Error.ShmOpenFailed` (or a no-op for `unlinkName`) on Android so Zig drops the dead branches and the `std.c.shm_*` extern references vanish from the object file.

`preview_mode.zig`: add an `extern "c" fn __errno()` declaration and branch on `builtin.target.abi == .android` in `errno()`. Same dead-code-elimination story — the linker only emits a reference to the right thunk per target.

## Verification

Local against `flying-platform-labelle` on Zig 0.16, after the existing Android PR stack (labelle-toolkit/labelle-assembler v0.27.0 + labelle-toolkit/labelle-imgui v0.5.0):

```
$ nm -D zig-out/lib/libgame.so | grep -iE 'shm_|errno'
                 U __errno@LIBC      # ← Bionic's symbol, present at runtime

$ labelle android run
labelle: app launched on device

$ adb shell dumpsys window | grep mCurrentFocus
mCurrentFocus=Window{... com.labelle.flying_platform/android.app.NativeActivity}
```

Screenshot confirms the full game renders on-device — sprite scene, worker characters, imgui Build menu (Production / Living / Infrastructure), construction tooltip, status overlay.

## Test plan

- [x] Desktop / WASM / iOS untouched (new branches only fire when `target.abi == .android` / `.androideabi`)
- [x] `libgame.so` `dlopen`s on a Samsung Tab device
- [x] Game runs end-to-end on the device with imgui rendering
- [ ] CI green