### PR TITLE
Eager filesystem registry scan (#561)

### DIFF
--- a/spec/registry_scan_spec.zig
+++ b/spec/registry_scan_spec.zig
@@ -210,4 +210,61 @@ pub const RegistryScanSpec = struct {
             try std.testing.expectError(error.DuplicatePrefabName, result);
         }
     };
+
+    // ── idempotent scan across a scene reload ───────────────────────
+
+    pub const @"loadScene called twice on the same game" = struct {
+        var tmp_dir: std.testing.TmpDir = undefined;
+        var game: Game = undefined;
+
+        test "tests:before" {
+            tmp_dir = std.testing.tmpDir(.{});
+            try tmp_dir.dir.createDir(std.testing.io, "prefabs", .default_dir);
+            try tmp_dir.dir.createDir(std.testing.io, "scenes", .default_dir);
+
+            try tmp_dir.dir.writeFile(std.testing.io, .{
+                .sub_path = "prefabs/widget.jsonc",
+                .data =
+                \\{ "name": "super_widget",
+                \\  "root": { "components": { "Marker": { "id": 99 } } } }
+                ,
+            });
+            try tmp_dir.dir.writeFile(std.testing.io, .{
+                .sub_path = "scenes/main.jsonc",
+                .data =
+                \\{ "root": { "children": [
+                \\  { "prefab": "super_widget" }
+                \\] } }
+                ,
+            });
+
+            game = Game.init(zspec.allocator);
+        }
+
+        test "tests:after" {
+            game.deinit();
+            tmp_dir.cleanup();
+        }
+
+        // A scene reload (e.g. F9 in the games) calls `loadScene`
+        // again on the same game-lifetime `PrefabCache`. The eager
+        // registry scan re-runs; without an idempotency guard it
+        // would re-encounter every file the first scan registered and
+        // wrongly raise `error.DuplicatePrefabName`. The scan tracks
+        // already-walked directories, so the second call is a no-op
+        // for the scan and must succeed.
+        test "the second loadScene does not raise DuplicatePrefabName" {
+            const scene_path = try tmpPath(&tmp_dir, "scenes/main.jsonc");
+            defer zspec.allocator.free(scene_path);
+            const prefab_dir = try tmpPath(&tmp_dir, "prefabs");
+            defer zspec.allocator.free(prefab_dir);
+
+            try Bridge.loadScene(&game, scene_path, prefab_dir);
+            // Second load — must not error on the re-scan.
+            try Bridge.loadScene(&game, scene_path, prefab_dir);
+
+            // The prefab still resolves after the reload.
+            try expect.notToBeNull(findMarker(&game, 99));
+        }
+    };
 };

