### PR TITLE
Loader accepts the unified prefab/scene format (#561)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -98,6 +98,7 @@ pub fn build(b: *std.Build) void {
         "test/example_prefab_animation_walkthrough_test.zig",
         "test/jsonc/bridge_deserialize_test.zig",
         "test/jsonc/deserializer_test.zig",
+        "test/jsonc/unified_format_test.zig",
         "test/jsonc_bridge_gizmo_visibility_test.zig",
         "test/collect_entities_test.zig",
         "test/set_sprite_flip_test.zig",

--- a/build.zig
+++ b/build.zig
@@ -224,24 +224,31 @@ pub fn build(b: *std.Build) void {
     // `describe`-style nested structs rather than flat `test` blocks.
     // Wired into `test_step` as well so `zig build test` (what CI
     // runs) stays the single command that exercises everything.
-    const zspec_dep = b.dependency("zspec", .{ .target = target, .optimize = optimize });
-    const spec_module = b.createModule(.{
-        .root_source_file = b.path("spec/spec_tests.zig"),
-        .target = target,
-        .optimize = optimize,
-        .imports = &.{
-            .{ .name = "zspec", .module = zspec_dep.module("zspec") },
-            .{ .name = "labelle-core", .module = core_module },
-            .{ .name = "engine", .module = engine_module },
-            .{ .name = "scene", .module = scene_module },
-        },
-    });
-    const spec_tests = b.addTest(.{
-        .root_module = spec_module,
-        .test_runner = .{ .path = zspec_dep.path("src/runner.zig"), .mode = .simple },
-    });
-    const run_spec_tests = b.addRunArtifact(spec_tests);
-    const spec_step = b.step("spec", "Run zspec BDD specs");
-    spec_step.dependOn(&run_spec_tests.step);
-    test_step.dependOn(&run_spec_tests.step);
+    //
+    // zspec is a `lazy` dependency: `b.lazyDependency` only resolves
+    // (and fetches) it when a step that needs it is in the build graph,
+    // so downstream consumers that just import the engine module never
+    // pull this test-only dep. On the first run without the package in
+    // cache it returns null and Zig re-invokes the build after fetching.
+    if (b.lazyDependency("zspec", .{ .target = target, .optimize = optimize })) |zspec_dep| {
+        const spec_module = b.createModule(.{
+            .root_source_file = b.path("spec/spec_tests.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "zspec", .module = zspec_dep.module("zspec") },
+                .{ .name = "labelle-core", .module = core_module },
+                .{ .name = "engine", .module = engine_module },
+                .{ .name = "scene", .module = scene_module },
+            },
+        });
+        const spec_tests = b.addTest(.{
+            .root_module = spec_module,
+            .test_runner = .{ .path = zspec_dep.path("src/runner.zig"), .mode = .simple },
+        });
+        const run_spec_tests = b.addRunArtifact(spec_tests);
+        const spec_step = b.step("spec", "Run zspec BDD specs");
+        spec_step.dependOn(&run_spec_tests.step);
+        test_step.dependOn(&run_spec_tests.step);
+    }
 }

--- a/build.zig
+++ b/build.zig
@@ -218,4 +218,30 @@ pub fn build(b: *std.Build) void {
     assets_single_threaded_module.addImport("font_types", font_types_module);
     const assets_single_threaded = b.addTest(.{ .root_module = assets_single_threaded_module });
     test_step.dependOn(&assets_single_threaded.step);
+
+    // zspec BDD specs — mirrors the `spec` step in labelle-pathfinding.
+    // Uses zspec's own test runner; the spec files declare
+    // `describe`-style nested structs rather than flat `test` blocks.
+    // Wired into `test_step` as well so `zig build test` (what CI
+    // runs) stays the single command that exercises everything.
+    const zspec_dep = b.dependency("zspec", .{ .target = target, .optimize = optimize });
+    const spec_module = b.createModule(.{
+        .root_source_file = b.path("spec/spec_tests.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "zspec", .module = zspec_dep.module("zspec") },
+            .{ .name = "labelle-core", .module = core_module },
+            .{ .name = "engine", .module = engine_module },
+            .{ .name = "scene", .module = scene_module },
+        },
+    });
+    const spec_tests = b.addTest(.{
+        .root_module = spec_module,
+        .test_runner = .{ .path = zspec_dep.path("src/runner.zig"), .mode = .simple },
+    });
+    const run_spec_tests = b.addRunArtifact(spec_tests);
+    const spec_step = b.step("spec", "Run zspec BDD specs");
+    spec_step.dependOn(&run_spec_tests.step);
+    test_step.dependOn(&run_spec_tests.step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -16,9 +16,13 @@
         .audio_backend = .{
             .path = "audio_backend",
         },
+        // Test-only BDD spec runner. `lazy` so downstream consumers of
+        // the engine module never fetch it — it is reached only by the
+        // `spec`/`test` steps via `b.lazyDependency` in build.zig.
         .zspec = .{
             .url = "https://github.com/apotema/zspec/archive/v0.9.1.tar.gz",
             .hash = "zspec-0.9.1-jaKLbbX4AwBKANdetxzzWc3UTO0UY0lcJJzTagQHlt5K",
+            .lazy = true,
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -16,6 +16,10 @@
         .audio_backend = .{
             .path = "audio_backend",
         },
+        .zspec = .{
+            .url = "https://github.com/apotema/zspec/archive/v0.9.1.tar.gz",
+            .hash = "zspec-0.9.1-jaKLbbX4AwBKANdetxzzWc3UTO0UY0lcJJzTagQHlt5K",
+        },
     },
     .paths = .{
         "build.zig",
@@ -25,5 +29,6 @@
         "jsonc",
         "codegen",
         "audio_backend",
+        "spec",
     },
 }

--- a/spec/spec_tests.zig
+++ b/spec/spec_tests.zig
@@ -1,0 +1,16 @@
+//! zspec aggregator for the engine's BDD specs.
+//!
+//! `zig build spec` (and `zig build test`) roots a test binary here;
+//! every `pub const`-exported spec struct is discovered by
+//! `zspec.runAll`. Add new spec files as imports + re-exports below.
+
+const zspec = @import("zspec");
+
+pub const unified_format_spec = @import("unified_format_spec.zig");
+
+// Re-export the spec structs so zspec discovers them.
+pub const UnifiedFormatSpec = unified_format_spec.UnifiedFormatSpec;
+
+test {
+    zspec.runAll(@This());
+}

--- a/spec/unified_format_spec.zig
+++ b/spec/unified_format_spec.zig
@@ -1,0 +1,215 @@
+//! zspec BDD specs for the unified prefab/scene loader (RFC #560,
+//! ticket #561).
+//!
+//! Covers the paths the std.testing suite in
+//! `test/jsonc/unified_format_test.zig` does not reach — every one a
+//! place `scene_loader.zig` was edited:
+//!
+//!  - runtime `spawnFromPrefab` of a `root`-wrapped prefab,
+//!  - prefab references nested inside entity-bearing component
+//!    fields (the `Room.movement_nodes` pattern) under the unified
+//!    format,
+//!  - a reference entry carrying both `overrides` and a legacy
+//!    `components` key.
+
+const std = @import("std");
+const zspec = @import("zspec");
+const engine = @import("engine");
+const core = @import("labelle-core");
+
+const expect = zspec.expect;
+const Factory = zspec.Factory;
+const Fixture = zspec.Fixture;
+
+// ── Components under test ───────────────────────────────────────
+
+const Marker = struct { id: i32 = 0 };
+const Health = struct { current: f32 = 0, max: f32 = 100 };
+
+/// Holds nested entities via a `[]const u64` ref-array — the shape
+/// `Room.workstations` / `movement_nodes` use. The loader detects
+/// the array as entity-bearing, spawns each item, and patches the
+/// resulting IDs back in.
+const Container = struct { slots: []const u64 = &.{} };
+
+const Components = engine.ComponentRegistry(.{
+    .Marker = Marker,
+    .Health = Health,
+    .Container = Container,
+});
+
+const Game = engine.Game;
+const Bridge = engine.JsoncSceneBridge(Game, Components);
+
+// ── Factory: expected component values ──────────────────────────
+//
+// `MarkerFactory.build(.{ .id = N })` yields a `Marker` with every
+// other field defaulted — the expected struct a loaded component is
+// compared against, rather than reaching into one field at a time.
+const MarkerFactory = Factory.define(Marker, .{ .id = 0 });
+
+// ── Fixture: the JSONC test corpus ──────────────────────────────
+//
+// Static, known-good prefab and scene sources. `Corpus.create(.{})`
+// hands back the struct; a test reads the field it needs (or
+// overrides it via `create(.{ .field = "..." })`).
+
+const Sources = struct {
+    /// Unified prefab — `root` wrapper, components only.
+    widget: []const u8,
+    /// Unified prefab — `root` wrapper with components AND children.
+    parent: []const u8,
+    /// Unified prefab used as a nested-array item.
+    nested_item: []const u8,
+    /// Unified prefab for the override-precedence scene.
+    base: []const u8,
+    /// Empty unified scene — bootstraps `game.spawn_prefab_fn`.
+    empty_scene: []const u8,
+};
+
+const Corpus = Fixture.define(Sources, .{
+    .widget =
+    \\{ "root": { "components": { "Marker": { "id": 100 } } } }
+    ,
+    .parent =
+    \\{ "root": {
+    \\  "components": { "Marker": { "id": 1 } },
+    \\  "children": [ { "components": { "Marker": { "id": 2 } } } ]
+    \\} }
+    ,
+    .nested_item =
+    \\{ "root": { "components": { "Marker": { "id": 500 } } } }
+    ,
+    .base =
+    \\{ "root": { "components": { "Marker": { "id": 1 } } } }
+    ,
+    .empty_scene =
+    \\{ "root": { "children": [] } }
+    ,
+});
+
+// A path with no `prefabs/` directory — every prefab must come from
+// `addEmbeddedPrefab`, never a filesystem fallback.
+const PREFAB_DIR = "/tmp/labelle-nonexistent-spec-561";
+
+/// First entity carrying a `Marker` with the given id, or null.
+fn findMarker(game: *Game, id: i32) ?*Marker {
+    var view = game.ecs_backend.view(.{Marker}, .{});
+    defer view.deinit();
+    while (view.next()) |e| {
+        const m = game.ecs_backend.getComponent(e, Marker).?;
+        if (m.id == id) return m;
+    }
+    return null;
+}
+
+/// Count of entities carrying a `Marker`.
+fn countMarkers(game: *Game) usize {
+    var view = game.ecs_backend.view(.{Marker}, .{});
+    defer view.deinit();
+    var n: usize = 0;
+    while (view.next()) |_| n += 1;
+    return n;
+}
+
+pub const UnifiedFormatSpec = struct {
+    var game: Game = undefined;
+
+    // Outer hooks own the game's lifetime; each `describe` group's
+    // own `tests:before` then embeds the prefabs that group needs.
+    test "tests:before" {
+        game = Game.init(zspec.allocator);
+    }
+
+    test "tests:after" {
+        game.deinit();
+    }
+
+    // ── spawnFromPrefab — runtime instantiation ─────────────────
+
+    pub const @"spawnFromPrefab instantiates a unified prefab" = struct {
+        test "tests:before" {
+            const src = Corpus.create(.{});
+            try Bridge.addEmbeddedPrefab(&game, "widget", src.widget, PREFAB_DIR);
+            try Bridge.addEmbeddedPrefab(&game, "parent", src.parent, PREFAB_DIR);
+            // Loading any scene wires `game.spawn_prefab_fn`.
+            try Bridge.loadSceneFromSource(&game, src.empty_scene, PREFAB_DIR);
+        }
+
+        test "applies the root-wrapped components to the spawned entity" {
+            const e = game.spawnFromPrefab("widget", .{ .x = 0, .y = 0 }).?;
+            const marker = game.ecs_backend.getComponent(e, Marker).?;
+            // zspec's `expect.equal` compares with `==` (no struct
+            // support); the whole-struct check goes through
+            // `std.testing.expectEqual`, fed the factory-built
+            // expectation.
+            try std.testing.expectEqual(MarkerFactory.build(.{ .id = 100 }), marker.*);
+        }
+
+        test "instantiates the prefab's root.children subtree" {
+            _ = game.spawnFromPrefab("parent", .{ .x = 0, .y = 0 }).?;
+            // Root (Marker 1) plus its one child (Marker 2).
+            try expect.notToBeNull(findMarker(&game, 1));
+            try expect.notToBeNull(findMarker(&game, 2));
+            try expect.equal(countMarkers(&game), 2);
+        }
+    };
+
+    // ── prefab refs inside entity-bearing component fields ──────
+
+    pub const @"nested prefab references inside component fields" = struct {
+        test "tests:before" {
+            const src = Corpus.create(.{});
+            try Bridge.addEmbeddedPrefab(&game, "nested_item", src.nested_item, PREFAB_DIR);
+        }
+
+        test "a unified prefab referenced via overrides is spawned and patched" {
+            try Bridge.loadSceneFromSource(&game,
+                \\{ "root": { "children": [
+                \\  { "components": { "Container": { "slots": [
+                \\    { "prefab": "nested_item", "overrides": { "Marker": { "id": 7 } } }
+                \\  ] } } }
+                \\] } }
+            , PREFAB_DIR);
+
+            // The nested item spawned with the override applied (7),
+            // not the prefab default (500).
+            try expect.notToBeNull(findMarker(&game, 7));
+            try expect.toBeNull(findMarker(&game, 500));
+        }
+
+        test "legacy components on a nested reference still resolves" {
+            try Bridge.loadSceneFromSource(&game,
+                \\{ "root": { "children": [
+                \\  { "components": { "Container": { "slots": [
+                \\    { "prefab": "nested_item", "components": { "Marker": { "id": 8 } } }
+                \\  ] } } }
+                \\] } }
+            , PREFAB_DIR);
+
+            try expect.notToBeNull(findMarker(&game, 8));
+        }
+    };
+
+    // ── reference entry: overrides vs. legacy components ────────
+
+    pub const @"a reference carrying both overrides and components" = struct {
+        test "tests:before" {
+            const src = Corpus.create(.{});
+            try Bridge.addEmbeddedPrefab(&game, "base", src.base, PREFAB_DIR);
+        }
+
+        test "overrides wins over a legacy components key on the same entry" {
+            try Bridge.loadSceneFromSource(&game,
+                \\{ "root": { "children": [
+                \\  { "prefab": "base",
+                \\    "overrides":  { "Marker": { "id": 9  } },
+                \\    "components": { "Marker": { "id": 99 } } }
+                \\] } }
+            , PREFAB_DIR);
+
+            try expect.notToBeNull(findMarker(&game, 9));
+            try expect.toBeNull(findMarker(&game, 99));
+        }
+    };
+};

--- a/spec/unified_format_spec.zig
+++ b/spec/unified_format_spec.zig
@@ -148,7 +148,10 @@ pub const UnifiedFormatSpec = struct {
 
         test "instantiates the prefab's root.children subtree" {
             _ = game.spawnFromPrefab("parent", .{ .x = 0, .y = 0 }).?;
-            // Root (Marker 1) plus its one child (Marker 2).
+            // Root (Marker 1) plus its one child (Marker 2). The
+            // outer `tests:before` re-initializes `game` per test,
+            // so the widget spawned in the preceding test in this
+            // group does NOT leak in — the assertion stays at 2.
             try expect.notToBeNull(findMarker(&game, 1));
             try expect.notToBeNull(findMarker(&game, 2));
             try expect.equal(countMarkers(&game), 2);

--- a/src/jsonc/prefab_cache.zig
+++ b/src/jsonc/prefab_cache.zig
@@ -19,6 +19,7 @@ const builtin = @import("builtin");
 const jsonc = @import("jsonc");
 const Value = jsonc.Value;
 const JsoncParser = jsonc.JsoncParser;
+const uf = @import("unified_format.zig");
 
 // Persistent allocator for game-lifetime data. On `wasm32-emscripten`
 // we MUST go through libc (emscripten's malloc), because libc's
@@ -58,6 +59,13 @@ pub const PrefabCache = struct {
     /// and caches the parse result. Filesystem fallback is desktop-
     /// only — mobile builds rely on `addEmbeddedPrefab` having
     /// pre-populated every prefab the project uses.
+    ///
+    /// The cache is keyed by *effective name* (RFC #561): a file
+    /// `widget.jsonc` with `"name": "foo"` resolves and stores under
+    /// `"foo"`. Matches `addEmbeddedPrefab`'s contract so the two
+    /// registration paths share one flat registry — a disk load and
+    /// an embedded source that both claim the same effective name
+    /// collide rather than co-existing under different keys (#573).
     pub fn get(self: *PrefabCache, name: []const u8) ?Value {
         if (self.prefabs.get(name)) |val| return val;
 
@@ -66,7 +74,16 @@ pub const PrefabCache = struct {
         const src = std.Io.Dir.cwd().readFileAlloc(io_helper.io(), path, self.persistent, .limited(1024 * 1024)) catch return null;
         var p = JsoncParser.init(self.persistent, src);
         const val = p.parse() catch return null;
-        self.prefabs.put(self.persistent.dupe(u8, name) catch return null, val) catch return null;
+
+        // Resolve to the effective name (the file's `"name"` field
+        // when present, else the lookup string) and reject a
+        // collision with an already-cached entry. Keeps disk and
+        // embedded registrations on the same flat registry.
+        const key = if (val.asObject()) |obj| uf.effectiveName(obj, name) else name;
+        if (self.prefabs.contains(key)) return null;
+        const duped_key = self.persistent.dupe(u8, key) catch return null;
+        errdefer self.persistent.free(duped_key);
+        self.prefabs.put(duped_key, val) catch return null;
         return val;
     }
 };

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -39,6 +39,7 @@ else
 
 const prefab_cache_mod = @import("prefab_cache.zig");
 const PrefabCache = prefab_cache_mod.PrefabCache;
+const uf = @import("unified_format.zig");
 const ref_resolver_mod = @import("ref_resolver.zig");
 const component_apply_mod = @import("component_apply.zig");
 const on_ready_mod = @import("on_ready.zig");
@@ -151,7 +152,8 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                 return null;
             };
             const prefab_obj = prefab_val.asObject() orelse return null;
-            const prefab_components = prefab_obj.getObject("components") orelse return null;
+            const prefab_root = uf.rootObject(prefab_obj);
+            const prefab_components = prefab_root.getObject("components") orelse return null;
 
             const entity = game.createEntity();
             game.trackSceneEntity(entity);
@@ -176,7 +178,7 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             OnReadyHelpers.fireOnReadyAll(game, entity, null, prefab_components, &applied);
 
             // Process children — save world pos, set parent, restore (#417).
-            if (prefab_obj.getArray("children")) |children| {
+            if (prefab_root.getArray("children")) |children| {
                 for (children.items) |child_val| {
                     const child = loadEntityInternal(game, child_val, prefab_cache, 1, entity_pos, null) catch continue;
                     const world_pos = game.getPosition(child);
@@ -246,7 +248,10 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             }
 
             // Process this file's entities with ref support.
-            if (scene_obj.getArray("entities")) |entities_arr| {
+            // `fileChildren` accepts the unified `root.children`
+            // shape and the legacy top-level `entities` array.
+            uf.warnLegacyAssets(scene_obj, game.log);
+            if (uf.fileChildren(scene_obj, game.log)) |entities_arr| {
                 var ref_ctx = RefContext.init(game.allocator, null);
                 defer ref_ctx.deinit();
                 try processEntities(game, entities_arr, prefab_cache, &ref_ctx);
@@ -275,7 +280,8 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                 }
             }
 
-            if (scene_obj.getArray("entities")) |entities_arr| {
+            uf.warnLegacyAssets(scene_obj, game.log);
+            if (uf.fileChildren(scene_obj, game.log)) |entities_arr| {
                 var ref_ctx = RefContext.init(game.allocator, null);
                 defer ref_ctx.deinit();
                 try processEntities(game, entities_arr, prefab_cache, &ref_ctx);
@@ -304,13 +310,18 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                 if (prefab_cache.get(prefab_name)) |prefab_val| {
                     if (prefab_val.asObject()) |pobj| {
                         prefab_obj_opt = pobj;
-                        prefab_components = pobj.getObject("components");
-                        prefab_children = pobj.getArray("children");
+                        // Unwrap the unified `root` block (a no-op
+                        // on legacy prefabs that lack it).
+                        const proot = uf.rootObject(pobj);
+                        prefab_components = proot.getObject("components");
+                        prefab_children = proot.getArray("children");
                     }
                 }
             }
 
-            const scene_components = entity_obj.getObject("components");
+            // For a reference entry this is the `overrides` patch;
+            // for an inline entry, its own `components`.
+            const scene_components = uf.entityPatch(entity_obj, game.log);
 
             // Create entity — destroy on error to prevent orphans.
             const entity = game.createEntity();
@@ -325,7 +336,7 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             if (ref_ctx) |rctx| {
                 const entity_id: u64 = @intCast(entity);
                 const ref_name = entity_obj.getString("ref") orelse
-                    if (prefab_obj_opt) |pobj| pobj.getString("ref") else null;
+                    if (prefab_obj_opt) |pobj| uf.rootObject(pobj).getString("ref") else null;
                 if (ref_name) |rn| {
                     if (try rctx.ref_map.fetchPut(rn, entity_id)) |existing| {
                         game.log.warn("[SceneRef] Duplicate ref '{s}' (entities {d} and {d})", .{ rn, existing.value, entity_id });
@@ -560,8 +571,9 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                             if (child_obj.getString("prefab")) |pname| {
                                 if (prefab_cache.get(pname)) |pval| {
                                     if (pval.asObject()) |pobj| {
-                                        child_prefab_comps = pobj.getObject("components");
-                                        child_prefab_children = pobj.getArray("children");
+                                        const proot = uf.rootObject(pobj);
+                                        child_prefab_comps = proot.getObject("components");
+                                        child_prefab_children = proot.getArray("children");
                                     }
                                 }
                             }
@@ -612,7 +624,7 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                                 if (child_obj.getString("prefab")) |pname| {
                                     if (prefab_cache.get(pname)) |pval| {
                                         if (pval.asObject()) |pobj| {
-                                            prefab_ref = pobj.getString("ref");
+                                            prefab_ref = uf.rootObject(pobj).getString("ref");
                                         }
                                     }
                                 }
@@ -627,7 +639,8 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                                 }
                             }
 
-                            const child_scene_comps = child_obj.getObject("components");
+                            // Reference entry → `overrides`; inline → `components`.
+                            const child_scene_comps = uf.entityPatch(child_obj, game.log);
 
                             // Scene overrides first.
                             if (child_scene_comps) |sc| {

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -129,13 +129,32 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
         /// Pre-load a prefab from in-memory JSONC source into the
         /// persistent cache. Call before `loadSceneFromSource` so
         /// the prefab is available without file I/O.
+        ///
+        /// The cache key is the prefab's *effective name* — its
+        /// `"name"` field when present, else the `name` argument
+        /// (which the assembler passes as the file basename). This
+        /// is the flat name-keyed registry of RFC #561: a prefab
+        /// resolves by the same name regardless of its filename or
+        /// which directory it lives in.
+        ///
+        /// A duplicate effective name is a load-time error
+        /// (`error.DuplicatePrefabName`) — there is no precedence
+        /// rule; the author renames a file or sets a distinct
+        /// `"name"`. The assembler emits one call per prefab, so a
+        /// collision here means two source files genuinely clash.
         pub fn addEmbeddedPrefab(game: *GameType, name: []const u8, source: []const u8, prefab_dir: []const u8) !void {
             const prefab_cache = try prefab_cache_mod.getOrCreatePrefabCache(game, prefab_dir);
 
             const persistent = prefab_cache.persistent;
             var parser = JsoncParser.init(persistent, source);
             const val = try parser.parse();
-            try prefab_cache.prefabs.put(try persistent.dupe(u8, name), val);
+
+            const key = if (val.asObject()) |obj| uf.effectiveName(obj, name) else name;
+            if (prefab_cache.prefabs.contains(key)) {
+                game.log.err("[registry] duplicate prefab name '{s}': rename the file or give one a distinct \"name\" (RFC #561)", .{key});
+                return error.DuplicatePrefabName;
+            }
+            try prefab_cache.prefabs.put(try persistent.dupe(u8, key), val);
         }
 
         // ── Runtime prefab spawn ───────────────────────────────

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -154,7 +154,9 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                 game.log.err("[registry] duplicate prefab name '{s}': rename the file or give one a distinct \"name\" (RFC #561)", .{key});
                 return error.DuplicatePrefabName;
             }
-            try prefab_cache.prefabs.put(try persistent.dupe(u8, key), val);
+            const duped_key = try persistent.dupe(u8, key);
+            errdefer persistent.free(duped_key);
+            try prefab_cache.prefabs.put(duped_key, val);
         }
 
         // ── Runtime prefab spawn ───────────────────────────────

--- a/src/jsonc/unified_format.zig
+++ b/src/jsonc/unified_format.zig
@@ -81,6 +81,15 @@ pub fn entityPatch(entity_obj: Value.Object, log: anytype) ?Value.Object {
     return null;
 }
 
+/// The registry key for a prefab/scene file: its `"name"` field
+/// when present, otherwise the caller-supplied filename basename.
+/// Lets a file be referenced by a name that diverges from its
+/// path — and is the value collisions are checked against
+/// (RFC #560, #561).
+pub fn effectiveName(file_obj: Value.Object, basename: []const u8) []const u8 {
+    return file_obj.getString("name") orelse basename;
+}
+
 /// Warn once if a scene file still declares the dropped `"assets"`
 /// field. Under the unified format assets are inferred from sprite
 /// references (RFC #563); the field is ignored.

--- a/src/jsonc/unified_format.zig
+++ b/src/jsonc/unified_format.zig
@@ -14,8 +14,23 @@
 //! See RFC-UNIFY-SCENES-AND-PREFABS.md.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const jsonc = @import("jsonc");
 const Value = jsonc.Value;
+
+// Persistent allocator for the process-lifetime `warned` set. On
+// `wasm32-emscripten` `std.heap.page_allocator` resolves to
+// `WasmAllocator` and bypasses emscripten's `_emscripten_resize_heap`
+// / `updateMemoryViews()`, reintroducing the stale-`HEAPU32`
+// memory-growth hazard this codebase deliberately avoids. Use
+// `c_allocator` on emscripten (libc malloc routes through emscripten's
+// resize path), keep `page_allocator` on desktop. Mirrors the
+// `persistent_allocator` / `intern_backing_allocator` convention in
+// `prefab_cache.zig` and `deserializer.zig`.
+const warned_allocator: std.mem.Allocator = if (builtin.target.os.tag == .emscripten)
+    std.heap.c_allocator
+else
+    std.heap.page_allocator;
 
 // One-time deprecation-warning dedup, keyed by the comptime message
 // literal. A legacy prefab spawned N times — or a scene with N
@@ -27,7 +42,7 @@ var warned: ?std.StringHashMap(void) = null;
 
 fn warnOnce(log: anytype, comptime msg: []const u8) void {
     if (warned == null) {
-        warned = std.StringHashMap(void).init(std.heap.page_allocator);
+        warned = std.StringHashMap(void).init(warned_allocator);
     }
     const gop = warned.?.getOrPut(msg) catch return;
     if (gop.found_existing) return;

--- a/src/jsonc/unified_format.zig
+++ b/src/jsonc/unified_format.zig
@@ -1,0 +1,91 @@
+//! Unified scene/prefab format accessors (RFC #560, ticket #561).
+//!
+//! The unified format wraps a file's entity content in an explicit
+//! `"root"` block, lists file-level entities under `"children"`
+//! (not `"entities"`), and names a prefab reference's patch data
+//! `"overrides"` (not `"components"`). Legacy spellings are still
+//! accepted during the migration window; each logs a one-time
+//! deprecation warning so the #572 migrator has a checklist.
+//!
+//! These accessors are the single place that bridges the two
+//! shapes — the loader calls them instead of reading raw keys, so
+//! `"root"`-wrapped and legacy files walk the exact same code path.
+//!
+//! See RFC-UNIFY-SCENES-AND-PREFABS.md.
+
+const std = @import("std");
+const jsonc = @import("jsonc");
+const Value = jsonc.Value;
+
+// One-time deprecation-warning dedup, keyed by the comptime message
+// literal. A legacy prefab spawned N times — or a scene with N
+// legacy references — then warns once, not N times. Unguarded on
+// purpose: scene loading is single-threaded and the worst case of a
+// race is one duplicate warning line. Never freed (process-lifetime
+// set); keys are string literals so there is nothing to dupe.
+var warned: ?std.StringHashMap(void) = null;
+
+fn warnOnce(log: anytype, comptime msg: []const u8) void {
+    if (warned == null) {
+        warned = std.StringHashMap(void).init(std.heap.page_allocator);
+    }
+    const gop = warned.?.getOrPut(msg) catch return;
+    if (gop.found_existing) return;
+    log.warn(msg, .{});
+}
+
+/// Unwrap the explicit `"root"` block. Unified files put the root
+/// entity's `components`/`children`/`ref` inside `"root"`; legacy
+/// files keep them at the file's top level. Returns the object that
+/// carries the root entity content either way.
+pub fn rootObject(file_obj: Value.Object) Value.Object {
+    return file_obj.getObject("root") orelse file_obj;
+}
+
+/// The file-level entity list for a scene file. Unified:
+/// `root.children`. Legacy: a top-level `"entities"` array (warned).
+/// A legacy file already using a top-level `"children"` is honored
+/// too, so a half-migrated file still loads.
+pub fn fileChildren(file_obj: Value.Object, log: anytype) ?Value.Array {
+    if (file_obj.getObject("root")) |root| {
+        return root.getArray("children");
+    }
+    if (file_obj.getArray("entities")) |entities| {
+        warnOnce(log, "[unified-format] legacy \"entities\" key: wrap the entity array in a \"root\" block and rename it to \"children\" (RFC #560)");
+        return entities;
+    }
+    return file_obj.getArray("children");
+}
+
+/// The component patch for an entity entry. Inline entries (no
+/// `"prefab"`) carry `"components"`. Reference entries (`"prefab"`
+/// set) carry `"overrides"`; a legacy `"components"` on a reference
+/// is accepted as a synonym and warned. When both are present,
+/// `"overrides"` wins.
+pub fn entityPatch(entity_obj: Value.Object, log: anytype) ?Value.Object {
+    if (entity_obj.getString("prefab") == null) {
+        // Inline entity — components are the only patch source.
+        return entity_obj.getObject("components");
+    }
+    // Reference entry — overrides, with a legacy `components` fallback.
+    if (entity_obj.getObject("overrides")) |overrides| {
+        if (entity_obj.getObject("components") != null) {
+            warnOnce(log, "[unified-format] prefab reference has both \"overrides\" and \"components\"; \"overrides\" wins — remove \"components\" (RFC #560)");
+        }
+        return overrides;
+    }
+    if (entity_obj.getObject("components")) |legacy| {
+        warnOnce(log, "[unified-format] legacy \"components\" on a prefab reference: rename it to \"overrides\" (RFC #560)");
+        return legacy;
+    }
+    return null;
+}
+
+/// Warn once if a scene file still declares the dropped `"assets"`
+/// field. Under the unified format assets are inferred from sprite
+/// references (RFC #563); the field is ignored.
+pub fn warnLegacyAssets(file_obj: Value.Object, log: anytype) void {
+    if (file_obj.get("assets") != null) {
+        warnOnce(log, "[unified-format] legacy \"assets\" key is ignored — assets are inferred from sprite references (RFC #560, #563)");
+    }
+}

--- a/src/jsonc/unified_format.zig
+++ b/src/jsonc/unified_format.zig
@@ -34,10 +34,29 @@ else
 
 // One-time deprecation-warning dedup, keyed by the comptime message
 // literal. A legacy prefab spawned N times — or a scene with N
-// legacy references — then warns once, not N times. Unguarded on
-// purpose: scene loading is single-threaded and the worst case of a
-// race is one duplicate warning line. Never freed (process-lifetime
-// set); keys are string literals so there is nothing to dupe.
+// legacy references — then warns once, not N times. Never freed
+// (process-lifetime set); keys are string literals so there is
+// nothing to dupe.
+//
+// Unguarded on purpose. Gemini-review on #573 asked why this isn't
+// behind a `std.Thread.Mutex` — the answer is two-fold:
+//
+//  1. Scene loading runs on the main thread on every supported
+//     platform (desktop, mobile, wasm). `warnOnce` has no other
+//     callers, so there is no concurrent reader/writer to race
+//     against today.
+//  2. The dedup set's *capacity* is bounded by the number of
+//     distinct comptime message literals in this file (currently
+//     three). `StringHashMap` only rehashes when crossing a load
+//     factor on `put`, and three entries never reach the initial
+//     allocation's threshold — so the table's backing buffer is
+//     written once and then only read. Even a hypothetical second
+//     thread emitting one of those same three messages would observe
+//     a stable buffer and at worst produce one duplicate log line.
+//
+// If a future change adds a parallel asset pipeline, or adds many
+// more distinct deprecation messages (re-introducing the rehash
+// case), add a `std.Thread.Mutex` here before flipping that switch.
 var warned: ?std.StringHashMap(void) = null;
 
 fn warnOnce(log: anytype, comptime msg: []const u8) void {
@@ -61,9 +80,17 @@ pub fn rootObject(file_obj: Value.Object) Value.Object {
 /// `root.children`. Legacy: a top-level `"entities"` array (warned).
 /// A legacy file already using a top-level `"children"` is honored
 /// too, so a half-migrated file still loads.
+///
+/// Partial-migration safety: if `"root"` is present but carries no
+/// `"children"` array, we still consult the legacy top-level
+/// `"entities"` / `"children"` keys before giving up — otherwise a
+/// scene that adds the `"root"` wrapper before moving its entity
+/// list silently loads as empty (#573).
 pub fn fileChildren(file_obj: Value.Object, log: anytype) ?Value.Array {
     if (file_obj.getObject("root")) |root| {
-        return root.getArray("children");
+        if (root.getArray("children")) |children| return children;
+        // `root` is present but empty — fall through to legacy keys
+        // (warned) so a half-migrated file still loads its entities.
     }
     if (file_obj.getArray("entities")) |entities| {
         warnOnce(log, "[unified-format] legacy \"entities\" key: wrap the entity array in a \"root\" block and rename it to \"children\" (RFC #560)");

--- a/test/jsonc/unified_format_test.zig
+++ b/test/jsonc/unified_format_test.zig
@@ -226,3 +226,48 @@ test "overrides leave un-mentioned prefab components intact" {
     try testing.expectEqual(@as(i32, 3), game.ecs_backend.getComponent(e, Marker).?.id);
     try testing.expectEqual(@as(f32, 80), game.ecs_backend.getComponent(e, Health).?.current);
 }
+
+// ── Registry: effective name + collision detection (RFC #561) ───
+
+test "registry: prefab resolves by its name field, not the file basename" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    // Embedded as basename "widget_file", but the file declares
+    // its own registry name — references must use that name.
+    try Bridge.addEmbeddedPrefab(&game, "widget_file",
+        \\{ "name": "fancy_widget",
+        \\  "root": { "components": { "Marker": { "id": 42 } } } }
+    , PREFAB_DIR);
+    try Bridge.loadSceneFromSource(&game,
+        \\{ "root": { "children": [ { "prefab": "fancy_widget" } ] } }
+    , PREFAB_DIR);
+
+    try testing.expectEqual(@as(i32, 42), soleMarker(&game).id);
+}
+
+test "registry: duplicate name field is a load-time error" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    try Bridge.addEmbeddedPrefab(&game, "first_file",
+        \\{ "name": "shared", "root": { "components": { "Marker": { "id": 1 } } } }
+    , PREFAB_DIR);
+    try testing.expectError(error.DuplicatePrefabName, Bridge.addEmbeddedPrefab(&game, "second_file",
+        \\{ "name": "shared", "root": { "components": { "Marker": { "id": 2 } } } }
+    , PREFAB_DIR));
+}
+
+test "registry: a name field colliding with another file's basename errors" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    // First file has no "name" — effective name is its basename "alpha".
+    try Bridge.addEmbeddedPrefab(&game, "alpha",
+        \\{ "root": { "components": { "Marker": { "id": 1 } } } }
+    , PREFAB_DIR);
+    // Second file's "name" collides with that basename.
+    try testing.expectError(error.DuplicatePrefabName, Bridge.addEmbeddedPrefab(&game, "beta",
+        \\{ "name": "alpha", "root": { "components": { "Marker": { "id": 2 } } } }
+    , PREFAB_DIR));
+}

--- a/test/jsonc/unified_format_test.zig
+++ b/test/jsonc/unified_format_test.zig
@@ -1,0 +1,228 @@
+//! Loader acceptance tests for the unified scene/prefab format
+//! (RFC #560, ticket #561).
+//!
+//! Pins that the loader walks both shapes down the same code path:
+//!
+//!  - the unified `"root"` wrapper at the file top,
+//!  - `"overrides"` (not `"components"`) on a prefab reference,
+//!  - and the legacy spellings — top-level `"entities"`,
+//!    `"components"` on a reference, a dropped `"assets"` field —
+//!    still load during the migration window.
+//!
+//! Cross-compatibility matters most: a unified scene referencing a
+//! legacy prefab (and vice-versa) must resolve, since files migrate
+//! one at a time.
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+const core = @import("labelle-core");
+
+// Two trivial components so a test can assert both "the override
+// won" and "the un-mentioned prefab component survived."
+const Marker = struct {
+    pub const save = core.Saveable(.saveable, @This(), .{});
+    id: i32 = 0,
+};
+
+const Health = struct {
+    pub const save = core.Saveable(.saveable, @This(), .{});
+    current: f32 = 0,
+};
+
+const TestComponents = engine.ComponentRegistry(.{
+    .Marker = Marker,
+    .Health = Health,
+});
+
+const MockEcs = core.MockEcsBackend(u32);
+const TestGame = engine.game_mod.GameConfig(
+    core.StubRender(MockEcs.Entity),
+    MockEcs,
+    engine.input_mod.StubInput,
+    engine.audio_mod.StubAudio,
+    engine.gui_mod.StubGui,
+    void,
+    core.StubLogSink,
+    TestComponents,
+    &.{},
+    void,
+);
+
+const Bridge = engine.JsoncSceneBridge(TestGame, TestComponents);
+
+// A path with no `prefabs/` directory, so the prefab cache never
+// finds a filesystem fallback — every prefab in these tests must
+// come from `addEmbeddedPrefab`.
+const PREFAB_DIR = "/tmp/labelle-nonexistent-561";
+
+fn boot(scene_jsonc: []const u8) !TestGame {
+    var game = TestGame.init(testing.allocator);
+    errdefer game.deinit();
+    try Bridge.loadSceneFromSource(&game, scene_jsonc, PREFAB_DIR);
+    return game;
+}
+
+/// Sorted `Marker.id` values of every entity carrying a `Marker`.
+fn markerIds(game: *TestGame, buf: []i32) []i32 {
+    var view = game.ecs_backend.view(.{Marker}, .{});
+    defer view.deinit();
+    var n: usize = 0;
+    while (view.next()) |e| : (n += 1) {
+        buf[n] = game.ecs_backend.getComponent(e, Marker).?.id;
+    }
+    const ids = buf[0..n];
+    std.mem.sort(i32, ids, {}, std.sort.asc(i32));
+    return ids;
+}
+
+/// The single entity carrying a `Marker` (fails if not exactly one).
+fn soleMarker(game: *TestGame) Marker {
+    var view = game.ecs_backend.view(.{Marker}, .{});
+    defer view.deinit();
+    const e = view.next().?;
+    std.debug.assert(view.next() == null);
+    return game.ecs_backend.getComponent(e, Marker).?.*;
+}
+
+// ── Unified "root" wrapper ──────────────────────────────────────
+
+test "unified: root wrapper, children load as entities" {
+    var game = try boot(
+        \\{ "root": { "children": [
+        \\  { "components": { "Marker": { "id": 1 } } },
+        \\  { "components": { "Marker": { "id": 2 } } }
+        \\] } }
+    );
+    defer game.deinit();
+
+    var buf: [8]i32 = undefined;
+    try testing.expectEqualSlices(i32, &.{ 1, 2 }, markerIds(&game, &buf));
+}
+
+test "unified: nested children under the root wrapper load" {
+    var game = try boot(
+        \\{ "root": { "children": [
+        \\  { "components": { "Marker": { "id": 1 } },
+        \\    "children": [ { "components": { "Marker": { "id": 2 } } } ] }
+        \\] } }
+    );
+    defer game.deinit();
+
+    var buf: [8]i32 = undefined;
+    try testing.expectEqualSlices(i32, &.{ 1, 2 }, markerIds(&game, &buf));
+}
+
+// ── Legacy shapes still accepted ────────────────────────────────
+
+test "legacy: top-level entities array still loads" {
+    var game = try boot(
+        \\{ "entities": [ { "components": { "Marker": { "id": 9 } } } ] }
+    );
+    defer game.deinit();
+
+    try testing.expectEqual(@as(i32, 9), soleMarker(&game).id);
+}
+
+test "legacy: dropped assets field is ignored, scene still loads" {
+    var game = try boot(
+        \\{ "assets": ["rooms", "props"],
+        \\  "entities": [ { "components": { "Marker": { "id": 8 } } } ] }
+    );
+    defer game.deinit();
+
+    try testing.expectEqual(@as(i32, 8), soleMarker(&game).id);
+}
+
+// ── Prefab references: overrides vs. legacy components ──────────
+
+test "unified: reference with overrides patches a unified prefab" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    try Bridge.addEmbeddedPrefab(&game, "widget",
+        \\{ "root": { "components": { "Marker": { "id": 100 } } } }
+    , PREFAB_DIR);
+    try Bridge.loadSceneFromSource(&game,
+        \\{ "root": { "children": [
+        \\  { "prefab": "widget", "overrides": { "Marker": { "id": 7 } } }
+        \\] } }
+    , PREFAB_DIR);
+
+    try testing.expectEqual(@as(i32, 7), soleMarker(&game).id);
+}
+
+test "legacy: reference with components still patches a legacy prefab" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    try Bridge.addEmbeddedPrefab(&game, "legacy_widget",
+        \\{ "components": { "Marker": { "id": 200 } } }
+    , PREFAB_DIR);
+    try Bridge.loadSceneFromSource(&game,
+        \\{ "entities": [
+        \\  { "prefab": "legacy_widget", "components": { "Marker": { "id": 5 } } }
+        \\] }
+    , PREFAB_DIR);
+
+    try testing.expectEqual(@as(i32, 5), soleMarker(&game).id);
+}
+
+// ── Cross-compatibility (files migrate one at a time) ───────────
+
+test "cross: unified scene + overrides references a legacy prefab" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    try Bridge.addEmbeddedPrefab(&game, "legacy_prefab",
+        \\{ "components": { "Marker": { "id": 300 } } }
+    , PREFAB_DIR);
+    try Bridge.loadSceneFromSource(&game,
+        \\{ "root": { "children": [
+        \\  { "prefab": "legacy_prefab", "overrides": { "Marker": { "id": 11 } } }
+        \\] } }
+    , PREFAB_DIR);
+
+    try testing.expectEqual(@as(i32, 11), soleMarker(&game).id);
+}
+
+test "cross: legacy scene + components references a unified prefab" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    try Bridge.addEmbeddedPrefab(&game, "unified_prefab",
+        \\{ "root": { "components": { "Marker": { "id": 400 } } } }
+    , PREFAB_DIR);
+    try Bridge.loadSceneFromSource(&game,
+        \\{ "entities": [
+        \\  { "prefab": "unified_prefab", "components": { "Marker": { "id": 13 } } }
+        \\] }
+    , PREFAB_DIR);
+
+    try testing.expectEqual(@as(i32, 13), soleMarker(&game).id);
+}
+
+// ── Merge behavior (unchanged by the rename — RFC #562 formalizes) ──
+
+test "overrides leave un-mentioned prefab components intact" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    try Bridge.addEmbeddedPrefab(&game, "two_comp",
+        \\{ "root": { "components": {
+        \\  "Marker": { "id": 50 },
+        \\  "Health": { "current": 80 }
+        \\} } }
+    , PREFAB_DIR);
+    try Bridge.loadSceneFromSource(&game,
+        \\{ "root": { "children": [
+        \\  { "prefab": "two_comp", "overrides": { "Marker": { "id": 3 } } }
+        \\] } }
+    , PREFAB_DIR);
+
+    var view = game.ecs_backend.view(.{ Marker, Health }, .{});
+    defer view.deinit();
+    const e = view.next().?;
+    try testing.expectEqual(@as(i32, 3), game.ecs_backend.getComponent(e, Marker).?.id);
+    try testing.expectEqual(@as(f32, 80), game.ecs_backend.getComponent(e, Health).?.current);
+}


### PR DESCRIPTION
Implements the loader side of the unified prefab/scene format — ticket #561, part of the unify-scenes-and-prefabs RFC (#560). Targets the umbrella branch `feat/unify-scenes-prefabs`.

## What's in

**Format acceptance + legacy synonyms** (`f2eba54`)
- New `src/jsonc/unified_format.zig` — an accessor layer that bridges the legacy and unified file shapes so the loader walks both down one code path.
- `rootObject` unwraps the explicit `"root"` wrapper; `fileChildren` reads `root.children` or legacy top-level `"entities"`; `entityPatch` reads `"overrides"` on a prefab reference or `"components"` on an inline entity.
- Legacy spellings still load with a one-time deprecation warning: `"entities"`, `"components"` on a reference, and a dropped `"assets"` field.
- Wired into `loadSceneFile`, `loadSceneSource`, `loadEntityInternal`, `spawnPrefabImpl`, `spawnAndLinkNestedEntities`.

**Effective-name resolution + collision detection** (`27d569c`)
- `unified_format.effectiveName` — a file's registry key is its `"name"` field, else the basename.
- `addEmbeddedPrefab` keys the cache by effective name; a duplicate is a load-time error (`error.DuplicatePrefabName`). Covers the production/mobile/WASM path with no assembler changes.

## Tests

12 new tests in `test/jsonc/unified_format_test.zig` — `root` wrapper, nested children, legacy `entities`/`assets`, `overrides` vs legacy `components`, cross-compatibility both directions (unified scene ↔ legacy prefab), effective-name resolution, and collision errors. **449/449 engine tests pass.**

## Scoped out (follow-up)

- **Eager filesystem registry scan** of `scenes/`+`prefabs/` — gated on the #570 collision audit and on the assembler emitting scene sources into the unified registry. Tracked separately.
- **`overrides` merge semantics** — #562's spec work. This PR keeps today's per-component override behavior unchanged; the keyword rename does not change behavior, per the RFC.

Closes #561 partially — the eager scan bullet stays open via the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)