### PR TITLE
Single shared entity-tree walker with cycle detection (#569)

### DIFF
--- a/spec/spec_tests.zig
+++ b/spec/spec_tests.zig
@@ -9,11 +9,13 @@ const zspec = @import("zspec");
 pub const unified_format_spec = @import("unified_format_spec.zig");
 pub const override_merge_spec = @import("override_merge_spec.zig");
 pub const registry_scan_spec = @import("registry_scan_spec.zig");
+pub const tree_walker_spec = @import("tree_walker_spec.zig");
 
 // Re-export the spec structs so zspec discovers them.
 pub const UnifiedFormatSpec = unified_format_spec.UnifiedFormatSpec;
 pub const OverrideMergeSpec = override_merge_spec.OverrideMergeSpec;
 pub const RegistryScanSpec = registry_scan_spec.RegistryScanSpec;
+pub const TreeWalkerSpec = tree_walker_spec.TreeWalkerSpec;
 
 test {
     zspec.runAll(@This());

--- a/spec/tree_walker_spec.zig
+++ b/spec/tree_walker_spec.zig
@@ -441,6 +441,50 @@ pub const TreeWalkerSpec = struct {
         }
     };
 
+    // ── scene-declared repetition of a prefab is not a cycle ────
+    //
+    // A reference-chain cycle (A's body references B's body
+    // references A's body) is what `error.PrefabCycle` exists to
+    // catch — NOT a scene that legitimately spawns two instances of
+    // the same prefab in a `children` array. The expansion stack
+    // must release the parent's prefab name before recursing into
+    // the parent's scene-declared `children`; otherwise a sibling /
+    // child reference to the same prefab is falsely flagged.
+
+    pub const @"a scene child re-referencing the parent's prefab" = struct {
+        test "is not a cycle (scene-declared, not reference-chain)" {
+            const a = arena.allocator();
+            const src = Corpus.create(.{});
+
+            var table = PrefabTable.init(a);
+            defer table.deinit();
+            // `leaf` is a plain prefab with no children — two
+            // instances are independent finite trees.
+            try table.add("leaf", src.leaf_prefab);
+
+            // Parent references `leaf`; one of its scene-declared
+            // children also references `leaf`. This is a tree with
+            // two `leaf` instances, not a reference cycle.
+            const root = try parse(a,
+                \\{ "prefab": "leaf", "children": [
+                \\  { "prefab": "leaf" }
+                \\] }
+            );
+
+            var visits: std.ArrayList(Visit) = .empty;
+            var ctx = tw.WalkContext.init(a);
+            defer ctx.deinit();
+
+            try tw.walk(&ctx, table.resolver(), root, Recorder{ .list = &visits, .allocator = a });
+            // Parent + one scene child.
+            try expect.equal(visits.items.len, 2);
+            try expect.equal(visits.items[0].origin, tw.Origin.root);
+            try expect.toBeTrue(visits.items[0].has_prefab_root);
+            try expect.equal(visits.items[1].origin, tw.Origin.child);
+            try expect.toBeTrue(visits.items[1].has_prefab_root);
+        }
+    };
+
     pub const @"an override leaving a cyclic component field intact" = struct {
         test "still detects the cycle" {
             const a = arena.allocator();

--- a/spec/tree_walker_spec.zig
+++ b/spec/tree_walker_spec.zig
@@ -125,6 +125,14 @@ const Sources = struct {
     /// Two prefabs forming a `chain_a -> chain_b -> chain_a` cycle.
     chain_a_prefab: []const u8,
     chain_b_prefab: []const u8,
+    /// A prefab whose `Room.movement_nodes` component field embeds a
+    /// reference back to itself — a cycle that lives purely inside a
+    /// component field, not in `children`.
+    room_cycle_prefab: []const u8,
+    /// A prefab whose `Room.movement_nodes` has an entity-like item
+    /// only at index 1 (a non-entity scalar at index 0). Pins the
+    /// "scan ALL items" fix — a `[0]`-only probe would miss it.
+    room_nonfirst_prefab: []const u8,
 };
 
 const Corpus = Fixture.define(Sources, .{
@@ -153,17 +161,31 @@ const Corpus = Fixture.define(Sources, .{
     .chain_b_prefab =
     \\{ "root": { "children": [ { "prefab": "chain_a" } ] } }
     ,
+    .room_cycle_prefab =
+    \\{ "root": { "components": { "Room": { "movement_nodes": [
+    \\  { "prefab": "room_cycle" }
+    \\] } } } }
+    ,
+    .room_nonfirst_prefab =
+    \\{ "root": { "components": { "Room": { "movement_nodes": [
+    \\  42,
+    \\  { "prefab": "room_nonfirst" }
+    \\] } } } }
+    ,
 });
 
-/// A resolver that knows no prefabs — for inline-only walks.
+/// A resolver that knows no prefabs — for inline-only walks. `ctx`
+/// points at a process-lifetime static (the `get` fn ignores it
+/// anyway) so the resolver never carries a dangling stack pointer.
+const Empty = struct {
+    var anchor: u8 = 0;
+    fn get(_: *anyopaque, _: []const u8) ?Value {
+        return null;
+    }
+};
+
 fn emptyResolver() tw.Resolver {
-    const Empty = struct {
-        fn get(_: *anyopaque, _: []const u8) ?Value {
-            return null;
-        }
-    };
-    var dummy: u8 = 0;
-    return .{ .ctx = &dummy, .getFn = &Empty.get };
+    return .{ .ctx = &Empty.anchor, .getFn = &Empty.get };
 }
 
 pub const TreeWalkerSpec = struct {
@@ -317,6 +339,135 @@ pub const TreeWalkerSpec = struct {
             // One visit: the reference entry, with its prefab resolved.
             try expect.equal(visits.items.len, 1);
             try expect.toBeTrue(visits.items[0].has_prefab_root);
+        }
+    };
+
+    // ── cycle through a non-first component-array item ──────────
+    //
+    // The runtime nested-entity spawn scans EVERY item of a
+    // component array; the walker must too. A cycle reachable only
+    // through an entity-like item that is not `[0]` (here index 0
+    // is the scalar `42`) would be missed by a `[0]`-only probe.
+
+    pub const @"a cycle via a non-first component-array item" = struct {
+        test "is still detected (walker scans all items)" {
+            const a = arena.allocator();
+            const src = Corpus.create(.{});
+
+            var table = PrefabTable.init(a);
+            defer table.deinit();
+            try table.add("room_nonfirst", src.room_nonfirst_prefab);
+
+            var ref_entries = [_]Value.Object.Entry{
+                .{ .key = "prefab", .value = .{ .string = "room_nonfirst" } },
+            };
+            const ref = Value{ .object = .{ .entries = &ref_entries } };
+
+            var visits: std.ArrayList(Visit) = .empty;
+            var ctx = tw.WalkContext.init(a);
+            defer ctx.deinit();
+
+            const result = tw.walk(&ctx, table.resolver(), ref, Recorder{ .list = &visits, .allocator = a });
+            try expect.toReturnError(result, error.PrefabCycle);
+
+            const chain = try ctx.formatCycleChain(a);
+            try expect.equal(chain, @as([]const u8, "room_nonfirst -> room_nonfirst"));
+        }
+    };
+
+    // ── effective (post-#562-merge) component traversal ─────────
+    //
+    // The walker reasons about the MERGED component tree: an
+    // `overrides` entry that replaces or removes an entity-bearing
+    // component changes which nested entities actually exist, so a
+    // valid scene that overrides away a cyclic field must NOT be
+    // rejected with `error.PrefabCycle`.
+
+    pub const @"an override replacing a cyclic component field" = struct {
+        test "does not raise a false PrefabCycle" {
+            const a = arena.allocator();
+            const src = Corpus.create(.{});
+
+            var table = PrefabTable.init(a);
+            defer table.deinit();
+            // `room_cycle`'s prefab body has a self-referential
+            // `Room.movement_nodes`.
+            try table.add("room_cycle", src.room_cycle_prefab);
+
+            // A reference to `room_cycle` whose `overrides` replaces
+            // the whole `Room` component with a non-cyclic value —
+            // the effective tree has no cycle.
+            const ref = try parse(a,
+                \\{ "prefab": "room_cycle", "overrides": {
+                \\  "Room": { "movement_nodes": [] }
+                \\} }
+            );
+
+            var visits: std.ArrayList(Visit) = .empty;
+            var ctx = tw.WalkContext.init(a);
+            defer ctx.deinit();
+
+            // Must walk to completion — the override emptied the
+            // cyclic field, so there is no cycle to find.
+            try tw.walk(&ctx, table.resolver(), ref, Recorder{ .list = &visits, .allocator = a });
+            try expect.equal(visits.items.len, 1);
+            try expect.toBeTrue(visits.items[0].has_prefab_root);
+        }
+    };
+
+    pub const @"an override removing a cyclic component" = struct {
+        test "does not raise a false PrefabCycle" {
+            const a = arena.allocator();
+            const src = Corpus.create(.{});
+
+            var table = PrefabTable.init(a);
+            defer table.deinit();
+            try table.add("room_cycle", src.room_cycle_prefab);
+
+            // A `null` override removes the whole `Room` component
+            // (RFC #562 component removal) — the cyclic field is
+            // gone from the effective tree.
+            const ref = try parse(a,
+                \\{ "prefab": "room_cycle", "overrides": { "Room": null } }
+            );
+
+            var visits: std.ArrayList(Visit) = .empty;
+            var ctx = tw.WalkContext.init(a);
+            defer ctx.deinit();
+
+            try tw.walk(&ctx, table.resolver(), ref, Recorder{ .list = &visits, .allocator = a });
+            try expect.equal(visits.items.len, 1);
+            try expect.toBeTrue(visits.items[0].has_prefab_root);
+        }
+    };
+
+    pub const @"an override leaving a cyclic component field intact" = struct {
+        test "still detects the cycle" {
+            const a = arena.allocator();
+            const src = Corpus.create(.{});
+
+            var table = PrefabTable.init(a);
+            defer table.deinit();
+            try table.add("room_cycle", src.room_cycle_prefab);
+
+            // An override that touches an UNRELATED component must
+            // not mask the still-present cyclic `Room.movement_nodes`
+            // — the deep-merge keeps it.
+            const ref = try parse(a,
+                \\{ "prefab": "room_cycle", "overrides": {
+                \\  "Marker": { "id": 7 }
+                \\} }
+            );
+
+            var visits: std.ArrayList(Visit) = .empty;
+            var ctx = tw.WalkContext.init(a);
+            defer ctx.deinit();
+
+            const result = tw.walk(&ctx, table.resolver(), ref, Recorder{ .list = &visits, .allocator = a });
+            try expect.toReturnError(result, error.PrefabCycle);
+
+            const chain = try ctx.formatCycleChain(a);
+            try expect.equal(chain, @as([]const u8, "room_cycle -> room_cycle"));
         }
     };
 };

--- a/spec/tree_walker_spec.zig
+++ b/spec/tree_walker_spec.zig
@@ -1,0 +1,322 @@
+//! zspec BDD specs for the shared entity-tree walker (RFC #560,
+//! ticket #569).
+//!
+//! The walker is the single traversal entry point every entity-tree
+//! consumer (instantiation, save/load tagging, postLoad firing,
+//! asset inference) shares. These specs pin:
+//!
+//!  - the normative pre-order walk crossing BOTH `children` AND
+//!    prefab references nested in entity-bearing component fields
+//!    (the `Room.movement_nodes` pattern),
+//!  - prefab-reference expansion through a resolver,
+//!  - cycle detection reporting the FULL chain (`A -> B -> A`), for
+//!    a direct self-cycle and a multi-hop cycle.
+//!
+//! See RFC-UNIFY-SCENES-AND-PREFABS.md.
+
+const std = @import("std");
+const zspec = @import("zspec");
+const engine = @import("engine");
+
+const expect = zspec.expect;
+const Fixture = zspec.Fixture;
+
+const tw = engine.tree_walker;
+const Value = engine.SceneValue;
+const JsoncParser = engine.JsoncParser;
+
+// ── A static prefab table standing in for PrefabCache ───────────
+//
+// The walker resolves `prefab` names through a `Resolver`; in
+// production that is `PrefabCache.get`. The specs back it with a
+// parse-on-demand table over a fixed JSONC corpus so a walk can be
+// exercised without the full scene-loader machinery.
+
+const PrefabTable = struct {
+    arena: std.heap.ArenaAllocator,
+    entries: std.StringHashMap(Value),
+
+    fn init(allocator: std.mem.Allocator) PrefabTable {
+        return .{
+            .arena = std.heap.ArenaAllocator.init(allocator),
+            .entries = std.StringHashMap(Value).init(allocator),
+        };
+    }
+
+    fn deinit(self: *PrefabTable) void {
+        self.entries.deinit();
+        self.arena.deinit();
+    }
+
+    /// Parse `source` and register it under `name`.
+    fn add(self: *PrefabTable, name: []const u8, source: []const u8) !void {
+        var parser = JsoncParser.init(self.arena.allocator(), source);
+        const val = try parser.parse();
+        try self.entries.put(name, val);
+    }
+
+    fn get(ctx: *anyopaque, name: []const u8) ?Value {
+        const self: *PrefabTable = @ptrCast(@alignCast(ctx));
+        return self.entries.get(name);
+    }
+
+    fn resolver(self: *PrefabTable) tw.Resolver {
+        return .{ .ctx = self, .getFn = &PrefabTable.get };
+    }
+};
+
+/// Parse a single JSONC source into a `Value` in `arena`.
+fn parse(arena: std.mem.Allocator, source: []const u8) !Value {
+    var parser = JsoncParser.init(arena, source);
+    return parser.parse();
+}
+
+// ── A recording visitor ─────────────────────────────────────────
+//
+// Captures every visited node so a test can assert on the count,
+// the walk order, and each node's origin / depth / component name.
+
+const Visit = struct {
+    origin: tw.Origin,
+    depth: usize,
+    component_name: ?[]const u8,
+    has_prefab_root: bool,
+    /// The visited entity's `Marker.id`, or `null` when it carries
+    /// no inline `Marker` — a cheap identity probe for ordering
+    /// assertions. Prefab-sourced markers are not visible here
+    /// (the walker yields the *reference* entry, not the resolved
+    /// prefab body).
+    marker_id: ?i64,
+};
+
+const Recorder = struct {
+    pub const VisitError = error{OutOfMemory};
+
+    list: *std.ArrayList(Visit),
+    allocator: std.mem.Allocator,
+
+    pub fn visit(self: Recorder, node: tw.Node(VisitError)) VisitError!void {
+        var marker_id: ?i64 = null;
+        if (node.obj.getObject("components")) |c| {
+            if (c.getObject("Marker")) |m| marker_id = m.getInteger("id");
+        }
+        try self.list.append(self.allocator, .{
+            .origin = node.origin,
+            .depth = node.depth,
+            .component_name = node.component_name,
+            .has_prefab_root = node.prefab_root != null,
+            .marker_id = marker_id,
+        });
+    }
+};
+
+// ── JSONC corpus ────────────────────────────────────────────────
+
+const Sources = struct {
+    /// Entity with two `children`.
+    parent_two_children: []const u8,
+    /// Entity whose `Room` component carries a `movement_nodes`
+    /// entity-bearing array — the second structural birth-place.
+    room_with_nodes: []const u8,
+    /// A leaf prefab body.
+    leaf_prefab: []const u8,
+    /// A prefab that references itself directly (`self -> self`).
+    self_cycle_prefab: []const u8,
+    /// Two prefabs forming a `chain_a -> chain_b -> chain_a` cycle.
+    chain_a_prefab: []const u8,
+    chain_b_prefab: []const u8,
+};
+
+const Corpus = Fixture.define(Sources, .{
+    .parent_two_children =
+    \\{ "components": { "Marker": { "id": 1 } }, "children": [
+    \\  { "components": { "Marker": { "id": 2 } } },
+    \\  { "components": { "Marker": { "id": 3 } } }
+    \\] }
+    ,
+    .room_with_nodes =
+    \\{ "components": { "Room": { "movement_nodes": [
+    \\  { "components": { "Marker": { "id": 10 } } },
+    \\  { "prefab": "leaf" }
+    \\] } } }
+    ,
+    .leaf_prefab =
+    \\{ "root": { "components": { "Marker": { "id": 99 } } } }
+    ,
+    .self_cycle_prefab =
+    \\{ "root": { "components": { "Marker": { "id": 1 } },
+    \\  "children": [ { "prefab": "self" } ] } }
+    ,
+    .chain_a_prefab =
+    \\{ "root": { "children": [ { "prefab": "chain_b" } ] } }
+    ,
+    .chain_b_prefab =
+    \\{ "root": { "children": [ { "prefab": "chain_a" } ] } }
+    ,
+});
+
+/// A resolver that knows no prefabs — for inline-only walks.
+fn emptyResolver() tw.Resolver {
+    const Empty = struct {
+        fn get(_: *anyopaque, _: []const u8) ?Value {
+            return null;
+        }
+    };
+    var dummy: u8 = 0;
+    return .{ .ctx = &dummy, .getFn = &Empty.get };
+}
+
+pub const TreeWalkerSpec = struct {
+    var arena: std.heap.ArenaAllocator = undefined;
+
+    test "tests:before" {
+        arena = std.heap.ArenaAllocator.init(zspec.allocator);
+    }
+
+    test "tests:after" {
+        arena.deinit();
+    }
+
+    // ── crossing the `children` array ───────────────────────────
+
+    pub const @"walking an entity with a children array" = struct {
+        test "visits the root pre-order then every child" {
+            const a = arena.allocator();
+            const src = Corpus.create(.{});
+            const root = try parse(a, src.parent_two_children);
+
+            var visits: std.ArrayList(Visit) = .empty;
+            var ctx = tw.WalkContext.init(a);
+            defer ctx.deinit();
+
+            try tw.walk(&ctx, emptyResolver(), root, Recorder{ .list = &visits, .allocator = a });
+
+            try expect.equal(visits.items.len, 3);
+            // Pre-order: root first.
+            try expect.equal(visits.items[0].origin, tw.Origin.root);
+            try expect.equal(visits.items[0].marker_id.?, @as(i64, 1));
+            // Then each child, in array order, at depth 1.
+            try expect.equal(visits.items[1].origin, tw.Origin.child);
+            try expect.equal(visits.items[1].depth, @as(usize, 1));
+            try expect.equal(visits.items[1].marker_id.?, @as(i64, 2));
+            try expect.equal(visits.items[2].marker_id.?, @as(i64, 3));
+        }
+    };
+
+    // ── crossing entity-bearing component fields ────────────────
+
+    pub const @"walking prefab refs nested in component fields" = struct {
+        test "crosses a Room.movement_nodes entity array" {
+            const a = arena.allocator();
+            const src = Corpus.create(.{});
+
+            var table = PrefabTable.init(a);
+            defer table.deinit();
+            try table.add("leaf", src.leaf_prefab);
+
+            const root = try parse(a, src.room_with_nodes);
+
+            var visits: std.ArrayList(Visit) = .empty;
+            var ctx = tw.WalkContext.init(a);
+            defer ctx.deinit();
+
+            try tw.walk(&ctx, table.resolver(), root, Recorder{ .list = &visits, .allocator = a });
+
+            // Root Room entity + two movement_nodes entries.
+            try expect.equal(visits.items.len, 3);
+            try expect.equal(visits.items[0].origin, tw.Origin.root);
+
+            // The nested inline entity is reached via the component
+            // field and attributed to the `Room` component.
+            try expect.equal(visits.items[1].origin, tw.Origin.component_field);
+            try expect.equal(visits.items[1].component_name.?, @as([]const u8, "Room"));
+            try expect.equal(visits.items[1].marker_id.?, @as(i64, 10));
+
+            // The nested *prefab reference* is crossed too and its
+            // prefab resolved.
+            try expect.equal(visits.items[2].origin, tw.Origin.component_field);
+            try expect.toBeTrue(visits.items[2].has_prefab_root);
+        }
+    };
+
+    // ── cycle detection ─────────────────────────────────────────
+
+    pub const @"a direct self-referential prefab cycle" = struct {
+        test "errors with the full chain self -> self" {
+            const a = arena.allocator();
+            const src = Corpus.create(.{});
+
+            var table = PrefabTable.init(a);
+            defer table.deinit();
+            try table.add("self", src.self_cycle_prefab);
+
+            // A scene-level reference entry to the cyclic prefab.
+            var ref_entries = [_]Value.Object.Entry{
+                .{ .key = "prefab", .value = .{ .string = "self" } },
+            };
+            const ref = Value{ .object = .{ .entries = &ref_entries } };
+
+            var visits: std.ArrayList(Visit) = .empty;
+            var ctx = tw.WalkContext.init(a);
+            defer ctx.deinit();
+
+            const result = tw.walk(&ctx, table.resolver(), ref, Recorder{ .list = &visits, .allocator = a });
+            try expect.toReturnError(result, error.PrefabCycle);
+
+            const chain = try ctx.formatCycleChain(a);
+            try expect.equal(chain, @as([]const u8, "self -> self"));
+        }
+    };
+
+    pub const @"a multi-hop prefab cycle" = struct {
+        test "errors with the full chain chain_a -> chain_b -> chain_a" {
+            const a = arena.allocator();
+            const src = Corpus.create(.{});
+
+            var table = PrefabTable.init(a);
+            defer table.deinit();
+            try table.add("chain_a", src.chain_a_prefab);
+            try table.add("chain_b", src.chain_b_prefab);
+
+            var ref_entries = [_]Value.Object.Entry{
+                .{ .key = "prefab", .value = .{ .string = "chain_a" } },
+            };
+            const ref = Value{ .object = .{ .entries = &ref_entries } };
+
+            var visits: std.ArrayList(Visit) = .empty;
+            var ctx = tw.WalkContext.init(a);
+            defer ctx.deinit();
+
+            const result = tw.walk(&ctx, table.resolver(), ref, Recorder{ .list = &visits, .allocator = a });
+            try expect.toReturnError(result, error.PrefabCycle);
+
+            const chain = try ctx.formatCycleChain(a);
+            try expect.equal(chain, @as([]const u8, "chain_a -> chain_b -> chain_a"));
+        }
+    };
+
+    pub const @"an acyclic prefab tree" = struct {
+        test "walks to completion without a cycle error" {
+            const a = arena.allocator();
+            const src = Corpus.create(.{});
+
+            var table = PrefabTable.init(a);
+            defer table.deinit();
+            try table.add("leaf", src.leaf_prefab);
+
+            var ref_entries = [_]Value.Object.Entry{
+                .{ .key = "prefab", .value = .{ .string = "leaf" } },
+            };
+            const ref = Value{ .object = .{ .entries = &ref_entries } };
+
+            var visits: std.ArrayList(Visit) = .empty;
+            var ctx = tw.WalkContext.init(a);
+            defer ctx.deinit();
+
+            try tw.walk(&ctx, table.resolver(), ref, Recorder{ .list = &visits, .allocator = a });
+            // One visit: the reference entry, with its prefab resolved.
+            try expect.equal(visits.items.len, 1);
+            try expect.toBeTrue(visits.items[0].has_prefab_root);
+        }
+    };
+};

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -231,7 +231,6 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             };
             const prefab_obj = prefab_val.asObject() orelse return null;
             const prefab_root = uf.rootObject(prefab_obj);
-            const prefab_components = prefab_root.getObject("components") orelse return null;
 
             // Cycle gate. Walk a synthetic reference entry so the
             // shared walker pushes `name` onto its expansion stack
@@ -239,6 +238,12 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             // or via a child / nested component field) is caught
             // (RFC #569). On a cycle the chain is logged and the
             // spawn fails (`null`) rather than recursing forever.
+            //
+            // Run UNCONDITIONALLY, before the `components` lookup
+            // below: a cyclic prefab whose `root` has no `components`
+            // (the cycle lives purely in `root.children`) would
+            // otherwise bypass the diagnostic via the early `return
+            // null` and just silently fail to spawn.
             {
                 var ref_entries = [_]Value.Object.Entry{
                     .{ .key = "prefab", .value = .{ .string = name } },
@@ -249,6 +254,8 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                     return null;
                 };
             }
+
+            const prefab_components = prefab_root.getObject("components") orelse return null;
 
             const entity = game.createEntity();
             game.trackSceneEntity(entity);

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -43,6 +43,28 @@ const uf = @import("unified_format.zig");
 const ref_resolver_mod = @import("ref_resolver.zig");
 const component_apply_mod = @import("component_apply.zig");
 const on_ready_mod = @import("on_ready.zig");
+const tree_walker = @import("tree_walker.zig");
+
+/// Adapt a `PrefabCache` into a `tree_walker.Resolver`. The walker
+/// expands `prefab` references through this so its cycle detector
+/// sees the same reference graph the instantiation pass does.
+fn prefabResolver(cache: *PrefabCache) tree_walker.Resolver {
+    const Wrap = struct {
+        fn get(ctx: *anyopaque, name: []const u8) ?Value {
+            const c: *PrefabCache = @ptrCast(@alignCast(ctx));
+            return c.get(name);
+        }
+    };
+    return .{ .ctx = cache, .getFn = &Wrap.get };
+}
+
+/// A walker visitor that does nothing — used when the only thing a
+/// walk needs to surface is cycle detection (the walker raises
+/// `error.PrefabCycle` on its own; the visitor never has to act).
+const CycleCheckVisitor = struct {
+    pub const VisitError = error{};
+    pub fn visit(_: CycleCheckVisitor, _: tree_walker.Node(VisitError)) VisitError!void {}
+};
 
 pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
     const Entity = GameType.EntityType;
@@ -52,8 +74,32 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
     const OnReadyHelpers = on_ready_mod.OnReady(GameType, Components);
 
     return struct {
-        pub const LoadEntityError = error{ IncludeDepthExceeded, OutOfMemory, InvalidFormat };
+        pub const LoadEntityError = error{ IncludeDepthExceeded, OutOfMemory, InvalidFormat, PrefabCycle };
         pub const MAX_DEPTH: usize = 16;
+
+        // ── Cycle detection (RFC #569) ─────────────────────────
+
+        /// Run the shared entity-tree walker over `entity_value`
+        /// purely for its cycle detector. A referenced-prefab cycle
+        /// (`A -> B -> A`) is a load-time error: the full chain is
+        /// logged and `error.PrefabCycle` propagates so the loader
+        /// aborts before instantiating a tree that would recurse
+        /// forever. Both inference (static) and instantiation
+        /// (runtime) gate on this shared check.
+        fn checkEntityTreeCycles(game: *GameType, entity_value: Value, prefab_cache: *PrefabCache) LoadEntityError!void {
+            var ctx = tree_walker.WalkContext.init(game.allocator);
+            defer ctx.deinit();
+            tree_walker.walk(&ctx, prefabResolver(prefab_cache), entity_value, CycleCheckVisitor{}) catch |err| switch (err) {
+                error.PrefabCycle => {
+                    const chain = ctx.formatCycleChain(game.allocator) catch "<unknown>";
+                    defer if (!std.mem.eql(u8, chain, "<unknown>")) game.allocator.free(chain);
+                    game.log.err("[scene] prefab reference cycle: {s} (RFC #560, #569)", .{chain});
+                    return error.PrefabCycle;
+                },
+                error.DepthExceeded => return error.IncludeDepthExceeded,
+                error.OutOfMemory => return error.OutOfMemory,
+            };
+        }
 
         // ── Public entry points ────────────────────────────────
 
@@ -187,6 +233,23 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             const prefab_root = uf.rootObject(prefab_obj);
             const prefab_components = prefab_root.getObject("components") orelse return null;
 
+            // Cycle gate. Walk a synthetic reference entry so the
+            // shared walker pushes `name` onto its expansion stack
+            // — that way a prefab that references itself (directly
+            // or via a child / nested component field) is caught
+            // (RFC #569). On a cycle the chain is logged and the
+            // spawn fails (`null`) rather than recursing forever.
+            {
+                var ref_entries = [_]Value.Object.Entry{
+                    .{ .key = "prefab", .value = .{ .string = name } },
+                };
+                const ref_entry = Value{ .object = .{ .entries = &ref_entries } };
+                checkEntityTreeCycles(game, ref_entry, prefab_cache) catch |err| {
+                    game.log.err("[spawnPrefab] '{s}' not spawned: {s}", .{ name, @errorName(err) });
+                    return null;
+                };
+            }
+
             const entity = game.createEntity();
             game.trackSceneEntity(entity);
             game.setPosition(entity, pos);
@@ -229,6 +292,14 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
         /// Process entities from a parsed scene, with two-pass ref
         /// resolution.
         fn processEntities(game: *GameType, entities_arr: Value.Array, prefab_cache: *PrefabCache, ref_ctx: *RefContext) LoadEntityError!void {
+            // Pass 0: cycle gate. The shared tree-walker crosses
+            // both `children` and prefab refs nested in component
+            // fields, so a cycle hidden in either path is caught
+            // before any entity is created (RFC #569).
+            for (entities_arr.items) |entity_val| {
+                try checkEntityTreeCycles(game, entity_val, prefab_cache);
+            }
+
             // Pass 1: create entities, apply components (with
             // `@ref` → 0), collect refs.
             for (entities_arr.items) |entity_val| {

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -86,13 +86,30 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
         /// aborts before instantiating a tree that would recurse
         /// forever. Both inference (static) and instantiation
         /// (runtime) gate on this shared check.
-        fn checkEntityTreeCycles(game: *GameType, entity_value: Value, prefab_cache: *PrefabCache) LoadEntityError!void {
-            var ctx = tree_walker.WalkContext.init(game.allocator);
-            defer ctx.deinit();
-            tree_walker.walk(&ctx, prefabResolver(prefab_cache), entity_value, CycleCheckVisitor{}) catch |err| switch (err) {
+        fn checkEntityTreeCycles(
+            game: *GameType,
+            entity_value: Value,
+            prefab_cache: *PrefabCache,
+            ctx: *tree_walker.WalkContext,
+        ) LoadEntityError!void {
+            // Track the loader's recursion limit so the walk fails
+            // with the same depth ceiling `loadEntityInternal` does
+            // — a tree the loader would reject as too deep is
+            // surfaced here as `IncludeDepthExceeded`, not silently
+            // walked.
+            ctx.max_depth = MAX_DEPTH;
+            tree_walker.walk(ctx, prefabResolver(prefab_cache), entity_value, CycleCheckVisitor{}) catch |err| switch (err) {
                 error.PrefabCycle => {
-                    const chain = ctx.formatCycleChain(game.allocator) catch "<unknown>";
-                    defer if (!std.mem.eql(u8, chain, "<unknown>")) game.allocator.free(chain);
+                    // `formatCycleChain` either returns an
+                    // allocator-owned slice (success) or raises
+                    // `OutOfMemory`. Use an optional to signal which
+                    // one, rather than a literal-string fallback —
+                    // a string-equality probe to decide whether to
+                    // free is brittle (and just happens to work
+                    // because no real chain is "<unknown>").
+                    const chain_opt: ?[]const u8 = ctx.formatCycleChain(game.allocator) catch null;
+                    defer if (chain_opt) |c| game.allocator.free(c);
+                    const chain = chain_opt orelse "<unknown>";
                     game.log.err("[scene] prefab reference cycle: {s} (RFC #560, #569)", .{chain});
                     return error.PrefabCycle;
                 },
@@ -249,7 +266,9 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                     .{ .key = "prefab", .value = .{ .string = name } },
                 };
                 const ref_entry = Value{ .object = .{ .entries = &ref_entries } };
-                checkEntityTreeCycles(game, ref_entry, prefab_cache) catch |err| {
+                var cycle_ctx = tree_walker.WalkContext.init(game.allocator);
+                defer cycle_ctx.deinit();
+                checkEntityTreeCycles(game, ref_entry, prefab_cache, &cycle_ctx) catch |err| {
                     game.log.err("[spawnPrefab] '{s}' not spawned: {s}", .{ name, @errorName(err) });
                     return null;
                 };
@@ -303,8 +322,17 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             // both `children` and prefab refs nested in component
             // fields, so a cycle hidden in either path is caught
             // before any entity is created (RFC #569).
+            //
+            // One `WalkContext` for the whole scene: its expansion
+            // stack and diagnostic buffer keep their capacity across
+            // entries, so a scene with N top-level entities does N
+            // walks but only one set of ArrayList growths.
+            var cycle_ctx = tree_walker.WalkContext.init(game.allocator);
+            defer cycle_ctx.deinit();
             for (entities_arr.items) |entity_val| {
-                try checkEntityTreeCycles(game, entity_val, prefab_cache);
+                cycle_ctx.stack.clearRetainingCapacity();
+                cycle_ctx.cycle_chain.clearRetainingCapacity();
+                try checkEntityTreeCycles(game, entity_val, prefab_cache, &cycle_ctx);
             }
 
             // Pass 1: create entities, apply components (with

--- a/src/jsonc/tree_walker.zig
+++ b/src/jsonc/tree_walker.zig
@@ -231,7 +231,20 @@ fn walkEntry(
             }
         }
     }
-    defer if (pushed_prefab) {
+    // The expansion stack only guards against *reference-chain*
+    // cycles (A's body references B's body references A's body).
+    // Steps 1 and 2 walk content that belongs to this prefab's body,
+    // so the stack must include this prefab while they recurse. Step
+    // 3 walks the entry's own scene-declared `children`, which are a
+    // SEPARATE entity tree the scene attached — a child there that
+    // references this same prefab is a new finite expansion, not a
+    // recursive one. So pop the stack between step 2 and step 3 to
+    // avoid a false `error.PrefabCycle` on a legitimate scene entry
+    // like `{ "prefab": "A", "children": [{ "prefab": "A" }] }`.
+    // `errdefer` covers an early return from steps 1 or 2; the
+    // happy-path pop below clears `pushed_prefab` so it does not
+    // double-pop.
+    errdefer if (pushed_prefab) {
         _ = ctx.stack.pop();
     };
 
@@ -276,6 +289,14 @@ fn walkEntry(
         if (try effectiveComponents(merge_arena, prefab_components, patch)) |eff| {
             try walkComponentFields(ctx, merge_arena, resolver, eff, depth, visitor);
         }
+    }
+
+    // The prefab's body (steps 1 and 2) is fully expanded — pop
+    // before walking scene-declared children so a child that
+    // references the same prefab is not mistaken for a cycle.
+    if (pushed_prefab) {
+        _ = ctx.stack.pop();
+        pushed_prefab = false;
     }
 
     // ── 3. the entry's own children array ───────────────────────

--- a/src/jsonc/tree_walker.zig
+++ b/src/jsonc/tree_walker.zig
@@ -25,8 +25,11 @@
 //!
 //!   1. prefab-defined children (`prefab.root.children`),
 //!   2. entity entries nested inside component fields, in component
-//!      declaration order then array order — prefab components
-//!      first, then the entry's own `components`/`overrides`,
+//!      declaration order then array order — walked over the
+//!      **effective** component set (the prefab components with the
+//!      reference entry's `overrides` deep-merged in and `null`
+//!      removals applied, RFC #562), so the traversal matches the
+//!      tree the loader actually instantiates,
 //!   3. the entry's own `children` array.
 //!
 //! This order is the contract the hook-order spec (#561) builds on:
@@ -51,6 +54,14 @@ const std = @import("std");
 const jsonc = @import("jsonc");
 const Value = jsonc.Value;
 const uf = @import("unified_format.zig");
+
+/// Per-walk scratch allocations — the merged effective-component
+/// trees built while reasoning about `overrides` (RFC #562). Owned by
+/// the walk; freed when the walk finishes. Kept separate from
+/// `WalkContext` (which lives on a caller's stack and is read for
+/// `cycle_chain` after the walk returns) so a single arena reset
+/// frees every merge without touching the diagnostic buffers.
+const MergeArena = std.heap.ArenaAllocator;
 
 /// Error set for a tree walk. `PrefabCycle` carries no payload —
 /// the offending chain is reported through `WalkContext.cycle_chain`
@@ -178,11 +189,14 @@ pub fn walk(
     root_value: Value,
     visitor: anytype,
 ) (WalkError || @TypeOf(visitor).VisitError)!void {
-    try walkEntry(ctx, resolver, root_value, .root, 0, null, visitor);
+    var merge_arena = MergeArena.init(ctx.allocator);
+    defer merge_arena.deinit();
+    try walkEntry(ctx, &merge_arena, resolver, root_value, .root, 0, null, visitor);
 }
 
 fn walkEntry(
     ctx: *WalkContext,
+    merge_arena: *MergeArena,
     resolver: Resolver,
     entity_value: Value,
     origin: Origin,
@@ -236,37 +250,116 @@ fn walkEntry(
     if (prefab_root) |proot| {
         if (proot.getArray("children")) |children| {
             for (children.items) |child_val| {
-                try walkEntry(ctx, resolver, child_val, .prefab_child, depth + 1, null, visitor);
+                try walkEntry(ctx, merge_arena, resolver, child_val, .prefab_child, depth + 1, null, visitor);
             }
         }
     }
 
     // ── 2. entity entries nested in component fields ────────────
-    // Prefab components first, then the entry's own patch — the
-    // entry-side patch is walked too because an `overrides` block
-    // can introduce nested entities of its own.
-    if (prefab_root) |proot| {
-        if (proot.getObject("components")) |pc| {
-            try walkComponentFields(ctx, resolver, pc, depth, visitor);
+    // The walker must reason about the **effective** component tree
+    // — the post-#562-merge result the loader actually instantiates,
+    // not the raw prefab components. A reference entry's `overrides`
+    // can replace an entity-bearing field with a non-cyclic value,
+    // or a `null` override can remove a whole component; in either
+    // case the entity-bearing fields the prefab declared no longer
+    // exist, so walking the raw prefab components would chase a
+    // cycle through a field the merged tree has dropped.
+    //
+    // `effectiveComponents` mirrors `loadEntityInternal`: it deep-
+    // merges each override onto the prefab's same-named component
+    // (RFC #562, `uf.mergedOverride`), drops `null`-removed
+    // components, and carries through override-only components.
+    {
+        const prefab_components: ?Value.Object =
+            if (prefab_root) |proot| proot.getObject("components") else null;
+        const patch = uf.entityPatch(obj, NoopLog{});
+        if (try effectiveComponents(merge_arena, prefab_components, patch)) |eff| {
+            try walkComponentFields(ctx, merge_arena, resolver, eff, depth, visitor);
         }
-    }
-    if (uf.entityPatch(obj, NoopLog{})) |patch| {
-        try walkComponentFields(ctx, resolver, patch, depth, visitor);
     }
 
     // ── 3. the entry's own children array ───────────────────────
     if (obj.getArray("children")) |children| {
         for (children.items) |child_val| {
-            try walkEntry(ctx, resolver, child_val, .child, depth + 1, null, visitor);
+            try walkEntry(ctx, merge_arena, resolver, child_val, .child, depth + 1, null, visitor);
         }
     }
 }
 
+/// Build the **effective** component object for an entity entry:
+/// the prefab's components with the reference entry's `overrides`
+/// applied (RFC #562 deep-merge / `null` removal). This is the same
+/// component set `SceneLoader.loadEntityInternal` instantiates, so
+/// the walker's nested-entity traversal sees exactly the fields the
+/// runtime will spawn — no false `PrefabCycle` on a field an
+/// override replaced or removed.
+///
+/// Returns `null` only when neither side carries components. The
+/// merged tree lives in `merge_arena`; leaf values are shared with
+/// the inputs (same contract as `uf.mergeValues`).
+fn effectiveComponents(
+    merge_arena: *MergeArena,
+    prefab_components: ?Value.Object,
+    patch: ?Value.Object,
+) error{OutOfMemory}!?Value.Object {
+    // Inline entry (no prefab) — its `components` ARE the effective
+    // set; nothing to merge.
+    const pc = prefab_components orelse return patch;
+    // Reference entry with no `overrides` — the prefab components
+    // are the effective set unchanged.
+    const ov = patch orelse return pc;
+
+    const a = merge_arena.allocator();
+    var entries: std.ArrayListUnmanaged(Value.Object.Entry) = .empty;
+
+    // Start from the prefab components, dropping any the override
+    // removes via a JSONC `null` (component-level removal, #562).
+    for (pc.entries) |pe| {
+        const removed = blk: {
+            for (ov.entries) |oe| {
+                if (std.mem.eql(u8, oe.key, pe.key))
+                    break :blk oe.value == .null_value;
+            }
+            break :blk false;
+        };
+        if (removed) continue;
+        // Deep-merge the override onto this prefab component when
+        // the override names it; otherwise keep the prefab value.
+        var value = pe.value;
+        for (ov.entries) |oe| {
+            if (std.mem.eql(u8, oe.key, pe.key) and oe.value != .null_value) {
+                value = uf.mergeValues(pe.value, oe.value, a);
+                break;
+            }
+        }
+        try entries.append(a, .{ .key = pe.key, .value = value });
+    }
+
+    // Add override-only components (present in `overrides` but not
+    // the prefab), skipping `null` removals of nonexistent keys.
+    for (ov.entries) |oe| {
+        if (oe.value == .null_value) continue;
+        const in_prefab = blk: {
+            for (pc.entries) |pe| {
+                if (std.mem.eql(u8, pe.key, oe.key)) break :blk true;
+            }
+            break :blk false;
+        };
+        if (!in_prefab) try entries.append(a, .{ .key = oe.key, .value = oe.value });
+    }
+
+    return Value.Object{ .entries = try entries.toOwnedSlice(a) };
+}
+
 /// Walk every entity entry nested inside a component object's array
-/// fields. A field is "entity-bearing" when its first array element
-/// looks like an entity entry (`isEntityLike`).
+/// fields. A field is "entity-bearing" when ANY array element looks
+/// like an entity entry (`isEntityLike`) — consistent with the
+/// loader's `spawnAndLinkNestedEntities`, which scans every item.
+/// Checking only `[0]` would miss a cycle reached through an
+/// entity-like item that is not first in the array.
 fn walkComponentFields(
     ctx: *WalkContext,
+    merge_arena: *MergeArena,
     resolver: Resolver,
     components: Value.Object,
     depth: usize,
@@ -277,10 +370,9 @@ fn walkComponentFields(
         for (comp_obj.entries) |field| {
             const arr = field.value.asArray() orelse continue;
             if (arr.items.len == 0) continue;
-            if (!isEntityLike(arr.items[0])) continue;
             for (arr.items) |item| {
                 if (!isEntityLike(item)) continue;
-                try walkEntry(ctx, resolver, item, .component_field, depth + 1, entry.key, visitor);
+                try walkEntry(ctx, merge_arena, resolver, item, .component_field, depth + 1, entry.key, visitor);
             }
         }
     }

--- a/src/jsonc/tree_walker.zig
+++ b/src/jsonc/tree_walker.zig
@@ -1,0 +1,305 @@
+//! Shared entity-tree walker (RFC #560, ticket #569).
+//!
+//! The unified scene/prefab format grows entities in **two**
+//! structural places:
+//!
+//!   1. the `children` array of an entity, and
+//!   2. prefab references embedded inside entity-bearing component
+//!      fields — the `Room.movement_nodes` / `Workstation.storages`
+//!      pattern, where a component field is an array of entity
+//!      entries.
+//!
+//! Every consumer that walks the tree (entity instantiation,
+//! save/load prefab tagging, `postLoad` hook firing, asset
+//! inference, gizmo registration) must cross *both* paths. A walker
+//! that crosses one but not the other is exactly the bug shape of
+//! engine #467 / #470 / flying-platform-labelle #286 — so N
+//! independent traversals re-introduce that bug N times. This module
+//! is the single traversal entry point so there is exactly one
+//! `children`-and-component-field recursion in the engine.
+//!
+//! ## Walk order (normative)
+//!
+//! For each entity entry the walker yields the entry itself
+//! **first** (pre-order), then descends in this fixed order:
+//!
+//!   1. prefab-defined children (`prefab.root.children`),
+//!   2. entity entries nested inside component fields, in component
+//!      declaration order then array order — prefab components
+//!      first, then the entry's own `components`/`overrides`,
+//!   3. the entry's own `children` array.
+//!
+//! This order is the contract the hook-order spec (#561) builds on:
+//! a parent's `postLoad` sees its prefab subtree, then its nested
+//! component entities, then its scene-declared children.
+//!
+//! ## Cycle detection
+//!
+//! A prefab-reference cycle (`A -> B -> A`) is a load-time error.
+//! The walker tracks the chain of prefab names currently being
+//! expanded; re-entering a name already on the stack is
+//! `error.PrefabCycle`, and the full chain (e.g. `A -> B -> A`) is
+//! written to the caller-supplied diagnostic buffer so the error
+//! message can name every link, not just "cycle detected".
+//!
+//! The walker is allocation-light: it owns a single growable stack
+//! of prefab names for cycle detection and nothing else. It does not
+//! parse, does not touch the ECS, and does not resolve `@ref`s —
+//! callers layer those concerns on top of the yielded entries.
+
+const std = @import("std");
+const jsonc = @import("jsonc");
+const Value = jsonc.Value;
+const uf = @import("unified_format.zig");
+
+/// Error set for a tree walk. `PrefabCycle` carries no payload —
+/// the offending chain is reported through `WalkContext.cycle_chain`
+/// so the caller can format a message that names every link.
+pub const WalkError = error{
+    /// A prefab reference re-entered a prefab already being
+    /// expanded on the current branch. See `cycle_chain`.
+    PrefabCycle,
+    /// The walk nested deeper than `max_depth` — a runaway tree or
+    /// a `children`/component-field structure with no natural base.
+    DepthExceeded,
+    OutOfMemory,
+};
+
+/// How a particular entity entry was reached. Consumers that treat
+/// the two structural birth-places differently (save/load tags only
+/// prefab-tree descendants as `PrefabChild`; gizmo registration may
+/// skip component-field entities) branch on this.
+pub const Origin = enum {
+    /// The walk's starting entry.
+    root,
+    /// Reached through an entity's `children` array.
+    child,
+    /// Reached through `prefab.root.children` of a referenced prefab.
+    prefab_child,
+    /// Reached through an entity entry nested inside a component
+    /// field (the `Room.movement_nodes` pattern).
+    component_field,
+};
+
+/// One visit handed to the caller's `visit` callback.
+pub fn Node(comptime VisitError: type) type {
+    _ = VisitError;
+    return struct {
+        /// The entity entry's JSONC object — its `components` /
+        /// `overrides` / `prefab` / `children` keys.
+        obj: Value.Object,
+        /// The raw `Value` the object came from (handy for callers
+        /// that re-dispatch into existing `Value`-keyed helpers).
+        value: Value,
+        /// How this entry was reached.
+        origin: Origin,
+        /// Nesting depth — `0` for the root entry.
+        depth: usize,
+        /// When `origin == .component_field`, the name of the
+        /// component whose field carried this entry (e.g.
+        /// `"Room"`); `null` otherwise. Lets a consumer attribute a
+        /// nested entity to its owning component.
+        component_name: ?[]const u8,
+        /// The resolved prefab object when this entry referenced a
+        /// `prefab` that was found, else `null`. Already unwrapped
+        /// past the `root` block.
+        prefab_root: ?Value.Object,
+    };
+}
+
+/// Per-walk mutable state: the cycle-detection stack and the
+/// diagnostic chain buffer. One `WalkContext` per top-level walk;
+/// callers `init` it, run the walk, then read `cycle_chain` if the
+/// walk returned `error.PrefabCycle`.
+pub const WalkContext = struct {
+    /// Prefab names currently being expanded, innermost last. A
+    /// reference to a name already here is a cycle.
+    stack: std.ArrayListUnmanaged([]const u8) = .empty,
+    /// Filled with the offending chain when a cycle is hit — the
+    /// stack at the point of detection plus the repeated name.
+    /// Borrowed slices into the walked tree / prefab registry; valid
+    /// as long as those outlive the context.
+    cycle_chain: std.ArrayListUnmanaged([]const u8) = .empty,
+    allocator: std.mem.Allocator,
+    /// Hard recursion cap — a malformed tree (or a cycle the prefab
+    /// resolver fails to surface) can't run away.
+    max_depth: usize = 64,
+
+    pub fn init(allocator: std.mem.Allocator) WalkContext {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(self: *WalkContext) void {
+        self.stack.deinit(self.allocator);
+        self.cycle_chain.deinit(self.allocator);
+    }
+
+    /// Render the recorded cycle chain as `A -> B -> A`. The
+    /// returned slice is owned by `out_alloc`. Empty when no cycle
+    /// was recorded.
+    pub fn formatCycleChain(self: *const WalkContext, out_alloc: std.mem.Allocator) ![]const u8 {
+        if (self.cycle_chain.items.len == 0) return out_alloc.dupe(u8, "");
+        var buf: std.ArrayListUnmanaged(u8) = .empty;
+        errdefer buf.deinit(out_alloc);
+        for (self.cycle_chain.items, 0..) |name, i| {
+            if (i != 0) try buf.appendSlice(out_alloc, " -> ");
+            try buf.appendSlice(out_alloc, name);
+        }
+        return buf.toOwnedSlice(out_alloc);
+    }
+};
+
+/// A prefab resolver: maps a prefab name to its parsed `Value`, or
+/// `null` when the name is unknown. `PrefabCache.get` satisfies this
+/// directly; tests pass a closure over a static table.
+pub const Resolver = struct {
+    ctx: *anyopaque,
+    getFn: *const fn (ctx: *anyopaque, name: []const u8) ?Value,
+
+    pub fn get(self: Resolver, name: []const u8) ?Value {
+        return self.getFn(self.ctx, name);
+    }
+};
+
+/// Walk the entity tree rooted at `root_value`, invoking `visitor`
+/// once per entity entry in the normative pre-order. `visitor` must
+/// expose `pub fn visit(self, node) VisitError!void` where `node` is
+/// `Node(VisitError)`.
+///
+/// `resolver` resolves `prefab` references so the walk can descend
+/// into prefab subtrees; pass a resolver that always returns `null`
+/// to walk only the inline structure (no prefab expansion).
+///
+/// Returns `error.PrefabCycle` (with `ctx.cycle_chain` populated) on
+/// a referenced-prefab cycle, or any error the visitor raises.
+pub fn walk(
+    ctx: *WalkContext,
+    resolver: Resolver,
+    root_value: Value,
+    visitor: anytype,
+) (WalkError || @TypeOf(visitor).VisitError)!void {
+    try walkEntry(ctx, resolver, root_value, .root, 0, null, visitor);
+}
+
+fn walkEntry(
+    ctx: *WalkContext,
+    resolver: Resolver,
+    entity_value: Value,
+    origin: Origin,
+    depth: usize,
+    component_name: ?[]const u8,
+    visitor: anytype,
+) (WalkError || @TypeOf(visitor).VisitError)!void {
+    const VisitError = @TypeOf(visitor).VisitError;
+    if (depth > ctx.max_depth) return error.DepthExceeded;
+
+    const obj = entity_value.asObject() orelse return;
+
+    // Resolve a `prefab` reference, if any. A reference to a prefab
+    // already on the expansion stack is a cycle — record the full
+    // chain and bail before recursing.
+    var prefab_root: ?Value.Object = null;
+    var pushed_prefab: bool = false;
+    if (obj.getString("prefab")) |prefab_name| {
+        for (ctx.stack.items) |on_stack| {
+            if (std.mem.eql(u8, on_stack, prefab_name)) {
+                ctx.cycle_chain.clearRetainingCapacity();
+                try ctx.cycle_chain.appendSlice(ctx.allocator, ctx.stack.items);
+                try ctx.cycle_chain.append(ctx.allocator, prefab_name);
+                return error.PrefabCycle;
+            }
+        }
+        if (resolver.get(prefab_name)) |prefab_val| {
+            if (prefab_val.asObject()) |pobj| {
+                prefab_root = uf.rootObject(pobj);
+                try ctx.stack.append(ctx.allocator, prefab_name);
+                pushed_prefab = true;
+            }
+        }
+    }
+    defer if (pushed_prefab) {
+        _ = ctx.stack.pop();
+    };
+
+    // Pre-order: yield this entry before descending.
+    const node: Node(VisitError) = .{
+        .obj = obj,
+        .value = entity_value,
+        .origin = origin,
+        .depth = depth,
+        .component_name = component_name,
+        .prefab_root = prefab_root,
+    };
+    try visitor.visit(node);
+
+    // ── 1. prefab-defined children ──────────────────────────────
+    if (prefab_root) |proot| {
+        if (proot.getArray("children")) |children| {
+            for (children.items) |child_val| {
+                try walkEntry(ctx, resolver, child_val, .prefab_child, depth + 1, null, visitor);
+            }
+        }
+    }
+
+    // ── 2. entity entries nested in component fields ────────────
+    // Prefab components first, then the entry's own patch — the
+    // entry-side patch is walked too because an `overrides` block
+    // can introduce nested entities of its own.
+    if (prefab_root) |proot| {
+        if (proot.getObject("components")) |pc| {
+            try walkComponentFields(ctx, resolver, pc, depth, visitor);
+        }
+    }
+    if (uf.entityPatch(obj, NoopLog{})) |patch| {
+        try walkComponentFields(ctx, resolver, patch, depth, visitor);
+    }
+
+    // ── 3. the entry's own children array ───────────────────────
+    if (obj.getArray("children")) |children| {
+        for (children.items) |child_val| {
+            try walkEntry(ctx, resolver, child_val, .child, depth + 1, null, visitor);
+        }
+    }
+}
+
+/// Walk every entity entry nested inside a component object's array
+/// fields. A field is "entity-bearing" when its first array element
+/// looks like an entity entry (`isEntityLike`).
+fn walkComponentFields(
+    ctx: *WalkContext,
+    resolver: Resolver,
+    components: Value.Object,
+    depth: usize,
+    visitor: anytype,
+) (WalkError || @TypeOf(visitor).VisitError)!void {
+    for (components.entries) |entry| {
+        const comp_obj = entry.value.asObject() orelse continue;
+        for (comp_obj.entries) |field| {
+            const arr = field.value.asArray() orelse continue;
+            if (arr.items.len == 0) continue;
+            if (!isEntityLike(arr.items[0])) continue;
+            for (arr.items) |item| {
+                if (!isEntityLike(item)) continue;
+                try walkEntry(ctx, resolver, item, .component_field, depth + 1, entry.key, visitor);
+            }
+        }
+    }
+}
+
+/// Whether a `Value` looks like an entity definition — it has a
+/// `prefab` string or a `components` object. Mirrors
+/// `component_apply.isEntityLike`; kept here so the walker has no
+/// dependency on the component-apply machinery (which is generic
+/// over `GameType`).
+pub fn isEntityLike(value: Value) bool {
+    const obj = value.asObject() orelse return false;
+    return obj.getString("prefab") != null or obj.getObject("components") != null;
+}
+
+/// A `log`-shaped no-op — `uf.entityPatch` takes a logger to emit
+/// deprecation warnings, but a pure structural walk should stay
+/// silent (the instantiation pass already warns once per file).
+const NoopLog = struct {
+    pub fn warn(_: NoopLog, comptime _: []const u8, _: anytype) void {}
+    pub fn err(_: NoopLog, comptime _: []const u8, _: anytype) void {}
+};

--- a/src/jsonc/tree_walker.zig
+++ b/src/jsonc/tree_walker.zig
@@ -349,7 +349,7 @@ fn effectiveComponents(
         var value = pe.value;
         for (ov.entries) |oe| {
             if (std.mem.eql(u8, oe.key, pe.key) and oe.value != .null_value) {
-                value = uf.mergeValues(pe.value, oe.value, a);
+                value = try uf.mergeValues(pe.value, oe.value, a);
                 break;
             }
         }

--- a/src/root.zig
+++ b/src/root.zig
@@ -227,6 +227,13 @@ pub const JsoncSceneBridgeWithGizmos = @import("jsonc_scene_bridge.zig").JsoncSc
 // the piece they need without going through the full bridge.
 pub const jsonc_deserializer = @import("jsonc/deserializer.zig");
 
+// ── Entity-tree walker (RFC #569) ──
+// The single shared traversal for every entity-tree consumer —
+// crosses both `children` and prefab refs nested in component
+// fields, with prefab-cycle detection. Re-exported so specs and
+// downstream tooling (asset inference, editors) use one walker.
+pub const tree_walker = @import("jsonc/tree_walker.zig");
+
 // ── Scene Value & JSONC Parser ──
 pub const SceneValue = jsonc_mod.Value;
 pub const JsoncParser = jsonc_mod.JsoncParser;


### PR DESCRIPTION
A single shared entity-tree walker for the unified prefab/scene format — ticket #569, part of RFC #560.

**Stacked on #574** (base `feat/562-overrides-merge-rules`). Review #573 → #574 → this in order; the base retargets as each lands.

## What's in

**`src/jsonc/tree_walker.zig`** — the shared walker. Walks a JSONC `Value` entity tree in a documented pre-order, crossing **both** `children` arrays and prefab references nested inside entity-bearing component fields (the `Room.movement_nodes` pattern). Resolves `prefab` references through a `Resolver` interface (`PrefabCache` satisfies it directly). Detects referenced-prefab **cycles** via an expansion stack and reports the full chain (`A -> B -> A`). Visitors are generic — each node carries its `Origin` (root / child / prefab_child / component_field), depth, owning component, and resolved prefab root. Re-exported as `engine.tree_walker`.

## Consumer migration

- **Migrated:** scene/prefab instantiation. `processEntities` runs a walker pre-pass over every top-level entity as a load-time cycle gate before any entity is created; `spawnPrefabImpl` gates runtime `spawnFromPrefab` the same way. The loader previously had **no** cycle detection — a cyclic graph just hit `IncludeDepthExceeded` with no actionable message; now it logs the chain and returns `error.PrefabCycle`.
- **Deferred (follow-up):** save/load prefab tagging, `postLoad` hook firing, asset inference (#563). These walk the tree inline within `loadEntityInternal`; folding them onto the visitor API is best co-designed once #563 lands a second consumer. The gizmo/save-load *mixins* walk the runtime ECS tree, not the JSONC tree — out of scope.

## Tests

`spec/tree_walker_spec.zig` — 5 zspec specs: `children` crossing (pre-order), component-field crossing, direct + multi-hop cycles (full chain in the message), and an acyclic prefab tree. `zig build spec`: 17/17. `zig build test`: green (verified).

Resolves #569.

🤖 Generated with [Claude Code](https://claude.com/claude-code)