--- a/spec/registry_scan_spec.zig
+++ b/spec/registry_scan_spec.zig
@@ -1,0 +1,213 @@
+//! zspec BDD specs for the eager filesystem registry scan
+//! (RFC #560, ticket #561).
+//!
+//! `loadScene` (the desktop entry point) recursively scans the
+//! project's `prefabs/` and sibling `scenes/` directories up-front,
+//! populating the flat name-keyed registry. These specs cover the
+//! behaviours that scan unlocks — none reachable through the embedded
+//! `addEmbeddedPrefab` path the other specs use:
+//!
+//!  - a prefab resolved by a `"name"` that diverges from its filename,
+//!  - a scene file found by the scan (recursively, in a subdirectory),
+//!  - two files sharing an effective name → `error.DuplicatePrefabName`.
+//!
+//! Each example builds a throwaway project tree under `std.testing`'s
+//! tmp dir so the scan has a real filesystem to walk.
+
+const std = @import("std");
+const zspec = @import("zspec");
+const engine = @import("engine");
+const core = @import("labelle-core");
+
+const expect = zspec.expect;
+
+// ── Components under test ───────────────────────────────────────────
+
+const Marker = struct { id: i32 = 0 };
+
+const Components = engine.ComponentRegistry(.{
+    .Marker = Marker,
+});
+
+const Game = engine.Game;
+const Bridge = engine.JsoncSceneBridge(Game, Components);
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+/// Absolute path to `sub` inside the tmp dir.
+fn tmpPath(tmp_dir: *std.testing.TmpDir, sub: []const u8) ![]const u8 {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const len = try tmp_dir.dir.realPath(std.testing.io, &buf);
+    return std.fmt.allocPrint(zspec.allocator, "{s}/{s}", .{ buf[0..len], sub });
+}
+
+/// First entity carrying a `Marker` with the given id, or null.
+fn findMarker(game: *Game, id: i32) ?*Marker {
+    var view = game.ecs_backend.view(.{Marker}, .{});
+    defer view.deinit();
+    while (view.next()) |e| {
+        const m = game.ecs_backend.getComponent(e, Marker).?;
+        if (m.id == id) return m;
+    }
+    return null;
+}
+
+pub const RegistryScanSpec = struct {
+    // ── prefab found by a divergent "name" ──────────────────────────
+
+    pub const @"a prefab whose name diverges from its filename" = struct {
+        var tmp_dir: std.testing.TmpDir = undefined;
+        var game: Game = undefined;
+
+        test "tests:before" {
+            tmp_dir = std.testing.tmpDir(.{});
+            try tmp_dir.dir.createDir(std.testing.io, "prefabs", .default_dir);
+            try tmp_dir.dir.createDir(std.testing.io, "scenes", .default_dir);
+
+            // File `widget.jsonc` declares a divergent effective name
+            // `"super_widget"`. Lazy basename lookup would miss it;
+            // only the eager scan keys it by its `"name"` field.
+            try tmp_dir.dir.writeFile(std.testing.io, .{
+                .sub_path = "prefabs/widget.jsonc",
+                .data =
+                \\{ "name": "super_widget",
+                \\  "root": { "components": { "Marker": { "id": 42 } } } }
+                ,
+            });
+            try tmp_dir.dir.writeFile(std.testing.io, .{
+                .sub_path = "scenes/main.jsonc",
+                .data =
+                \\{ "root": { "children": [
+                \\  { "prefab": "super_widget" }
+                \\] } }
+                ,
+            });
+
+            game = Game.init(zspec.allocator);
+        }
+
+        test "tests:after" {
+            game.deinit();
+            tmp_dir.cleanup();
+        }
+
+        test "the scene resolves the prefab by its \"name\" field" {
+            const scene_path = try tmpPath(&tmp_dir, "scenes/main.jsonc");
+            defer zspec.allocator.free(scene_path);
+            const prefab_dir = try tmpPath(&tmp_dir, "prefabs");
+            defer zspec.allocator.free(prefab_dir);
+            try Bridge.loadScene(&game, scene_path, prefab_dir);
+
+            // Prefab applied → entity carries Marker id 42.
+            try expect.notToBeNull(findMarker(&game, 42));
+        }
+    };
+
+    // ── scene found by the scan ─────────────────────────────────────
+
+    pub const @"a scene file discovered by the recursive scan" = struct {
+        var tmp_dir: std.testing.TmpDir = undefined;
+        var game: Game = undefined;
+
+        test "tests:before" {
+            tmp_dir = std.testing.tmpDir(.{});
+            try tmp_dir.dir.createDir(std.testing.io, "prefabs", .default_dir);
+            try tmp_dir.dir.createDir(std.testing.io, "scenes", .default_dir);
+            // A nested subdirectory exercises the recursive walk.
+            try tmp_dir.dir.createDir(std.testing.io, "scenes/levels", .default_dir);
+
+            try tmp_dir.dir.writeFile(std.testing.io, .{
+                .sub_path = "scenes/levels/arena.jsonc",
+                .data =
+                \\{ "name": "arena_one",
+                \\  "root": { "components": { "Marker": { "id": 7 } } } }
+                ,
+            });
+            // The scene we actually load. It references `arena_one`
+            // by effective name — a file that lives only under
+            // `scenes/levels/`, so resolving it proves the recursive
+            // scan walked the `scenes/` tree and registered it.
+            try tmp_dir.dir.writeFile(std.testing.io, .{
+                .sub_path = "scenes/boot.jsonc",
+                .data =
+                \\{ "root": { "children": [
+                \\  { "prefab": "arena_one" }
+                \\] } }
+                ,
+            });
+
+            game = Game.init(zspec.allocator);
+        }
+
+        test "tests:after" {
+            game.deinit();
+            tmp_dir.cleanup();
+        }
+
+        test "the nested scene is registered under its effective name" {
+            const scene_path = try tmpPath(&tmp_dir, "scenes/boot.jsonc");
+            defer zspec.allocator.free(scene_path);
+            const prefab_dir = try tmpPath(&tmp_dir, "prefabs");
+            defer zspec.allocator.free(prefab_dir);
+            try Bridge.loadScene(&game, scene_path, prefab_dir);
+
+            // `boot.jsonc` referenced `arena_one`, a file living only
+            // under `scenes/levels/`. Resolving it (Marker id 7
+            // applied) proves the scan walked `scenes/` recursively
+            // and keyed it by its `"name"`.
+            try expect.notToBeNull(findMarker(&game, 7));
+        }
+    };
+
+    // ── effective-name collision ────────────────────────────────────
+
+    pub const @"two files sharing an effective name" = struct {
+        var tmp_dir: std.testing.TmpDir = undefined;
+        var game: Game = undefined;
+
+        test "tests:before" {
+            tmp_dir = std.testing.tmpDir(.{});
+            try tmp_dir.dir.createDir(std.testing.io, "prefabs", .default_dir);
+            try tmp_dir.dir.createDir(std.testing.io, "scenes", .default_dir);
+
+            // Two prefab files collide: `box.jsonc` keyed by its
+            // basename `box`, and `crate.jsonc` whose `"name"` field
+            // is also `"box"`.
+            try tmp_dir.dir.writeFile(std.testing.io, .{
+                .sub_path = "prefabs/box.jsonc",
+                .data =
+                \\{ "root": { "components": { "Marker": { "id": 1 } } } }
+                ,
+            });
+            try tmp_dir.dir.writeFile(std.testing.io, .{
+                .sub_path = "prefabs/crate.jsonc",
+                .data =
+                \\{ "name": "box",
+                \\  "root": { "components": { "Marker": { "id": 2 } } } }
+                ,
+            });
+            try tmp_dir.dir.writeFile(std.testing.io, .{
+                .sub_path = "scenes/main.jsonc",
+                .data =
+                \\{ "root": { "children": [] } }
+                ,
+            });
+
+            game = Game.init(zspec.allocator);
+        }
+
+        test "tests:after" {
+            game.deinit();
+            tmp_dir.cleanup();
+        }
+
+        test "the scan raises error.DuplicatePrefabName" {
+            const scene_path = try tmpPath(&tmp_dir, "scenes/main.jsonc");
+            defer zspec.allocator.free(scene_path);
+            const prefab_dir = try tmpPath(&tmp_dir, "prefabs");
+            defer zspec.allocator.free(prefab_dir);
+            const result = Bridge.loadScene(&game, scene_path, prefab_dir);
+            try std.testing.expectError(error.DuplicatePrefabName, result);
+        }
+    };
+};

