### PR TITLE
Deep-merge semantics for prefab overrides (#562)

### DIFF
--- a/RFC-OVERRIDES-MERGE-RULES.md
+++ b/RFC-OVERRIDES-MERGE-RULES.md
@@ -1,0 +1,127 @@
+# RFC Addendum: `overrides` Merge Rules
+
+**Status:** Accepted
+**Resolves:** open question 3 of `RFC-UNIFY-SCENES-AND-PREFABS.md` (#560)
+**Ticket:** #562
+
+## Scope
+
+In the unified prefab/scene format, a **reference entry** instantiates an
+existing prefab and may patch it:
+
+```jsonc
+{ "prefab": "hydroponics", "overrides": { "Health": { "current": 30 } } }
+```
+
+`overrides` is a map of component-name → patch. This document specifies
+exactly how that patch combines with the referenced prefab's components.
+
+The rules apply **everywhere a reference entry can appear** — in a
+`children` array, and inside an entity-bearing component field (the
+`Room.movement_nodes` pattern). They do **not** apply to the runtime
+`game.spawnFromPrefab(name, pos)` path, which takes no overrides.
+
+## The rule, in one line
+
+`overrides` is a **deep merge** onto the referenced prefab's component
+set: objects merge recursively, arrays and scalars replace, and a
+component whose patch value is `null` is removed.
+
+## Per-case specification
+
+Let *prefab* be the referenced prefab's components and *ov* be the
+`overrides` map.
+
+### 1. Component in *prefab* only
+
+Kept verbatim.
+
+### 2. Component in *ov* only
+
+Added to the instance, exactly as written.
+
+### 3. Component in both — deep merge
+
+The component value is merged field by field:
+
+- A field present in *ov* **and** in *prefab*, both **objects** → merge
+  recurses into it.
+- A field present in *ov* and in *prefab*, not both objects → the *ov*
+  value **replaces** the *prefab* value.
+- A field present in *prefab* only → **kept**.
+- A field present in *ov* only → **added**.
+
+```jsonc
+// prefab    Box { "size": { "w": 1, "h": 2 }, "label_len": 5 }
+// override  Box { "size": { "w": 9 } }
+// result    Box { "size": { "w": 9, "h": 2 }, "label_len": 5 }
+//                          ^^^^^^  overridden
+//                                  ^^^^^^^ h, label_len inherited
+```
+
+A field the override omits keeps the prefab's value. This is the key
+change from the pre-#562 behavior, where a partial override of a
+component silently reset the unmentioned fields to their struct
+defaults.
+
+### 4. Arrays and scalars replace — no element merge
+
+When a field's value is an array (or a string, number, boolean), the
+override value replaces the prefab value outright. Arrays are **not**
+merged element-wise; there is no append, no index-merge.
+
+```jsonc
+// prefab    Tags { "values": [1, 2, 3] }
+// override  Tags { "values": [9] }
+// result    Tags { "values": [9] }
+```
+
+To extend a list, restate it in full. Element-wise list semantics were
+considered and rejected: they need a per-element identity (index? key?)
+that JSONC component data does not carry, and the failure mode (a
+silent wrong-length list) is worse than the verbosity of restating.
+
+### 5. Component removal — `"Name": null`
+
+A component whose override value is JSONC `null` is **removed** from
+the instance: it is neither applied nor does its `onReady` / `postLoad`
+hook fire. Sibling components are untouched.
+
+```jsonc
+// prefab    { "Marker": { "id": 99 }, "Health": { "current": 50 } }
+// override  { "Marker": null }
+// result    { "Health": { "current": 50 } }   // Marker dropped
+```
+
+Removing a component the prefab does not declare is a no-op. Removing
+`Position` simply means the instance keeps the engine's default
+position — `Position` is not a removable ECS component in the usual
+sense.
+
+`null` is only special at the **component** level (a top-level entry of
+`overrides`). Inside a component value, `null` is an ordinary field
+value: it sets an optional (`?T`) field to null and is otherwise
+deserialized normally.
+
+## Lifecycle parity
+
+A merged component fires its `onReady` / `postLoad` hook exactly once,
+the same as a non-overridden component. A removed component fires
+nothing. Entity-bearing fields (`[]const u64` ref-arrays such as
+`Room.movement_nodes`) survive the merge — overriding one field of a
+component does not drop the prefab's nested entities declared in
+another field; they still spawn.
+
+## Implementation
+
+- `unified_format.mergeValues(base, patch, arena)` — the recursive deep
+  merge over JSONC `Value` trees.
+- `unified_format.mergedOverride(prefab_components, key, override, arena)`
+  — picks the prefab's matching component and merges, or returns the
+  override as-is when the prefab has no such component.
+- The loader (`scene_loader.zig`) merges per component in
+  `loadEntityInternal` and `spawnAndLinkNestedEntities`, and skips a
+  `null` override (recording it so the prefab fallback and the
+  `onReady` pass skip it too).
+
+Coverage: `spec/override_merge_spec.zig`.

--- a/spec/override_merge_spec.zig
+++ b/spec/override_merge_spec.zig
@@ -1,0 +1,230 @@
+//! zspec BDD specs for `overrides` merge semantics (RFC #560,
+//! ticket #562).
+//!
+//! `overrides` on a prefab reference deep-merges onto the prefab's
+//! components:
+//!  - objects merge recursively — a field the override omits keeps
+//!    the prefab's value;
+//!  - arrays and scalars replace outright;
+//!  - a component whose override value is `null` is removed.
+//!
+//! See RFC-OVERRIDES-MERGE-RULES.md.
+
+const std = @import("std");
+const zspec = @import("zspec");
+const engine = @import("engine");
+
+const expect = zspec.expect;
+const Factory = zspec.Factory;
+const Fixture = zspec.Fixture;
+
+// ── Components under test ───────────────────────────────────────
+
+const Marker = struct { id: i32 = 0 };
+const Health = struct { current: f32 = 0, max: f32 = 100 };
+
+/// Nested struct — exercises recursive object merge.
+const Size = struct { w: f32 = 0, h: f32 = 0 };
+const Box = struct { size: Size = .{}, label_len: i32 = 0 };
+
+/// Plain (non-entity) slice field — exercises array replacement.
+const Tags = struct { values: []const i32 = &.{} };
+
+/// Entity-bearing `slots` plus a scalar `tag` — exercises a
+/// deep-merged component keeping its prefab's nested entities.
+const Container = struct { slots: []const u64 = &.{}, tag: i32 = 0 };
+
+const Components = engine.ComponentRegistry(.{
+    .Marker = Marker,
+    .Health = Health,
+    .Box = Box,
+    .Tags = Tags,
+    .Container = Container,
+});
+
+const Game = engine.Game;
+const Bridge = engine.JsoncSceneBridge(Game, Components);
+
+const HealthFactory = Factory.define(Health, .{ .current = 0, .max = 100 });
+
+// ── Fixture: prefab corpus ──────────────────────────────────────
+
+const Sources = struct {
+    /// Two-field component — for field-level inheritance.
+    health: []const u8,
+    /// Nested struct + scalar — for recursive merge.
+    box: []const u8,
+    /// Plain slice field — for array replacement.
+    tags: []const u8,
+    /// Two components — for removal + sibling survival.
+    pair: []const u8,
+    /// Entity-bearing `slots` + scalar — for merged-component
+    /// nested-entity survival.
+    container: []const u8,
+};
+
+const Corpus = Fixture.define(Sources, .{
+    .health =
+    \\{ "root": { "components": { "Health": { "current": 80, "max": 100 } } } }
+    ,
+    .box =
+    \\{ "root": { "components": {
+    \\  "Box": { "size": { "w": 1, "h": 2 }, "label_len": 5 }
+    \\} } }
+    ,
+    .tags =
+    \\{ "root": { "components": { "Tags": { "values": [1, 2, 3] } } } }
+    ,
+    .pair =
+    \\{ "root": { "components": {
+    \\  "Marker": { "id": 99 },
+    \\  "Health": { "current": 50, "max": 70 }
+    \\} } }
+    ,
+    .container =
+    \\{ "root": { "components": {
+    \\  "Marker": { "id": 99 },
+    \\  "Container": { "tag": 1, "slots": [
+    \\    { "components": { "Marker": { "id": 1 } } }
+    \\  ] }
+    \\} } }
+    ,
+});
+
+const PREFAB_DIR = "/tmp/labelle-nonexistent-spec-562";
+
+/// The sole entity carrying component `T` (asserts exactly one).
+fn sole(game: *Game, comptime T: type) *T {
+    var view = game.ecs_backend.view(.{T}, .{});
+    defer view.deinit();
+    const e = view.next().?;
+    std.debug.assert(view.next() == null);
+    return game.ecs_backend.getComponent(e, T).?;
+}
+
+/// First entity carrying a `Marker` with the given id, or null.
+fn findMarker(game: *Game, id: i32) ?*Marker {
+    var view = game.ecs_backend.view(.{Marker}, .{});
+    defer view.deinit();
+    while (view.next()) |e| {
+        const m = game.ecs_backend.getComponent(e, Marker).?;
+        if (m.id == id) return m;
+    }
+    return null;
+}
+
+pub const OverrideMergeSpec = struct {
+    var game: Game = undefined;
+
+    test "tests:before" {
+        game = Game.init(zspec.allocator);
+    }
+
+    test "tests:after" {
+        game.deinit();
+    }
+
+    // ── Deep field-level merge ──────────────────────────────────
+
+    pub const @"a component named in overrides deep-merges over the prefab" = struct {
+        test "tests:before" {
+            const src = Corpus.create(.{});
+            try Bridge.addEmbeddedPrefab(&game, "health", src.health, PREFAB_DIR);
+            try Bridge.addEmbeddedPrefab(&game, "box", src.box, PREFAB_DIR);
+            try Bridge.addEmbeddedPrefab(&game, "tags", src.tags, PREFAB_DIR);
+        }
+
+        test "a field the override omits keeps the prefab's value" {
+            try Bridge.loadSceneFromSource(&game,
+                \\{ "root": { "children": [
+                \\  { "prefab": "health", "overrides": { "Health": { "current": 30 } } }
+                \\] } }
+            , PREFAB_DIR);
+            // current overridden; max inherited from the prefab.
+            try std.testing.expectEqual(
+                HealthFactory.build(.{ .current = 30, .max = 100 }),
+                sole(&game, Health).*,
+            );
+        }
+
+        test "merge recurses into nested struct fields" {
+            try Bridge.loadSceneFromSource(&game,
+                \\{ "root": { "children": [
+                \\  { "prefab": "box", "overrides": { "Box": { "size": { "w": 9 } } } }
+                \\] } }
+            , PREFAB_DIR);
+            const box = sole(&game, Box);
+            // size.w overridden; size.h and label_len inherited.
+            try expect.equal(box.size.w, 9);
+            try expect.equal(box.size.h, 2);
+            try expect.equal(box.label_len, 5);
+        }
+
+        test "an array field is replaced outright, not element-merged" {
+            try Bridge.loadSceneFromSource(&game,
+                \\{ "root": { "children": [
+                \\  { "prefab": "tags", "overrides": { "Tags": { "values": [9] } } }
+                \\] } }
+            , PREFAB_DIR);
+            const tags = sole(&game, Tags);
+            try expect.equal(tags.values.len, 1);
+            try expect.equal(tags.values[0], 9);
+        }
+    };
+
+    // ── Component removal via null ──────────────────────────────
+
+    pub const @"a null override removes a component" = struct {
+        test "tests:before" {
+            const src = Corpus.create(.{});
+            try Bridge.addEmbeddedPrefab(&game, "pair", src.pair, PREFAB_DIR);
+        }
+
+        test "the named component is dropped from the instance" {
+            try Bridge.loadSceneFromSource(&game,
+                \\{ "root": { "children": [
+                \\  { "prefab": "pair", "overrides": { "Marker": null } }
+                \\] } }
+            , PREFAB_DIR);
+            var view = game.ecs_backend.view(.{Health}, .{});
+            defer view.deinit();
+            const e = view.next().?;
+            try expect.toBeNull(game.ecs_backend.getComponent(e, Marker));
+        }
+
+        test "sibling components the override leaves alone survive" {
+            try Bridge.loadSceneFromSource(&game,
+                \\{ "root": { "children": [
+                \\  { "prefab": "pair", "overrides": { "Marker": null } }
+                \\] } }
+            , PREFAB_DIR);
+            // Health untouched — kept verbatim from the prefab.
+            try std.testing.expectEqual(
+                HealthFactory.build(.{ .current = 50, .max = 70 }),
+                sole(&game, Health).*,
+            );
+        }
+    };
+
+    // ── Merged component keeps its prefab's entity fields ───────
+
+    pub const @"deep-merging a component preserves its entity-bearing fields" = struct {
+        test "tests:before" {
+            const src = Corpus.create(.{});
+            try Bridge.addEmbeddedPrefab(&game, "container", src.container, PREFAB_DIR);
+        }
+
+        test "overriding one field still spawns the prefab's nested entities" {
+            try Bridge.loadSceneFromSource(&game,
+                \\{ "root": { "children": [
+                \\  { "prefab": "container", "overrides": { "Container": { "tag": 5 } } }
+                \\] } }
+            , PREFAB_DIR);
+            // tag patched; slots inherited from the prefab, so its
+            // nested Marker entity must still spawn.
+            try expect.equal(sole(&game, Container).tag, 5);
+            try expect.notToBeNull(findMarker(&game, 1)); // nested entity
+            try expect.notToBeNull(findMarker(&game, 99)); // root entity
+        }
+    };
+};

--- a/spec/override_merge_spec.zig
+++ b/spec/override_merge_spec.zig
@@ -206,6 +206,31 @@ pub const OverrideMergeSpec = struct {
         }
     };
 
+    // ── `null` is removal only for a reference's overrides ──────
+
+    pub const @"a null in an inline entity's components is not a removal" = struct {
+        // No prefab registered — these are pure inline entities
+        // (no `prefab` key), so their `components` block is not an
+        // `overrides` block and carries no removal semantics.
+
+        test "a null component does not suppress sibling inline components" {
+            // RFC #562 scopes `null`-as-removal to a reference
+            // entry's `overrides`. An inline `components` `null` is
+            // just a (malformed) value — it must not delete the
+            // entity or silence its other components.
+            try Bridge.loadSceneFromSource(&game,
+                \\{ "root": { "children": [
+                \\  { "components": { "Marker": null, "Health": { "current": 7, "max": 9 } } }
+                \\] } }
+            , PREFAB_DIR);
+            // The sibling Health component still applies normally.
+            try std.testing.expectEqual(
+                HealthFactory.build(.{ .current = 7, .max = 9 }),
+                sole(&game, Health).*,
+            );
+        }
+    };
+
     // ── Merged component keeps its prefab's entity fields ───────
 
     pub const @"deep-merging a component preserves its entity-bearing fields" = struct {

--- a/spec/spec_tests.zig
+++ b/spec/spec_tests.zig
@@ -7,9 +7,11 @@
 const zspec = @import("zspec");
 
 pub const unified_format_spec = @import("unified_format_spec.zig");
+pub const override_merge_spec = @import("override_merge_spec.zig");
 
 // Re-export the spec structs so zspec discovers them.
 pub const UnifiedFormatSpec = unified_format_spec.UnifiedFormatSpec;
+pub const OverrideMergeSpec = override_merge_spec.OverrideMergeSpec;
 
 test {
     zspec.runAll(@This());

--- a/src/jsonc/on_ready.zig
+++ b/src/jsonc/on_ready.zig
@@ -42,6 +42,10 @@ pub fn OnReady(comptime GameType: type, comptime Components: type) type {
         ) void {
             if (scene_components) |sc| {
                 for (sc.entries) |entry| {
+                    // A `null` override removes the component
+                    // (RFC #562) — nothing was applied, so fire no
+                    // hook for it.
+                    if (entry.value == .null_value) continue;
                     fireOnReadyByName(game, entity, entry.key);
                 }
             }

--- a/src/jsonc/on_ready.zig
+++ b/src/jsonc/on_ready.zig
@@ -14,7 +14,7 @@
 //! Callers instantiate once per bridge type:
 //!
 //!     const Hooks = OnReady(GameType, Components);
-//!     Hooks.fireOnReadyAll(game, entity, scene_components, prefab_components, &applied);
+//!     Hooks.fireOnReadyAll(game, entity, scene_components, prefab_components, &applied, is_reference);
 //!     Hooks.patchEntityIdField(game, parent, "Workstation", "storages", ids);
 
 const std = @import("std");
@@ -33,19 +33,28 @@ pub fn OnReady(comptime GameType: type, comptime Components: type) type {
         /// then the prefab block skips anything already handled) so
         /// hooks see exactly one fire per component, regardless of
         /// where the component originated.
+        ///
+        /// `is_reference` is true when `scene_components` is a
+        /// prefab reference's `overrides` block. Only then does a
+        /// `null` value mean component removal (RFC #562). For an
+        /// inline entity's `components` a `null` has no removal
+        /// semantics, so its hook must still fire.
         pub fn fireOnReadyAll(
             game: *GameType,
             entity: Entity,
             scene_components: ?Value.Object,
             prefab_components: ?Value.Object,
             applied: *std.StringHashMap(void),
+            is_reference: bool,
         ) void {
             if (scene_components) |sc| {
                 for (sc.entries) |entry| {
                     // A `null` override removes the component
                     // (RFC #562) — nothing was applied, so fire no
-                    // hook for it.
-                    if (entry.value == .null_value) continue;
+                    // hook for it. Removal is scoped to reference
+                    // entries' `overrides`; an inline `components`
+                    // `null` is not a removal and still fires.
+                    if (is_reference and entry.value == .null_value) continue;
                     fireOnReadyByName(game, entity, entry.key);
                 }
             }

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -363,22 +363,36 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                 }
             }
 
-            // Build merged component map: prefab defaults, then
-            // scene overrides.
+            // Build the entity's component set: prefab defaults
+            // patched by the reference entry's `overrides`. An
+            // override deep-merges onto the prefab's same-named
+            // component — patching only the fields it names — and a
+            // `null` override removes the component (RFC #562).
+            //
+            // The merge tree lives in `merge_arena`; its leaf
+            // strings are shared with the prefab/override inputs, so
+            // `@ref` names collected from a merged component stay
+            // valid into the pass-2 patch even after the arena frees.
+            var merge_arena = std.heap.ArenaAllocator.init(game.allocator);
+            defer merge_arena.deinit();
+
+            // `applied` records every override key — including
+            // `null` removals — so the prefab blocks below skip them.
             var applied = std.StringHashMap(void).init(game.allocator);
             defer applied.deinit();
 
-            // Apply scene components (these override prefab
-            // defaults).
+            // Apply scene/override components, each deep-merged over
+            // the prefab's matching component.
             if (scene_components) |sc| {
                 for (sc.entries) |entry| {
-                    try ApplyHelpers.applyComponentWithRefs(game, entity, entry.key, entry.value, parent_offset, ref_ctx);
                     try applied.put(entry.key, {});
+                    if (entry.value == .null_value) continue; // removal
+                    const effective = uf.mergedOverride(prefab_components, entry.key, entry.value, merge_arena.allocator());
+                    try ApplyHelpers.applyComponentWithRefs(game, entity, entry.key, effective, parent_offset, ref_ctx);
                 }
             }
 
-            // Apply prefab components (skip if already overridden
-            // by scene).
+            // Apply prefab components the override did not touch.
             if (prefab_components) |pc| {
                 for (pc.entries) |entry| {
                     if (!applied.contains(entry.key)) {
@@ -392,10 +406,15 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             const entity_pos = game.getPosition(entity);
 
             // Spawn nested entity arrays and collect IDs to patch
-            // back into components.
+            // back into components. Override components use the same
+            // merged value as the apply pass — a deep-merged
+            // component keeps the prefab's entity-bearing fields, so
+            // their nested entities must still spawn.
             if (scene_components) |sc| {
                 for (sc.entries) |entry| {
-                    spawnAndLinkNestedEntities(game, entity, entry.key, entry.value, entity_pos, prefab_cache, depth, ref_ctx);
+                    if (entry.value == .null_value) continue;
+                    const effective = uf.mergedOverride(prefab_components, entry.key, entry.value, merge_arena.allocator());
+                    spawnAndLinkNestedEntities(game, entity, entry.key, effective, entity_pos, prefab_cache, depth, ref_ctx);
                 }
             }
             if (prefab_components) |pc| {
@@ -561,6 +580,11 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
         ) void {
             const obj = comp_value.asObject() orelse return;
 
+            // Arena for deep-merged override component values
+            // (RFC #562) — mirrors the block in `loadEntityInternal`.
+            var merge_arena = std.heap.ArenaAllocator.init(game.allocator);
+            defer merge_arena.deinit();
+
             for (obj.entries) |entry| {
                 const arr = entry.value.asArray() orelse continue;
 
@@ -661,10 +685,14 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                             // Reference entry → `overrides`; inline → `components`.
                             const child_scene_comps = uf.entityPatch(child_obj, game.log);
 
-                            // Scene overrides first.
+                            // Override components first, each
+                            // deep-merged over the prefab's match;
+                            // a `null` override removes it (#562).
                             if (child_scene_comps) |sc| {
                                 for (sc.entries) |e| {
-                                    ApplyHelpers.applyComponentWithRefs(game, child, e.key, e.value, parent_world_pos, nested_ref_ctx) catch |err| {
+                                    if (e.value == .null_value) continue;
+                                    const effective = uf.mergedOverride(child_prefab_comps, e.key, e.value, merge_arena.allocator());
+                                    ApplyHelpers.applyComponentWithRefs(game, child, e.key, effective, parent_world_pos, nested_ref_ctx) catch |err| {
                                         game.log.err("[NestedEntity] Failed to apply {s}: {s}", .{ e.key, @errorName(err) });
                                     };
                                 }
@@ -691,7 +719,9 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                             const child_pos = game.getPosition(child);
                             if (child_scene_comps) |sc| {
                                 for (sc.entries) |e| {
-                                    spawnAndLinkNestedEntities(game, child, e.key, e.value, child_pos, prefab_cache, depth + 1, nested_ref_ctx);
+                                    if (e.value == .null_value) continue;
+                                    const effective = uf.mergedOverride(child_prefab_comps, e.key, e.value, merge_arena.allocator());
+                                    spawnAndLinkNestedEntities(game, child, e.key, effective, child_pos, prefab_cache, depth + 1, nested_ref_ctx);
                                 }
                             }
                             if (child_prefab_comps) |pc| {

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -194,7 +194,9 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             // Fire onReady hooks.
             var applied = std.StringHashMap(void).init(game.allocator);
             defer applied.deinit();
-            OnReadyHelpers.fireOnReadyAll(game, entity, null, prefab_components, &applied);
+            // No scene/override components here — `is_reference` is
+            // moot (the scene loop is skipped on a null block).
+            OnReadyHelpers.fireOnReadyAll(game, entity, null, prefab_components, &applied, false);
 
             // Process children — save world pos, set parent, restore (#417).
             if (prefab_root.getArray("children")) |children| {
@@ -342,6 +344,11 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             // for an inline entry, its own `components`.
             const scene_components = uf.entityPatch(entity_obj, game.log);
 
+            // `null`-as-removal is scoped to reference entries'
+            // `overrides` (RFC #562) — an inline entity's
+            // `components` have no removal semantics.
+            const is_reference = entity_obj.getString("prefab") != null;
+
             // Create entity — destroy on error to prevent orphans.
             const entity = game.createEntity();
             game.trackSceneEntity(entity);
@@ -386,8 +393,13 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             if (scene_components) |sc| {
                 for (sc.entries) |entry| {
                     try applied.put(entry.key, {});
-                    if (entry.value == .null_value) continue; // removal
-                    const effective = uf.mergedOverride(prefab_components, entry.key, entry.value, merge_arena.allocator());
+                    // A `null` override removes a component, but only
+                    // for a reference entry's `overrides`. An inline
+                    // entity's `components` carry no removal meaning
+                    // — a `null` there is just a (likely malformed)
+                    // value, not a deletion.
+                    if (is_reference and entry.value == .null_value) continue; // removal
+                    const effective = try uf.mergedOverride(prefab_components, entry.key, entry.value, merge_arena.allocator());
                     try ApplyHelpers.applyComponentWithRefs(game, entity, entry.key, effective, parent_offset, ref_ctx);
                 }
             }
@@ -412,8 +424,8 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             // their nested entities must still spawn.
             if (scene_components) |sc| {
                 for (sc.entries) |entry| {
-                    if (entry.value == .null_value) continue;
-                    const effective = uf.mergedOverride(prefab_components, entry.key, entry.value, merge_arena.allocator());
+                    if (is_reference and entry.value == .null_value) continue;
+                    const effective = try uf.mergedOverride(prefab_components, entry.key, entry.value, merge_arena.allocator());
                     spawnAndLinkNestedEntities(game, entity, entry.key, effective, entity_pos, prefab_cache, depth, ref_ctx);
                 }
             }
@@ -427,7 +439,7 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
 
             // Fire onReady for all applied components (after entity
             // is fully assembled).
-            OnReadyHelpers.fireOnReadyAll(game, entity, scene_components, prefab_components, &applied);
+            OnReadyHelpers.fireOnReadyAll(game, entity, scene_components, prefab_components, &applied, is_reference);
 
             // Process children recursively (prefab children +
             // entity-level children).
@@ -685,13 +697,23 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                             // Reference entry → `overrides`; inline → `components`.
                             const child_scene_comps = uf.entityPatch(child_obj, game.log);
 
+                            // `null`-as-removal is scoped to a
+                            // reference entry's `overrides` (RFC #562).
+                            const child_is_reference = child_obj.getString("prefab") != null;
+
                             // Override components first, each
                             // deep-merged over the prefab's match;
                             // a `null` override removes it (#562).
                             if (child_scene_comps) |sc| {
                                 for (sc.entries) |e| {
-                                    if (e.value == .null_value) continue;
-                                    const effective = uf.mergedOverride(child_prefab_comps, e.key, e.value, merge_arena.allocator());
+                                    // `null`-as-removal applies only
+                                    // to a reference entry's
+                                    // `overrides` (RFC #562).
+                                    if (child_is_reference and e.value == .null_value) continue;
+                                    const effective = uf.mergedOverride(child_prefab_comps, e.key, e.value, merge_arena.allocator()) catch |err| {
+                                        game.log.err("[NestedEntity] Failed to merge override {s}: {s}", .{ e.key, @errorName(err) });
+                                        continue;
+                                    };
                                     ApplyHelpers.applyComponentWithRefs(game, child, e.key, effective, parent_world_pos, nested_ref_ctx) catch |err| {
                                         game.log.err("[NestedEntity] Failed to apply {s}: {s}", .{ e.key, @errorName(err) });
                                     };
@@ -719,8 +741,11 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                             const child_pos = game.getPosition(child);
                             if (child_scene_comps) |sc| {
                                 for (sc.entries) |e| {
-                                    if (e.value == .null_value) continue;
-                                    const effective = uf.mergedOverride(child_prefab_comps, e.key, e.value, merge_arena.allocator());
+                                    if (child_is_reference and e.value == .null_value) continue;
+                                    const effective = uf.mergedOverride(child_prefab_comps, e.key, e.value, merge_arena.allocator()) catch |err| {
+                                        game.log.err("[NestedEntity] Failed to merge override {s}: {s}", .{ e.key, @errorName(err) });
+                                        continue;
+                                    };
                                     spawnAndLinkNestedEntities(game, child, e.key, effective, child_pos, prefab_cache, depth + 1, nested_ref_ctx);
                                 }
                             }
@@ -800,7 +825,7 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                                     nested_applied.put(e.key, {}) catch {};
                                 }
                             }
-                            OnReadyHelpers.fireOnReadyAll(game, child, child_scene_comps, child_prefab_comps, &nested_applied);
+                            OnReadyHelpers.fireOnReadyAll(game, child, child_scene_comps, child_prefab_comps, &nested_applied, child_is_reference);
                         }
 
                         ids[idx] = @intCast(child);

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -388,18 +388,35 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             var applied = std.StringHashMap(void).init(game.allocator);
             defer applied.deinit();
 
+            // Precompute the effective (merged) value for each override
+            // entry once, in `merge_arena`, so the apply-component and
+            // spawn-nested-entity passes share the same merged tree
+            // instead of redoing the deep-merge per pass. `null`
+            // entries here mark removals that both passes must skip
+            // in lockstep.
+            const effective_overrides: ?[]?Value = if (scene_components) |sc| blk: {
+                const slice = try merge_arena.allocator().alloc(?Value, sc.entries.len);
+                for (sc.entries, 0..) |entry, i| {
+                    if (is_reference and entry.value == .null_value) {
+                        slice[i] = null;
+                    } else {
+                        slice[i] = try uf.mergedOverride(prefab_components, entry.key, entry.value, merge_arena.allocator());
+                    }
+                }
+                break :blk slice;
+            } else null;
+
             // Apply scene/override components, each deep-merged over
             // the prefab's matching component.
             if (scene_components) |sc| {
-                for (sc.entries) |entry| {
+                for (sc.entries, 0..) |entry, i| {
                     try applied.put(entry.key, {});
                     // A `null` override removes a component, but only
                     // for a reference entry's `overrides`. An inline
                     // entity's `components` carry no removal meaning
                     // — a `null` there is just a (likely malformed)
                     // value, not a deletion.
-                    if (is_reference and entry.value == .null_value) continue; // removal
-                    const effective = try uf.mergedOverride(prefab_components, entry.key, entry.value, merge_arena.allocator());
+                    const effective = effective_overrides.?[i] orelse continue; // removal
                     try ApplyHelpers.applyComponentWithRefs(game, entity, entry.key, effective, parent_offset, ref_ctx);
                 }
             }
@@ -418,14 +435,13 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             const entity_pos = game.getPosition(entity);
 
             // Spawn nested entity arrays and collect IDs to patch
-            // back into components. Override components use the same
-            // merged value as the apply pass — a deep-merged
-            // component keeps the prefab's entity-bearing fields, so
-            // their nested entities must still spawn.
+            // back into components. Reuses `effective_overrides`
+            // computed above — a deep-merged component keeps the
+            // prefab's entity-bearing fields, so their nested
+            // entities must still spawn.
             if (scene_components) |sc| {
-                for (sc.entries) |entry| {
-                    if (is_reference and entry.value == .null_value) continue;
-                    const effective = try uf.mergedOverride(prefab_components, entry.key, entry.value, merge_arena.allocator());
+                for (sc.entries, 0..) |entry, i| {
+                    const effective = effective_overrides.?[i] orelse continue;
                     spawnAndLinkNestedEntities(game, entity, entry.key, effective, entity_pos, prefab_cache, depth, ref_ctx);
                 }
             }
@@ -701,19 +717,39 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                             // reference entry's `overrides` (RFC #562).
                             const child_is_reference = child_obj.getString("prefab") != null;
 
+                            // Precompute the effective (merged) value
+                            // for each override entry once, in
+                            // `merge_arena`, so the apply-component
+                            // and recurse-nested-entity passes share
+                            // the same merged tree. `null` slots mark
+                            // removals or merge failures both passes
+                            // must skip in lockstep.
+                            const child_effective: ?[]?Value = if (child_scene_comps) |sc| blk: {
+                                const slice = merge_arena.allocator().alloc(?Value, sc.entries.len) catch break :blk null;
+                                for (sc.entries, 0..) |e, i| {
+                                    if (child_is_reference and e.value == .null_value) {
+                                        slice[i] = null;
+                                    } else if (uf.mergedOverride(child_prefab_comps, e.key, e.value, merge_arena.allocator())) |eff| {
+                                        slice[i] = eff;
+                                    } else |err| {
+                                        game.log.err("[NestedEntity] Failed to merge override {s}: {s}", .{ e.key, @errorName(err) });
+                                        slice[i] = null;
+                                    }
+                                }
+                                break :blk slice;
+                            } else null;
+
                             // Override components first, each
                             // deep-merged over the prefab's match;
                             // a `null` override removes it (#562).
                             if (child_scene_comps) |sc| {
-                                for (sc.entries) |e| {
+                                for (sc.entries, 0..) |e, i| {
                                     // `null`-as-removal applies only
                                     // to a reference entry's
-                                    // `overrides` (RFC #562).
-                                    if (child_is_reference and e.value == .null_value) continue;
-                                    const effective = uf.mergedOverride(child_prefab_comps, e.key, e.value, merge_arena.allocator()) catch |err| {
-                                        game.log.err("[NestedEntity] Failed to merge override {s}: {s}", .{ e.key, @errorName(err) });
-                                        continue;
-                                    };
+                                    // `overrides` (RFC #562). A null
+                                    // slot here also covers merge
+                                    // failures already logged above.
+                                    const effective = (child_effective orelse break)[i] orelse continue;
                                     ApplyHelpers.applyComponentWithRefs(game, child, e.key, effective, parent_world_pos, nested_ref_ctx) catch |err| {
                                         game.log.err("[NestedEntity] Failed to apply {s}: {s}", .{ e.key, @errorName(err) });
                                     };
@@ -737,15 +773,12 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                             }
 
                             // Recursively spawn nested entities
-                            // inside this child's components.
+                            // inside this child's components. Reuses
+                            // `child_effective` from the apply pass.
                             const child_pos = game.getPosition(child);
                             if (child_scene_comps) |sc| {
-                                for (sc.entries) |e| {
-                                    if (child_is_reference and e.value == .null_value) continue;
-                                    const effective = uf.mergedOverride(child_prefab_comps, e.key, e.value, merge_arena.allocator()) catch |err| {
-                                        game.log.err("[NestedEntity] Failed to merge override {s}: {s}", .{ e.key, @errorName(err) });
-                                        continue;
-                                    };
+                                for (sc.entries, 0..) |e, i| {
+                                    const effective = (child_effective orelse break)[i] orelse continue;
                                     spawnAndLinkNestedEntities(game, child, e.key, effective, child_pos, prefab_cache, depth + 1, nested_ref_ctx);
                                 }
                             }

--- a/src/jsonc/unified_format.zig
+++ b/src/jsonc/unified_format.zig
@@ -121,7 +121,10 @@ pub fn mergeValues(base: Value, patch: Value, arena: std.mem.Allocator) error{Ou
     const patch_obj = patch.asObject() orelse return patch;
 
     var entries: std.ArrayListUnmanaged(Value.Object.Entry) = .empty;
-    try entries.appendSlice(arena, base_obj.entries);
+    // Pre-size for the worst case (every patch key is new) so the
+    // hot loop below appends without reallocating mid-merge.
+    try entries.ensureTotalCapacity(arena, base_obj.entries.len + patch_obj.entries.len);
+    entries.appendSliceAssumeCapacity(base_obj.entries);
 
     for (patch_obj.entries) |pe| {
         for (entries.items) |*existing| {
@@ -135,7 +138,7 @@ pub fn mergeValues(base: Value, patch: Value, arena: std.mem.Allocator) error{Ou
                 break;
             }
         } else {
-            try entries.append(arena, pe);
+            entries.appendAssumeCapacity(pe);
         }
     }
     return .{ .object = .{ .entries = entries.items } };

--- a/src/jsonc/unified_format.zig
+++ b/src/jsonc/unified_format.zig
@@ -112,14 +112,16 @@ pub fn warnLegacyAssets(file_obj: Value.Object, log: anytype) void {
 ///
 /// The returned tree's entry arrays come from `arena`; leaf values
 /// (strings, numbers) are shared with `base`/`patch`, so the result
-/// must not outlive either input. On allocation failure it degrades
-/// to `patch` (whole-component replacement — the pre-#562 behavior).
-pub fn mergeValues(base: Value, patch: Value, arena: std.mem.Allocator) Value {
+/// must not outlive either input. Allocation failure is propagated
+/// as `error.OutOfMemory` — silently degrading to whole-component
+/// replacement would drop the prefab's inherited fields and violate
+/// the accepted deep-merge semantics (RFC #562).
+pub fn mergeValues(base: Value, patch: Value, arena: std.mem.Allocator) error{OutOfMemory}!Value {
     const base_obj = base.asObject() orelse return patch;
     const patch_obj = patch.asObject() orelse return patch;
 
     var entries: std.ArrayListUnmanaged(Value.Object.Entry) = .empty;
-    entries.appendSlice(arena, base_obj.entries) catch return patch;
+    try entries.appendSlice(arena, base_obj.entries);
 
     for (patch_obj.entries) |pe| {
         for (entries.items) |*existing| {
@@ -127,13 +129,13 @@ pub fn mergeValues(base: Value, patch: Value, arena: std.mem.Allocator) Value {
                 const both_objects =
                     existing.value.asObject() != null and pe.value.asObject() != null;
                 existing.value = if (both_objects)
-                    mergeValues(existing.value, pe.value, arena)
+                    try mergeValues(existing.value, pe.value, arena)
                 else
                     pe.value;
                 break;
             }
         } else {
-            entries.append(arena, pe) catch return patch;
+            try entries.append(arena, pe);
         }
     }
     return .{ .object = .{ .entries = entries.items } };
@@ -143,12 +145,15 @@ pub fn mergeValues(base: Value, patch: Value, arena: std.mem.Allocator) Value {
 /// override deep-merged onto the prefab's same-named component when
 /// the prefab declares one, otherwise the override value as-is.
 /// Callers handle a `null` override (component removal) first.
+///
+/// Propagates `error.OutOfMemory` from the underlying merge — the
+/// caller must not fall back to whole-component replacement.
 pub fn mergedOverride(
     prefab_components: ?Value.Object,
     key: []const u8,
     override_value: Value,
     arena: std.mem.Allocator,
-) Value {
+) error{OutOfMemory}!Value {
     const pc = prefab_components orelse return override_value;
     const base = pc.get(key) orelse return override_value;
     return mergeValues(base, override_value, arena);

--- a/src/jsonc/unified_format.zig
+++ b/src/jsonc/unified_format.zig
@@ -98,3 +98,58 @@ pub fn warnLegacyAssets(file_obj: Value.Object, log: anytype) void {
         warnOnce(log, "[unified-format] legacy \"assets\" key is ignored — assets are inferred from sprite references (RFC #560, #563)");
     }
 }
+
+// ── Override merge (RFC #562) ───────────────────────────────────
+
+/// Deep-merge `patch` onto `base`, returning a new `Value`.
+///
+/// Objects merge recursively — keys only in `base` are kept, keys
+/// only in `patch` are added, and a key in both recurses when both
+/// sides are objects. Arrays and scalars in `patch` replace
+/// outright (no element-wise list merge). A JSONC `null` in `patch`
+/// is carried through as a value — component-level removal is
+/// handled by the caller before this is reached.
+///
+/// The returned tree's entry arrays come from `arena`; leaf values
+/// (strings, numbers) are shared with `base`/`patch`, so the result
+/// must not outlive either input. On allocation failure it degrades
+/// to `patch` (whole-component replacement — the pre-#562 behavior).
+pub fn mergeValues(base: Value, patch: Value, arena: std.mem.Allocator) Value {
+    const base_obj = base.asObject() orelse return patch;
+    const patch_obj = patch.asObject() orelse return patch;
+
+    var entries: std.ArrayListUnmanaged(Value.Object.Entry) = .empty;
+    entries.appendSlice(arena, base_obj.entries) catch return patch;
+
+    for (patch_obj.entries) |pe| {
+        for (entries.items) |*existing| {
+            if (std.mem.eql(u8, existing.key, pe.key)) {
+                const both_objects =
+                    existing.value.asObject() != null and pe.value.asObject() != null;
+                existing.value = if (both_objects)
+                    mergeValues(existing.value, pe.value, arena)
+                else
+                    pe.value;
+                break;
+            }
+        } else {
+            entries.append(arena, pe) catch return patch;
+        }
+    }
+    return .{ .object = .{ .entries = entries.items } };
+}
+
+/// The effective value to apply for an overridden component: the
+/// override deep-merged onto the prefab's same-named component when
+/// the prefab declares one, otherwise the override value as-is.
+/// Callers handle a `null` override (component removal) first.
+pub fn mergedOverride(
+    prefab_components: ?Value.Object,
+    key: []const u8,
+    override_value: Value,
+    arena: std.mem.Allocator,
+) Value {
+    const pc = prefab_components orelse return override_value;
+    const base = pc.get(key) orelse return override_value;
+    return mergeValues(base, override_value, arena);
+}


### PR DESCRIPTION
Specifies and implements the merge rules for `overrides` on a prefab reference — resolves open question 3 of the unify-scenes-and-prefabs RFC (#560), ticket #562.

**Stacked on #573** (base `feat/561-unified-loader`) — #562 builds on #561's `overrides` keyword. Review/merge #573 first; this PR's base retargets to the umbrella branch once #573 lands.

## Decisions (confirmed with the project owner)

- **Deep field-level merge** — a field the override omits keeps the prefab's value, recursing into nested struct fields. This changes the pre-#562 behavior, where a partial override silently reset unmentioned fields to their struct defaults (the footgun the RFC's open question called out).
- **Arrays and scalars replace** outright — no element-wise list merge.
- **`"Name": null` removes a component** from the instance; siblings untouched; the removed component fires no `onReady`/`postLoad`.

## What's in

- `RFC-OVERRIDES-MERGE-RULES.md` — the spec doc, per-case with examples.
- `unified_format.mergeValues` / `mergedOverride` — recursive merge over JSONC `Value` trees. Merged trees are arena-scoped with leaf strings shared from the inputs, so deferred `@ref` names collected from a merged component stay valid into pass-2 resolution.
- `scene_loader.zig` — `loadEntityInternal` and `spawnAndLinkNestedEntities` merge per component and skip a `null` override (recorded in `applied` so the prefab fallback skips it too). A deep-merged component keeps its prefab's entity-bearing fields, so the nested-entity spawn pass uses the merged value.
- `on_ready.fireOnReadyAll` — skips a `null` override.

## Tests

6 zspec specs in `spec/override_merge_spec.zig` — field inheritance, nested-struct recursion, array replacement, component removal, sibling survival, and nested-entity survival through a merge.

**449 std.testing + 12 zspec tests pass.** The deep-merge behavior change regressed nothing — existing content uses full-component overrides (or `Position` with both fields).

Resolves #562.

🤖 Generated with [Claude Code](https://claude.com/claude-code)