--- a/spec/registry_scan_spec.zig
+++ b/spec/registry_scan_spec.zig
@@ -267,4 +267,78 @@ pub const RegistryScanSpec = struct {
             try expect.notToBeNull(findMarker(&game, 99));
         }
     };
+
+    // ── failure-recovery: retry succeeds after the collision is fixed ──
+
+    pub const @"a reload after a DuplicatePrefabName is fixed" = struct {
+        var tmp_dir: std.testing.TmpDir = undefined;
+        var game: Game = undefined;
+
+        test "tests:before" {
+            tmp_dir = std.testing.tmpDir(.{});
+            try tmp_dir.dir.createDir(std.testing.io, "prefabs", .default_dir);
+            try tmp_dir.dir.createDir(std.testing.io, "scenes", .default_dir);
+
+            // Two prefabs intentionally collide on the effective name
+            // `"widget"` — `widget.jsonc` keyed by basename and
+            // `dup.jsonc` whose `"name"` field is also `"widget"`.
+            try tmp_dir.dir.writeFile(std.testing.io, .{
+                .sub_path = "prefabs/widget.jsonc",
+                .data =
+                \\{ "root": { "components": { "Marker": { "id": 11 } } } }
+                ,
+            });
+            try tmp_dir.dir.writeFile(std.testing.io, .{
+                .sub_path = "prefabs/dup.jsonc",
+                .data =
+                \\{ "name": "widget",
+                \\  "root": { "components": { "Marker": { "id": 22 } } } }
+                ,
+            });
+            try tmp_dir.dir.writeFile(std.testing.io, .{
+                .sub_path = "scenes/main.jsonc",
+                .data =
+                \\{ "root": { "children": [
+                \\  { "prefab": "widget" }
+                \\] } }
+                ,
+            });
+
+            game = Game.init(zspec.allocator);
+        }
+
+        test "tests:after" {
+            game.deinit();
+            tmp_dir.cleanup();
+        }
+
+        // First `loadScene` aborts mid-walk with
+        // `error.DuplicatePrefabName`. Without the fix in
+        // `scanDir`, `scanned_dirs` would have already recorded
+        // `prefabs/` before the walk, so a retry — even after the
+        // collision is gone — would early-return and leave the
+        // half-populated cache permanently stale. The fix records
+        // the directory only after the walk succeeds, so retry
+        // re-walks and finishes cleanly.
+        test "the retry resolves the prefab cleanly" {
+            const scene_path = try tmpPath(&tmp_dir, "scenes/main.jsonc");
+            defer zspec.allocator.free(scene_path);
+            const prefab_dir = try tmpPath(&tmp_dir, "prefabs");
+            defer zspec.allocator.free(prefab_dir);
+
+            // First load: the collision fires.
+            try std.testing.expectError(
+                error.DuplicatePrefabName,
+                Bridge.loadScene(&game, scene_path, prefab_dir),
+            );
+
+            // User "fixes" the project by removing the offending file.
+            try tmp_dir.dir.deleteFile(std.testing.io, "prefabs/dup.jsonc");
+
+            // Retry now succeeds — and resolves `widget` to the
+            // surviving prefab (Marker id 11).
+            try Bridge.loadScene(&game, scene_path, prefab_dir);
+            try expect.notToBeNull(findMarker(&game, 11));
+        }
+    };
 };

--- a/spec/spec_tests.zig
+++ b/spec/spec_tests.zig
@@ -8,10 +8,12 @@ const zspec = @import("zspec");
 
 pub const unified_format_spec = @import("unified_format_spec.zig");
 pub const override_merge_spec = @import("override_merge_spec.zig");
+pub const registry_scan_spec = @import("registry_scan_spec.zig");
 
 // Re-export the spec structs so zspec discovers them.
 pub const UnifiedFormatSpec = unified_format_spec.UnifiedFormatSpec;
 pub const OverrideMergeSpec = override_merge_spec.OverrideMergeSpec;
+pub const RegistryScanSpec = registry_scan_spec.RegistryScanSpec;
 
 test {
     zspec.runAll(@This());

--- a/src/jsonc/prefab_cache.zig
+++ b/src/jsonc/prefab_cache.zig
@@ -53,6 +53,12 @@ pub const PrefabCache = struct {
     /// raise `error.DuplicatePrefabName`. A genuine collision between
     /// two *distinct* files in a not-yet-scanned directory still
     /// errors. Keys are duped into `persistent` (game-lifetime).
+    ///
+    /// An entry is added *only after* a directory's walk completes
+    /// successfully — a walk aborted by `error.DuplicatePrefabName`
+    /// (or any other mid-walk failure) leaves the directory un-marked
+    /// so a later reload (after the user fixes the collision) can
+    /// retry the scan instead of being permanently locked out.
     scanned_dirs: std.StringHashMap(void),
 
     pub fn init(allocator: std.mem.Allocator, prefab_dir: []const u8) PrefabCache {
@@ -198,28 +204,46 @@ pub fn scanRegistry(cache: *PrefabCache, log: anytype, prefab_dir: []const u8) !
 /// the cache keyed by effective name. A directory that cannot be
 /// opened (typically absent) is silently skipped.
 ///
-/// Idempotent: a directory already recorded in `cache.scanned_dirs`
-/// (from an earlier `loadScene` on this game-lifetime cache) is
-/// skipped, so a scene reload does not re-register — and thus does
-/// not falsely collide on — files the first scan already cached.
+/// Transactional: parsed entries are staged in a local map and
+/// committed into `cache.prefabs` only after the *entire* walk
+/// completes without error. A walk aborted partway (e.g. by
+/// `error.DuplicatePrefabName` on a collision the user is about to
+/// fix) leaves `cache.prefabs` and `cache.scanned_dirs` untouched, so
+/// a subsequent reload — after the user removes one of the colliding
+/// files — re-runs the walk and succeeds. Without staging, a partial
+/// first walk would leave half-populated cache entries that either
+/// shadow the now-canonical file or self-collide on the retry.
+///
+/// Idempotent across normal reloads: a directory recorded in
+/// `cache.scanned_dirs` (from a previous *successful* walk on this
+/// game-lifetime cache) is skipped entirely, so a normal scene reload
+/// (e.g. F9) does not re-register — and thus does not falsely collide
+/// on — files the first scan already cached.
 fn scanDir(cache: *PrefabCache, log: anytype, dir_path: []const u8) !void {
     const io = io_helper.io();
 
-    // Skip directories already walked by a previous scan. Normalize a
-    // trailing slash so `prefabs` and `prefabs/` map to one key.
+    // Skip directories already walked by a previous successful scan.
+    // Normalize a trailing slash so `prefabs` and `prefabs/` map to
+    // one key.
     const dir_key = std.mem.trimEnd(u8, dir_path, "/");
     if (cache.scanned_dirs.contains(dir_key)) return;
 
     var dir = std.Io.Dir.cwd().openDir(io, dir_path, .{ .iterate = true }) catch return;
     defer dir.close(io);
 
-    // Record the directory as scanned. Done after a successful open so
-    // a directory that does not exist yet (skipped above) can still be
-    // picked up by a later scan once it is created.
-    try cache.scanned_dirs.put(try cache.persistent.dupe(u8, dir_key), {});
-
     var walker = try dir.walk(cache.temp);
     defer walker.deinit();
+
+    // Stage this walk's inserts in a temp-allocator map. We commit
+    // them into `cache.prefabs` only after the loop completes without
+    // error. If the loop returns early (e.g. duplicate-name), the
+    // staging map is discarded by `deinit`, leaving the persistent
+    // cache untouched. The parsed `Value` trees and their backing
+    // `src` buffers are themselves in `cache.persistent` (game-
+    // lifetime, page-allocator) and harmlessly leaked on the error
+    // path — same property the rest of the cache relies on.
+    var staged = std.StringHashMap(Value).init(cache.temp);
+    defer staged.deinit();
 
     while (try walker.next(io)) |entry| {
         if (entry.kind != .file) continue;
@@ -243,10 +267,24 @@ fn scanDir(cache: *PrefabCache, log: anytype, dir_path: []const u8) !void {
         const basename = entry.basename[0 .. entry.basename.len - ".jsonc".len];
         const key = if (val.asObject()) |obj| uf.effectiveName(obj, basename) else basename;
 
-        if (cache.prefabs.contains(key)) {
+        // Collisions are checked against both the already-committed
+        // cache and the current walk's staging map — two distinct
+        // files in this walk that share an effective name must error
+        // even though neither is in `cache.prefabs` yet.
+        if (cache.prefabs.contains(key) or staged.contains(key)) {
             log.err("[registry] duplicate name '{s}' (from '{s}'): rename the file or give one a distinct \"name\" (RFC #561)", .{ key, entry.path });
             return error.DuplicatePrefabName;
         }
-        try cache.prefabs.put(try cache.persistent.dupe(u8, key), val);
+        // Stage with a persistent-allocator key: it will be moved into
+        // `cache.prefabs` (which uses `cache.persistent`) on commit.
+        try staged.put(try cache.persistent.dupe(u8, key), val);
     }
+
+    // Commit: walk succeeded, fold the staged entries into the
+    // permanent cache and mark the directory done.
+    var it = staged.iterator();
+    while (it.next()) |kv| {
+        try cache.prefabs.put(kv.key_ptr.*, kv.value_ptr.*);
+    }
+    try cache.scanned_dirs.put(try cache.persistent.dupe(u8, dir_key), {});
 }

--- a/src/jsonc/prefab_cache.zig
+++ b/src/jsonc/prefab_cache.zig
@@ -120,3 +120,101 @@ pub fn getOrCreatePrefabCache(game: anytype, prefab_dir: []const u8) !*PrefabCac
     }
     return try initPersistentCache(game, prefab_dir);
 }
+
+// ── Eager filesystem registry scan (RFC #560, ticket #561) ──────────
+//
+// On desktop, the flat name-keyed registry is populated up-front by
+// recursively walking the project's `prefabs/` and `scenes/`
+// directories. This is what makes a file resolvable by an effective
+// name (its `"name"` field) that diverges from its filename basename,
+// and what lets cross-file effective-name collisions be caught as a
+// hard load-time error instead of silently shadowing.
+//
+// It is the filesystem counterpart of `addEmbeddedPrefab`, which the
+// assembler emits for WASM/mobile builds (no filesystem). WASM/mobile
+// must NOT run this scan — `std.Io` is `failing` there (see
+// `io_helper.zig`) and prefabs arrive exclusively via the embedded
+// path. The scan is therefore gated on a non-emscripten target, and
+// additionally skips any directory it cannot open (a desktop project
+// may legitimately ship only one of `prefabs/`/`scenes/`).
+
+const is_wasm_emscripten = builtin.target.os.tag == .emscripten;
+
+/// Recursively scan a project's `prefabs/` and `scenes/` directories
+/// into the flat name-keyed registry held by `cache`.
+///
+/// `prefab_dir` is the project's prefab directory (the same value
+/// passed to `loadScene`); the sibling `scenes/` directory is derived
+/// by convention — `<dirname(prefab_dir)>/scenes`. Either directory
+/// may be absent; a missing directory is skipped, not an error.
+///
+/// Each `.jsonc` file is parsed and keyed by its *effective name*
+/// (`unified_format.effectiveName` — its `"name"` field if present,
+/// else the filename basename without the extension). A duplicate
+/// effective name across any two scanned files raises
+/// `error.DuplicatePrefabName` — mirrors `addEmbeddedPrefab`; there
+/// is no precedence rule, the author renames a file or sets a
+/// distinct `"name"`.
+///
+/// No-op on WASM/mobile (`wasm32-emscripten`) — those builds rely on
+/// the assembler-emitted embedded prefab/scene sources and have no
+/// filesystem.
+pub fn scanRegistry(cache: *PrefabCache, log: anytype, prefab_dir: []const u8) !void {
+    if (is_wasm_emscripten) return;
+
+    try scanDir(cache, log, prefab_dir);
+
+    // Derive the sibling `scenes/` directory by convention. The
+    // project layout is `<project>/prefabs` + `<project>/scenes`, so
+    // replace the prefab dir's last path component with `scenes`.
+    const parent = std.fs.path.dirname(prefab_dir);
+    const scenes_dir = if (parent) |p|
+        try std.fs.path.join(cache.temp, &.{ p, "scenes" })
+    else
+        try cache.temp.dupe(u8, "scenes");
+    defer cache.temp.free(scenes_dir);
+
+    try scanDir(cache, log, scenes_dir);
+}
+
+/// Recursively walk one directory, parsing every `.jsonc` file into
+/// the cache keyed by effective name. A directory that cannot be
+/// opened (typically absent) is silently skipped.
+fn scanDir(cache: *PrefabCache, log: anytype, dir_path: []const u8) !void {
+    const io = io_helper.io();
+
+    var dir = std.Io.Dir.cwd().openDir(io, dir_path, .{ .iterate = true }) catch return;
+    defer dir.close(io);
+
+    var walker = try dir.walk(cache.temp);
+    defer walker.deinit();
+
+    while (try walker.next(io)) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.endsWith(u8, entry.basename, ".jsonc")) continue;
+
+        // Read + parse into the persistent allocator: the parsed
+        // `Value` tree is game-lifetime data (deserialized components
+        // hold slices into it), the same contract as `get`.
+        const src = entry.dir.readFileAlloc(io, entry.basename, cache.persistent, .limited(1024 * 1024)) catch |err| {
+            log.warn("[registry] failed to read '{s}': {s}", .{ entry.path, @errorName(err) });
+            continue;
+        };
+        var parser = JsoncParser.init(cache.persistent, src);
+        const val = parser.parse() catch |err| {
+            log.warn("[registry] failed to parse '{s}': {s}", .{ entry.path, @errorName(err) });
+            continue;
+        };
+
+        // Effective name = `"name"` field, else filename basename
+        // without the `.jsonc` extension.
+        const basename = entry.basename[0 .. entry.basename.len - ".jsonc".len];
+        const key = if (val.asObject()) |obj| uf.effectiveName(obj, basename) else basename;
+
+        if (cache.prefabs.contains(key)) {
+            log.err("[registry] duplicate name '{s}' (from '{s}'): rename the file or give one a distinct \"name\" (RFC #561)", .{ key, entry.path });
+            return error.DuplicatePrefabName;
+        }
+        try cache.prefabs.put(try cache.persistent.dupe(u8, key), val);
+    }
+}

--- a/src/jsonc/prefab_cache.zig
+++ b/src/jsonc/prefab_cache.zig
@@ -43,6 +43,17 @@ pub const PrefabCache = struct {
     persistent: std.mem.Allocator,
     temp: std.mem.Allocator,
     prefab_dir: []const u8,
+    /// Directories already walked by `scanRegistry`/`scanDir`, keyed
+    /// by the (trailing-slash-normalized) path. The eager scan is
+    /// idempotent: a second `loadScene` (a normal scene reload —
+    /// e.g. F9 in the games) re-runs the scan into this same
+    /// game-lifetime cache, and a directory already in this set is
+    /// skipped rather than re-walked. Without this, the second scan
+    /// would re-encounter every already-registered file and wrongly
+    /// raise `error.DuplicatePrefabName`. A genuine collision between
+    /// two *distinct* files in a not-yet-scanned directory still
+    /// errors. Keys are duped into `persistent` (game-lifetime).
+    scanned_dirs: std.StringHashMap(void),
 
     pub fn init(allocator: std.mem.Allocator, prefab_dir: []const u8) PrefabCache {
         const persistent = persistent_allocator;
@@ -51,6 +62,7 @@ pub const PrefabCache = struct {
             .persistent = persistent,
             .temp = allocator,
             .prefab_dir = prefab_dir,
+            .scanned_dirs = std.StringHashMap(void).init(persistent),
         };
     }
 
@@ -167,7 +179,12 @@ pub fn scanRegistry(cache: *PrefabCache, log: anytype, prefab_dir: []const u8) !
     // Derive the sibling `scenes/` directory by convention. The
     // project layout is `<project>/prefabs` + `<project>/scenes`, so
     // replace the prefab dir's last path component with `scenes`.
-    const parent = std.fs.path.dirname(prefab_dir);
+    //
+    // Strip a trailing slash first: `dirname("foo/prefabs/")` returns
+    // `"foo/prefabs"`, which would derive `foo/prefabs/scenes` instead
+    // of the intended sibling `foo/scenes`.
+    const normalized = std.mem.trimEnd(u8, prefab_dir, "/");
+    const parent = std.fs.path.dirname(normalized);
     const scenes_dir = if (parent) |p|
         try std.fs.path.join(cache.temp, &.{ p, "scenes" })
     else
@@ -180,11 +197,26 @@ pub fn scanRegistry(cache: *PrefabCache, log: anytype, prefab_dir: []const u8) !
 /// Recursively walk one directory, parsing every `.jsonc` file into
 /// the cache keyed by effective name. A directory that cannot be
 /// opened (typically absent) is silently skipped.
+///
+/// Idempotent: a directory already recorded in `cache.scanned_dirs`
+/// (from an earlier `loadScene` on this game-lifetime cache) is
+/// skipped, so a scene reload does not re-register — and thus does
+/// not falsely collide on — files the first scan already cached.
 fn scanDir(cache: *PrefabCache, log: anytype, dir_path: []const u8) !void {
     const io = io_helper.io();
 
+    // Skip directories already walked by a previous scan. Normalize a
+    // trailing slash so `prefabs` and `prefabs/` map to one key.
+    const dir_key = std.mem.trimEnd(u8, dir_path, "/");
+    if (cache.scanned_dirs.contains(dir_key)) return;
+
     var dir = std.Io.Dir.cwd().openDir(io, dir_path, .{ .iterate = true }) catch return;
     defer dir.close(io);
+
+    // Record the directory as scanned. Done after a successful open so
+    // a directory that does not exist yet (skipped above) can still be
+    // picked up by a later scan once it is created.
+    try cache.scanned_dirs.put(try cache.persistent.dupe(u8, dir_key), {});
 
     var walker = try dir.walk(cache.temp);
     defer walker.deinit();

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -66,6 +66,17 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             // `loadScene` is a desktop path.
             const prefab_cache = try prefab_cache_mod.getOrCreatePrefabCache(game, prefab_dir);
 
+            // Eagerly populate the flat name-keyed registry from the
+            // filesystem (RFC #560, #561): recursively scan the
+            // project's `prefabs/` and sibling `scenes/` directories
+            // up-front. This resolves files whose `"name"` diverges
+            // from their basename and catches cross-file effective-
+            // name collisions as a hard load-time error. Desktop-only
+            // — no-op on WASM/mobile, where there is no filesystem
+            // and prefabs/scenes arrive via the assembler-emitted
+            // embedded sources / `addEmbeddedPrefab`.
+            try prefab_cache_mod.scanRegistry(prefab_cache, game.log, prefab_dir);
+
             try loadSceneFile(game, scene_path, prefab_cache, 0);
 
             // Enable runtime prefab spawning.


### PR DESCRIPTION
The remaining piece of #561 — the eager filesystem scan of `scenes/` + `prefabs/` into the flat name-keyed registry. Part of RFC #560.

**Stacked on #573** (base `feat/561-unified-loader`).

## What's in

- `prefab_cache.zig` — `scanRegistry` + `scanDir`: a recursive `.jsonc` walk that parses each file, computes its effective name (`unified_format.effectiveName` — `"name"` field or basename), and populates the `PrefabCache` keyed by effective name. A duplicate effective name across any two scanned files raises `error.DuplicatePrefabName` (same contract as `addEmbeddedPrefab`).
- `scene_loader.zig` — wired into the desktop `loadScene` path. The `scenes/` directory is derived by convention as the sibling of `prefab_dir` (`<dirname(prefab_dir)>/scenes`).

This makes name-divergent files resolvable on desktop and catches scene/prefab cross-collisions at load time — the #570 audit (PR #575) confirmed no real collisions exist, so enabling the hard error is safe.

## WASM / mobile safety

`scanRegistry` returns immediately on `emscripten` (no filesystem — prefabs/scenes arrive via `addEmbeddedPrefab` / embedded sources). Only the desktop `loadScene` path calls it; `loadSceneFromSource` and `addEmbeddedPrefab` are untouched. A missing `scenes/` or `prefabs/` directory is skipped silently.

## Tests

`spec/registry_scan_spec.zig` — 3 zspec specs: prefab found by a divergent `"name"`, scene found via recursive subdirectory scan, collision raising the error. `zig build spec` 9/9; `zig build test` green.

Note for future test authors: the scan now runs on every desktop `loadScene`, so a new test with two same-effective-name files under `prefabs/`/`scenes/` will hard-fail by design.

Completes #561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)