### PR TITLE
Umbrella: unify scenes and prefabs (#560)

### DIFF
--- a/RFC-COLLISION-AUDIT.md
+++ b/RFC-COLLISION-AUDIT.md
@@ -1,0 +1,92 @@
+# RFC #560 — `scenes/` / `prefabs/` Name-Collision Audit (Issue #570)
+
+**Date:** 2026-05-21
+**Branch:** `feat/570-collision-audit` (off `origin/feat/unify-scenes-prefabs`)
+**Scope:** Audit every in-tree project for effective-name collisions across `scenes/`
+and `prefabs/` before #561 merges both directories into one flat name-keyed registry.
+
+## Method
+
+RFC #560 introduces a flat, name-keyed registry. Every `.jsonc` file under a project's
+`scenes/` and `prefabs/` directories resolves by an **effective name**:
+
+- the top-level JSON `"name"` string field if present, otherwise
+- the filename basename without the `.jsonc` extension.
+
+A **collision** is two `.jsonc` files within the *same project* that resolve to the
+same effective name. After #561, `scenes/` and `prefabs/` are scanned into one
+registry, so a scene and a prefab resolving to the same name is a **cross-directory
+collision** — the case #570 specifically warns about.
+
+Every `.jsonc` file under each project's `scenes/` and `prefabs/` (including nested
+subfolders) was recursively listed and JSONC-parsed (comments and trailing commas
+stripped) to extract the effective name. Generated `.labelle/` build-output
+directories were excluded — they are build artifacts, copies of the source trees.
+
+## Per-Project Inventory
+
+| Project | `scenes/` `.jsonc` | `prefabs/` `.jsonc` | Notes |
+|---|---:|---:|---|
+| `flying-platform-labelle` | 36 | 54 | All `.jsonc`. Only project materially affected. |
+| `labelle-cli/test/plugin-manifest-test` | 1 | 0 | `scenes/main.jsonc` only; no `prefabs/`. |
+| `labelle-cli/test/imgui-anchor-test` | 1 | 0 | `scenes/main.jsonc` only; no `prefabs/`. |
+| `labelle-cli/test/nuklear-plugin-test` | 1 | 0 (empty) | `scenes/main.jsonc`; `prefabs/` exists but empty. |
+| `labelle-cli/test/gui-plugin-test` | 1 | 0 (empty) | `scenes/main.jsonc`; `prefabs/` exists but empty. |
+| `bouncing-ball` | 0 | 0 | Uses legacy `scenes/main.zon` — not `.jsonc`. |
+| `labelle-gui/examples/project_1` | 0 | 0 | Uses legacy `scenes/main.zon`; `prefabs/` empty (`.gitkeep`). |
+| `labelle-cli/examples/raylib_carry_test` | 0 | 0 | `prefabs/` source dir empty (only `.labelle/` generated). |
+| `labelle-cli/examples/raylib` | 0 | 0 | Only `.labelle/` generated dirs, no source `.jsonc`. |
+| `bakery-game` | 0 | 0 | Cloned read-only; uses legacy `.zon` (see below). |
+
+**Total `.jsonc` files audited: 94** (90 in `flying-platform-labelle`,
+4 single-scene `labelle-cli` test fixtures).
+
+### `flying-platform-labelle` detail
+
+- `scenes/` — 5 top-level (`save_load_smoke`, `colony`, `loading`, `menu`, `main`),
+  16 under `scenes/debug/`, 15 under `scenes/debug/bandit/`. All carry an explicit
+  `"name"` field equal to their basename.
+- `prefabs/` — 54 files across `background/`, `carcase/`, `characters/`, `furniture/`,
+  `items/`, `rooms/`, `storage/`, `workstations/`. None carry a `"name"` field;
+  all resolve by basename.
+
+### `bakery-game` (cloned read-only to `/tmp/bakery-game-audit`)
+
+Clone succeeded. `scenes/main.zon` and 6 prefabs (`baker`, `bread`, `flour`, `oven`,
+`water`, `water_well`) — **all `.zon`**, not `.jsonc`. Not scanned by the `.jsonc`
+registry, so it cannot collide under #561. (It will need format migration separately
+under RFC #560, but that is out of scope for this collision audit.)
+
+## Collisions Found
+
+**None.**
+
+- No within-`scenes/` collisions in any project.
+- No within-`prefabs/` collisions in any project.
+- No scene-vs-prefab cross-directory collisions in any project.
+
+Every effective name in `flying-platform-labelle` is unique across the combined
+`scenes/` + `prefabs/` namespace. Each `labelle-cli` test fixture has a single
+`scenes/main.jsonc` and an empty or absent `prefabs/`, so collisions are impossible.
+The `main` name appears once per project but never twice within one project.
+
+## Verdict
+
+**Safe.** It is safe to enable the unified registry's hard collision error as part of
+#561. No file needs to be renamed and no `"name"` field needs to be added or changed
+in any in-tree project. The merged `scenes/` + `prefabs/` scan will not land red.
+
+Acceptance criteria of #570 are met:
+- Zero basename/effective-name collisions across `scenes/` + `prefabs/` in every
+  in-tree project.
+- #561 can merge without breaking any project's load.
+
+### Caveats / follow-ups (not collisions, out of #570 scope)
+
+- `bouncing-ball`, `labelle-gui/examples/project_1`, and `bakery-game` still use the
+  legacy `.zon` scene/prefab format. They are invisible to the `.jsonc` registry scan,
+  so they pose no collision risk for #561, but they require the format migration
+  tracked elsewhere under RFC #560.
+- All 54 `flying-platform-labelle` prefabs resolve by basename only (no `"name"`
+  field). They are currently collision-free, but adding `"name"` fields later — or
+  introducing new files — should preserve uniqueness across the combined namespace.

--- a/RFC-OVERRIDES-MERGE-RULES.md
+++ b/RFC-OVERRIDES-MERGE-RULES.md
@@ -1,0 +1,127 @@
+# RFC Addendum: `overrides` Merge Rules
+
+**Status:** Accepted
+**Resolves:** open question 3 of `RFC-UNIFY-SCENES-AND-PREFABS.md` (#560)
+**Ticket:** #562
+
+## Scope
+
+In the unified prefab/scene format, a **reference entry** instantiates an
+existing prefab and may patch it:
+
+```jsonc
+{ "prefab": "hydroponics", "overrides": { "Health": { "current": 30 } } }
+```
+
+`overrides` is a map of component-name → patch. This document specifies
+exactly how that patch combines with the referenced prefab's components.
+
+The rules apply **everywhere a reference entry can appear** — in a
+`children` array, and inside an entity-bearing component field (the
+`Room.movement_nodes` pattern). They do **not** apply to the runtime
+`game.spawnFromPrefab(name, pos)` path, which takes no overrides.
+
+## The rule, in one line
+
+`overrides` is a **deep merge** onto the referenced prefab's component
+set: objects merge recursively, arrays and scalars replace, and a
+component whose patch value is `null` is removed.
+
+## Per-case specification
+
+Let *prefab* be the referenced prefab's components and *ov* be the
+`overrides` map.
+
+### 1. Component in *prefab* only
+
+Kept verbatim.
+
+### 2. Component in *ov* only
+
+Added to the instance, exactly as written.
+
+### 3. Component in both — deep merge
+
+The component value is merged field by field:
+
+- A field present in *ov* **and** in *prefab*, both **objects** → merge
+  recurses into it.
+- A field present in *ov* and in *prefab*, not both objects → the *ov*
+  value **replaces** the *prefab* value.
+- A field present in *prefab* only → **kept**.
+- A field present in *ov* only → **added**.
+
+```jsonc
+// prefab    Box { "size": { "w": 1, "h": 2 }, "label_len": 5 }
+// override  Box { "size": { "w": 9 } }
+// result    Box { "size": { "w": 9, "h": 2 }, "label_len": 5 }
+//                          ^^^^^^  overridden
+//                                  ^^^^^^^ h, label_len inherited
+```
+
+A field the override omits keeps the prefab's value. This is the key
+change from the pre-#562 behavior, where a partial override of a
+component silently reset the unmentioned fields to their struct
+defaults.
+
+### 4. Arrays and scalars replace — no element merge
+
+When a field's value is an array (or a string, number, boolean), the
+override value replaces the prefab value outright. Arrays are **not**
+merged element-wise; there is no append, no index-merge.
+
+```jsonc
+// prefab    Tags { "values": [1, 2, 3] }
+// override  Tags { "values": [9] }
+// result    Tags { "values": [9] }
+```
+
+To extend a list, restate it in full. Element-wise list semantics were
+considered and rejected: they need a per-element identity (index? key?)
+that JSONC component data does not carry, and the failure mode (a
+silent wrong-length list) is worse than the verbosity of restating.
+
+### 5. Component removal — `"Name": null`
+
+A component whose override value is JSONC `null` is **removed** from
+the instance: it is neither applied nor does its `onReady` / `postLoad`
+hook fire. Sibling components are untouched.
+
+```jsonc
+// prefab    { "Marker": { "id": 99 }, "Health": { "current": 50 } }
+// override  { "Marker": null }
+// result    { "Health": { "current": 50 } }   // Marker dropped
+```
+
+Removing a component the prefab does not declare is a no-op. Removing
+`Position` simply means the instance keeps the engine's default
+position — `Position` is not a removable ECS component in the usual
+sense.
+
+`null` is only special at the **component** level (a top-level entry of
+`overrides`). Inside a component value, `null` is an ordinary field
+value: it sets an optional (`?T`) field to null and is otherwise
+deserialized normally.
+
+## Lifecycle parity
+
+A merged component fires its `onReady` / `postLoad` hook exactly once,
+the same as a non-overridden component. A removed component fires
+nothing. Entity-bearing fields (`[]const u64` ref-arrays such as
+`Room.movement_nodes`) survive the merge — overriding one field of a
+component does not drop the prefab's nested entities declared in
+another field; they still spawn.
+
+## Implementation
+
+- `unified_format.mergeValues(base, patch, arena)` — the recursive deep
+  merge over JSONC `Value` trees.
+- `unified_format.mergedOverride(prefab_components, key, override, arena)`
+  — picks the prefab's matching component and merges, or returns the
+  override as-is when the prefab has no such component.
+- The loader (`scene_loader.zig`) merges per component in
+  `loadEntityInternal` and `spawnAndLinkNestedEntities`, and skips a
+  `null` override (recording it so the prefab fallback and the
+  `onReady` pass skip it too).
+
+Coverage: `spec/override_merge_spec.zig`.

--- a/RFC-UNIFY-SCENES-AND-PREFABS.md
+++ b/RFC-UNIFY-SCENES-AND-PREFABS.md
@@ -51,17 +51,29 @@ Adopt one unified file format — the **prefab** — that every `.jsonc` under `
 
 ### Unified shape
 
-File-level metadata sits at the top of the file. The entity tree lives inside an explicit `"root"` block:
+File-level metadata sits at the top of the file. The entity tree lives inside an explicit `"root"` block. The `"root"` block follows the same two-mode grammar as child entries (§Child entries below) — inline (authoring) or reference (instantiating a base prefab):
 
 ```jsonc
+// Mode A — inline root (authoring)
 {
     "name"?: "...",             // file-level — registry key, defaults to the filename basename
-    "root": {                   // required — the prefab's root entity
-        "components"?: { ... }, // optional — components on the root entity
-        "children"?:   [ ... ]  // optional — sub-entities (see Child entries)
+    "root": {
+        "components"?: { ... }, // components on the root entity
+        "children"?:   [ ... ]  // sub-entities (see Child entries)
+    }
+}
+
+// Mode B — reference root (instantiating a base, for component-only variants)
+{
+    "name"?: "...",
+    "root": {
+        "prefab":     "base_name",   // required — the prefab this one extends
+        "overrides"?: { ... }        // optional — root-component patches over the base
     }
 }
 ```
+
+Reference-mode root is the natural way to express component-only variants without duplicating the base's inline tree — e.g., `red_box.jsonc` says `{ "root": { "prefab": "box", "overrides": { "Color": "red" } } }` and inherits box's children automatically. The same §B2 rule applies here as at child entries: reference-mode root cannot declare `children` — instantiating doesn't author. If a variant needs to *add* children (not just tune components), use inline mode at the root and accept the inline duplication (§Examples below).
 
 A **child entry** follows a slightly different grammar — children are entity descriptors, not whole files, so they don't carry file-level metadata or a `"root"` wrapper. Two disjoint modes:
 
@@ -247,7 +259,7 @@ The `components` -> `overrides` rename preserves the existing prefab-reference b
 - An override for an existing component is a **shallow struct-field overlay**: start from the prefab-authored component value, then replace each field named by the override. Nested structs and lists are replaced as whole field values, not deep-merged or appended.
 - An override that names a component absent from the referenced prefab adds that component to the instantiated root.
 - Components omitted from `overrides` are kept unchanged.
-- Nested entity-array fields inside an override keep today's special case: the merge skips them because the loader expands those definitions into entity IDs separately.
+- Nested entity-array fields inside an override keep today's special case: the *deep-merge step* skips them because the loader expands those definitions into entity IDs separately. The override can still replace the whole array — supplying a list at the call site causes the loader to spawn that list instead of the base's list, exactly as today. The "skip" only means we don't element-by-element merge two arrays; the whole-field-replacement semantics from the rest of the merge still apply. Omitting the field at the call site keeps the base's spawned entities.
 
 Component removal is the only new surface area and stays with #562: decide whether a syntax like `"Position": null` is supported, and if so whether removal can affect required engine components.
 
@@ -352,12 +364,15 @@ for each r in new_required:
     assets.acquire(r)          // *** acquire NEW first ***
 wait until assets.allReady(new_required)
 spawn B's tree
-for each r in (A's tracked set ∪ A's lazy set):
-    assets.release(r)          // *** release OLD after ***
-destroy A's tree
+destroy A's tree               // releases A's tracked + lazy refs via the
+                               // root-destruction cascade defined above —
+                               // no separate release loop here
 ```
 
-Acquire-new-first means resources shared between A and B never see refcount zero — no thrashing reload. Resources only-in-A unload after the swap; resources only-in-B load fresh.
+Two ordering properties matter:
+
+1. **Acquire-new-first** means resources shared between A and B never see refcount zero between releases — no thrashing reload. The shared resource refcount goes `1 → 2` (B acquires while A still holds), then `2 → 1` (A's tree destruction releases). Resources only-in-A go `1 → 0` and unload; only-in-B go `0 → 1` and load fresh.
+2. **Destruction-drives-release** means there is *exactly one* path through which A's resources are released: the `for each r in remembered: assets.release(r)` step that runs when A's root is destroyed. The transition algorithm doesn't emit a separate release loop — that would double-release every handle. It also means no system or render pass touches A's entities after their resources have been released: the entities and the resources disappear together in the destruction cascade.
 
 #### Loading scene pattern
 
@@ -422,7 +437,7 @@ A naming caveat: there's already a `gui_types.Image` in the imgui layer. The ECS
 Today scenes own a camera. Under unification:
 
 - If the instantiated tree contains a `Camera` component anywhere, the engine uses it as-is.
-- If not, the engine inserts a default `Camera` entity at world root **only through the state-binding entry path** (`project.labelle` initial state / state transition). Nested prefabs and script-driven `game.spawn(prefab_name)` calls do not get a default camera — that prevents "two cameras when I instance a scene inside a scene" and avoids conflating asset-owning script spawns with state roots.
+- If not, the engine inserts a default `Camera` entity **as a child of the state-bound prefab's root entity** — *not* at world root — **only through the state-binding entry path** (`project.labelle` initial state / state transition). Parenting the default camera under the state root is what makes the lifecycle work: destroying the state root cascades through `Parent` and tears the camera down with it, no orphan. Nested prefabs and script-driven `game.spawn(prefab_name)` calls do not get a default camera — that prevents "two cameras when I instance a scene inside a scene" and avoids conflating asset-owning script spawns with state roots.
 
 Explicit override stays available via a `Camera` component on the root entity:
 

--- a/RFC-UNIFY-SCENES-AND-PREFABS.md
+++ b/RFC-UNIFY-SCENES-AND-PREFABS.md
@@ -81,9 +81,109 @@ A **child entry** follows a slightly different grammar — children are entity d
 
 A child entry MUST be one mode or the other. `"components"` is only valid in inline mode; `"overrides"` is only valid in reference mode. Mixing the two is a load-time error.
 
-Reference mode today supports overrides only — it does not append children to the referenced prefab. Authors who need "an existing prefab plus extra children" define a wrapper prefab; this keeps the reuse model explicit and avoids drift from the original prefab's contract.
+Reference mode supports `overrides` and disallows `children`. The two halves of the grammar partition by intent, not by accident:
+
+- **Inline mode is authoring.** You are describing a fresh entity at this point in the file. `children` belongs here because you are building something — nesting is part of the description.
+- **Reference mode is instantiating.** You are calling out to an existing recipe. `overrides` belongs here because instantiation legitimately needs to tune the call site (a different position, a different label). Appending `children` would not be tuning the call — it would be quietly re-authoring the recipe at the use site.
+
+If a use site needs an authored variant ("the door from `door.jsonc`, but with a pressure-plate child"), the variant gets its own file. That file *is* the authoring; the wrapper prefab is not a workaround for a missing feature, it is the place the new contract lives. Reviewers see a named variant, scripts can spawn it by name, and the original prefab's contract is unchanged for every other use.
 
 Every JSON block in the tree corresponds to one entity. The word `"entities"` no longer appears in any file.
+
+### Examples
+
+Four shapes cover the patterns you'll see in practice. Each is a complete file under `<project>/prefabs/`.
+
+**1. Single semantic entity.** One root entity with its own components, no children. The simplest possible prefab.
+
+```jsonc
+// prefabs/furniture/bed.jsonc
+{
+    "root": {
+        "components": {
+            "Position": { "x": 0, "y": 0 },
+            "Sprite":   { "name": "bed" },
+            "Bed":      { "occupancy": 1 }
+        }
+    }
+}
+```
+
+**2. Collection prefab (aggregator root).** The root has no semantic role beyond `Position`; its job is identity and parenting. The children are prefab references — this prefab composes other prefabs.
+
+```jsonc
+// prefabs/rooms/kitchen.jsonc
+{
+    "root": {
+        "components": {
+            "Position": { "x": 0, "y": 0 },
+            "Room":     { "name": "kitchen" }
+        },
+        "children": [
+            { "prefab": "stove",   "overrides": { "Position": { "x": -32, "y": 0 } } },
+            { "prefab": "fridge",  "overrides": { "Position": { "x":  32, "y": 0 } } },
+            { "prefab": "counter", "overrides": { "Position": { "x":   0, "y": 24 } } }
+        ]
+    }
+}
+```
+
+The kitchen's root is the parent of all three appliances. Each appliance brings whatever children *its own file* declared — nothing is appended here. Overrides only tune call-site fields (`Position` here).
+
+**3. Authored variant (the "wrapper prefab").** When a use site needs to grow a prefab's content, the growth becomes a new authored entity in its own file. Inline children — full authoring at this level — express "the storage from `eis.jsonc`, plus a starting water item."
+
+```jsonc
+// prefabs/storage/eis_with_water.jsonc
+{
+    "root": {
+        "components": {
+            "Position": { "x": 0, "y": 0 },
+            "Sprite":   { "name": "eis" },
+            "Storage":  { "capacity": 8 }
+        },
+        "children": [
+            {
+                "components": {
+                    "Position": { "x": 0, "y": -4 },  // parent-rooted
+                    "Sprite":   { "name": "water_packet" },
+                    "Item":     { "kind": "water" }
+                }
+            }
+        ]
+    }
+}
+```
+
+This is a separate, named contract. Scenes referencing `eis_with_water` get the storage *and* the starting item every time; scenes referencing `eis` get a bare storage. Both names show up in code review and in `game.spawn(...)` call sites.
+
+**4. Scene (which is just a prefab used as an entry point).** Same grammar as anything else. Typically an aggregator root that mixes references and inline entities to lay out a level.
+
+```jsonc
+// prefabs/scenes/bandit_raid.jsonc
+{
+    "root": {
+        "children": [
+            { "prefab": "ship_carcase" },
+            { "prefab": "kitchen",         "overrides": { "Position": { "x": 240, "y": 120 } } },
+            { "prefab": "eis_with_water",  "overrides": { "Position": { "x": 180, "y":  80 } } },
+            {
+                "components": {
+                    "Position": { "x": 0, "y": 0 },
+                    "GameMode": { "kind": "raid" }
+                }
+            }
+        ]
+    }
+}
+```
+
+Three things to notice:
+
+- The scene's root carries no components — `Position` defaults to `{0, 0}` (§"Explicit root entity"), and a default `Camera` is inserted by the engine for state-bound prefabs (§"Camera — default inserted by the engine"). Pure aggregator.
+- The `kitchen` reference brings its full sub-tree (stove + fridge + counter); the scene doesn't see them individually.
+- The last child is inline — a one-off `GameMode` entity authored directly here because it isn't reused elsewhere. Inline vs. reference is a judgment call: anything reused goes in its own file.
+
+"Scene" is now shorthand for "a prefab the game enters as a top-level state" (§"State binding"). The grammar makes no distinction.
 
 ### Preserved capability: prefab references inside component data
 
@@ -92,7 +192,9 @@ Today, fields on a component typed `[]const u64` or `[]const Entity` can hold tu
 The unified format **preserves this capability unchanged**. Components can continue to hold entity-bearing fields and the same comptime detection runs against them. There are two side-effects of this choice:
 
 - A reference inside a component field uses the reference-mode grammar — `prefab` + `overrides` (B2 applies everywhere prefab refs appear, not just under `children`).
-- There remain two structural places where an entity can be born in a file: the `children` array, and inside an entity-bearing component field. Walkers that need to enumerate spawned entities (asset inference, save/load, post-load hook firing, gizmo registration) must traverse both. This asymmetry is a known cost of preserving today's ergonomics; revisiting it is out of scope for this RFC.
+- There remain two structural places where an entity can be born in a file: the `children` array, and inside an entity-bearing component field. This asymmetry is a known cost of preserving today's ergonomics; revisiting it is out of scope for this RFC.
+
+To avoid recreating the same bug class at a smaller scale, #561 must introduce one shared entity-tree walker utility. Asset inference, save/load enumeration, post-load hook dispatch, gizmo registration, and any future "visit every spawned entity" consumer call that utility rather than each writing its own traversal. The utility is responsible for visiting both `children` and entity-bearing component fields in file order, following referenced prefabs with cycle detection, and surfacing a single callback shape for "inline entity" vs "prefab reference + overrides". Consumers can layer their own behavior on top, but they do not get to choose a traversal subset by accident.
 
 ### Explicit root entity
 
@@ -130,6 +232,20 @@ If two files resolve to the same effective name, the engine **errors at load tim
 - Add `"name": "..."` to one of them with a different value.
 
 Both are visible in code review. A precedence rule (e.g., "scenes win") would quietly paper over collisions and create hard-to-debug bugs when a feature branch happens to introduce one.
+
+Because #561 merges two previously separate namespaces, the implementation must start with a pre-flight audit command/check that scans current `scenes/` and `prefabs/` using the same effective-name rule and reports collisions before enabling the merged registry by default. A project can plausibly have both `scenes/foo.jsonc` and `prefabs/foo.jsonc` today; that pair must be identified as a migration item, not discovered only after the loader path flips.
+
+### Override merge semantics
+
+The `components` -> `overrides` rename preserves the existing prefab-reference behavior:
+
+- The referenced prefab's root components are created first.
+- An override for an existing component is a **shallow struct-field overlay**: start from the prefab-authored component value, then replace each field named by the override. Nested structs and lists are replaced as whole field values, not deep-merged or appended.
+- An override that names a component absent from the referenced prefab adds that component to the instantiated root.
+- Components omitted from `overrides` are kept unchanged.
+- Nested entity-array fields inside an override keep today's special case: the merge skips them because the loader expands those definitions into entity IDs separately.
+
+Component removal is the only new surface area and stays with #562: decide whether a syntax like `"Position": null` is supported, and if so whether removal can affect required engine components.
 
 ### Convention (non-enforced)
 
@@ -180,9 +296,11 @@ For every prefab in the registry, walk the static tree once and produce `prefab_
 
 The walker treats false positives (a string that happens to match a sprite name but isn't a visual reference) as harmless — they pre-load an unneeded resource. The alternative (per-component declaration of which fields are visual refs) would force every component author to remember to declare, and missed declarations would cause silent missing-texture bugs at runtime.
 
-#### Acquire / spawn / release lifecycle
+"Harmless" here means correctness-harmless, not cost-free. A false positive can load an unneeded atlas, which matters on memory-constrained Android targets. The #566 audit must measure this risk in real projects and either accept it explicitly for v1 or narrow the inference rule (for example, by preferring known visual component fields and falling back to `AssetManifest` for script-only assets). Lazy-on-miss already makes false negatives recoverable via pop-in, so mobile memory pressure is allowed to bias the final rule toward less eagerness if the audit finds large over-loads.
 
-Every top-level prefab instantiation (a state transition or `game.spawn(prefab_name)` from a script):
+#### Asset acquire / spawn / release lifecycle
+
+Every asset-owning prefab instantiation (a state transition or `game.spawn(prefab_name)` from a script):
 
 ```
 required = prefab_required_resources[name]   // pre-computed
@@ -193,7 +311,7 @@ spawn entity tree
 remember `required` on the spawned root entity
 ```
 
-Children spawned as part of the tree do NOT acquire — the top-level spawn's recursive `required` set already includes their resources.
+Children spawned as part of the tree do NOT acquire — the asset-owning spawn's recursive `required` set already includes their resources. This notion of "asset-owning spawn" is broader than "state root": script calls to `game.spawn(prefab_name)` acquire and release their own resources, but they are not state entry points and do not receive state-only behavior such as default camera insertion.
 
 On root destruction:
 
@@ -300,7 +418,7 @@ A naming caveat: there's already a `gui_types.Image` in the imgui layer. The ECS
 Today scenes own a camera. Under unification:
 
 - If the instantiated tree contains a `Camera` component anywhere, the engine uses it as-is.
-- If not, the engine inserts a default `Camera` entity at world root **only when the prefab is being instantiated as a root** (i.e., via the state-binding entry point). Nested prefabs don't get a default camera — that prevents "two cameras when I instance a scene inside a scene."
+- If not, the engine inserts a default `Camera` entity at world root **only through the state-binding entry path** (`project.labelle` initial state / state transition). Nested prefabs and script-driven `game.spawn(prefab_name)` calls do not get a default camera — that prevents "two cameras when I instance a scene inside a scene" and avoids conflating asset-owning script spawns with state roots.
 
 Explicit override stays available via a `Camera` component on the root entity:
 
@@ -448,6 +566,7 @@ Child entries within the tree never gain a `"root"` wrapper — only the file's 
 
 ### Loader migration
 
+- Before enabling the merged registry, run the effective-name collision audit across both directories and resolve any duplicates (`scenes/foo.jsonc` + `prefabs/foo.jsonc`, explicit `"name"` duplicates, or basename duplicates in nested folders).
 - Add the `scenes/` directory to the registry scan.
 - Detect the legacy keys `"entities"`, `"assets"`, and `"components"` on reference entries; emit a deprecation warning. Treat `"entities"` as a synonym for `"children"`, and treat `"components"` on a reference entry (one with a `"prefab"` field) as a synonym for `"overrides"`. This lets the codebase migrate file-by-file without a single atomic switch. Plan to remove the legacy synonyms after all in-tree files are migrated.
 
@@ -461,24 +580,29 @@ Child entries within the tree never gain a `"root"` wrapper — only the file's 
 - Editor / authoring tool changes beyond pointing at the unified registry.
 - Hot-reload semantics for the implicit root entity (likely simplified — the same destroy-and-reinstantiate path scenes use today still applies, just on the root).
 
+## Save-file compatibility
+
+Inventing a root entity for scenes changes the persisted tree shape for any save format that records scene-rooted entities directly. #561 should not silently reinterpret old saves as already-rooted trees. The migration plan needs an explicit save-version gate: either old saves are declared unsupported across this RFC boundary, or the loader recognizes the previous scene-rooted format and wraps those entities under the new synthetic root during load. The choice is project policy, but the break must be visible rather than accidental.
+
 ## Open questions
 
 1. **Rename of `project.labelle`'s `.initial_scene`.** Candidates: `.initial_prefab`, `.entry`, `.entry_prefab`, `.root`, `.initial_root`. Lean toward `.initial_prefab` for symmetry with the unified vocabulary. Keep `.initial_scene` as a legacy alias for one or two release cycles.
 
 2. **Soft convention enforcement.** Should the engine emit a load-time warning when `"name"` is set and doesn't match the filename basename, or stay silent? The doc-only convention is the least intrusive; a lint-style warning catches accidental divergence; an error would be heavy-handed.
 
-3. **`overrides` merge semantics.** With `overrides` as its own keyword (separate from `components`), the merge rules need to be specified precisely in one place: shallow vs deep merge, list-replace vs list-append, what happens to components in the referenced prefab that the override does not mention (kept), how to *remove* a component the referenced prefab has (probably an explicit syntax like `"Position": null`, but worth deciding). The unification doesn't change today's behavior; it just renames the keyword. This is the moment to write the rules down.
+3. **Component removal in `overrides`.** The behavior-preserving merge rules are specified above: shallow component-field overlay, list/struct field replacement, omitted components kept, new components added. The remaining new decision is whether to support removing a component from the referenced prefab (probably an explicit syntax like `"Position": null`, but worth deciding), and whether some engine-required components are protected from removal.
 
-4. **Asset inference completeness audit.** Are there atlases or audio banks today that are loaded from scripts, never from a Sprite/Image component reference or in a static prefab field the walker can see? Walk the project before removing the `"assets"` field to make sure inference + `AssetManifest` + lazy-on-miss cover every case in practice. If significant gaps exist, the migration plan grows a "add `AssetManifest` to scenes X, Y, Z" step.
+4. **Asset inference completeness and over-load audit.** Are there atlases or audio banks today that are loaded from scripts, never from a Sprite/Image component reference or in a static prefab field the walker can see? Conversely, does the every-string rule pull in large false-positive atlases on Android/mobile targets? Walk the project before removing the `"assets"` field to make sure inference + `AssetManifest` + lazy-on-miss cover every case in practice without unacceptable memory over-load. If significant gaps exist, the migration plan grows a "add `AssetManifest` to scenes X, Y, Z" step; if significant false positives exist, the inference rule narrows before shipping.
 
 5. **Engine API for pending-transition resources.** The loading scene needs to know which resources are in flight for the next state to drive its progress bar. Proposed shape: `game.pendingTransitionResources() → []const []const u8`. Alternative: a callback API on `game.transitionToRoot(name, .{ .on_progress = fn(ratio: f32) {} })`. Decide whichever feels more idiomatic.
 
 ### Resolved during RFC discussion (not blocking)
 
 - **`AssetCatalog` foundation.** The unification reuses `AssetCatalog`'s existing refcount, async decode, and frame-budgeted upload. No new async infrastructure introduced by this RFC.
-- **Walker scope.** Walks every string in component data against the reverse index; false positives load an unneeded asset (cheap) rather than miss a needed one (a bug). Resolves Q1.
+- **Walker scope.** A single shared entity-tree walker visits `children` and entity-bearing component fields; asset inference currently walks every string in component data against the reverse index, with #566 auditing mobile over-load risk before finalizing the rule. Resolves Q1's traversal-shape concern without pretending false positives are free.
 - **When inference runs.** Two phases — Phase A builds the reverse index + per-prefab required-resources at startup; Phase B looks up and acquires at top-level spawn. Resolves Q2.
 - **Reverse-index collisions.** Load-time error at engine startup, case-sensitive exact match. Resolves Q3.
 - **Late spawns / lazy fallback.** Lazy async pop-in via `findSprite` / `findImage` miss → `assets.acquire` attributed to the active state's world root, released at next state transition. Resolves Q4.
 - **Acquire/release lifecycle.** Per-top-level-spawn, with acquire-new-first / release-old-after ordering on state transitions to avoid thrashing shared resources. Resolves Q5.
 - **Image vs Sprite.** Two distinct components, each with one job. Image is for standalone PNGs via `AssetCatalog`; v1 scope explicitly excludes animation, dynamic name swapping, and sub-rect cropping.
+- **Flat-list sugar for aggregator scenes (rejected).** Considered allowing pure-aggregator files to be authored as a top-level list (`[ {prefab:...}, ... ]`) with the loader synthesizing an empty root. Saves ~4 lines per file. Rejected because: (a) the moment a file needs a root component, a `name` override, or any future file-level metadata it must be rewritten into the rooted form — a cliff that's invisible until you hit it and forces a full-file diff; (b) the cases where the sugar helps (no root components, no metadata) are already the simplest files, where authoring time isn't the bottleneck; (c) two surface shapes for the same runtime forces every tool that *writes* files (migrator, editor save path, sidecar JSON) to pick a canonical form, eroding any "I authored it this way" benefit. The rooted form is canonical everywhere.

--- a/RFC-UNIFY-SCENES-AND-PREFABS.md
+++ b/RFC-UNIFY-SCENES-AND-PREFABS.md
@@ -86,6 +86,8 @@ Reference mode supports `overrides` and disallows `children`. The two halves of 
 - **Inline mode is authoring.** You are describing a fresh entity at this point in the file. `children` belongs here because you are building something — nesting is part of the description.
 - **Reference mode is instantiating.** You are calling out to an existing recipe. `overrides` belongs here because instantiation legitimately needs to tune the call site (a different position, a different label). Appending `children` would not be tuning the call — it would be quietly re-authoring the recipe at the use site.
 
+Put plainly: **authoring lets you nest; instantiating doesn't.** Inside a file is authoring, so `children` is freely allowed (a prefab's own file can declare any tree it wants). Pointing at someone else's file is instantiating, so only `overrides` is allowed at that site — no `children` appended.
+
 If a use site needs an authored variant ("the door from `door.jsonc`, but with a pressure-plate child"), the variant gets its own file. That file *is* the authoring; the wrapper prefab is not a workaround for a missing feature, it is the place the new contract lives. Reviewers see a named variant, scripts can spawn it by name, and the original prefab's contract is unchanged for every other use.
 
 Every JSON block in the tree corresponds to one entity. The word `"entities"` no longer appears in any file.

--- a/RFC-UNIFY-SCENES-AND-PREFABS.md
+++ b/RFC-UNIFY-SCENES-AND-PREFABS.md
@@ -139,27 +139,161 @@ Recommend in docs that when `"name"` is set, its value equal the file's basename
 
 Scene-today behaviors that don't belong in the prefab format itself find new homes — each chosen to fit labelle's existing ECS / convention-based patterns.
 
-### Assets — inferred, with a component escape hatch
+### Assets — inference + lazy fallback over `AssetCatalog`
 
-Today scenes declare `"assets": ["background", "cloud", ...]` — a list of named resource bundles from `project.labelle`. Under unification:
+Today scenes declare `"assets": ["background", "cloud", ...]` — a list of named resource bundles from `project.labelle`. Under unification the field is dropped; loading is driven by inference, with an explicit-declaration escape hatch and a lazy-on-miss safety net.
 
-- **Primary path: inference.** The engine walks the prefab tree at instantiation, collects all `Sprite.sprite_name` references (and prefab-reference-inside-component values like `Room.movement_nodes` and `Room.workstations`), and maps each to its declaring resource bundle via the project's `.resources` declarations. Required bundles are loaded before instantiation.
-- **Escape hatch: `AssetManifest` component.** When inference can't see an asset — sounds, atlases referenced only by scripts, atlases lazily attached via runtime overlays — declare it explicitly:
+The mechanism builds on `AssetCatalog` (`labelle-engine/src/assets/`, introduced by RFC-ASSET-STREAMING), which already provides:
 
-  ```jsonc
-  {
-      "root": {
-          "components": {
-              "AssetManifest": { "load": ["intro_audio", "cinematic_overlay"] }
-          },
-          "children": [ ... ]
-      }
-  }
-  ```
+- A registry of declared assets keyed by name; each entry has a state (`registered → queued → decoding → ready/failed`) and a refcount.
+- Worker-thread decode (3 workers, SPSC ring buffers).
+- Main-thread upload with a per-frame budget.
+- Refcounted unload — assets drop back to `registered` when refcount hits zero, GPU memory freed.
 
-  Any prefab can carry an `AssetManifest`, and nested manifests are unioned with the parent's at instantiation. This composes cleanly: a "test harness" prefab can wrap a real scene and add fixtures' asset deps without touching the scene file.
+The unification adds two things on top: a **reverse index** mapping sprite/image names to their containing assets, and a **walker** that pre-computes per-prefab required-resources at engine startup. Acquire/release calls into `AssetCatalog` are made at top-level spawn / destroy.
 
-The `"assets"` field is dropped from every scene file during migration.
+#### Reverse index (built once at engine startup)
+
+```zig
+const ResourceRef = union(enum) {
+    atlas: []const u8,   // bundle name (the atlas that contains this sprite)
+    image: []const u8,   // asset name (the standalone image itself)
+};
+const reverse_index: std.StringHashMap(ResourceRef);
+```
+
+Built by parsing every entry in `project.labelle`'s `.resources`:
+
+- An entry with `.json` (atlas + JSON metadata): parse the JSON, extract every sprite path, insert `(sprite_path → .{ .atlas = bundle_name })`.
+- An entry without `.json` (standalone image): insert `(asset_name → .{ .image = asset_name })`.
+
+**Collisions** (two atlases declaring the same sprite path, or any other name conflict): **load-time error at engine startup**. Exact-match comparison, case-sensitive. The cost of being strict is "rename a duplicate sprite"; the cost of being lenient is silent shadowing bugs that only manifest under specific atlas-load orders.
+
+#### Walker (runs once per prefab at engine startup)
+
+For every prefab in the registry, walk the static tree once and produce `prefab_name → required_resources[]`:
+
+- Recurse through `children` array entries.
+- Recurse through nested prefab references inside entity-bearing component fields (the preserved C1 pattern — `Room.movement_nodes`, `Room.workstations`, etc.).
+- For every component value, walk every nested struct/array/string field. For each string, look it up in the reverse index. Hits add the resource to the prefab's required set.
+- Union with `AssetManifest.load` declarations found on any entity in the tree.
+
+The walker treats false positives (a string that happens to match a sprite name but isn't a visual reference) as harmless — they pre-load an unneeded resource. The alternative (per-component declaration of which fields are visual refs) would force every component author to remember to declare, and missed declarations would cause silent missing-texture bugs at runtime.
+
+#### Acquire / spawn / release lifecycle
+
+Every top-level prefab instantiation (a state transition or `game.spawn(prefab_name)` from a script):
+
+```
+required = prefab_required_resources[name]   // pre-computed
+for each r in required:
+    assets.acquire(r)
+wait until assets.allReady(required)         // loading scene masks this
+spawn entity tree
+remember `required` on the spawned root entity
+```
+
+Children spawned as part of the tree do NOT acquire — the top-level spawn's recursive `required` set already includes their resources.
+
+On root destruction:
+
+```
+for each r in remembered:
+    assets.release(r)
+```
+
+#### Lazy on-miss (async pop-in)
+
+When `findSprite` / `findImage` misses (sprite or image name not in any currently-loaded resource):
+
+```
+r = reverse_index[name]
+if r != null and assets state != .failed:
+    assets.acquire(r)        // attribute to active state's world root
+    return null this frame   // renderer skips
+else:
+    log "unknown sprite/image: <name>" once per name
+    return null permanently
+```
+
+The renderer treats a null lookup as "skip this entity's visual this frame." When the load completes (`assets.isReady(r)`), subsequent frames render normally. The sprite or image pops in.
+
+Lazy acquires are tracked on the **active state's world root**, not per-entity. They're released at the next state transition. This keeps bookkeeping simple at the cost of holding lazy-loaded resources slightly longer than strictly needed.
+
+#### State transition ordering
+
+State A → State B:
+
+```
+new_required = prefab_required_resources[B]
+for each r in new_required:
+    assets.acquire(r)          // *** acquire NEW first ***
+wait until assets.allReady(new_required)
+spawn B's tree
+for each r in (A's tracked set ∪ A's lazy set):
+    assets.release(r)          // *** release OLD after ***
+destroy A's tree
+```
+
+Acquire-new-first means resources shared between A and B never see refcount zero — no thrashing reload. Resources only-in-A unload after the swap; resources only-in-B load fresh.
+
+#### Loading scene pattern
+
+The wait between acquire-new and spawn-B is masked by the existing loading-scene pattern: the old (loading) state stays alive and rendering until the new state is ready. Nothing new — `AssetCatalog` already exposes:
+
+- `assets.progress(slice) → ratio` for the loading bar.
+- `assets.allReady(slice) → bool` for the transition trigger.
+- `assets.lastError(name)` for failure surfaces.
+
+The engine adds an API for the loading script to discover which resources are in flight (proposed: `game.pendingTransitionResources() → []const []const u8`). The loading script polls `assets.progress(...)` on that slice each frame and renders accordingly.
+
+#### `AssetManifest` component (eager escape hatch)
+
+When the walker can't see an asset — script-computed sprite names, runtime overlays, audio banks, raw bytes loaded by scripts — declare it explicitly on the prefab that needs it eagerly:
+
+```jsonc
+{
+    "root": {
+        "components": {
+            "AssetManifest": { "load": ["intro_audio", "cinematic_overlay"] }
+        },
+        "children": [ ... ]
+    }
+}
+```
+
+`AssetManifest` declarations are merged into the prefab's `required_resources` set by the walker (at engine startup). Any prefab can carry one, anywhere in the tree — nested manifests are unioned with the root's set. This composes cleanly: a "test harness" prefab can wrap a real scene and add fixture asset deps without touching the scene file.
+
+Lifetime semantics for manifest-declared resources match inference-derived ones: acquired at top-level spawn, released at root destruction.
+
+#### Standalone `Image` component
+
+Today entities can only display images via atlas-sprites (`Sprite.sprite_name` → `TextureManager.findSprite`). The unification adds an `Image` component for entities that need a standalone PNG (no atlas, no sub-rect):
+
+```jsonc
+"Image": {
+    "name": "logo_splash",       // AssetCatalog asset key
+    "pivot": "bottom_left",      // same enum as Sprite
+    "layer": "ui",               // same layering as Sprite
+    "z_index": 10,               // same
+    "visible": true              // optional
+}
+```
+
+The walker treats `Image.name` references the same as `Sprite.sprite_name` references — both resolve through the unified reverse index above. `AssetCatalog.acquire` / `isReady` / `getTexture` drive the load.
+
+V1 scope is deliberately narrow: no animation, no dynamic name swapping, no sub-rect cropping. If those are needed, use `Sprite` + an atlas. The `Image` component is for single static PNG entities only.
+
+`.resources` declarations in `project.labelle` accept both shapes by making `.json` optional — presence selects the atlas loader, absence selects the catalog `image` loader:
+
+```
+.resources = .{
+    .{ .name = "rooms",        .json = "assets/rooms.json", .texture = "assets/rooms.png" },  // atlas
+    .{ .name = "logo_splash",  .texture = "assets/logo.png" },                                  // standalone
+}
+```
+
+A naming caveat: there's already a `gui_types.Image` in the imgui layer. The ECS `Image` component is distinct (different module, different render path). Worth a docs callout to avoid confusion.
 
 ### Camera — default inserted by the engine
 
@@ -335,6 +469,16 @@ Child entries within the tree never gain a `"root"` wrapper — only the file's 
 
 3. **`overrides` merge semantics.** With `overrides` as its own keyword (separate from `components`), the merge rules need to be specified precisely in one place: shallow vs deep merge, list-replace vs list-append, what happens to components in the referenced prefab that the override does not mention (kept), how to *remove* a component the referenced prefab has (probably an explicit syntax like `"Position": null`, but worth deciding). The unification doesn't change today's behavior; it just renames the keyword. This is the moment to write the rules down.
 
-4. **Asset inference completeness audit.** Are there atlases or audio banks today that are loaded from scripts, never from a Sprite component? Walk the project before removing the `"assets"` field to make sure inference + `AssetManifest` cover every case. If significant gaps exist, the migration plan grows a "add `AssetManifest` to scenes X, Y, Z" step.
+4. **Asset inference completeness audit.** Are there atlases or audio banks today that are loaded from scripts, never from a Sprite/Image component reference or in a static prefab field the walker can see? Walk the project before removing the `"assets"` field to make sure inference + `AssetManifest` + lazy-on-miss cover every case in practice. If significant gaps exist, the migration plan grows a "add `AssetManifest` to scenes X, Y, Z" step.
 
-5. **`AssetManifest` lifetime.** When a prefab carrying `AssetManifest` is destroyed, should the listed bundles be reference-counted / unloaded? Probably yes (so a finished cinematic scene releases its audio bank), but the bookkeeping needs to be specified — multiple instantiations of the same prefab should not double-count, and bundles referenced by multiple manifests should only unload when the last manifest is gone.
+5. **Engine API for pending-transition resources.** The loading scene needs to know which resources are in flight for the next state to drive its progress bar. Proposed shape: `game.pendingTransitionResources() → []const []const u8`. Alternative: a callback API on `game.transitionToRoot(name, .{ .on_progress = fn(ratio: f32) {} })`. Decide whichever feels more idiomatic.
+
+### Resolved during RFC discussion (not blocking)
+
+- **`AssetCatalog` foundation.** The unification reuses `AssetCatalog`'s existing refcount, async decode, and frame-budgeted upload. No new async infrastructure introduced by this RFC.
+- **Walker scope.** Walks every string in component data against the reverse index; false positives load an unneeded asset (cheap) rather than miss a needed one (a bug). Resolves Q1.
+- **When inference runs.** Two phases — Phase A builds the reverse index + per-prefab required-resources at startup; Phase B looks up and acquires at top-level spawn. Resolves Q2.
+- **Reverse-index collisions.** Load-time error at engine startup, case-sensitive exact match. Resolves Q3.
+- **Late spawns / lazy fallback.** Lazy async pop-in via `findSprite` / `findImage` miss → `assets.acquire` attributed to the active state's world root, released at next state transition. Resolves Q4.
+- **Acquire/release lifecycle.** Per-top-level-spawn, with acquire-new-first / release-old-after ordering on state transitions to avoid thrashing shared resources. Resolves Q5.
+- **Image vs Sprite.** Two distinct components, each with one job. Image is for standalone PNGs via `AssetCatalog`; v1 scope explicitly excludes animation, dynamic name swapping, and sub-rect cropping.

--- a/RFC-UNIFY-SCENES-AND-PREFABS.md
+++ b/RFC-UNIFY-SCENES-AND-PREFABS.md
@@ -90,6 +90,8 @@ Put plainly: **authoring lets you nest; instantiating doesn't.** Inside a file i
 
 If a use site needs an authored variant ("the door from `door.jsonc`, but with a pressure-plate child"), the variant gets its own file. That file *is* the authoring; the wrapper prefab is not a workaround for a missing feature, it is the place the new contract lives. Reviewers see a named variant, scripts can spawn it by name, and the original prefab's contract is unchanged for every other use.
 
+**Behavior change from the current loader.** Today's `jsonc/scene_loader.zig:683-704` explicitly accepts both prefab children and appended call-site children at a reference site (the second `if` branch under the "Process children (prefab children + inline children)" comment). The unified loader (#561/#573) must reject this shape at load time, not silently accept it. A scan of `flying-platform-labelle` at the time of writing shows zero existing files use the pattern, so no content migration is required — but the pre-flight audit from #570/#575 should be extended to flag any occurrences before #573 lands, so a stray case can't sneak in through a branch that wasn't surveyed.
+
 Every JSON block in the tree corresponds to one entity. The word `"entities"` no longer appears in any file.
 
 ### Examples

--- a/RFC-UNIFY-SCENES-AND-PREFABS.md
+++ b/RFC-UNIFY-SCENES-AND-PREFABS.md
@@ -1,0 +1,340 @@
+# RFC: Unify Scenes and Prefabs
+
+**Status:** Draft
+**Author:** Alexandre
+**Date:** 2026-05-20
+
+## Problem
+
+Scenes and prefabs do almost the same thing — describe a tree of entities and their components — but the engine treats them as two separate concepts with two separate file formats, two separate code paths, and two separate sets of assumptions about lifecycle. The asymmetry is small, and that's exactly why it keeps biting us: most of the time the two are interchangeable, until one corner case reveals that the engine remembered one and forgot the other.
+
+Recent bugs that all share the same shape — "the engine treated scene entities differently from prefab entities, by accident":
+
+- **labelle-engine #467** — Nested scene entities didn't fire `postLoad`, silently breaking `Workstation.postLoad`'s slot-table rebuild. The prefab path fired the hook; the scene path didn't.
+- **labelle-engine #470** — `Parent` wasn't persisted for scene-rooted entities, so children of parented scene nodes lost their parent on save/load and rendered at raw local position, drifting to scene origin.
+- **flying-platform-labelle #286** — Decor children of room prefabs disappeared after F9 because the save-load restore path treated scene roots and prefab roots differently.
+
+Each was a one-line fix in a different place, and each was a separate session of "figure out which code path was the asymmetric one." The structural fix is to remove the asymmetry: **make scenes a special case of prefabs (or rather, make them not special at all)**, so there's one file format, one loader, one lifecycle, one save/load path.
+
+Today's file shapes:
+
+```jsonc
+// scenes/main.jsonc — today
+{
+    "name": "main",
+    "assets": ["background", "cloud", "characters", "rooms", "ship", "objects"],
+    "entities": [
+        { "prefab": "background_sky", "components": { "Position": { "x": 0, "y": 768 } } },
+        { "prefab": "ship_carcase",   "components": { "Position": { "x": 0, "y": 0   } } }
+    ]
+}
+```
+
+```jsonc
+// prefabs/stair_room.jsonc — today
+{
+    "components": {
+        "Sprite": { "sprite_name": "ladder/ladder_room/ladder_room_bottom.png", ... },
+        "Room":   { "room_type": "stair_room", "movement_nodes": [...] }
+    },
+    "children": [
+        { "prefab": "ladder", "components": { "Position": { "x": 54, "y": 0 } } }
+    ]
+}
+```
+
+The grammars are 90% the same. Each entry in `entities` has the same shape as each entry in `children`. The deltas are cosmetic (`entities` vs `children`), structural (scenes have no root entity), and behavioral (scenes declare `assets`, scenes own a camera, scenes bind to game states).
+
+## Proposal
+
+Adopt one unified file format — the **prefab** — that every `.jsonc` under `scenes/` or `prefabs/` follows. The engine builds a single flat registry from both directories. The directories themselves remain as authoring convention (a hint that a file is *likely* to be used as a root vs. a part), but carry no semantics — any prefab can be used as a root, and any prefab can be nested inside another.
+
+### Unified shape
+
+File-level metadata sits at the top of the file. The entity tree lives inside an explicit `"root"` block:
+
+```jsonc
+{
+    "name"?: "...",             // file-level — registry key, defaults to the filename basename
+    "root": {                   // required — the prefab's root entity
+        "components"?: { ... }, // optional — components on the root entity
+        "children"?:   [ ... ]  // optional — sub-entities (see Child entries)
+    }
+}
+```
+
+A **child entry** follows a slightly different grammar — children are entity descriptors, not whole files, so they don't carry file-level metadata or a `"root"` wrapper. Two disjoint modes:
+
+```jsonc
+// inline — defines a fresh entity (may have its own children)
+{
+    "components"?: { ... },     // components for THIS entity
+    "children"?:   [ ... ]      // recursive same grammar
+}
+
+// reference — instantiates an existing prefab with optional root-component overrides
+{
+    "prefab":      "name",      // required — the prefab to instantiate
+    "overrides"?:  { ... }      // optional — patched on top of the referenced prefab's root components
+}
+```
+
+A child entry MUST be one mode or the other. `"components"` is only valid in inline mode; `"overrides"` is only valid in reference mode. Mixing the two is a load-time error.
+
+Reference mode today supports overrides only — it does not append children to the referenced prefab. Authors who need "an existing prefab plus extra children" define a wrapper prefab; this keeps the reuse model explicit and avoids drift from the original prefab's contract.
+
+Every JSON block in the tree corresponds to one entity. The word `"entities"` no longer appears in any file.
+
+### Preserved capability: prefab references inside component data
+
+Today, fields on a component typed `[]const u64` or `[]const Entity` can hold tuples of entity definitions in the source file. The engine detects them at comptime (`labelle-engine/scene/src/entity_writer.zig`'s `isNestedEntityArray` / `hasNestedEntityFields`), spawns the entities, and stores their resulting IDs back into the array. `Room.movement_nodes`, `Room.workstations`, and similar fields use this pattern.
+
+The unified format **preserves this capability unchanged**. Components can continue to hold entity-bearing fields and the same comptime detection runs against them. There are two side-effects of this choice:
+
+- A reference inside a component field uses the reference-mode grammar — `prefab` + `overrides` (B2 applies everywhere prefab refs appear, not just under `children`).
+- There remain two structural places where an entity can be born in a file: the `children` array, and inside an entity-bearing component field. Walkers that need to enumerate spawned entities (asset inference, save/load, post-load hook firing, gizmo registration) must traverse both. This asymmetry is a known cost of preserving today's ergonomics; revisiting it is out of scope for this RFC.
+
+### Explicit root entity
+
+Today's scenes have no root entity; their `entities` array spawns world-rooted. Under unification, **every prefab — including ones used as scenes — has a single root entity**, and that root is named explicitly via the `"root"` wrapper at the top of every file. The wrapper is the cornerstone of the proposal because it makes the rest fall out:
+
+- **Lifetime is uniform.** "Unload scene" becomes "destroy the root entity"; the `Parent` cascade does the work. No special scene-unload path.
+- **Save/load is uniform.** Serialize the tree rooted at the prefab's root. Same code path for any prefab.
+- **Composability is real.** A scene nested inside another scene is just a sub-tree under a parent entity. No "two world roots" problem.
+- **Scene-level config rides on the root entity as components** (`AssetManifest`, `CameraSettings`, etc.), fitting the existing ECS pattern instead of growing scene-special fields.
+- **File-level vs entity-level concerns are visibly separated.** `"name"` (registry key) at the top; entity content under `"root"`. Future file-level additions — `"version"`, `"imports"`, `"deprecated"` — have a natural home without entangling with the root entity. Tooling (and LLMs authoring or refactoring these files) sees the structure directly rather than inferring it from a convention.
+
+Child positions in scenes today are world-rooted; under unification they become parent-rooted. With the scene's root at `Position { x: 0, y: 0 }` (the default when omitted), the child coordinates are unchanged. No content migration is needed for positions.
+
+## Resolution and naming
+
+### One flat registry
+
+The engine scans both `scenes/` and `prefabs/` recursively and builds one flat name-keyed registry. References (`{ "prefab": "hydroponics" }`) resolve against that registry, regardless of which directory the target file lives in.
+
+### Effective name
+
+```
+effective_name(file) =
+    file."name" field   if present
+    | basename(file)    otherwise
+```
+
+The optional `"name"` field is lifted from today's scene format and made available to all prefabs. When absent, the filename basename (without extension) is used. This matches how prefabs are referenced today (`"prefab": "hydroponics"` finds `prefabs/rooms/hydroponics.jsonc`).
+
+### Collisions
+
+If two files resolve to the same effective name, the engine **errors at load time**. There is no precedence rule — collisions are explicit acts that the author can resolve in two ways:
+
+- Rename one of the files, or
+- Add `"name": "..."` to one of them with a different value.
+
+Both are visible in code review. A precedence rule (e.g., "scenes win") would quietly paper over collisions and create hard-to-debug bugs when a feature branch happens to introduce one.
+
+### Convention (non-enforced)
+
+Recommend in docs that when `"name"` is set, its value equal the file's basename unless there's a reason to diverge. This keeps the common case predictable while preserving the flexibility for the small number of cases where it actually matters (test fixtures, renames-without-moves, friendlier registry IDs for deeply-nested files).
+
+## Behavior homes
+
+Scene-today behaviors that don't belong in the prefab format itself find new homes — each chosen to fit labelle's existing ECS / convention-based patterns.
+
+### Assets — inferred, with a component escape hatch
+
+Today scenes declare `"assets": ["background", "cloud", ...]` — a list of named resource bundles from `project.labelle`. Under unification:
+
+- **Primary path: inference.** The engine walks the prefab tree at instantiation, collects all `Sprite.sprite_name` references (and prefab-reference-inside-component values like `Room.movement_nodes` and `Room.workstations`), and maps each to its declaring resource bundle via the project's `.resources` declarations. Required bundles are loaded before instantiation.
+- **Escape hatch: `AssetManifest` component.** When inference can't see an asset — sounds, atlases referenced only by scripts, atlases lazily attached via runtime overlays — declare it explicitly:
+
+  ```jsonc
+  {
+      "root": {
+          "components": {
+              "AssetManifest": { "load": ["intro_audio", "cinematic_overlay"] }
+          },
+          "children": [ ... ]
+      }
+  }
+  ```
+
+  Any prefab can carry an `AssetManifest`, and nested manifests are unioned with the parent's at instantiation. This composes cleanly: a "test harness" prefab can wrap a real scene and add fixtures' asset deps without touching the scene file.
+
+The `"assets"` field is dropped from every scene file during migration.
+
+### Camera — default inserted by the engine
+
+Today scenes own a camera. Under unification:
+
+- If the instantiated tree contains a `Camera` component anywhere, the engine uses it as-is.
+- If not, the engine inserts a default `Camera` entity at world root **only when the prefab is being instantiated as a root** (i.e., via the state-binding entry point). Nested prefabs don't get a default camera — that prevents "two cameras when I instance a scene inside a scene."
+
+Explicit override stays available via a `Camera` component on the root entity:
+
+```jsonc
+{
+    "root": {
+        "components": {
+            "Camera": { "x": 0, "y": 0, "zoom": 2.0 }
+        },
+        "children": [ ... ]
+    }
+}
+```
+
+### Lifecycle — destroy the root entity
+
+Scene swaps today have a bespoke "unload everything" path. Under unification:
+
+- Loading a prefab as the root instantiates its tree and remembers the root entity ID.
+- Unloading is destroying that root entity. `Parent` cascade (post-#470) destroys the whole subtree.
+
+This collapses scene-unload and prefab-destroy into the same operation, and is the structural reason save/load and post-load hooks become uniform (the asymmetry from #467 / #470 / #286 goes away).
+
+### State binding — stays in `project.labelle`
+
+State → root-prefab mapping continues to live in `project.labelle`. The field currently named `.initial_scene` is the entry point and is renamed for clarity (see Open Questions). State transitions trigger a root-prefab swap: destroy the current root, instantiate the new one.
+
+## Migration
+
+### File-by-file changes
+
+**Scenes** lose two fields, adopt the `root` wrapper, and rename `"components"` to `"overrides"` on every prefab reference:
+
+1. Delete the `"assets": [...]` field.
+2. Rename `"entities"` → `"children"`.
+3. Wrap the `"children"` array inside an explicit `"root": { ... }` block.
+4. For each entry that has a `"prefab"` field, rename its `"components"` (now overrides) → `"overrides"`. Inline entries (no `"prefab"`) keep `"components"` as-is.
+5. The `"name"` field stays at the top (file-level metadata, not inside `"root"`). It can be removed if the file's basename already matches.
+
+**Prefabs** keep their root `"components"` and `"children"` (move them under `"root"`), and apply the same `"components"` → `"overrides"` rename on every nested prefab reference — including references buried inside entity-bearing component fields like `Room.movement_nodes`:
+
+1. Wrap the file's existing `"components"` and `"children"` fields inside `"root": { ... }`.
+2. For every entry in `"children"` or inside an entity-bearing component field that has a `"prefab"` key, rename its `"components"` → `"overrides"`.
+
+Both migrations are mechanical and can be done with a `jq`-style script or a one-shot editor pass.
+
+Worked examples, before/after:
+
+```jsonc
+// BEFORE — scenes/main.jsonc
+{
+    "name": "main",
+    "assets": ["background", "cloud", "characters", "rooms", "ship", "objects"],
+    "entities": [
+        { "prefab": "background_sky", "components": { "Position": { "x": 0, "y": 768 } } },
+        { "prefab": "ship_carcase",   "components": { "Position": { "x": 0, "y": 0   } } }
+    ]
+}
+```
+
+```jsonc
+// AFTER — scenes/main.jsonc
+{
+    // "name" omitted — defaults to "main" from the filename
+    // No "assets" — inferred from Sprite references in the tree
+    "root": {
+        "children": [
+            { "prefab": "background_sky", "overrides": { "Position": { "x": 0, "y": 768 } } },
+            { "prefab": "ship_carcase",   "overrides": { "Position": { "x": 0, "y": 0   } } }
+        ]
+    }
+}
+```
+
+```jsonc
+// BEFORE — prefabs/worker.jsonc
+{
+    "components": { "Worker": {}, "Health": { "current": 100, "max": 100 } },
+    "children": [
+        { "components": { "Sprite": { "sprite_name": "thirsty/png/thirsty_0001.png", ... }, "StatusOverlay": { "kind": "thirsty" } } }
+    ]
+}
+```
+
+```jsonc
+// AFTER — prefabs/worker.jsonc
+{
+    "root": {
+        "components": { "Worker": {}, "Health": { "current": 100, "max": 100 } },
+        "children": [
+            // inline child — no "prefab" key, so "components" stays as "components"
+            { "components": { "Sprite": { "sprite_name": "thirsty/png/thirsty_0001.png", ... }, "StatusOverlay": { "kind": "thirsty" } } }
+        ]
+    }
+}
+```
+
+A prefab that uses both `children` references and embedded entity refs inside component data shows the `components` → `overrides` rename applies in both places:
+
+```jsonc
+// BEFORE — prefabs/stair_room.jsonc
+{
+    "components": {
+        "Sprite": { "sprite_name": "ladder/ladder_room/ladder_room_bottom.png", ... },
+        "Room": {
+            "room_type": "stair_room",
+            "movement_nodes": [
+                { "prefab": "movement_node",  "components": { "Position": { "x": 20,  "y": 93 } } },
+                { "prefab": "movement_stair", "components": { "Position": { "x": 73,  "y": 93 } } },
+                { "prefab": "movement_node",  "components": { "Position": { "x": 126, "y": 93 } } }
+            ]
+        }
+    },
+    "children": [
+        { "prefab": "ladder", "components": { "Position": { "x": 54, "y": 0 } } }
+    ]
+}
+```
+
+```jsonc
+// AFTER — prefabs/stair_room.jsonc
+{
+    "root": {
+        "components": {
+            "Sprite": { "sprite_name": "ladder/ladder_room/ladder_room_bottom.png", ... },
+            "Room": {
+                "room_type": "stair_room",
+                "movement_nodes": [
+                    // refs inside component data — "components" → "overrides"
+                    { "prefab": "movement_node",  "overrides": { "Position": { "x": 20,  "y": 93 } } },
+                    { "prefab": "movement_stair", "overrides": { "Position": { "x": 73,  "y": 93 } } },
+                    { "prefab": "movement_node",  "overrides": { "Position": { "x": 126, "y": 93 } } }
+                ]
+            }
+        },
+        "children": [
+            // ref under children — same rename
+            { "prefab": "ladder", "overrides": { "Position": { "x": 54, "y": 0 } } }
+        ]
+    }
+}
+```
+
+Child entries within the tree never gain a `"root"` wrapper — only the file's outermost block does. The two child-entry modes (inline `components` vs. reference `overrides`) apply uniformly wherever a prefab reference can appear: in the `"children"` array, in entity-bearing component fields, and at any depth.
+
+### Loader migration
+
+- Add the `scenes/` directory to the registry scan.
+- Detect the legacy keys `"entities"`, `"assets"`, and `"components"` on reference entries; emit a deprecation warning. Treat `"entities"` as a synonym for `"children"`, and treat `"components"` on a reference entry (one with a `"prefab"` field) as a synonym for `"overrides"`. This lets the codebase migrate file-by-file without a single atomic switch. Plan to remove the legacy synonyms after all in-tree files are migrated.
+
+### Engine API
+
+`game.transitionToScene("name")` (or equivalent) keeps working — "scene" is a synonym for "root prefab" at the API level. Renaming the API symbol is out of scope for this RFC and can land separately.
+
+## Out of scope
+
+- Rename of the engine's runtime API surface (`transitionToScene`, etc.).
+- Editor / authoring tool changes beyond pointing at the unified registry.
+- Hot-reload semantics for the implicit root entity (likely simplified — the same destroy-and-reinstantiate path scenes use today still applies, just on the root).
+
+## Open questions
+
+1. **Rename of `project.labelle`'s `.initial_scene`.** Candidates: `.initial_prefab`, `.entry`, `.entry_prefab`, `.root`, `.initial_root`. Lean toward `.initial_prefab` for symmetry with the unified vocabulary. Keep `.initial_scene` as a legacy alias for one or two release cycles.
+
+2. **Soft convention enforcement.** Should the engine emit a load-time warning when `"name"` is set and doesn't match the filename basename, or stay silent? The doc-only convention is the least intrusive; a lint-style warning catches accidental divergence; an error would be heavy-handed.
+
+3. **`overrides` merge semantics.** With `overrides` as its own keyword (separate from `components`), the merge rules need to be specified precisely in one place: shallow vs deep merge, list-replace vs list-append, what happens to components in the referenced prefab that the override does not mention (kept), how to *remove* a component the referenced prefab has (probably an explicit syntax like `"Position": null`, but worth deciding). The unification doesn't change today's behavior; it just renames the keyword. This is the moment to write the rules down.
+
+4. **Asset inference completeness audit.** Are there atlases or audio banks today that are loaded from scripts, never from a Sprite component? Walk the project before removing the `"assets"` field to make sure inference + `AssetManifest` cover every case. If significant gaps exist, the migration plan grows a "add `AssetManifest` to scenes X, Y, Z" step.
+
+5. **`AssetManifest` lifetime.** When a prefab carrying `AssetManifest` is destroyed, should the listed bundles be reference-counted / unloaded? Probably yes (so a finished cinematic scene releases its audio bank), but the bookkeeping needs to be specified — multiple instantiations of the same prefab should not double-count, and bundles referenced by multiple manifests should only unload when the last manifest is gone.

--- a/build.zig
+++ b/build.zig
@@ -98,6 +98,7 @@ pub fn build(b: *std.Build) void {
         "test/example_prefab_animation_walkthrough_test.zig",
         "test/jsonc/bridge_deserialize_test.zig",
         "test/jsonc/deserializer_test.zig",
+        "test/jsonc/unified_format_test.zig",
         "test/jsonc_bridge_gizmo_visibility_test.zig",
         "test/collect_entities_test.zig",
         "test/set_sprite_flip_test.zig",

--- a/build.zig
+++ b/build.zig
@@ -224,24 +224,31 @@ pub fn build(b: *std.Build) void {
     // `describe`-style nested structs rather than flat `test` blocks.
     // Wired into `test_step` as well so `zig build test` (what CI
     // runs) stays the single command that exercises everything.
-    const zspec_dep = b.dependency("zspec", .{ .target = target, .optimize = optimize });
-    const spec_module = b.createModule(.{
-        .root_source_file = b.path("spec/spec_tests.zig"),
-        .target = target,
-        .optimize = optimize,
-        .imports = &.{
-            .{ .name = "zspec", .module = zspec_dep.module("zspec") },
-            .{ .name = "labelle-core", .module = core_module },
-            .{ .name = "engine", .module = engine_module },
-            .{ .name = "scene", .module = scene_module },
-        },
-    });
-    const spec_tests = b.addTest(.{
-        .root_module = spec_module,
-        .test_runner = .{ .path = zspec_dep.path("src/runner.zig"), .mode = .simple },
-    });
-    const run_spec_tests = b.addRunArtifact(spec_tests);
-    const spec_step = b.step("spec", "Run zspec BDD specs");
-    spec_step.dependOn(&run_spec_tests.step);
-    test_step.dependOn(&run_spec_tests.step);
+    //
+    // zspec is a `lazy` dependency: `b.lazyDependency` only resolves
+    // (and fetches) it when a step that needs it is in the build graph,
+    // so downstream consumers that just import the engine module never
+    // pull this test-only dep. On the first run without the package in
+    // cache it returns null and Zig re-invokes the build after fetching.
+    if (b.lazyDependency("zspec", .{ .target = target, .optimize = optimize })) |zspec_dep| {
+        const spec_module = b.createModule(.{
+            .root_source_file = b.path("spec/spec_tests.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "zspec", .module = zspec_dep.module("zspec") },
+                .{ .name = "labelle-core", .module = core_module },
+                .{ .name = "engine", .module = engine_module },
+                .{ .name = "scene", .module = scene_module },
+            },
+        });
+        const spec_tests = b.addTest(.{
+            .root_module = spec_module,
+            .test_runner = .{ .path = zspec_dep.path("src/runner.zig"), .mode = .simple },
+        });
+        const run_spec_tests = b.addRunArtifact(spec_tests);
+        const spec_step = b.step("spec", "Run zspec BDD specs");
+        spec_step.dependOn(&run_spec_tests.step);
+        test_step.dependOn(&run_spec_tests.step);
+    }
 }

--- a/build.zig
+++ b/build.zig
@@ -218,4 +218,30 @@ pub fn build(b: *std.Build) void {
     assets_single_threaded_module.addImport("font_types", font_types_module);
     const assets_single_threaded = b.addTest(.{ .root_module = assets_single_threaded_module });
     test_step.dependOn(&assets_single_threaded.step);
+
+    // zspec BDD specs — mirrors the `spec` step in labelle-pathfinding.
+    // Uses zspec's own test runner; the spec files declare
+    // `describe`-style nested structs rather than flat `test` blocks.
+    // Wired into `test_step` as well so `zig build test` (what CI
+    // runs) stays the single command that exercises everything.
+    const zspec_dep = b.dependency("zspec", .{ .target = target, .optimize = optimize });
+    const spec_module = b.createModule(.{
+        .root_source_file = b.path("spec/spec_tests.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "zspec", .module = zspec_dep.module("zspec") },
+            .{ .name = "labelle-core", .module = core_module },
+            .{ .name = "engine", .module = engine_module },
+            .{ .name = "scene", .module = scene_module },
+        },
+    });
+    const spec_tests = b.addTest(.{
+        .root_module = spec_module,
+        .test_runner = .{ .path = zspec_dep.path("src/runner.zig"), .mode = .simple },
+    });
+    const run_spec_tests = b.addRunArtifact(spec_tests);
+    const spec_step = b.step("spec", "Run zspec BDD specs");
+    spec_step.dependOn(&run_spec_tests.step);
+    test_step.dependOn(&run_spec_tests.step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -16,9 +16,13 @@
         .audio_backend = .{
             .path = "audio_backend",
         },
+        // Test-only BDD spec runner. `lazy` so downstream consumers of
+        // the engine module never fetch it — it is reached only by the
+        // `spec`/`test` steps via `b.lazyDependency` in build.zig.
         .zspec = .{
             .url = "https://github.com/apotema/zspec/archive/v0.9.1.tar.gz",
             .hash = "zspec-0.9.1-jaKLbbX4AwBKANdetxzzWc3UTO0UY0lcJJzTagQHlt5K",
+            .lazy = true,
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -16,6 +16,10 @@
         .audio_backend = .{
             .path = "audio_backend",
         },
+        .zspec = .{
+            .url = "https://github.com/apotema/zspec/archive/v0.9.1.tar.gz",
+            .hash = "zspec-0.9.1-jaKLbbX4AwBKANdetxzzWc3UTO0UY0lcJJzTagQHlt5K",
+        },
     },
     .paths = .{
         "build.zig",
@@ -25,5 +29,6 @@
         "jsonc",
         "codegen",
         "audio_backend",
+        "spec",
     },
 }

--- a/spec/override_merge_spec.zig
+++ b/spec/override_merge_spec.zig
@@ -1,0 +1,230 @@
+//! zspec BDD specs for `overrides` merge semantics (RFC #560,
+//! ticket #562).
+//!
+//! `overrides` on a prefab reference deep-merges onto the prefab's
+//! components:
+//!  - objects merge recursively — a field the override omits keeps
+//!    the prefab's value;
+//!  - arrays and scalars replace outright;
+//!  - a component whose override value is `null` is removed.
+//!
+//! See RFC-OVERRIDES-MERGE-RULES.md.
+
+const std = @import("std");
+const zspec = @import("zspec");
+const engine = @import("engine");
+
+const expect = zspec.expect;
+const Factory = zspec.Factory;
+const Fixture = zspec.Fixture;
+
+// ── Components under test ───────────────────────────────────────
+
+const Marker = struct { id: i32 = 0 };
+const Health = struct { current: f32 = 0, max: f32 = 100 };
+
+/// Nested struct — exercises recursive object merge.
+const Size = struct { w: f32 = 0, h: f32 = 0 };
+const Box = struct { size: Size = .{}, label_len: i32 = 0 };
+
+/// Plain (non-entity) slice field — exercises array replacement.
+const Tags = struct { values: []const i32 = &.{} };
+
+/// Entity-bearing `slots` plus a scalar `tag` — exercises a
+/// deep-merged component keeping its prefab's nested entities.
+const Container = struct { slots: []const u64 = &.{}, tag: i32 = 0 };
+
+const Components = engine.ComponentRegistry(.{
+    .Marker = Marker,
+    .Health = Health,
+    .Box = Box,
+    .Tags = Tags,
+    .Container = Container,
+});
+
+const Game = engine.Game;
+const Bridge = engine.JsoncSceneBridge(Game, Components);
+
+const HealthFactory = Factory.define(Health, .{ .current = 0, .max = 100 });
+
+// ── Fixture: prefab corpus ──────────────────────────────────────
+
+const Sources = struct {
+    /// Two-field component — for field-level inheritance.
+    health: []const u8,
+    /// Nested struct + scalar — for recursive merge.
+    box: []const u8,
+    /// Plain slice field — for array replacement.
+    tags: []const u8,
+    /// Two components — for removal + sibling survival.
+    pair: []const u8,
+    /// Entity-bearing `slots` + scalar — for merged-component
+    /// nested-entity survival.
+    container: []const u8,
+};
+
+const Corpus = Fixture.define(Sources, .{
+    .health =
+    \\{ "root": { "components": { "Health": { "current": 80, "max": 100 } } } }
+    ,
+    .box =
+    \\{ "root": { "components": {
+    \\  "Box": { "size": { "w": 1, "h": 2 }, "label_len": 5 }
+    \\} } }
+    ,
+    .tags =
+    \\{ "root": { "components": { "Tags": { "values": [1, 2, 3] } } } }
+    ,
+    .pair =
+    \\{ "root": { "components": {
+    \\  "Marker": { "id": 99 },
+    \\  "Health": { "current": 50, "max": 70 }
+    \\} } }
+    ,
+    .container =
+    \\{ "root": { "components": {
+    \\  "Marker": { "id": 99 },
+    \\  "Container": { "tag": 1, "slots": [
+    \\    { "components": { "Marker": { "id": 1 } } }
+    \\  ] }
+    \\} } }
+    ,
+});
+
+const PREFAB_DIR = "/tmp/labelle-nonexistent-spec-562";
+
+/// The sole entity carrying component `T` (asserts exactly one).
+fn sole(game: *Game, comptime T: type) *T {
+    var view = game.ecs_backend.view(.{T}, .{});
+    defer view.deinit();
+    const e = view.next().?;
+    std.debug.assert(view.next() == null);
+    return game.ecs_backend.getComponent(e, T).?;
+}
+
+/// First entity carrying a `Marker` with the given id, or null.
+fn findMarker(game: *Game, id: i32) ?*Marker {
+    var view = game.ecs_backend.view(.{Marker}, .{});
+    defer view.deinit();
+    while (view.next()) |e| {
+        const m = game.ecs_backend.getComponent(e, Marker).?;
+        if (m.id == id) return m;
+    }
+    return null;
+}
+
+pub const OverrideMergeSpec = struct {
+    var game: Game = undefined;
+
+    test "tests:before" {
+        game = Game.init(zspec.allocator);
+    }
+
+    test "tests:after" {
+        game.deinit();
+    }
+
+    // ── Deep field-level merge ──────────────────────────────────
+
+    pub const @"a component named in overrides deep-merges over the prefab" = struct {
+        test "tests:before" {
+            const src = Corpus.create(.{});
+            try Bridge.addEmbeddedPrefab(&game, "health", src.health, PREFAB_DIR);
+            try Bridge.addEmbeddedPrefab(&game, "box", src.box, PREFAB_DIR);
+            try Bridge.addEmbeddedPrefab(&game, "tags", src.tags, PREFAB_DIR);
+        }
+
+        test "a field the override omits keeps the prefab's value" {
+            try Bridge.loadSceneFromSource(&game,
+                \\{ "root": { "children": [
+                \\  { "prefab": "health", "overrides": { "Health": { "current": 30 } } }
+                \\] } }
+            , PREFAB_DIR);
+            // current overridden; max inherited from the prefab.
+            try std.testing.expectEqual(
+                HealthFactory.build(.{ .current = 30, .max = 100 }),
+                sole(&game, Health).*,
+            );
+        }
+
+        test "merge recurses into nested struct fields" {
+            try Bridge.loadSceneFromSource(&game,
+                \\{ "root": { "children": [
+                \\  { "prefab": "box", "overrides": { "Box": { "size": { "w": 9 } } } }
+                \\] } }
+            , PREFAB_DIR);
+            const box = sole(&game, Box);
+            // size.w overridden; size.h and label_len inherited.
+            try expect.equal(box.size.w, 9);
+            try expect.equal(box.size.h, 2);
+            try expect.equal(box.label_len, 5);
+        }
+
+        test "an array field is replaced outright, not element-merged" {
+            try Bridge.loadSceneFromSource(&game,
+                \\{ "root": { "children": [
+                \\  { "prefab": "tags", "overrides": { "Tags": { "values": [9] } } }
+                \\] } }
+            , PREFAB_DIR);
+            const tags = sole(&game, Tags);
+            try expect.equal(tags.values.len, 1);
+            try expect.equal(tags.values[0], 9);
+        }
+    };
+
+    // ── Component removal via null ──────────────────────────────
+
+    pub const @"a null override removes a component" = struct {
+        test "tests:before" {
+            const src = Corpus.create(.{});
+            try Bridge.addEmbeddedPrefab(&game, "pair", src.pair, PREFAB_DIR);
+        }
+
+        test "the named component is dropped from the instance" {
+            try Bridge.loadSceneFromSource(&game,
+                \\{ "root": { "children": [
+                \\  { "prefab": "pair", "overrides": { "Marker": null } }
+                \\] } }
+            , PREFAB_DIR);
+            var view = game.ecs_backend.view(.{Health}, .{});
+            defer view.deinit();
+            const e = view.next().?;
+            try expect.toBeNull(game.ecs_backend.getComponent(e, Marker));
+        }
+
+        test "sibling components the override leaves alone survive" {
+            try Bridge.loadSceneFromSource(&game,
+                \\{ "root": { "children": [
+                \\  { "prefab": "pair", "overrides": { "Marker": null } }
+                \\] } }
+            , PREFAB_DIR);
+            // Health untouched — kept verbatim from the prefab.
+            try std.testing.expectEqual(
+                HealthFactory.build(.{ .current = 50, .max = 70 }),
+                sole(&game, Health).*,
+            );
+        }
+    };
+
+    // ── Merged component keeps its prefab's entity fields ───────
+
+    pub const @"deep-merging a component preserves its entity-bearing fields" = struct {
+        test "tests:before" {
+            const src = Corpus.create(.{});
+            try Bridge.addEmbeddedPrefab(&game, "container", src.container, PREFAB_DIR);
+        }
+
+        test "overriding one field still spawns the prefab's nested entities" {
+            try Bridge.loadSceneFromSource(&game,
+                \\{ "root": { "children": [
+                \\  { "prefab": "container", "overrides": { "Container": { "tag": 5 } } }
+                \\] } }
+            , PREFAB_DIR);
+            // tag patched; slots inherited from the prefab, so its
+            // nested Marker entity must still spawn.
+            try expect.equal(sole(&game, Container).tag, 5);
+            try expect.notToBeNull(findMarker(&game, 1)); // nested entity
+            try expect.notToBeNull(findMarker(&game, 99)); // root entity
+        }
+    };
+};

--- a/spec/override_merge_spec.zig
+++ b/spec/override_merge_spec.zig
@@ -206,6 +206,31 @@ pub const OverrideMergeSpec = struct {
         }
     };
 
+    // ── `null` is removal only for a reference's overrides ──────
+
+    pub const @"a null in an inline entity's components is not a removal" = struct {
+        // No prefab registered — these are pure inline entities
+        // (no `prefab` key), so their `components` block is not an
+        // `overrides` block and carries no removal semantics.
+
+        test "a null component does not suppress sibling inline components" {
+            // RFC #562 scopes `null`-as-removal to a reference
+            // entry's `overrides`. An inline `components` `null` is
+            // just a (malformed) value — it must not delete the
+            // entity or silence its other components.
+            try Bridge.loadSceneFromSource(&game,
+                \\{ "root": { "children": [
+                \\  { "components": { "Marker": null, "Health": { "current": 7, "max": 9 } } }
+                \\] } }
+            , PREFAB_DIR);
+            // The sibling Health component still applies normally.
+            try std.testing.expectEqual(
+                HealthFactory.build(.{ .current = 7, .max = 9 }),
+                sole(&game, Health).*,
+            );
+        }
+    };
+
     // ── Merged component keeps its prefab's entity fields ───────
 
     pub const @"deep-merging a component preserves its entity-bearing fields" = struct {

--- a/spec/registry_scan_spec.zig
+++ b/spec/registry_scan_spec.zig
@@ -210,4 +210,61 @@ pub const RegistryScanSpec = struct {
             try std.testing.expectError(error.DuplicatePrefabName, result);
         }
     };
+
+    // ── idempotent scan across a scene reload ───────────────────────
+
+    pub const @"loadScene called twice on the same game" = struct {
+        var tmp_dir: std.testing.TmpDir = undefined;
+        var game: Game = undefined;
+
+        test "tests:before" {
+            tmp_dir = std.testing.tmpDir(.{});
+            try tmp_dir.dir.createDir(std.testing.io, "prefabs", .default_dir);
+            try tmp_dir.dir.createDir(std.testing.io, "scenes", .default_dir);
+
+            try tmp_dir.dir.writeFile(std.testing.io, .{
+                .sub_path = "prefabs/widget.jsonc",
+                .data =
+                \\{ "name": "super_widget",
+                \\  "root": { "components": { "Marker": { "id": 99 } } } }
+                ,
+            });
+            try tmp_dir.dir.writeFile(std.testing.io, .{
+                .sub_path = "scenes/main.jsonc",
+                .data =
+                \\{ "root": { "children": [
+                \\  { "prefab": "super_widget" }
+                \\] } }
+                ,
+            });
+
+            game = Game.init(zspec.allocator);
+        }
+
+        test "tests:after" {
+            game.deinit();
+            tmp_dir.cleanup();
+        }
+
+        // A scene reload (e.g. F9 in the games) calls `loadScene`
+        // again on the same game-lifetime `PrefabCache`. The eager
+        // registry scan re-runs; without an idempotency guard it
+        // would re-encounter every file the first scan registered and
+        // wrongly raise `error.DuplicatePrefabName`. The scan tracks
+        // already-walked directories, so the second call is a no-op
+        // for the scan and must succeed.
+        test "the second loadScene does not raise DuplicatePrefabName" {
+            const scene_path = try tmpPath(&tmp_dir, "scenes/main.jsonc");
+            defer zspec.allocator.free(scene_path);
+            const prefab_dir = try tmpPath(&tmp_dir, "prefabs");
+            defer zspec.allocator.free(prefab_dir);
+
+            try Bridge.loadScene(&game, scene_path, prefab_dir);
+            // Second load — must not error on the re-scan.
+            try Bridge.loadScene(&game, scene_path, prefab_dir);
+
+            // The prefab still resolves after the reload.
+            try expect.notToBeNull(findMarker(&game, 99));
+        }
+    };
 };

--- a/spec/registry_scan_spec.zig
+++ b/spec/registry_scan_spec.zig
@@ -1,0 +1,213 @@
+//! zspec BDD specs for the eager filesystem registry scan
+//! (RFC #560, ticket #561).
+//!
+//! `loadScene` (the desktop entry point) recursively scans the
+//! project's `prefabs/` and sibling `scenes/` directories up-front,
+//! populating the flat name-keyed registry. These specs cover the
+//! behaviours that scan unlocks — none reachable through the embedded
+//! `addEmbeddedPrefab` path the other specs use:
+//!
+//!  - a prefab resolved by a `"name"` that diverges from its filename,
+//!  - a scene file found by the scan (recursively, in a subdirectory),
+//!  - two files sharing an effective name → `error.DuplicatePrefabName`.
+//!
+//! Each example builds a throwaway project tree under `std.testing`'s
+//! tmp dir so the scan has a real filesystem to walk.
+
+const std = @import("std");
+const zspec = @import("zspec");
+const engine = @import("engine");
+const core = @import("labelle-core");
+
+const expect = zspec.expect;
+
+// ── Components under test ───────────────────────────────────────────
+
+const Marker = struct { id: i32 = 0 };
+
+const Components = engine.ComponentRegistry(.{
+    .Marker = Marker,
+});
+
+const Game = engine.Game;
+const Bridge = engine.JsoncSceneBridge(Game, Components);
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+/// Absolute path to `sub` inside the tmp dir.
+fn tmpPath(tmp_dir: *std.testing.TmpDir, sub: []const u8) ![]const u8 {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const len = try tmp_dir.dir.realPath(std.testing.io, &buf);
+    return std.fmt.allocPrint(zspec.allocator, "{s}/{s}", .{ buf[0..len], sub });
+}
+
+/// First entity carrying a `Marker` with the given id, or null.
+fn findMarker(game: *Game, id: i32) ?*Marker {
+    var view = game.ecs_backend.view(.{Marker}, .{});
+    defer view.deinit();
+    while (view.next()) |e| {
+        const m = game.ecs_backend.getComponent(e, Marker).?;
+        if (m.id == id) return m;
+    }
+    return null;
+}
+
+pub const RegistryScanSpec = struct {
+    // ── prefab found by a divergent "name" ──────────────────────────
+
+    pub const @"a prefab whose name diverges from its filename" = struct {
+        var tmp_dir: std.testing.TmpDir = undefined;
+        var game: Game = undefined;
+
+        test "tests:before" {
+            tmp_dir = std.testing.tmpDir(.{});
+            try tmp_dir.dir.createDir(std.testing.io, "prefabs", .default_dir);
+            try tmp_dir.dir.createDir(std.testing.io, "scenes", .default_dir);
+
+            // File `widget.jsonc` declares a divergent effective name
+            // `"super_widget"`. Lazy basename lookup would miss it;
+            // only the eager scan keys it by its `"name"` field.
+            try tmp_dir.dir.writeFile(std.testing.io, .{
+                .sub_path = "prefabs/widget.jsonc",
+                .data =
+                \\{ "name": "super_widget",
+                \\  "root": { "components": { "Marker": { "id": 42 } } } }
+                ,
+            });
+            try tmp_dir.dir.writeFile(std.testing.io, .{
+                .sub_path = "scenes/main.jsonc",
+                .data =
+                \\{ "root": { "children": [
+                \\  { "prefab": "super_widget" }
+                \\] } }
+                ,
+            });
+
+            game = Game.init(zspec.allocator);
+        }
+
+        test "tests:after" {
+            game.deinit();
+            tmp_dir.cleanup();
+        }
+
+        test "the scene resolves the prefab by its \"name\" field" {
+            const scene_path = try tmpPath(&tmp_dir, "scenes/main.jsonc");
+            defer zspec.allocator.free(scene_path);
+            const prefab_dir = try tmpPath(&tmp_dir, "prefabs");
+            defer zspec.allocator.free(prefab_dir);
+            try Bridge.loadScene(&game, scene_path, prefab_dir);
+
+            // Prefab applied → entity carries Marker id 42.
+            try expect.notToBeNull(findMarker(&game, 42));
+        }
+    };
+
+    // ── scene found by the scan ─────────────────────────────────────
+
+    pub const @"a scene file discovered by the recursive scan" = struct {
+        var tmp_dir: std.testing.TmpDir = undefined;
+        var game: Game = undefined;
+
+        test "tests:before" {
+            tmp_dir = std.testing.tmpDir(.{});
+            try tmp_dir.dir.createDir(std.testing.io, "prefabs", .default_dir);
+            try tmp_dir.dir.createDir(std.testing.io, "scenes", .default_dir);
+            // A nested subdirectory exercises the recursive walk.
+            try tmp_dir.dir.createDir(std.testing.io, "scenes/levels", .default_dir);
+
+            try tmp_dir.dir.writeFile(std.testing.io, .{
+                .sub_path = "scenes/levels/arena.jsonc",
+                .data =
+                \\{ "name": "arena_one",
+                \\  "root": { "components": { "Marker": { "id": 7 } } } }
+                ,
+            });
+            // The scene we actually load. It references `arena_one`
+            // by effective name — a file that lives only under
+            // `scenes/levels/`, so resolving it proves the recursive
+            // scan walked the `scenes/` tree and registered it.
+            try tmp_dir.dir.writeFile(std.testing.io, .{
+                .sub_path = "scenes/boot.jsonc",
+                .data =
+                \\{ "root": { "children": [
+                \\  { "prefab": "arena_one" }
+                \\] } }
+                ,
+            });
+
+            game = Game.init(zspec.allocator);
+        }
+
+        test "tests:after" {
+            game.deinit();
+            tmp_dir.cleanup();
+        }
+
+        test "the nested scene is registered under its effective name" {
+            const scene_path = try tmpPath(&tmp_dir, "scenes/boot.jsonc");
+            defer zspec.allocator.free(scene_path);
+            const prefab_dir = try tmpPath(&tmp_dir, "prefabs");
+            defer zspec.allocator.free(prefab_dir);
+            try Bridge.loadScene(&game, scene_path, prefab_dir);
+
+            // `boot.jsonc` referenced `arena_one`, a file living only
+            // under `scenes/levels/`. Resolving it (Marker id 7
+            // applied) proves the scan walked `scenes/` recursively
+            // and keyed it by its `"name"`.
+            try expect.notToBeNull(findMarker(&game, 7));
+        }
+    };
+
+    // ── effective-name collision ────────────────────────────────────
+
+    pub const @"two files sharing an effective name" = struct {
+        var tmp_dir: std.testing.TmpDir = undefined;
+        var game: Game = undefined;
+
+        test "tests:before" {
+            tmp_dir = std.testing.tmpDir(.{});
+            try tmp_dir.dir.createDir(std.testing.io, "prefabs", .default_dir);
+            try tmp_dir.dir.createDir(std.testing.io, "scenes", .default_dir);
+
+            // Two prefab files collide: `box.jsonc` keyed by its
+            // basename `box`, and `crate.jsonc` whose `"name"` field
+            // is also `"box"`.
+            try tmp_dir.dir.writeFile(std.testing.io, .{
+                .sub_path = "prefabs/box.jsonc",
+                .data =
+                \\{ "root": { "components": { "Marker": { "id": 1 } } } }
+                ,
+            });
+            try tmp_dir.dir.writeFile(std.testing.io, .{
+                .sub_path = "prefabs/crate.jsonc",
+                .data =
+                \\{ "name": "box",
+                \\  "root": { "components": { "Marker": { "id": 2 } } } }
+                ,
+            });
+            try tmp_dir.dir.writeFile(std.testing.io, .{
+                .sub_path = "scenes/main.jsonc",
+                .data =
+                \\{ "root": { "children": [] } }
+                ,
+            });
+
+            game = Game.init(zspec.allocator);
+        }
+
+        test "tests:after" {
+            game.deinit();
+            tmp_dir.cleanup();
+        }
+
+        test "the scan raises error.DuplicatePrefabName" {
+            const scene_path = try tmpPath(&tmp_dir, "scenes/main.jsonc");
+            defer zspec.allocator.free(scene_path);
+            const prefab_dir = try tmpPath(&tmp_dir, "prefabs");
+            defer zspec.allocator.free(prefab_dir);
+            const result = Bridge.loadScene(&game, scene_path, prefab_dir);
+            try std.testing.expectError(error.DuplicatePrefabName, result);
+        }
+    };
+};

--- a/spec/registry_scan_spec.zig
+++ b/spec/registry_scan_spec.zig
@@ -267,4 +267,78 @@ pub const RegistryScanSpec = struct {
             try expect.notToBeNull(findMarker(&game, 99));
         }
     };
+
+    // ── failure-recovery: retry succeeds after the collision is fixed ──
+
+    pub const @"a reload after a DuplicatePrefabName is fixed" = struct {
+        var tmp_dir: std.testing.TmpDir = undefined;
+        var game: Game = undefined;
+
+        test "tests:before" {
+            tmp_dir = std.testing.tmpDir(.{});
+            try tmp_dir.dir.createDir(std.testing.io, "prefabs", .default_dir);
+            try tmp_dir.dir.createDir(std.testing.io, "scenes", .default_dir);
+
+            // Two prefabs intentionally collide on the effective name
+            // `"widget"` — `widget.jsonc` keyed by basename and
+            // `dup.jsonc` whose `"name"` field is also `"widget"`.
+            try tmp_dir.dir.writeFile(std.testing.io, .{
+                .sub_path = "prefabs/widget.jsonc",
+                .data =
+                \\{ "root": { "components": { "Marker": { "id": 11 } } } }
+                ,
+            });
+            try tmp_dir.dir.writeFile(std.testing.io, .{
+                .sub_path = "prefabs/dup.jsonc",
+                .data =
+                \\{ "name": "widget",
+                \\  "root": { "components": { "Marker": { "id": 22 } } } }
+                ,
+            });
+            try tmp_dir.dir.writeFile(std.testing.io, .{
+                .sub_path = "scenes/main.jsonc",
+                .data =
+                \\{ "root": { "children": [
+                \\  { "prefab": "widget" }
+                \\] } }
+                ,
+            });
+
+            game = Game.init(zspec.allocator);
+        }
+
+        test "tests:after" {
+            game.deinit();
+            tmp_dir.cleanup();
+        }
+
+        // First `loadScene` aborts mid-walk with
+        // `error.DuplicatePrefabName`. Without the fix in
+        // `scanDir`, `scanned_dirs` would have already recorded
+        // `prefabs/` before the walk, so a retry — even after the
+        // collision is gone — would early-return and leave the
+        // half-populated cache permanently stale. The fix records
+        // the directory only after the walk succeeds, so retry
+        // re-walks and finishes cleanly.
+        test "the retry resolves the prefab cleanly" {
+            const scene_path = try tmpPath(&tmp_dir, "scenes/main.jsonc");
+            defer zspec.allocator.free(scene_path);
+            const prefab_dir = try tmpPath(&tmp_dir, "prefabs");
+            defer zspec.allocator.free(prefab_dir);
+
+            // First load: the collision fires.
+            try std.testing.expectError(
+                error.DuplicatePrefabName,
+                Bridge.loadScene(&game, scene_path, prefab_dir),
+            );
+
+            // User "fixes" the project by removing the offending file.
+            try tmp_dir.dir.deleteFile(std.testing.io, "prefabs/dup.jsonc");
+
+            // Retry now succeeds — and resolves `widget` to the
+            // surviving prefab (Marker id 11).
+            try Bridge.loadScene(&game, scene_path, prefab_dir);
+            try expect.notToBeNull(findMarker(&game, 11));
+        }
+    };
 };

--- a/spec/spec_tests.zig
+++ b/spec/spec_tests.zig
@@ -7,9 +7,11 @@
 const zspec = @import("zspec");
 
 pub const unified_format_spec = @import("unified_format_spec.zig");
+pub const override_merge_spec = @import("override_merge_spec.zig");
 
 // Re-export the spec structs so zspec discovers them.
 pub const UnifiedFormatSpec = unified_format_spec.UnifiedFormatSpec;
+pub const OverrideMergeSpec = override_merge_spec.OverrideMergeSpec;
 
 test {
     zspec.runAll(@This());

--- a/spec/spec_tests.zig
+++ b/spec/spec_tests.zig
@@ -1,0 +1,16 @@
+//! zspec aggregator for the engine's BDD specs.
+//!
+//! `zig build spec` (and `zig build test`) roots a test binary here;
+//! every `pub const`-exported spec struct is discovered by
+//! `zspec.runAll`. Add new spec files as imports + re-exports below.
+
+const zspec = @import("zspec");
+
+pub const unified_format_spec = @import("unified_format_spec.zig");
+
+// Re-export the spec structs so zspec discovers them.
+pub const UnifiedFormatSpec = unified_format_spec.UnifiedFormatSpec;
+
+test {
+    zspec.runAll(@This());
+}

--- a/spec/spec_tests.zig
+++ b/spec/spec_tests.zig
@@ -8,10 +8,12 @@ const zspec = @import("zspec");
 
 pub const unified_format_spec = @import("unified_format_spec.zig");
 pub const override_merge_spec = @import("override_merge_spec.zig");
+pub const registry_scan_spec = @import("registry_scan_spec.zig");
 
 // Re-export the spec structs so zspec discovers them.
 pub const UnifiedFormatSpec = unified_format_spec.UnifiedFormatSpec;
 pub const OverrideMergeSpec = override_merge_spec.OverrideMergeSpec;
+pub const RegistryScanSpec = registry_scan_spec.RegistryScanSpec;
 
 test {
     zspec.runAll(@This());

--- a/spec/spec_tests.zig
+++ b/spec/spec_tests.zig
@@ -9,11 +9,13 @@ const zspec = @import("zspec");
 pub const unified_format_spec = @import("unified_format_spec.zig");
 pub const override_merge_spec = @import("override_merge_spec.zig");
 pub const registry_scan_spec = @import("registry_scan_spec.zig");
+pub const tree_walker_spec = @import("tree_walker_spec.zig");
 
 // Re-export the spec structs so zspec discovers them.
 pub const UnifiedFormatSpec = unified_format_spec.UnifiedFormatSpec;
 pub const OverrideMergeSpec = override_merge_spec.OverrideMergeSpec;
 pub const RegistryScanSpec = registry_scan_spec.RegistryScanSpec;
+pub const TreeWalkerSpec = tree_walker_spec.TreeWalkerSpec;
 
 test {
     zspec.runAll(@This());

--- a/spec/tree_walker_spec.zig
+++ b/spec/tree_walker_spec.zig
@@ -441,6 +441,50 @@ pub const TreeWalkerSpec = struct {
         }
     };
 
+    // ── scene-declared repetition of a prefab is not a cycle ────
+    //
+    // A reference-chain cycle (A's body references B's body
+    // references A's body) is what `error.PrefabCycle` exists to
+    // catch — NOT a scene that legitimately spawns two instances of
+    // the same prefab in a `children` array. The expansion stack
+    // must release the parent's prefab name before recursing into
+    // the parent's scene-declared `children`; otherwise a sibling /
+    // child reference to the same prefab is falsely flagged.
+
+    pub const @"a scene child re-referencing the parent's prefab" = struct {
+        test "is not a cycle (scene-declared, not reference-chain)" {
+            const a = arena.allocator();
+            const src = Corpus.create(.{});
+
+            var table = PrefabTable.init(a);
+            defer table.deinit();
+            // `leaf` is a plain prefab with no children — two
+            // instances are independent finite trees.
+            try table.add("leaf", src.leaf_prefab);
+
+            // Parent references `leaf`; one of its scene-declared
+            // children also references `leaf`. This is a tree with
+            // two `leaf` instances, not a reference cycle.
+            const root = try parse(a,
+                \\{ "prefab": "leaf", "children": [
+                \\  { "prefab": "leaf" }
+                \\] }
+            );
+
+            var visits: std.ArrayList(Visit) = .empty;
+            var ctx = tw.WalkContext.init(a);
+            defer ctx.deinit();
+
+            try tw.walk(&ctx, table.resolver(), root, Recorder{ .list = &visits, .allocator = a });
+            // Parent + one scene child.
+            try expect.equal(visits.items.len, 2);
+            try expect.equal(visits.items[0].origin, tw.Origin.root);
+            try expect.toBeTrue(visits.items[0].has_prefab_root);
+            try expect.equal(visits.items[1].origin, tw.Origin.child);
+            try expect.toBeTrue(visits.items[1].has_prefab_root);
+        }
+    };
+
     pub const @"an override leaving a cyclic component field intact" = struct {
         test "still detects the cycle" {
             const a = arena.allocator();

--- a/spec/tree_walker_spec.zig
+++ b/spec/tree_walker_spec.zig
@@ -125,6 +125,14 @@ const Sources = struct {
     /// Two prefabs forming a `chain_a -> chain_b -> chain_a` cycle.
     chain_a_prefab: []const u8,
     chain_b_prefab: []const u8,
+    /// A prefab whose `Room.movement_nodes` component field embeds a
+    /// reference back to itself — a cycle that lives purely inside a
+    /// component field, not in `children`.
+    room_cycle_prefab: []const u8,
+    /// A prefab whose `Room.movement_nodes` has an entity-like item
+    /// only at index 1 (a non-entity scalar at index 0). Pins the
+    /// "scan ALL items" fix — a `[0]`-only probe would miss it.
+    room_nonfirst_prefab: []const u8,
 };
 
 const Corpus = Fixture.define(Sources, .{
@@ -153,17 +161,31 @@ const Corpus = Fixture.define(Sources, .{
     .chain_b_prefab =
     \\{ "root": { "children": [ { "prefab": "chain_a" } ] } }
     ,
+    .room_cycle_prefab =
+    \\{ "root": { "components": { "Room": { "movement_nodes": [
+    \\  { "prefab": "room_cycle" }
+    \\] } } } }
+    ,
+    .room_nonfirst_prefab =
+    \\{ "root": { "components": { "Room": { "movement_nodes": [
+    \\  42,
+    \\  { "prefab": "room_nonfirst" }
+    \\] } } } }
+    ,
 });
 
-/// A resolver that knows no prefabs — for inline-only walks.
+/// A resolver that knows no prefabs — for inline-only walks. `ctx`
+/// points at a process-lifetime static (the `get` fn ignores it
+/// anyway) so the resolver never carries a dangling stack pointer.
+const Empty = struct {
+    var anchor: u8 = 0;
+    fn get(_: *anyopaque, _: []const u8) ?Value {
+        return null;
+    }
+};
+
 fn emptyResolver() tw.Resolver {
-    const Empty = struct {
-        fn get(_: *anyopaque, _: []const u8) ?Value {
-            return null;
-        }
-    };
-    var dummy: u8 = 0;
-    return .{ .ctx = &dummy, .getFn = &Empty.get };
+    return .{ .ctx = &Empty.anchor, .getFn = &Empty.get };
 }
 
 pub const TreeWalkerSpec = struct {
@@ -317,6 +339,135 @@ pub const TreeWalkerSpec = struct {
             // One visit: the reference entry, with its prefab resolved.
             try expect.equal(visits.items.len, 1);
             try expect.toBeTrue(visits.items[0].has_prefab_root);
+        }
+    };
+
+    // ── cycle through a non-first component-array item ──────────
+    //
+    // The runtime nested-entity spawn scans EVERY item of a
+    // component array; the walker must too. A cycle reachable only
+    // through an entity-like item that is not `[0]` (here index 0
+    // is the scalar `42`) would be missed by a `[0]`-only probe.
+
+    pub const @"a cycle via a non-first component-array item" = struct {
+        test "is still detected (walker scans all items)" {
+            const a = arena.allocator();
+            const src = Corpus.create(.{});
+
+            var table = PrefabTable.init(a);
+            defer table.deinit();
+            try table.add("room_nonfirst", src.room_nonfirst_prefab);
+
+            var ref_entries = [_]Value.Object.Entry{
+                .{ .key = "prefab", .value = .{ .string = "room_nonfirst" } },
+            };
+            const ref = Value{ .object = .{ .entries = &ref_entries } };
+
+            var visits: std.ArrayList(Visit) = .empty;
+            var ctx = tw.WalkContext.init(a);
+            defer ctx.deinit();
+
+            const result = tw.walk(&ctx, table.resolver(), ref, Recorder{ .list = &visits, .allocator = a });
+            try expect.toReturnError(result, error.PrefabCycle);
+
+            const chain = try ctx.formatCycleChain(a);
+            try expect.equal(chain, @as([]const u8, "room_nonfirst -> room_nonfirst"));
+        }
+    };
+
+    // ── effective (post-#562-merge) component traversal ─────────
+    //
+    // The walker reasons about the MERGED component tree: an
+    // `overrides` entry that replaces or removes an entity-bearing
+    // component changes which nested entities actually exist, so a
+    // valid scene that overrides away a cyclic field must NOT be
+    // rejected with `error.PrefabCycle`.
+
+    pub const @"an override replacing a cyclic component field" = struct {
+        test "does not raise a false PrefabCycle" {
+            const a = arena.allocator();
+            const src = Corpus.create(.{});
+
+            var table = PrefabTable.init(a);
+            defer table.deinit();
+            // `room_cycle`'s prefab body has a self-referential
+            // `Room.movement_nodes`.
+            try table.add("room_cycle", src.room_cycle_prefab);
+
+            // A reference to `room_cycle` whose `overrides` replaces
+            // the whole `Room` component with a non-cyclic value —
+            // the effective tree has no cycle.
+            const ref = try parse(a,
+                \\{ "prefab": "room_cycle", "overrides": {
+                \\  "Room": { "movement_nodes": [] }
+                \\} }
+            );
+
+            var visits: std.ArrayList(Visit) = .empty;
+            var ctx = tw.WalkContext.init(a);
+            defer ctx.deinit();
+
+            // Must walk to completion — the override emptied the
+            // cyclic field, so there is no cycle to find.
+            try tw.walk(&ctx, table.resolver(), ref, Recorder{ .list = &visits, .allocator = a });
+            try expect.equal(visits.items.len, 1);
+            try expect.toBeTrue(visits.items[0].has_prefab_root);
+        }
+    };
+
+    pub const @"an override removing a cyclic component" = struct {
+        test "does not raise a false PrefabCycle" {
+            const a = arena.allocator();
+            const src = Corpus.create(.{});
+
+            var table = PrefabTable.init(a);
+            defer table.deinit();
+            try table.add("room_cycle", src.room_cycle_prefab);
+
+            // A `null` override removes the whole `Room` component
+            // (RFC #562 component removal) — the cyclic field is
+            // gone from the effective tree.
+            const ref = try parse(a,
+                \\{ "prefab": "room_cycle", "overrides": { "Room": null } }
+            );
+
+            var visits: std.ArrayList(Visit) = .empty;
+            var ctx = tw.WalkContext.init(a);
+            defer ctx.deinit();
+
+            try tw.walk(&ctx, table.resolver(), ref, Recorder{ .list = &visits, .allocator = a });
+            try expect.equal(visits.items.len, 1);
+            try expect.toBeTrue(visits.items[0].has_prefab_root);
+        }
+    };
+
+    pub const @"an override leaving a cyclic component field intact" = struct {
+        test "still detects the cycle" {
+            const a = arena.allocator();
+            const src = Corpus.create(.{});
+
+            var table = PrefabTable.init(a);
+            defer table.deinit();
+            try table.add("room_cycle", src.room_cycle_prefab);
+
+            // An override that touches an UNRELATED component must
+            // not mask the still-present cyclic `Room.movement_nodes`
+            // — the deep-merge keeps it.
+            const ref = try parse(a,
+                \\{ "prefab": "room_cycle", "overrides": {
+                \\  "Marker": { "id": 7 }
+                \\} }
+            );
+
+            var visits: std.ArrayList(Visit) = .empty;
+            var ctx = tw.WalkContext.init(a);
+            defer ctx.deinit();
+
+            const result = tw.walk(&ctx, table.resolver(), ref, Recorder{ .list = &visits, .allocator = a });
+            try expect.toReturnError(result, error.PrefabCycle);
+
+            const chain = try ctx.formatCycleChain(a);
+            try expect.equal(chain, @as([]const u8, "room_cycle -> room_cycle"));
         }
     };
 };

--- a/spec/tree_walker_spec.zig
+++ b/spec/tree_walker_spec.zig
@@ -1,0 +1,322 @@
+//! zspec BDD specs for the shared entity-tree walker (RFC #560,
+//! ticket #569).
+//!
+//! The walker is the single traversal entry point every entity-tree
+//! consumer (instantiation, save/load tagging, postLoad firing,
+//! asset inference) shares. These specs pin:
+//!
+//!  - the normative pre-order walk crossing BOTH `children` AND
+//!    prefab references nested in entity-bearing component fields
+//!    (the `Room.movement_nodes` pattern),
+//!  - prefab-reference expansion through a resolver,
+//!  - cycle detection reporting the FULL chain (`A -> B -> A`), for
+//!    a direct self-cycle and a multi-hop cycle.
+//!
+//! See RFC-UNIFY-SCENES-AND-PREFABS.md.
+
+const std = @import("std");
+const zspec = @import("zspec");
+const engine = @import("engine");
+
+const expect = zspec.expect;
+const Fixture = zspec.Fixture;
+
+const tw = engine.tree_walker;
+const Value = engine.SceneValue;
+const JsoncParser = engine.JsoncParser;
+
+// ── A static prefab table standing in for PrefabCache ───────────
+//
+// The walker resolves `prefab` names through a `Resolver`; in
+// production that is `PrefabCache.get`. The specs back it with a
+// parse-on-demand table over a fixed JSONC corpus so a walk can be
+// exercised without the full scene-loader machinery.
+
+const PrefabTable = struct {
+    arena: std.heap.ArenaAllocator,
+    entries: std.StringHashMap(Value),
+
+    fn init(allocator: std.mem.Allocator) PrefabTable {
+        return .{
+            .arena = std.heap.ArenaAllocator.init(allocator),
+            .entries = std.StringHashMap(Value).init(allocator),
+        };
+    }
+
+    fn deinit(self: *PrefabTable) void {
+        self.entries.deinit();
+        self.arena.deinit();
+    }
+
+    /// Parse `source` and register it under `name`.
+    fn add(self: *PrefabTable, name: []const u8, source: []const u8) !void {
+        var parser = JsoncParser.init(self.arena.allocator(), source);
+        const val = try parser.parse();
+        try self.entries.put(name, val);
+    }
+
+    fn get(ctx: *anyopaque, name: []const u8) ?Value {
+        const self: *PrefabTable = @ptrCast(@alignCast(ctx));
+        return self.entries.get(name);
+    }
+
+    fn resolver(self: *PrefabTable) tw.Resolver {
+        return .{ .ctx = self, .getFn = &PrefabTable.get };
+    }
+};
+
+/// Parse a single JSONC source into a `Value` in `arena`.
+fn parse(arena: std.mem.Allocator, source: []const u8) !Value {
+    var parser = JsoncParser.init(arena, source);
+    return parser.parse();
+}
+
+// ── A recording visitor ─────────────────────────────────────────
+//
+// Captures every visited node so a test can assert on the count,
+// the walk order, and each node's origin / depth / component name.
+
+const Visit = struct {
+    origin: tw.Origin,
+    depth: usize,
+    component_name: ?[]const u8,
+    has_prefab_root: bool,
+    /// The visited entity's `Marker.id`, or `null` when it carries
+    /// no inline `Marker` — a cheap identity probe for ordering
+    /// assertions. Prefab-sourced markers are not visible here
+    /// (the walker yields the *reference* entry, not the resolved
+    /// prefab body).
+    marker_id: ?i64,
+};
+
+const Recorder = struct {
+    pub const VisitError = error{OutOfMemory};
+
+    list: *std.ArrayList(Visit),
+    allocator: std.mem.Allocator,
+
+    pub fn visit(self: Recorder, node: tw.Node(VisitError)) VisitError!void {
+        var marker_id: ?i64 = null;
+        if (node.obj.getObject("components")) |c| {
+            if (c.getObject("Marker")) |m| marker_id = m.getInteger("id");
+        }
+        try self.list.append(self.allocator, .{
+            .origin = node.origin,
+            .depth = node.depth,
+            .component_name = node.component_name,
+            .has_prefab_root = node.prefab_root != null,
+            .marker_id = marker_id,
+        });
+    }
+};
+
+// ── JSONC corpus ────────────────────────────────────────────────
+
+const Sources = struct {
+    /// Entity with two `children`.
+    parent_two_children: []const u8,
+    /// Entity whose `Room` component carries a `movement_nodes`
+    /// entity-bearing array — the second structural birth-place.
+    room_with_nodes: []const u8,
+    /// A leaf prefab body.
+    leaf_prefab: []const u8,
+    /// A prefab that references itself directly (`self -> self`).
+    self_cycle_prefab: []const u8,
+    /// Two prefabs forming a `chain_a -> chain_b -> chain_a` cycle.
+    chain_a_prefab: []const u8,
+    chain_b_prefab: []const u8,
+};
+
+const Corpus = Fixture.define(Sources, .{
+    .parent_two_children =
+    \\{ "components": { "Marker": { "id": 1 } }, "children": [
+    \\  { "components": { "Marker": { "id": 2 } } },
+    \\  { "components": { "Marker": { "id": 3 } } }
+    \\] }
+    ,
+    .room_with_nodes =
+    \\{ "components": { "Room": { "movement_nodes": [
+    \\  { "components": { "Marker": { "id": 10 } } },
+    \\  { "prefab": "leaf" }
+    \\] } } }
+    ,
+    .leaf_prefab =
+    \\{ "root": { "components": { "Marker": { "id": 99 } } } }
+    ,
+    .self_cycle_prefab =
+    \\{ "root": { "components": { "Marker": { "id": 1 } },
+    \\  "children": [ { "prefab": "self" } ] } }
+    ,
+    .chain_a_prefab =
+    \\{ "root": { "children": [ { "prefab": "chain_b" } ] } }
+    ,
+    .chain_b_prefab =
+    \\{ "root": { "children": [ { "prefab": "chain_a" } ] } }
+    ,
+});
+
+/// A resolver that knows no prefabs — for inline-only walks.
+fn emptyResolver() tw.Resolver {
+    const Empty = struct {
+        fn get(_: *anyopaque, _: []const u8) ?Value {
+            return null;
+        }
+    };
+    var dummy: u8 = 0;
+    return .{ .ctx = &dummy, .getFn = &Empty.get };
+}
+
+pub const TreeWalkerSpec = struct {
+    var arena: std.heap.ArenaAllocator = undefined;
+
+    test "tests:before" {
+        arena = std.heap.ArenaAllocator.init(zspec.allocator);
+    }
+
+    test "tests:after" {
+        arena.deinit();
+    }
+
+    // ── crossing the `children` array ───────────────────────────
+
+    pub const @"walking an entity with a children array" = struct {
+        test "visits the root pre-order then every child" {
+            const a = arena.allocator();
+            const src = Corpus.create(.{});
+            const root = try parse(a, src.parent_two_children);
+
+            var visits: std.ArrayList(Visit) = .empty;
+            var ctx = tw.WalkContext.init(a);
+            defer ctx.deinit();
+
+            try tw.walk(&ctx, emptyResolver(), root, Recorder{ .list = &visits, .allocator = a });
+
+            try expect.equal(visits.items.len, 3);
+            // Pre-order: root first.
+            try expect.equal(visits.items[0].origin, tw.Origin.root);
+            try expect.equal(visits.items[0].marker_id.?, @as(i64, 1));
+            // Then each child, in array order, at depth 1.
+            try expect.equal(visits.items[1].origin, tw.Origin.child);
+            try expect.equal(visits.items[1].depth, @as(usize, 1));
+            try expect.equal(visits.items[1].marker_id.?, @as(i64, 2));
+            try expect.equal(visits.items[2].marker_id.?, @as(i64, 3));
+        }
+    };
+
+    // ── crossing entity-bearing component fields ────────────────
+
+    pub const @"walking prefab refs nested in component fields" = struct {
+        test "crosses a Room.movement_nodes entity array" {
+            const a = arena.allocator();
+            const src = Corpus.create(.{});
+
+            var table = PrefabTable.init(a);
+            defer table.deinit();
+            try table.add("leaf", src.leaf_prefab);
+
+            const root = try parse(a, src.room_with_nodes);
+
+            var visits: std.ArrayList(Visit) = .empty;
+            var ctx = tw.WalkContext.init(a);
+            defer ctx.deinit();
+
+            try tw.walk(&ctx, table.resolver(), root, Recorder{ .list = &visits, .allocator = a });
+
+            // Root Room entity + two movement_nodes entries.
+            try expect.equal(visits.items.len, 3);
+            try expect.equal(visits.items[0].origin, tw.Origin.root);
+
+            // The nested inline entity is reached via the component
+            // field and attributed to the `Room` component.
+            try expect.equal(visits.items[1].origin, tw.Origin.component_field);
+            try expect.equal(visits.items[1].component_name.?, @as([]const u8, "Room"));
+            try expect.equal(visits.items[1].marker_id.?, @as(i64, 10));
+
+            // The nested *prefab reference* is crossed too and its
+            // prefab resolved.
+            try expect.equal(visits.items[2].origin, tw.Origin.component_field);
+            try expect.toBeTrue(visits.items[2].has_prefab_root);
+        }
+    };
+
+    // ── cycle detection ─────────────────────────────────────────
+
+    pub const @"a direct self-referential prefab cycle" = struct {
+        test "errors with the full chain self -> self" {
+            const a = arena.allocator();
+            const src = Corpus.create(.{});
+
+            var table = PrefabTable.init(a);
+            defer table.deinit();
+            try table.add("self", src.self_cycle_prefab);
+
+            // A scene-level reference entry to the cyclic prefab.
+            var ref_entries = [_]Value.Object.Entry{
+                .{ .key = "prefab", .value = .{ .string = "self" } },
+            };
+            const ref = Value{ .object = .{ .entries = &ref_entries } };
+
+            var visits: std.ArrayList(Visit) = .empty;
+            var ctx = tw.WalkContext.init(a);
+            defer ctx.deinit();
+
+            const result = tw.walk(&ctx, table.resolver(), ref, Recorder{ .list = &visits, .allocator = a });
+            try expect.toReturnError(result, error.PrefabCycle);
+
+            const chain = try ctx.formatCycleChain(a);
+            try expect.equal(chain, @as([]const u8, "self -> self"));
+        }
+    };
+
+    pub const @"a multi-hop prefab cycle" = struct {
+        test "errors with the full chain chain_a -> chain_b -> chain_a" {
+            const a = arena.allocator();
+            const src = Corpus.create(.{});
+
+            var table = PrefabTable.init(a);
+            defer table.deinit();
+            try table.add("chain_a", src.chain_a_prefab);
+            try table.add("chain_b", src.chain_b_prefab);
+
+            var ref_entries = [_]Value.Object.Entry{
+                .{ .key = "prefab", .value = .{ .string = "chain_a" } },
+            };
+            const ref = Value{ .object = .{ .entries = &ref_entries } };
+
+            var visits: std.ArrayList(Visit) = .empty;
+            var ctx = tw.WalkContext.init(a);
+            defer ctx.deinit();
+
+            const result = tw.walk(&ctx, table.resolver(), ref, Recorder{ .list = &visits, .allocator = a });
+            try expect.toReturnError(result, error.PrefabCycle);
+
+            const chain = try ctx.formatCycleChain(a);
+            try expect.equal(chain, @as([]const u8, "chain_a -> chain_b -> chain_a"));
+        }
+    };
+
+    pub const @"an acyclic prefab tree" = struct {
+        test "walks to completion without a cycle error" {
+            const a = arena.allocator();
+            const src = Corpus.create(.{});
+
+            var table = PrefabTable.init(a);
+            defer table.deinit();
+            try table.add("leaf", src.leaf_prefab);
+
+            var ref_entries = [_]Value.Object.Entry{
+                .{ .key = "prefab", .value = .{ .string = "leaf" } },
+            };
+            const ref = Value{ .object = .{ .entries = &ref_entries } };
+
+            var visits: std.ArrayList(Visit) = .empty;
+            var ctx = tw.WalkContext.init(a);
+            defer ctx.deinit();
+
+            try tw.walk(&ctx, table.resolver(), ref, Recorder{ .list = &visits, .allocator = a });
+            // One visit: the reference entry, with its prefab resolved.
+            try expect.equal(visits.items.len, 1);
+            try expect.toBeTrue(visits.items[0].has_prefab_root);
+        }
+    };
+};

--- a/spec/unified_format_spec.zig
+++ b/spec/unified_format_spec.zig
@@ -1,0 +1,215 @@
+//! zspec BDD specs for the unified prefab/scene loader (RFC #560,
+//! ticket #561).
+//!
+//! Covers the paths the std.testing suite in
+//! `test/jsonc/unified_format_test.zig` does not reach — every one a
+//! place `scene_loader.zig` was edited:
+//!
+//!  - runtime `spawnFromPrefab` of a `root`-wrapped prefab,
+//!  - prefab references nested inside entity-bearing component
+//!    fields (the `Room.movement_nodes` pattern) under the unified
+//!    format,
+//!  - a reference entry carrying both `overrides` and a legacy
+//!    `components` key.
+
+const std = @import("std");
+const zspec = @import("zspec");
+const engine = @import("engine");
+const core = @import("labelle-core");
+
+const expect = zspec.expect;
+const Factory = zspec.Factory;
+const Fixture = zspec.Fixture;
+
+// ── Components under test ───────────────────────────────────────
+
+const Marker = struct { id: i32 = 0 };
+const Health = struct { current: f32 = 0, max: f32 = 100 };
+
+/// Holds nested entities via a `[]const u64` ref-array — the shape
+/// `Room.workstations` / `movement_nodes` use. The loader detects
+/// the array as entity-bearing, spawns each item, and patches the
+/// resulting IDs back in.
+const Container = struct { slots: []const u64 = &.{} };
+
+const Components = engine.ComponentRegistry(.{
+    .Marker = Marker,
+    .Health = Health,
+    .Container = Container,
+});
+
+const Game = engine.Game;
+const Bridge = engine.JsoncSceneBridge(Game, Components);
+
+// ── Factory: expected component values ──────────────────────────
+//
+// `MarkerFactory.build(.{ .id = N })` yields a `Marker` with every
+// other field defaulted — the expected struct a loaded component is
+// compared against, rather than reaching into one field at a time.
+const MarkerFactory = Factory.define(Marker, .{ .id = 0 });
+
+// ── Fixture: the JSONC test corpus ──────────────────────────────
+//
+// Static, known-good prefab and scene sources. `Corpus.create(.{})`
+// hands back the struct; a test reads the field it needs (or
+// overrides it via `create(.{ .field = "..." })`).
+
+const Sources = struct {
+    /// Unified prefab — `root` wrapper, components only.
+    widget: []const u8,
+    /// Unified prefab — `root` wrapper with components AND children.
+    parent: []const u8,
+    /// Unified prefab used as a nested-array item.
+    nested_item: []const u8,
+    /// Unified prefab for the override-precedence scene.
+    base: []const u8,
+    /// Empty unified scene — bootstraps `game.spawn_prefab_fn`.
+    empty_scene: []const u8,
+};
+
+const Corpus = Fixture.define(Sources, .{
+    .widget =
+    \\{ "root": { "components": { "Marker": { "id": 100 } } } }
+    ,
+    .parent =
+    \\{ "root": {
+    \\  "components": { "Marker": { "id": 1 } },
+    \\  "children": [ { "components": { "Marker": { "id": 2 } } } ]
+    \\} }
+    ,
+    .nested_item =
+    \\{ "root": { "components": { "Marker": { "id": 500 } } } }
+    ,
+    .base =
+    \\{ "root": { "components": { "Marker": { "id": 1 } } } }
+    ,
+    .empty_scene =
+    \\{ "root": { "children": [] } }
+    ,
+});
+
+// A path with no `prefabs/` directory — every prefab must come from
+// `addEmbeddedPrefab`, never a filesystem fallback.
+const PREFAB_DIR = "/tmp/labelle-nonexistent-spec-561";
+
+/// First entity carrying a `Marker` with the given id, or null.
+fn findMarker(game: *Game, id: i32) ?*Marker {
+    var view = game.ecs_backend.view(.{Marker}, .{});
+    defer view.deinit();
+    while (view.next()) |e| {
+        const m = game.ecs_backend.getComponent(e, Marker).?;
+        if (m.id == id) return m;
+    }
+    return null;
+}
+
+/// Count of entities carrying a `Marker`.
+fn countMarkers(game: *Game) usize {
+    var view = game.ecs_backend.view(.{Marker}, .{});
+    defer view.deinit();
+    var n: usize = 0;
+    while (view.next()) |_| n += 1;
+    return n;
+}
+
+pub const UnifiedFormatSpec = struct {
+    var game: Game = undefined;
+
+    // Outer hooks own the game's lifetime; each `describe` group's
+    // own `tests:before` then embeds the prefabs that group needs.
+    test "tests:before" {
+        game = Game.init(zspec.allocator);
+    }
+
+    test "tests:after" {
+        game.deinit();
+    }
+
+    // ── spawnFromPrefab — runtime instantiation ─────────────────
+
+    pub const @"spawnFromPrefab instantiates a unified prefab" = struct {
+        test "tests:before" {
+            const src = Corpus.create(.{});
+            try Bridge.addEmbeddedPrefab(&game, "widget", src.widget, PREFAB_DIR);
+            try Bridge.addEmbeddedPrefab(&game, "parent", src.parent, PREFAB_DIR);
+            // Loading any scene wires `game.spawn_prefab_fn`.
+            try Bridge.loadSceneFromSource(&game, src.empty_scene, PREFAB_DIR);
+        }
+
+        test "applies the root-wrapped components to the spawned entity" {
+            const e = game.spawnFromPrefab("widget", .{ .x = 0, .y = 0 }).?;
+            const marker = game.ecs_backend.getComponent(e, Marker).?;
+            // zspec's `expect.equal` compares with `==` (no struct
+            // support); the whole-struct check goes through
+            // `std.testing.expectEqual`, fed the factory-built
+            // expectation.
+            try std.testing.expectEqual(MarkerFactory.build(.{ .id = 100 }), marker.*);
+        }
+
+        test "instantiates the prefab's root.children subtree" {
+            _ = game.spawnFromPrefab("parent", .{ .x = 0, .y = 0 }).?;
+            // Root (Marker 1) plus its one child (Marker 2).
+            try expect.notToBeNull(findMarker(&game, 1));
+            try expect.notToBeNull(findMarker(&game, 2));
+            try expect.equal(countMarkers(&game), 2);
+        }
+    };
+
+    // ── prefab refs inside entity-bearing component fields ──────
+
+    pub const @"nested prefab references inside component fields" = struct {
+        test "tests:before" {
+            const src = Corpus.create(.{});
+            try Bridge.addEmbeddedPrefab(&game, "nested_item", src.nested_item, PREFAB_DIR);
+        }
+
+        test "a unified prefab referenced via overrides is spawned and patched" {
+            try Bridge.loadSceneFromSource(&game,
+                \\{ "root": { "children": [
+                \\  { "components": { "Container": { "slots": [
+                \\    { "prefab": "nested_item", "overrides": { "Marker": { "id": 7 } } }
+                \\  ] } } }
+                \\] } }
+            , PREFAB_DIR);
+
+            // The nested item spawned with the override applied (7),
+            // not the prefab default (500).
+            try expect.notToBeNull(findMarker(&game, 7));
+            try expect.toBeNull(findMarker(&game, 500));
+        }
+
+        test "legacy components on a nested reference still resolves" {
+            try Bridge.loadSceneFromSource(&game,
+                \\{ "root": { "children": [
+                \\  { "components": { "Container": { "slots": [
+                \\    { "prefab": "nested_item", "components": { "Marker": { "id": 8 } } }
+                \\  ] } } }
+                \\] } }
+            , PREFAB_DIR);
+
+            try expect.notToBeNull(findMarker(&game, 8));
+        }
+    };
+
+    // ── reference entry: overrides vs. legacy components ────────
+
+    pub const @"a reference carrying both overrides and components" = struct {
+        test "tests:before" {
+            const src = Corpus.create(.{});
+            try Bridge.addEmbeddedPrefab(&game, "base", src.base, PREFAB_DIR);
+        }
+
+        test "overrides wins over a legacy components key on the same entry" {
+            try Bridge.loadSceneFromSource(&game,
+                \\{ "root": { "children": [
+                \\  { "prefab": "base",
+                \\    "overrides":  { "Marker": { "id": 9  } },
+                \\    "components": { "Marker": { "id": 99 } } }
+                \\] } }
+            , PREFAB_DIR);
+
+            try expect.notToBeNull(findMarker(&game, 9));
+            try expect.toBeNull(findMarker(&game, 99));
+        }
+    };
+};

--- a/spec/unified_format_spec.zig
+++ b/spec/unified_format_spec.zig
@@ -148,7 +148,10 @@ pub const UnifiedFormatSpec = struct {
 
         test "instantiates the prefab's root.children subtree" {
             _ = game.spawnFromPrefab("parent", .{ .x = 0, .y = 0 }).?;
-            // Root (Marker 1) plus its one child (Marker 2).
+            // Root (Marker 1) plus its one child (Marker 2). The
+            // outer `tests:before` re-initializes `game` per test,
+            // so the widget spawned in the preceding test in this
+            // group does NOT leak in — the assertion stays at 2.
             try expect.notToBeNull(findMarker(&game, 1));
             try expect.notToBeNull(findMarker(&game, 2));
             try expect.equal(countMarkers(&game), 2);

--- a/src/jsonc/on_ready.zig
+++ b/src/jsonc/on_ready.zig
@@ -42,6 +42,10 @@ pub fn OnReady(comptime GameType: type, comptime Components: type) type {
         ) void {
             if (scene_components) |sc| {
                 for (sc.entries) |entry| {
+                    // A `null` override removes the component
+                    // (RFC #562) — nothing was applied, so fire no
+                    // hook for it.
+                    if (entry.value == .null_value) continue;
                     fireOnReadyByName(game, entity, entry.key);
                 }
             }

--- a/src/jsonc/on_ready.zig
+++ b/src/jsonc/on_ready.zig
@@ -14,7 +14,7 @@
 //! Callers instantiate once per bridge type:
 //!
 //!     const Hooks = OnReady(GameType, Components);
-//!     Hooks.fireOnReadyAll(game, entity, scene_components, prefab_components, &applied);
+//!     Hooks.fireOnReadyAll(game, entity, scene_components, prefab_components, &applied, is_reference);
 //!     Hooks.patchEntityIdField(game, parent, "Workstation", "storages", ids);
 
 const std = @import("std");
@@ -33,19 +33,28 @@ pub fn OnReady(comptime GameType: type, comptime Components: type) type {
         /// then the prefab block skips anything already handled) so
         /// hooks see exactly one fire per component, regardless of
         /// where the component originated.
+        ///
+        /// `is_reference` is true when `scene_components` is a
+        /// prefab reference's `overrides` block. Only then does a
+        /// `null` value mean component removal (RFC #562). For an
+        /// inline entity's `components` a `null` has no removal
+        /// semantics, so its hook must still fire.
         pub fn fireOnReadyAll(
             game: *GameType,
             entity: Entity,
             scene_components: ?Value.Object,
             prefab_components: ?Value.Object,
             applied: *std.StringHashMap(void),
+            is_reference: bool,
         ) void {
             if (scene_components) |sc| {
                 for (sc.entries) |entry| {
                     // A `null` override removes the component
                     // (RFC #562) — nothing was applied, so fire no
-                    // hook for it.
-                    if (entry.value == .null_value) continue;
+                    // hook for it. Removal is scoped to reference
+                    // entries' `overrides`; an inline `components`
+                    // `null` is not a removal and still fires.
+                    if (is_reference and entry.value == .null_value) continue;
                     fireOnReadyByName(game, entity, entry.key);
                 }
             }

--- a/src/jsonc/prefab_cache.zig
+++ b/src/jsonc/prefab_cache.zig
@@ -53,6 +53,12 @@ pub const PrefabCache = struct {
     /// raise `error.DuplicatePrefabName`. A genuine collision between
     /// two *distinct* files in a not-yet-scanned directory still
     /// errors. Keys are duped into `persistent` (game-lifetime).
+    ///
+    /// An entry is added *only after* a directory's walk completes
+    /// successfully — a walk aborted by `error.DuplicatePrefabName`
+    /// (or any other mid-walk failure) leaves the directory un-marked
+    /// so a later reload (after the user fixes the collision) can
+    /// retry the scan instead of being permanently locked out.
     scanned_dirs: std.StringHashMap(void),
 
     pub fn init(allocator: std.mem.Allocator, prefab_dir: []const u8) PrefabCache {
@@ -198,28 +204,46 @@ pub fn scanRegistry(cache: *PrefabCache, log: anytype, prefab_dir: []const u8) !
 /// the cache keyed by effective name. A directory that cannot be
 /// opened (typically absent) is silently skipped.
 ///
-/// Idempotent: a directory already recorded in `cache.scanned_dirs`
-/// (from an earlier `loadScene` on this game-lifetime cache) is
-/// skipped, so a scene reload does not re-register — and thus does
-/// not falsely collide on — files the first scan already cached.
+/// Transactional: parsed entries are staged in a local map and
+/// committed into `cache.prefabs` only after the *entire* walk
+/// completes without error. A walk aborted partway (e.g. by
+/// `error.DuplicatePrefabName` on a collision the user is about to
+/// fix) leaves `cache.prefabs` and `cache.scanned_dirs` untouched, so
+/// a subsequent reload — after the user removes one of the colliding
+/// files — re-runs the walk and succeeds. Without staging, a partial
+/// first walk would leave half-populated cache entries that either
+/// shadow the now-canonical file or self-collide on the retry.
+///
+/// Idempotent across normal reloads: a directory recorded in
+/// `cache.scanned_dirs` (from a previous *successful* walk on this
+/// game-lifetime cache) is skipped entirely, so a normal scene reload
+/// (e.g. F9) does not re-register — and thus does not falsely collide
+/// on — files the first scan already cached.
 fn scanDir(cache: *PrefabCache, log: anytype, dir_path: []const u8) !void {
     const io = io_helper.io();
 
-    // Skip directories already walked by a previous scan. Normalize a
-    // trailing slash so `prefabs` and `prefabs/` map to one key.
+    // Skip directories already walked by a previous successful scan.
+    // Normalize a trailing slash so `prefabs` and `prefabs/` map to
+    // one key.
     const dir_key = std.mem.trimEnd(u8, dir_path, "/");
     if (cache.scanned_dirs.contains(dir_key)) return;
 
     var dir = std.Io.Dir.cwd().openDir(io, dir_path, .{ .iterate = true }) catch return;
     defer dir.close(io);
 
-    // Record the directory as scanned. Done after a successful open so
-    // a directory that does not exist yet (skipped above) can still be
-    // picked up by a later scan once it is created.
-    try cache.scanned_dirs.put(try cache.persistent.dupe(u8, dir_key), {});
-
     var walker = try dir.walk(cache.temp);
     defer walker.deinit();
+
+    // Stage this walk's inserts in a temp-allocator map. We commit
+    // them into `cache.prefabs` only after the loop completes without
+    // error. If the loop returns early (e.g. duplicate-name), the
+    // staging map is discarded by `deinit`, leaving the persistent
+    // cache untouched. The parsed `Value` trees and their backing
+    // `src` buffers are themselves in `cache.persistent` (game-
+    // lifetime, page-allocator) and harmlessly leaked on the error
+    // path — same property the rest of the cache relies on.
+    var staged = std.StringHashMap(Value).init(cache.temp);
+    defer staged.deinit();
 
     while (try walker.next(io)) |entry| {
         if (entry.kind != .file) continue;
@@ -243,10 +267,24 @@ fn scanDir(cache: *PrefabCache, log: anytype, dir_path: []const u8) !void {
         const basename = entry.basename[0 .. entry.basename.len - ".jsonc".len];
         const key = if (val.asObject()) |obj| uf.effectiveName(obj, basename) else basename;
 
-        if (cache.prefabs.contains(key)) {
+        // Collisions are checked against both the already-committed
+        // cache and the current walk's staging map — two distinct
+        // files in this walk that share an effective name must error
+        // even though neither is in `cache.prefabs` yet.
+        if (cache.prefabs.contains(key) or staged.contains(key)) {
             log.err("[registry] duplicate name '{s}' (from '{s}'): rename the file or give one a distinct \"name\" (RFC #561)", .{ key, entry.path });
             return error.DuplicatePrefabName;
         }
-        try cache.prefabs.put(try cache.persistent.dupe(u8, key), val);
+        // Stage with a persistent-allocator key: it will be moved into
+        // `cache.prefabs` (which uses `cache.persistent`) on commit.
+        try staged.put(try cache.persistent.dupe(u8, key), val);
     }
+
+    // Commit: walk succeeded, fold the staged entries into the
+    // permanent cache and mark the directory done.
+    var it = staged.iterator();
+    while (it.next()) |kv| {
+        try cache.prefabs.put(kv.key_ptr.*, kv.value_ptr.*);
+    }
+    try cache.scanned_dirs.put(try cache.persistent.dupe(u8, dir_key), {});
 }

--- a/src/jsonc/prefab_cache.zig
+++ b/src/jsonc/prefab_cache.zig
@@ -120,3 +120,101 @@ pub fn getOrCreatePrefabCache(game: anytype, prefab_dir: []const u8) !*PrefabCac
     }
     return try initPersistentCache(game, prefab_dir);
 }
+
+// ── Eager filesystem registry scan (RFC #560, ticket #561) ──────────
+//
+// On desktop, the flat name-keyed registry is populated up-front by
+// recursively walking the project's `prefabs/` and `scenes/`
+// directories. This is what makes a file resolvable by an effective
+// name (its `"name"` field) that diverges from its filename basename,
+// and what lets cross-file effective-name collisions be caught as a
+// hard load-time error instead of silently shadowing.
+//
+// It is the filesystem counterpart of `addEmbeddedPrefab`, which the
+// assembler emits for WASM/mobile builds (no filesystem). WASM/mobile
+// must NOT run this scan — `std.Io` is `failing` there (see
+// `io_helper.zig`) and prefabs arrive exclusively via the embedded
+// path. The scan is therefore gated on a non-emscripten target, and
+// additionally skips any directory it cannot open (a desktop project
+// may legitimately ship only one of `prefabs/`/`scenes/`).
+
+const is_wasm_emscripten = builtin.target.os.tag == .emscripten;
+
+/// Recursively scan a project's `prefabs/` and `scenes/` directories
+/// into the flat name-keyed registry held by `cache`.
+///
+/// `prefab_dir` is the project's prefab directory (the same value
+/// passed to `loadScene`); the sibling `scenes/` directory is derived
+/// by convention — `<dirname(prefab_dir)>/scenes`. Either directory
+/// may be absent; a missing directory is skipped, not an error.
+///
+/// Each `.jsonc` file is parsed and keyed by its *effective name*
+/// (`unified_format.effectiveName` — its `"name"` field if present,
+/// else the filename basename without the extension). A duplicate
+/// effective name across any two scanned files raises
+/// `error.DuplicatePrefabName` — mirrors `addEmbeddedPrefab`; there
+/// is no precedence rule, the author renames a file or sets a
+/// distinct `"name"`.
+///
+/// No-op on WASM/mobile (`wasm32-emscripten`) — those builds rely on
+/// the assembler-emitted embedded prefab/scene sources and have no
+/// filesystem.
+pub fn scanRegistry(cache: *PrefabCache, log: anytype, prefab_dir: []const u8) !void {
+    if (is_wasm_emscripten) return;
+
+    try scanDir(cache, log, prefab_dir);
+
+    // Derive the sibling `scenes/` directory by convention. The
+    // project layout is `<project>/prefabs` + `<project>/scenes`, so
+    // replace the prefab dir's last path component with `scenes`.
+    const parent = std.fs.path.dirname(prefab_dir);
+    const scenes_dir = if (parent) |p|
+        try std.fs.path.join(cache.temp, &.{ p, "scenes" })
+    else
+        try cache.temp.dupe(u8, "scenes");
+    defer cache.temp.free(scenes_dir);
+
+    try scanDir(cache, log, scenes_dir);
+}
+
+/// Recursively walk one directory, parsing every `.jsonc` file into
+/// the cache keyed by effective name. A directory that cannot be
+/// opened (typically absent) is silently skipped.
+fn scanDir(cache: *PrefabCache, log: anytype, dir_path: []const u8) !void {
+    const io = io_helper.io();
+
+    var dir = std.Io.Dir.cwd().openDir(io, dir_path, .{ .iterate = true }) catch return;
+    defer dir.close(io);
+
+    var walker = try dir.walk(cache.temp);
+    defer walker.deinit();
+
+    while (try walker.next(io)) |entry| {
+        if (entry.kind != .file) continue;
+        if (!std.mem.endsWith(u8, entry.basename, ".jsonc")) continue;
+
+        // Read + parse into the persistent allocator: the parsed
+        // `Value` tree is game-lifetime data (deserialized components
+        // hold slices into it), the same contract as `get`.
+        const src = entry.dir.readFileAlloc(io, entry.basename, cache.persistent, .limited(1024 * 1024)) catch |err| {
+            log.warn("[registry] failed to read '{s}': {s}", .{ entry.path, @errorName(err) });
+            continue;
+        };
+        var parser = JsoncParser.init(cache.persistent, src);
+        const val = parser.parse() catch |err| {
+            log.warn("[registry] failed to parse '{s}': {s}", .{ entry.path, @errorName(err) });
+            continue;
+        };
+
+        // Effective name = `"name"` field, else filename basename
+        // without the `.jsonc` extension.
+        const basename = entry.basename[0 .. entry.basename.len - ".jsonc".len];
+        const key = if (val.asObject()) |obj| uf.effectiveName(obj, basename) else basename;
+
+        if (cache.prefabs.contains(key)) {
+            log.err("[registry] duplicate name '{s}' (from '{s}'): rename the file or give one a distinct \"name\" (RFC #561)", .{ key, entry.path });
+            return error.DuplicatePrefabName;
+        }
+        try cache.prefabs.put(try cache.persistent.dupe(u8, key), val);
+    }
+}

--- a/src/jsonc/prefab_cache.zig
+++ b/src/jsonc/prefab_cache.zig
@@ -43,6 +43,17 @@ pub const PrefabCache = struct {
     persistent: std.mem.Allocator,
     temp: std.mem.Allocator,
     prefab_dir: []const u8,
+    /// Directories already walked by `scanRegistry`/`scanDir`, keyed
+    /// by the (trailing-slash-normalized) path. The eager scan is
+    /// idempotent: a second `loadScene` (a normal scene reload —
+    /// e.g. F9 in the games) re-runs the scan into this same
+    /// game-lifetime cache, and a directory already in this set is
+    /// skipped rather than re-walked. Without this, the second scan
+    /// would re-encounter every already-registered file and wrongly
+    /// raise `error.DuplicatePrefabName`. A genuine collision between
+    /// two *distinct* files in a not-yet-scanned directory still
+    /// errors. Keys are duped into `persistent` (game-lifetime).
+    scanned_dirs: std.StringHashMap(void),
 
     pub fn init(allocator: std.mem.Allocator, prefab_dir: []const u8) PrefabCache {
         const persistent = persistent_allocator;
@@ -51,6 +62,7 @@ pub const PrefabCache = struct {
             .persistent = persistent,
             .temp = allocator,
             .prefab_dir = prefab_dir,
+            .scanned_dirs = std.StringHashMap(void).init(persistent),
         };
     }
 
@@ -167,7 +179,12 @@ pub fn scanRegistry(cache: *PrefabCache, log: anytype, prefab_dir: []const u8) !
     // Derive the sibling `scenes/` directory by convention. The
     // project layout is `<project>/prefabs` + `<project>/scenes`, so
     // replace the prefab dir's last path component with `scenes`.
-    const parent = std.fs.path.dirname(prefab_dir);
+    //
+    // Strip a trailing slash first: `dirname("foo/prefabs/")` returns
+    // `"foo/prefabs"`, which would derive `foo/prefabs/scenes` instead
+    // of the intended sibling `foo/scenes`.
+    const normalized = std.mem.trimEnd(u8, prefab_dir, "/");
+    const parent = std.fs.path.dirname(normalized);
     const scenes_dir = if (parent) |p|
         try std.fs.path.join(cache.temp, &.{ p, "scenes" })
     else
@@ -180,11 +197,26 @@ pub fn scanRegistry(cache: *PrefabCache, log: anytype, prefab_dir: []const u8) !
 /// Recursively walk one directory, parsing every `.jsonc` file into
 /// the cache keyed by effective name. A directory that cannot be
 /// opened (typically absent) is silently skipped.
+///
+/// Idempotent: a directory already recorded in `cache.scanned_dirs`
+/// (from an earlier `loadScene` on this game-lifetime cache) is
+/// skipped, so a scene reload does not re-register — and thus does
+/// not falsely collide on — files the first scan already cached.
 fn scanDir(cache: *PrefabCache, log: anytype, dir_path: []const u8) !void {
     const io = io_helper.io();
 
+    // Skip directories already walked by a previous scan. Normalize a
+    // trailing slash so `prefabs` and `prefabs/` map to one key.
+    const dir_key = std.mem.trimEnd(u8, dir_path, "/");
+    if (cache.scanned_dirs.contains(dir_key)) return;
+
     var dir = std.Io.Dir.cwd().openDir(io, dir_path, .{ .iterate = true }) catch return;
     defer dir.close(io);
+
+    // Record the directory as scanned. Done after a successful open so
+    // a directory that does not exist yet (skipped above) can still be
+    // picked up by a later scan once it is created.
+    try cache.scanned_dirs.put(try cache.persistent.dupe(u8, dir_key), {});
 
     var walker = try dir.walk(cache.temp);
     defer walker.deinit();

--- a/src/jsonc/prefab_cache.zig
+++ b/src/jsonc/prefab_cache.zig
@@ -19,6 +19,7 @@ const builtin = @import("builtin");
 const jsonc = @import("jsonc");
 const Value = jsonc.Value;
 const JsoncParser = jsonc.JsoncParser;
+const uf = @import("unified_format.zig");
 
 // Persistent allocator for game-lifetime data. On `wasm32-emscripten`
 // we MUST go through libc (emscripten's malloc), because libc's
@@ -58,6 +59,13 @@ pub const PrefabCache = struct {
     /// and caches the parse result. Filesystem fallback is desktop-
     /// only — mobile builds rely on `addEmbeddedPrefab` having
     /// pre-populated every prefab the project uses.
+    ///
+    /// The cache is keyed by *effective name* (RFC #561): a file
+    /// `widget.jsonc` with `"name": "foo"` resolves and stores under
+    /// `"foo"`. Matches `addEmbeddedPrefab`'s contract so the two
+    /// registration paths share one flat registry — a disk load and
+    /// an embedded source that both claim the same effective name
+    /// collide rather than co-existing under different keys (#573).
     pub fn get(self: *PrefabCache, name: []const u8) ?Value {
         if (self.prefabs.get(name)) |val| return val;
 
@@ -66,7 +74,16 @@ pub const PrefabCache = struct {
         const src = std.Io.Dir.cwd().readFileAlloc(io_helper.io(), path, self.persistent, .limited(1024 * 1024)) catch return null;
         var p = JsoncParser.init(self.persistent, src);
         const val = p.parse() catch return null;
-        self.prefabs.put(self.persistent.dupe(u8, name) catch return null, val) catch return null;
+
+        // Resolve to the effective name (the file's `"name"` field
+        // when present, else the lookup string) and reject a
+        // collision with an already-cached entry. Keeps disk and
+        // embedded registrations on the same flat registry.
+        const key = if (val.asObject()) |obj| uf.effectiveName(obj, name) else name;
+        if (self.prefabs.contains(key)) return null;
+        const duped_key = self.persistent.dupe(u8, key) catch return null;
+        errdefer self.persistent.free(duped_key);
+        self.prefabs.put(duped_key, val) catch return null;
         return val;
     }
 };

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -363,22 +363,36 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                 }
             }
 
-            // Build merged component map: prefab defaults, then
-            // scene overrides.
+            // Build the entity's component set: prefab defaults
+            // patched by the reference entry's `overrides`. An
+            // override deep-merges onto the prefab's same-named
+            // component — patching only the fields it names — and a
+            // `null` override removes the component (RFC #562).
+            //
+            // The merge tree lives in `merge_arena`; its leaf
+            // strings are shared with the prefab/override inputs, so
+            // `@ref` names collected from a merged component stay
+            // valid into the pass-2 patch even after the arena frees.
+            var merge_arena = std.heap.ArenaAllocator.init(game.allocator);
+            defer merge_arena.deinit();
+
+            // `applied` records every override key — including
+            // `null` removals — so the prefab blocks below skip them.
             var applied = std.StringHashMap(void).init(game.allocator);
             defer applied.deinit();
 
-            // Apply scene components (these override prefab
-            // defaults).
+            // Apply scene/override components, each deep-merged over
+            // the prefab's matching component.
             if (scene_components) |sc| {
                 for (sc.entries) |entry| {
-                    try ApplyHelpers.applyComponentWithRefs(game, entity, entry.key, entry.value, parent_offset, ref_ctx);
                     try applied.put(entry.key, {});
+                    if (entry.value == .null_value) continue; // removal
+                    const effective = uf.mergedOverride(prefab_components, entry.key, entry.value, merge_arena.allocator());
+                    try ApplyHelpers.applyComponentWithRefs(game, entity, entry.key, effective, parent_offset, ref_ctx);
                 }
             }
 
-            // Apply prefab components (skip if already overridden
-            // by scene).
+            // Apply prefab components the override did not touch.
             if (prefab_components) |pc| {
                 for (pc.entries) |entry| {
                     if (!applied.contains(entry.key)) {
@@ -392,10 +406,15 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             const entity_pos = game.getPosition(entity);
 
             // Spawn nested entity arrays and collect IDs to patch
-            // back into components.
+            // back into components. Override components use the same
+            // merged value as the apply pass — a deep-merged
+            // component keeps the prefab's entity-bearing fields, so
+            // their nested entities must still spawn.
             if (scene_components) |sc| {
                 for (sc.entries) |entry| {
-                    spawnAndLinkNestedEntities(game, entity, entry.key, entry.value, entity_pos, prefab_cache, depth, ref_ctx);
+                    if (entry.value == .null_value) continue;
+                    const effective = uf.mergedOverride(prefab_components, entry.key, entry.value, merge_arena.allocator());
+                    spawnAndLinkNestedEntities(game, entity, entry.key, effective, entity_pos, prefab_cache, depth, ref_ctx);
                 }
             }
             if (prefab_components) |pc| {
@@ -561,6 +580,11 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
         ) void {
             const obj = comp_value.asObject() orelse return;
 
+            // Arena for deep-merged override component values
+            // (RFC #562) — mirrors the block in `loadEntityInternal`.
+            var merge_arena = std.heap.ArenaAllocator.init(game.allocator);
+            defer merge_arena.deinit();
+
             for (obj.entries) |entry| {
                 const arr = entry.value.asArray() orelse continue;
 
@@ -661,10 +685,14 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                             // Reference entry → `overrides`; inline → `components`.
                             const child_scene_comps = uf.entityPatch(child_obj, game.log);
 
-                            // Scene overrides first.
+                            // Override components first, each
+                            // deep-merged over the prefab's match;
+                            // a `null` override removes it (#562).
                             if (child_scene_comps) |sc| {
                                 for (sc.entries) |e| {
-                                    ApplyHelpers.applyComponentWithRefs(game, child, e.key, e.value, parent_world_pos, nested_ref_ctx) catch |err| {
+                                    if (e.value == .null_value) continue;
+                                    const effective = uf.mergedOverride(child_prefab_comps, e.key, e.value, merge_arena.allocator());
+                                    ApplyHelpers.applyComponentWithRefs(game, child, e.key, effective, parent_world_pos, nested_ref_ctx) catch |err| {
                                         game.log.err("[NestedEntity] Failed to apply {s}: {s}", .{ e.key, @errorName(err) });
                                     };
                                 }
@@ -691,7 +719,9 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                             const child_pos = game.getPosition(child);
                             if (child_scene_comps) |sc| {
                                 for (sc.entries) |e| {
-                                    spawnAndLinkNestedEntities(game, child, e.key, e.value, child_pos, prefab_cache, depth + 1, nested_ref_ctx);
+                                    if (e.value == .null_value) continue;
+                                    const effective = uf.mergedOverride(child_prefab_comps, e.key, e.value, merge_arena.allocator());
+                                    spawnAndLinkNestedEntities(game, child, e.key, effective, child_pos, prefab_cache, depth + 1, nested_ref_ctx);
                                 }
                             }
                             if (child_prefab_comps) |pc| {

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -66,6 +66,17 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             // `loadScene` is a desktop path.
             const prefab_cache = try prefab_cache_mod.getOrCreatePrefabCache(game, prefab_dir);
 
+            // Eagerly populate the flat name-keyed registry from the
+            // filesystem (RFC #560, #561): recursively scan the
+            // project's `prefabs/` and sibling `scenes/` directories
+            // up-front. This resolves files whose `"name"` diverges
+            // from their basename and catches cross-file effective-
+            // name collisions as a hard load-time error. Desktop-only
+            // — no-op on WASM/mobile, where there is no filesystem
+            // and prefabs/scenes arrive via the assembler-emitted
+            // embedded sources / `addEmbeddedPrefab`.
+            try prefab_cache_mod.scanRegistry(prefab_cache, game.log, prefab_dir);
+
             try loadSceneFile(game, scene_path, prefab_cache, 0);
 
             // Enable runtime prefab spawning.

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -231,7 +231,6 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             };
             const prefab_obj = prefab_val.asObject() orelse return null;
             const prefab_root = uf.rootObject(prefab_obj);
-            const prefab_components = prefab_root.getObject("components") orelse return null;
 
             // Cycle gate. Walk a synthetic reference entry so the
             // shared walker pushes `name` onto its expansion stack
@@ -239,6 +238,12 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             // or via a child / nested component field) is caught
             // (RFC #569). On a cycle the chain is logged and the
             // spawn fails (`null`) rather than recursing forever.
+            //
+            // Run UNCONDITIONALLY, before the `components` lookup
+            // below: a cyclic prefab whose `root` has no `components`
+            // (the cycle lives purely in `root.children`) would
+            // otherwise bypass the diagnostic via the early `return
+            // null` and just silently fail to spawn.
             {
                 var ref_entries = [_]Value.Object.Entry{
                     .{ .key = "prefab", .value = .{ .string = name } },
@@ -249,6 +254,8 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                     return null;
                 };
             }
+
+            const prefab_components = prefab_root.getObject("components") orelse return null;
 
             const entity = game.createEntity();
             game.trackSceneEntity(entity);

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -194,7 +194,9 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             // Fire onReady hooks.
             var applied = std.StringHashMap(void).init(game.allocator);
             defer applied.deinit();
-            OnReadyHelpers.fireOnReadyAll(game, entity, null, prefab_components, &applied);
+            // No scene/override components here — `is_reference` is
+            // moot (the scene loop is skipped on a null block).
+            OnReadyHelpers.fireOnReadyAll(game, entity, null, prefab_components, &applied, false);
 
             // Process children — save world pos, set parent, restore (#417).
             if (prefab_root.getArray("children")) |children| {
@@ -342,6 +344,11 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             // for an inline entry, its own `components`.
             const scene_components = uf.entityPatch(entity_obj, game.log);
 
+            // `null`-as-removal is scoped to reference entries'
+            // `overrides` (RFC #562) — an inline entity's
+            // `components` have no removal semantics.
+            const is_reference = entity_obj.getString("prefab") != null;
+
             // Create entity — destroy on error to prevent orphans.
             const entity = game.createEntity();
             game.trackSceneEntity(entity);
@@ -386,8 +393,13 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             if (scene_components) |sc| {
                 for (sc.entries) |entry| {
                     try applied.put(entry.key, {});
-                    if (entry.value == .null_value) continue; // removal
-                    const effective = uf.mergedOverride(prefab_components, entry.key, entry.value, merge_arena.allocator());
+                    // A `null` override removes a component, but only
+                    // for a reference entry's `overrides`. An inline
+                    // entity's `components` carry no removal meaning
+                    // — a `null` there is just a (likely malformed)
+                    // value, not a deletion.
+                    if (is_reference and entry.value == .null_value) continue; // removal
+                    const effective = try uf.mergedOverride(prefab_components, entry.key, entry.value, merge_arena.allocator());
                     try ApplyHelpers.applyComponentWithRefs(game, entity, entry.key, effective, parent_offset, ref_ctx);
                 }
             }
@@ -412,8 +424,8 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             // their nested entities must still spawn.
             if (scene_components) |sc| {
                 for (sc.entries) |entry| {
-                    if (entry.value == .null_value) continue;
-                    const effective = uf.mergedOverride(prefab_components, entry.key, entry.value, merge_arena.allocator());
+                    if (is_reference and entry.value == .null_value) continue;
+                    const effective = try uf.mergedOverride(prefab_components, entry.key, entry.value, merge_arena.allocator());
                     spawnAndLinkNestedEntities(game, entity, entry.key, effective, entity_pos, prefab_cache, depth, ref_ctx);
                 }
             }
@@ -427,7 +439,7 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
 
             // Fire onReady for all applied components (after entity
             // is fully assembled).
-            OnReadyHelpers.fireOnReadyAll(game, entity, scene_components, prefab_components, &applied);
+            OnReadyHelpers.fireOnReadyAll(game, entity, scene_components, prefab_components, &applied, is_reference);
 
             // Process children recursively (prefab children +
             // entity-level children).
@@ -685,13 +697,23 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                             // Reference entry → `overrides`; inline → `components`.
                             const child_scene_comps = uf.entityPatch(child_obj, game.log);
 
+                            // `null`-as-removal is scoped to a
+                            // reference entry's `overrides` (RFC #562).
+                            const child_is_reference = child_obj.getString("prefab") != null;
+
                             // Override components first, each
                             // deep-merged over the prefab's match;
                             // a `null` override removes it (#562).
                             if (child_scene_comps) |sc| {
                                 for (sc.entries) |e| {
-                                    if (e.value == .null_value) continue;
-                                    const effective = uf.mergedOverride(child_prefab_comps, e.key, e.value, merge_arena.allocator());
+                                    // `null`-as-removal applies only
+                                    // to a reference entry's
+                                    // `overrides` (RFC #562).
+                                    if (child_is_reference and e.value == .null_value) continue;
+                                    const effective = uf.mergedOverride(child_prefab_comps, e.key, e.value, merge_arena.allocator()) catch |err| {
+                                        game.log.err("[NestedEntity] Failed to merge override {s}: {s}", .{ e.key, @errorName(err) });
+                                        continue;
+                                    };
                                     ApplyHelpers.applyComponentWithRefs(game, child, e.key, effective, parent_world_pos, nested_ref_ctx) catch |err| {
                                         game.log.err("[NestedEntity] Failed to apply {s}: {s}", .{ e.key, @errorName(err) });
                                     };
@@ -719,8 +741,11 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                             const child_pos = game.getPosition(child);
                             if (child_scene_comps) |sc| {
                                 for (sc.entries) |e| {
-                                    if (e.value == .null_value) continue;
-                                    const effective = uf.mergedOverride(child_prefab_comps, e.key, e.value, merge_arena.allocator());
+                                    if (child_is_reference and e.value == .null_value) continue;
+                                    const effective = uf.mergedOverride(child_prefab_comps, e.key, e.value, merge_arena.allocator()) catch |err| {
+                                        game.log.err("[NestedEntity] Failed to merge override {s}: {s}", .{ e.key, @errorName(err) });
+                                        continue;
+                                    };
                                     spawnAndLinkNestedEntities(game, child, e.key, effective, child_pos, prefab_cache, depth + 1, nested_ref_ctx);
                                 }
                             }
@@ -800,7 +825,7 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                                     nested_applied.put(e.key, {}) catch {};
                                 }
                             }
-                            OnReadyHelpers.fireOnReadyAll(game, child, child_scene_comps, child_prefab_comps, &nested_applied);
+                            OnReadyHelpers.fireOnReadyAll(game, child, child_scene_comps, child_prefab_comps, &nested_applied, child_is_reference);
                         }
 
                         ids[idx] = @intCast(child);

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -39,6 +39,7 @@ else
 
 const prefab_cache_mod = @import("prefab_cache.zig");
 const PrefabCache = prefab_cache_mod.PrefabCache;
+const uf = @import("unified_format.zig");
 const ref_resolver_mod = @import("ref_resolver.zig");
 const component_apply_mod = @import("component_apply.zig");
 const on_ready_mod = @import("on_ready.zig");
@@ -151,7 +152,8 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                 return null;
             };
             const prefab_obj = prefab_val.asObject() orelse return null;
-            const prefab_components = prefab_obj.getObject("components") orelse return null;
+            const prefab_root = uf.rootObject(prefab_obj);
+            const prefab_components = prefab_root.getObject("components") orelse return null;
 
             const entity = game.createEntity();
             game.trackSceneEntity(entity);
@@ -176,7 +178,7 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             OnReadyHelpers.fireOnReadyAll(game, entity, null, prefab_components, &applied);
 
             // Process children — save world pos, set parent, restore (#417).
-            if (prefab_obj.getArray("children")) |children| {
+            if (prefab_root.getArray("children")) |children| {
                 for (children.items) |child_val| {
                     const child = loadEntityInternal(game, child_val, prefab_cache, 1, entity_pos, null) catch continue;
                     const world_pos = game.getPosition(child);
@@ -246,7 +248,10 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             }
 
             // Process this file's entities with ref support.
-            if (scene_obj.getArray("entities")) |entities_arr| {
+            // `fileChildren` accepts the unified `root.children`
+            // shape and the legacy top-level `entities` array.
+            uf.warnLegacyAssets(scene_obj, game.log);
+            if (uf.fileChildren(scene_obj, game.log)) |entities_arr| {
                 var ref_ctx = RefContext.init(game.allocator, null);
                 defer ref_ctx.deinit();
                 try processEntities(game, entities_arr, prefab_cache, &ref_ctx);
@@ -275,7 +280,8 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                 }
             }
 
-            if (scene_obj.getArray("entities")) |entities_arr| {
+            uf.warnLegacyAssets(scene_obj, game.log);
+            if (uf.fileChildren(scene_obj, game.log)) |entities_arr| {
                 var ref_ctx = RefContext.init(game.allocator, null);
                 defer ref_ctx.deinit();
                 try processEntities(game, entities_arr, prefab_cache, &ref_ctx);
@@ -304,13 +310,18 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                 if (prefab_cache.get(prefab_name)) |prefab_val| {
                     if (prefab_val.asObject()) |pobj| {
                         prefab_obj_opt = pobj;
-                        prefab_components = pobj.getObject("components");
-                        prefab_children = pobj.getArray("children");
+                        // Unwrap the unified `root` block (a no-op
+                        // on legacy prefabs that lack it).
+                        const proot = uf.rootObject(pobj);
+                        prefab_components = proot.getObject("components");
+                        prefab_children = proot.getArray("children");
                     }
                 }
             }
 
-            const scene_components = entity_obj.getObject("components");
+            // For a reference entry this is the `overrides` patch;
+            // for an inline entry, its own `components`.
+            const scene_components = uf.entityPatch(entity_obj, game.log);
 
             // Create entity — destroy on error to prevent orphans.
             const entity = game.createEntity();
@@ -325,7 +336,7 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             if (ref_ctx) |rctx| {
                 const entity_id: u64 = @intCast(entity);
                 const ref_name = entity_obj.getString("ref") orelse
-                    if (prefab_obj_opt) |pobj| pobj.getString("ref") else null;
+                    if (prefab_obj_opt) |pobj| uf.rootObject(pobj).getString("ref") else null;
                 if (ref_name) |rn| {
                     if (try rctx.ref_map.fetchPut(rn, entity_id)) |existing| {
                         game.log.warn("[SceneRef] Duplicate ref '{s}' (entities {d} and {d})", .{ rn, existing.value, entity_id });
@@ -560,8 +571,9 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                             if (child_obj.getString("prefab")) |pname| {
                                 if (prefab_cache.get(pname)) |pval| {
                                     if (pval.asObject()) |pobj| {
-                                        child_prefab_comps = pobj.getObject("components");
-                                        child_prefab_children = pobj.getArray("children");
+                                        const proot = uf.rootObject(pobj);
+                                        child_prefab_comps = proot.getObject("components");
+                                        child_prefab_children = proot.getArray("children");
                                     }
                                 }
                             }
@@ -612,7 +624,7 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                                 if (child_obj.getString("prefab")) |pname| {
                                     if (prefab_cache.get(pname)) |pval| {
                                         if (pval.asObject()) |pobj| {
-                                            prefab_ref = pobj.getString("ref");
+                                            prefab_ref = uf.rootObject(pobj).getString("ref");
                                         }
                                     }
                                 }
@@ -627,7 +639,8 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                                 }
                             }
 
-                            const child_scene_comps = child_obj.getObject("components");
+                            // Reference entry → `overrides`; inline → `components`.
+                            const child_scene_comps = uf.entityPatch(child_obj, game.log);
 
                             // Scene overrides first.
                             if (child_scene_comps) |sc| {

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -129,13 +129,32 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
         /// Pre-load a prefab from in-memory JSONC source into the
         /// persistent cache. Call before `loadSceneFromSource` so
         /// the prefab is available without file I/O.
+        ///
+        /// The cache key is the prefab's *effective name* — its
+        /// `"name"` field when present, else the `name` argument
+        /// (which the assembler passes as the file basename). This
+        /// is the flat name-keyed registry of RFC #561: a prefab
+        /// resolves by the same name regardless of its filename or
+        /// which directory it lives in.
+        ///
+        /// A duplicate effective name is a load-time error
+        /// (`error.DuplicatePrefabName`) — there is no precedence
+        /// rule; the author renames a file or sets a distinct
+        /// `"name"`. The assembler emits one call per prefab, so a
+        /// collision here means two source files genuinely clash.
         pub fn addEmbeddedPrefab(game: *GameType, name: []const u8, source: []const u8, prefab_dir: []const u8) !void {
             const prefab_cache = try prefab_cache_mod.getOrCreatePrefabCache(game, prefab_dir);
 
             const persistent = prefab_cache.persistent;
             var parser = JsoncParser.init(persistent, source);
             const val = try parser.parse();
-            try prefab_cache.prefabs.put(try persistent.dupe(u8, name), val);
+
+            const key = if (val.asObject()) |obj| uf.effectiveName(obj, name) else name;
+            if (prefab_cache.prefabs.contains(key)) {
+                game.log.err("[registry] duplicate prefab name '{s}': rename the file or give one a distinct \"name\" (RFC #561)", .{key});
+                return error.DuplicatePrefabName;
+            }
+            try prefab_cache.prefabs.put(try persistent.dupe(u8, key), val);
         }
 
         // ── Runtime prefab spawn ───────────────────────────────

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -388,18 +388,35 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             var applied = std.StringHashMap(void).init(game.allocator);
             defer applied.deinit();
 
+            // Precompute the effective (merged) value for each override
+            // entry once, in `merge_arena`, so the apply-component and
+            // spawn-nested-entity passes share the same merged tree
+            // instead of redoing the deep-merge per pass. `null`
+            // entries here mark removals that both passes must skip
+            // in lockstep.
+            const effective_overrides: ?[]?Value = if (scene_components) |sc| blk: {
+                const slice = try merge_arena.allocator().alloc(?Value, sc.entries.len);
+                for (sc.entries, 0..) |entry, i| {
+                    if (is_reference and entry.value == .null_value) {
+                        slice[i] = null;
+                    } else {
+                        slice[i] = try uf.mergedOverride(prefab_components, entry.key, entry.value, merge_arena.allocator());
+                    }
+                }
+                break :blk slice;
+            } else null;
+
             // Apply scene/override components, each deep-merged over
             // the prefab's matching component.
             if (scene_components) |sc| {
-                for (sc.entries) |entry| {
+                for (sc.entries, 0..) |entry, i| {
                     try applied.put(entry.key, {});
                     // A `null` override removes a component, but only
                     // for a reference entry's `overrides`. An inline
                     // entity's `components` carry no removal meaning
                     // — a `null` there is just a (likely malformed)
                     // value, not a deletion.
-                    if (is_reference and entry.value == .null_value) continue; // removal
-                    const effective = try uf.mergedOverride(prefab_components, entry.key, entry.value, merge_arena.allocator());
+                    const effective = effective_overrides.?[i] orelse continue; // removal
                     try ApplyHelpers.applyComponentWithRefs(game, entity, entry.key, effective, parent_offset, ref_ctx);
                 }
             }
@@ -418,14 +435,13 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             const entity_pos = game.getPosition(entity);
 
             // Spawn nested entity arrays and collect IDs to patch
-            // back into components. Override components use the same
-            // merged value as the apply pass — a deep-merged
-            // component keeps the prefab's entity-bearing fields, so
-            // their nested entities must still spawn.
+            // back into components. Reuses `effective_overrides`
+            // computed above — a deep-merged component keeps the
+            // prefab's entity-bearing fields, so their nested
+            // entities must still spawn.
             if (scene_components) |sc| {
-                for (sc.entries) |entry| {
-                    if (is_reference and entry.value == .null_value) continue;
-                    const effective = try uf.mergedOverride(prefab_components, entry.key, entry.value, merge_arena.allocator());
+                for (sc.entries, 0..) |entry, i| {
+                    const effective = effective_overrides.?[i] orelse continue;
                     spawnAndLinkNestedEntities(game, entity, entry.key, effective, entity_pos, prefab_cache, depth, ref_ctx);
                 }
             }
@@ -701,19 +717,39 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                             // reference entry's `overrides` (RFC #562).
                             const child_is_reference = child_obj.getString("prefab") != null;
 
+                            // Precompute the effective (merged) value
+                            // for each override entry once, in
+                            // `merge_arena`, so the apply-component
+                            // and recurse-nested-entity passes share
+                            // the same merged tree. `null` slots mark
+                            // removals or merge failures both passes
+                            // must skip in lockstep.
+                            const child_effective: ?[]?Value = if (child_scene_comps) |sc| blk: {
+                                const slice = merge_arena.allocator().alloc(?Value, sc.entries.len) catch break :blk null;
+                                for (sc.entries, 0..) |e, i| {
+                                    if (child_is_reference and e.value == .null_value) {
+                                        slice[i] = null;
+                                    } else if (uf.mergedOverride(child_prefab_comps, e.key, e.value, merge_arena.allocator())) |eff| {
+                                        slice[i] = eff;
+                                    } else |err| {
+                                        game.log.err("[NestedEntity] Failed to merge override {s}: {s}", .{ e.key, @errorName(err) });
+                                        slice[i] = null;
+                                    }
+                                }
+                                break :blk slice;
+                            } else null;
+
                             // Override components first, each
                             // deep-merged over the prefab's match;
                             // a `null` override removes it (#562).
                             if (child_scene_comps) |sc| {
-                                for (sc.entries) |e| {
+                                for (sc.entries, 0..) |e, i| {
                                     // `null`-as-removal applies only
                                     // to a reference entry's
-                                    // `overrides` (RFC #562).
-                                    if (child_is_reference and e.value == .null_value) continue;
-                                    const effective = uf.mergedOverride(child_prefab_comps, e.key, e.value, merge_arena.allocator()) catch |err| {
-                                        game.log.err("[NestedEntity] Failed to merge override {s}: {s}", .{ e.key, @errorName(err) });
-                                        continue;
-                                    };
+                                    // `overrides` (RFC #562). A null
+                                    // slot here also covers merge
+                                    // failures already logged above.
+                                    const effective = (child_effective orelse break)[i] orelse continue;
                                     ApplyHelpers.applyComponentWithRefs(game, child, e.key, effective, parent_world_pos, nested_ref_ctx) catch |err| {
                                         game.log.err("[NestedEntity] Failed to apply {s}: {s}", .{ e.key, @errorName(err) });
                                     };
@@ -737,15 +773,12 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                             }
 
                             // Recursively spawn nested entities
-                            // inside this child's components.
+                            // inside this child's components. Reuses
+                            // `child_effective` from the apply pass.
                             const child_pos = game.getPosition(child);
                             if (child_scene_comps) |sc| {
-                                for (sc.entries) |e| {
-                                    if (child_is_reference and e.value == .null_value) continue;
-                                    const effective = uf.mergedOverride(child_prefab_comps, e.key, e.value, merge_arena.allocator()) catch |err| {
-                                        game.log.err("[NestedEntity] Failed to merge override {s}: {s}", .{ e.key, @errorName(err) });
-                                        continue;
-                                    };
+                                for (sc.entries, 0..) |e, i| {
+                                    const effective = (child_effective orelse break)[i] orelse continue;
                                     spawnAndLinkNestedEntities(game, child, e.key, effective, child_pos, prefab_cache, depth + 1, nested_ref_ctx);
                                 }
                             }

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -43,6 +43,28 @@ const uf = @import("unified_format.zig");
 const ref_resolver_mod = @import("ref_resolver.zig");
 const component_apply_mod = @import("component_apply.zig");
 const on_ready_mod = @import("on_ready.zig");
+const tree_walker = @import("tree_walker.zig");
+
+/// Adapt a `PrefabCache` into a `tree_walker.Resolver`. The walker
+/// expands `prefab` references through this so its cycle detector
+/// sees the same reference graph the instantiation pass does.
+fn prefabResolver(cache: *PrefabCache) tree_walker.Resolver {
+    const Wrap = struct {
+        fn get(ctx: *anyopaque, name: []const u8) ?Value {
+            const c: *PrefabCache = @ptrCast(@alignCast(ctx));
+            return c.get(name);
+        }
+    };
+    return .{ .ctx = cache, .getFn = &Wrap.get };
+}
+
+/// A walker visitor that does nothing — used when the only thing a
+/// walk needs to surface is cycle detection (the walker raises
+/// `error.PrefabCycle` on its own; the visitor never has to act).
+const CycleCheckVisitor = struct {
+    pub const VisitError = error{};
+    pub fn visit(_: CycleCheckVisitor, _: tree_walker.Node(VisitError)) VisitError!void {}
+};
 
 pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
     const Entity = GameType.EntityType;
@@ -52,8 +74,32 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
     const OnReadyHelpers = on_ready_mod.OnReady(GameType, Components);
 
     return struct {
-        pub const LoadEntityError = error{ IncludeDepthExceeded, OutOfMemory, InvalidFormat };
+        pub const LoadEntityError = error{ IncludeDepthExceeded, OutOfMemory, InvalidFormat, PrefabCycle };
         pub const MAX_DEPTH: usize = 16;
+
+        // ── Cycle detection (RFC #569) ─────────────────────────
+
+        /// Run the shared entity-tree walker over `entity_value`
+        /// purely for its cycle detector. A referenced-prefab cycle
+        /// (`A -> B -> A`) is a load-time error: the full chain is
+        /// logged and `error.PrefabCycle` propagates so the loader
+        /// aborts before instantiating a tree that would recurse
+        /// forever. Both inference (static) and instantiation
+        /// (runtime) gate on this shared check.
+        fn checkEntityTreeCycles(game: *GameType, entity_value: Value, prefab_cache: *PrefabCache) LoadEntityError!void {
+            var ctx = tree_walker.WalkContext.init(game.allocator);
+            defer ctx.deinit();
+            tree_walker.walk(&ctx, prefabResolver(prefab_cache), entity_value, CycleCheckVisitor{}) catch |err| switch (err) {
+                error.PrefabCycle => {
+                    const chain = ctx.formatCycleChain(game.allocator) catch "<unknown>";
+                    defer if (!std.mem.eql(u8, chain, "<unknown>")) game.allocator.free(chain);
+                    game.log.err("[scene] prefab reference cycle: {s} (RFC #560, #569)", .{chain});
+                    return error.PrefabCycle;
+                },
+                error.DepthExceeded => return error.IncludeDepthExceeded,
+                error.OutOfMemory => return error.OutOfMemory,
+            };
+        }
 
         // ── Public entry points ────────────────────────────────
 
@@ -187,6 +233,23 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             const prefab_root = uf.rootObject(prefab_obj);
             const prefab_components = prefab_root.getObject("components") orelse return null;
 
+            // Cycle gate. Walk a synthetic reference entry so the
+            // shared walker pushes `name` onto its expansion stack
+            // — that way a prefab that references itself (directly
+            // or via a child / nested component field) is caught
+            // (RFC #569). On a cycle the chain is logged and the
+            // spawn fails (`null`) rather than recursing forever.
+            {
+                var ref_entries = [_]Value.Object.Entry{
+                    .{ .key = "prefab", .value = .{ .string = name } },
+                };
+                const ref_entry = Value{ .object = .{ .entries = &ref_entries } };
+                checkEntityTreeCycles(game, ref_entry, prefab_cache) catch |err| {
+                    game.log.err("[spawnPrefab] '{s}' not spawned: {s}", .{ name, @errorName(err) });
+                    return null;
+                };
+            }
+
             const entity = game.createEntity();
             game.trackSceneEntity(entity);
             game.setPosition(entity, pos);
@@ -229,6 +292,14 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
         /// Process entities from a parsed scene, with two-pass ref
         /// resolution.
         fn processEntities(game: *GameType, entities_arr: Value.Array, prefab_cache: *PrefabCache, ref_ctx: *RefContext) LoadEntityError!void {
+            // Pass 0: cycle gate. The shared tree-walker crosses
+            // both `children` and prefab refs nested in component
+            // fields, so a cycle hidden in either path is caught
+            // before any entity is created (RFC #569).
+            for (entities_arr.items) |entity_val| {
+                try checkEntityTreeCycles(game, entity_val, prefab_cache);
+            }
+
             // Pass 1: create entities, apply components (with
             // `@ref` → 0), collect refs.
             for (entities_arr.items) |entity_val| {

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -154,7 +154,9 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                 game.log.err("[registry] duplicate prefab name '{s}': rename the file or give one a distinct \"name\" (RFC #561)", .{key});
                 return error.DuplicatePrefabName;
             }
-            try prefab_cache.prefabs.put(try persistent.dupe(u8, key), val);
+            const duped_key = try persistent.dupe(u8, key);
+            errdefer persistent.free(duped_key);
+            try prefab_cache.prefabs.put(duped_key, val);
         }
 
         // ── Runtime prefab spawn ───────────────────────────────

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -86,13 +86,30 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
         /// aborts before instantiating a tree that would recurse
         /// forever. Both inference (static) and instantiation
         /// (runtime) gate on this shared check.
-        fn checkEntityTreeCycles(game: *GameType, entity_value: Value, prefab_cache: *PrefabCache) LoadEntityError!void {
-            var ctx = tree_walker.WalkContext.init(game.allocator);
-            defer ctx.deinit();
-            tree_walker.walk(&ctx, prefabResolver(prefab_cache), entity_value, CycleCheckVisitor{}) catch |err| switch (err) {
+        fn checkEntityTreeCycles(
+            game: *GameType,
+            entity_value: Value,
+            prefab_cache: *PrefabCache,
+            ctx: *tree_walker.WalkContext,
+        ) LoadEntityError!void {
+            // Track the loader's recursion limit so the walk fails
+            // with the same depth ceiling `loadEntityInternal` does
+            // — a tree the loader would reject as too deep is
+            // surfaced here as `IncludeDepthExceeded`, not silently
+            // walked.
+            ctx.max_depth = MAX_DEPTH;
+            tree_walker.walk(ctx, prefabResolver(prefab_cache), entity_value, CycleCheckVisitor{}) catch |err| switch (err) {
                 error.PrefabCycle => {
-                    const chain = ctx.formatCycleChain(game.allocator) catch "<unknown>";
-                    defer if (!std.mem.eql(u8, chain, "<unknown>")) game.allocator.free(chain);
+                    // `formatCycleChain` either returns an
+                    // allocator-owned slice (success) or raises
+                    // `OutOfMemory`. Use an optional to signal which
+                    // one, rather than a literal-string fallback —
+                    // a string-equality probe to decide whether to
+                    // free is brittle (and just happens to work
+                    // because no real chain is "<unknown>").
+                    const chain_opt: ?[]const u8 = ctx.formatCycleChain(game.allocator) catch null;
+                    defer if (chain_opt) |c| game.allocator.free(c);
+                    const chain = chain_opt orelse "<unknown>";
                     game.log.err("[scene] prefab reference cycle: {s} (RFC #560, #569)", .{chain});
                     return error.PrefabCycle;
                 },
@@ -249,7 +266,9 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                     .{ .key = "prefab", .value = .{ .string = name } },
                 };
                 const ref_entry = Value{ .object = .{ .entries = &ref_entries } };
-                checkEntityTreeCycles(game, ref_entry, prefab_cache) catch |err| {
+                var cycle_ctx = tree_walker.WalkContext.init(game.allocator);
+                defer cycle_ctx.deinit();
+                checkEntityTreeCycles(game, ref_entry, prefab_cache, &cycle_ctx) catch |err| {
                     game.log.err("[spawnPrefab] '{s}' not spawned: {s}", .{ name, @errorName(err) });
                     return null;
                 };
@@ -303,8 +322,17 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             // both `children` and prefab refs nested in component
             // fields, so a cycle hidden in either path is caught
             // before any entity is created (RFC #569).
+            //
+            // One `WalkContext` for the whole scene: its expansion
+            // stack and diagnostic buffer keep their capacity across
+            // entries, so a scene with N top-level entities does N
+            // walks but only one set of ArrayList growths.
+            var cycle_ctx = tree_walker.WalkContext.init(game.allocator);
+            defer cycle_ctx.deinit();
             for (entities_arr.items) |entity_val| {
-                try checkEntityTreeCycles(game, entity_val, prefab_cache);
+                cycle_ctx.stack.clearRetainingCapacity();
+                cycle_ctx.cycle_chain.clearRetainingCapacity();
+                try checkEntityTreeCycles(game, entity_val, prefab_cache, &cycle_ctx);
             }
 
             // Pass 1: create entities, apply components (with

--- a/src/jsonc/tree_walker.zig
+++ b/src/jsonc/tree_walker.zig
@@ -231,7 +231,20 @@ fn walkEntry(
             }
         }
     }
-    defer if (pushed_prefab) {
+    // The expansion stack only guards against *reference-chain*
+    // cycles (A's body references B's body references A's body).
+    // Steps 1 and 2 walk content that belongs to this prefab's body,
+    // so the stack must include this prefab while they recurse. Step
+    // 3 walks the entry's own scene-declared `children`, which are a
+    // SEPARATE entity tree the scene attached — a child there that
+    // references this same prefab is a new finite expansion, not a
+    // recursive one. So pop the stack between step 2 and step 3 to
+    // avoid a false `error.PrefabCycle` on a legitimate scene entry
+    // like `{ "prefab": "A", "children": [{ "prefab": "A" }] }`.
+    // `errdefer` covers an early return from steps 1 or 2; the
+    // happy-path pop below clears `pushed_prefab` so it does not
+    // double-pop.
+    errdefer if (pushed_prefab) {
         _ = ctx.stack.pop();
     };
 
@@ -276,6 +289,14 @@ fn walkEntry(
         if (try effectiveComponents(merge_arena, prefab_components, patch)) |eff| {
             try walkComponentFields(ctx, merge_arena, resolver, eff, depth, visitor);
         }
+    }
+
+    // The prefab's body (steps 1 and 2) is fully expanded — pop
+    // before walking scene-declared children so a child that
+    // references the same prefab is not mistaken for a cycle.
+    if (pushed_prefab) {
+        _ = ctx.stack.pop();
+        pushed_prefab = false;
     }
 
     // ── 3. the entry's own children array ───────────────────────

--- a/src/jsonc/tree_walker.zig
+++ b/src/jsonc/tree_walker.zig
@@ -25,8 +25,11 @@
 //!
 //!   1. prefab-defined children (`prefab.root.children`),
 //!   2. entity entries nested inside component fields, in component
-//!      declaration order then array order — prefab components
-//!      first, then the entry's own `components`/`overrides`,
+//!      declaration order then array order — walked over the
+//!      **effective** component set (the prefab components with the
+//!      reference entry's `overrides` deep-merged in and `null`
+//!      removals applied, RFC #562), so the traversal matches the
+//!      tree the loader actually instantiates,
 //!   3. the entry's own `children` array.
 //!
 //! This order is the contract the hook-order spec (#561) builds on:
@@ -51,6 +54,14 @@ const std = @import("std");
 const jsonc = @import("jsonc");
 const Value = jsonc.Value;
 const uf = @import("unified_format.zig");
+
+/// Per-walk scratch allocations — the merged effective-component
+/// trees built while reasoning about `overrides` (RFC #562). Owned by
+/// the walk; freed when the walk finishes. Kept separate from
+/// `WalkContext` (which lives on a caller's stack and is read for
+/// `cycle_chain` after the walk returns) so a single arena reset
+/// frees every merge without touching the diagnostic buffers.
+const MergeArena = std.heap.ArenaAllocator;
 
 /// Error set for a tree walk. `PrefabCycle` carries no payload —
 /// the offending chain is reported through `WalkContext.cycle_chain`
@@ -178,11 +189,14 @@ pub fn walk(
     root_value: Value,
     visitor: anytype,
 ) (WalkError || @TypeOf(visitor).VisitError)!void {
-    try walkEntry(ctx, resolver, root_value, .root, 0, null, visitor);
+    var merge_arena = MergeArena.init(ctx.allocator);
+    defer merge_arena.deinit();
+    try walkEntry(ctx, &merge_arena, resolver, root_value, .root, 0, null, visitor);
 }
 
 fn walkEntry(
     ctx: *WalkContext,
+    merge_arena: *MergeArena,
     resolver: Resolver,
     entity_value: Value,
     origin: Origin,
@@ -236,37 +250,116 @@ fn walkEntry(
     if (prefab_root) |proot| {
         if (proot.getArray("children")) |children| {
             for (children.items) |child_val| {
-                try walkEntry(ctx, resolver, child_val, .prefab_child, depth + 1, null, visitor);
+                try walkEntry(ctx, merge_arena, resolver, child_val, .prefab_child, depth + 1, null, visitor);
             }
         }
     }
 
     // ── 2. entity entries nested in component fields ────────────
-    // Prefab components first, then the entry's own patch — the
-    // entry-side patch is walked too because an `overrides` block
-    // can introduce nested entities of its own.
-    if (prefab_root) |proot| {
-        if (proot.getObject("components")) |pc| {
-            try walkComponentFields(ctx, resolver, pc, depth, visitor);
+    // The walker must reason about the **effective** component tree
+    // — the post-#562-merge result the loader actually instantiates,
+    // not the raw prefab components. A reference entry's `overrides`
+    // can replace an entity-bearing field with a non-cyclic value,
+    // or a `null` override can remove a whole component; in either
+    // case the entity-bearing fields the prefab declared no longer
+    // exist, so walking the raw prefab components would chase a
+    // cycle through a field the merged tree has dropped.
+    //
+    // `effectiveComponents` mirrors `loadEntityInternal`: it deep-
+    // merges each override onto the prefab's same-named component
+    // (RFC #562, `uf.mergedOverride`), drops `null`-removed
+    // components, and carries through override-only components.
+    {
+        const prefab_components: ?Value.Object =
+            if (prefab_root) |proot| proot.getObject("components") else null;
+        const patch = uf.entityPatch(obj, NoopLog{});
+        if (try effectiveComponents(merge_arena, prefab_components, patch)) |eff| {
+            try walkComponentFields(ctx, merge_arena, resolver, eff, depth, visitor);
         }
-    }
-    if (uf.entityPatch(obj, NoopLog{})) |patch| {
-        try walkComponentFields(ctx, resolver, patch, depth, visitor);
     }
 
     // ── 3. the entry's own children array ───────────────────────
     if (obj.getArray("children")) |children| {
         for (children.items) |child_val| {
-            try walkEntry(ctx, resolver, child_val, .child, depth + 1, null, visitor);
+            try walkEntry(ctx, merge_arena, resolver, child_val, .child, depth + 1, null, visitor);
         }
     }
 }
 
+/// Build the **effective** component object for an entity entry:
+/// the prefab's components with the reference entry's `overrides`
+/// applied (RFC #562 deep-merge / `null` removal). This is the same
+/// component set `SceneLoader.loadEntityInternal` instantiates, so
+/// the walker's nested-entity traversal sees exactly the fields the
+/// runtime will spawn — no false `PrefabCycle` on a field an
+/// override replaced or removed.
+///
+/// Returns `null` only when neither side carries components. The
+/// merged tree lives in `merge_arena`; leaf values are shared with
+/// the inputs (same contract as `uf.mergeValues`).
+fn effectiveComponents(
+    merge_arena: *MergeArena,
+    prefab_components: ?Value.Object,
+    patch: ?Value.Object,
+) error{OutOfMemory}!?Value.Object {
+    // Inline entry (no prefab) — its `components` ARE the effective
+    // set; nothing to merge.
+    const pc = prefab_components orelse return patch;
+    // Reference entry with no `overrides` — the prefab components
+    // are the effective set unchanged.
+    const ov = patch orelse return pc;
+
+    const a = merge_arena.allocator();
+    var entries: std.ArrayListUnmanaged(Value.Object.Entry) = .empty;
+
+    // Start from the prefab components, dropping any the override
+    // removes via a JSONC `null` (component-level removal, #562).
+    for (pc.entries) |pe| {
+        const removed = blk: {
+            for (ov.entries) |oe| {
+                if (std.mem.eql(u8, oe.key, pe.key))
+                    break :blk oe.value == .null_value;
+            }
+            break :blk false;
+        };
+        if (removed) continue;
+        // Deep-merge the override onto this prefab component when
+        // the override names it; otherwise keep the prefab value.
+        var value = pe.value;
+        for (ov.entries) |oe| {
+            if (std.mem.eql(u8, oe.key, pe.key) and oe.value != .null_value) {
+                value = uf.mergeValues(pe.value, oe.value, a);
+                break;
+            }
+        }
+        try entries.append(a, .{ .key = pe.key, .value = value });
+    }
+
+    // Add override-only components (present in `overrides` but not
+    // the prefab), skipping `null` removals of nonexistent keys.
+    for (ov.entries) |oe| {
+        if (oe.value == .null_value) continue;
+        const in_prefab = blk: {
+            for (pc.entries) |pe| {
+                if (std.mem.eql(u8, pe.key, oe.key)) break :blk true;
+            }
+            break :blk false;
+        };
+        if (!in_prefab) try entries.append(a, .{ .key = oe.key, .value = oe.value });
+    }
+
+    return Value.Object{ .entries = try entries.toOwnedSlice(a) };
+}
+
 /// Walk every entity entry nested inside a component object's array
-/// fields. A field is "entity-bearing" when its first array element
-/// looks like an entity entry (`isEntityLike`).
+/// fields. A field is "entity-bearing" when ANY array element looks
+/// like an entity entry (`isEntityLike`) — consistent with the
+/// loader's `spawnAndLinkNestedEntities`, which scans every item.
+/// Checking only `[0]` would miss a cycle reached through an
+/// entity-like item that is not first in the array.
 fn walkComponentFields(
     ctx: *WalkContext,
+    merge_arena: *MergeArena,
     resolver: Resolver,
     components: Value.Object,
     depth: usize,
@@ -277,10 +370,9 @@ fn walkComponentFields(
         for (comp_obj.entries) |field| {
             const arr = field.value.asArray() orelse continue;
             if (arr.items.len == 0) continue;
-            if (!isEntityLike(arr.items[0])) continue;
             for (arr.items) |item| {
                 if (!isEntityLike(item)) continue;
-                try walkEntry(ctx, resolver, item, .component_field, depth + 1, entry.key, visitor);
+                try walkEntry(ctx, merge_arena, resolver, item, .component_field, depth + 1, entry.key, visitor);
             }
         }
     }

--- a/src/jsonc/tree_walker.zig
+++ b/src/jsonc/tree_walker.zig
@@ -1,0 +1,305 @@
+//! Shared entity-tree walker (RFC #560, ticket #569).
+//!
+//! The unified scene/prefab format grows entities in **two**
+//! structural places:
+//!
+//!   1. the `children` array of an entity, and
+//!   2. prefab references embedded inside entity-bearing component
+//!      fields — the `Room.movement_nodes` / `Workstation.storages`
+//!      pattern, where a component field is an array of entity
+//!      entries.
+//!
+//! Every consumer that walks the tree (entity instantiation,
+//! save/load prefab tagging, `postLoad` hook firing, asset
+//! inference, gizmo registration) must cross *both* paths. A walker
+//! that crosses one but not the other is exactly the bug shape of
+//! engine #467 / #470 / flying-platform-labelle #286 — so N
+//! independent traversals re-introduce that bug N times. This module
+//! is the single traversal entry point so there is exactly one
+//! `children`-and-component-field recursion in the engine.
+//!
+//! ## Walk order (normative)
+//!
+//! For each entity entry the walker yields the entry itself
+//! **first** (pre-order), then descends in this fixed order:
+//!
+//!   1. prefab-defined children (`prefab.root.children`),
+//!   2. entity entries nested inside component fields, in component
+//!      declaration order then array order — prefab components
+//!      first, then the entry's own `components`/`overrides`,
+//!   3. the entry's own `children` array.
+//!
+//! This order is the contract the hook-order spec (#561) builds on:
+//! a parent's `postLoad` sees its prefab subtree, then its nested
+//! component entities, then its scene-declared children.
+//!
+//! ## Cycle detection
+//!
+//! A prefab-reference cycle (`A -> B -> A`) is a load-time error.
+//! The walker tracks the chain of prefab names currently being
+//! expanded; re-entering a name already on the stack is
+//! `error.PrefabCycle`, and the full chain (e.g. `A -> B -> A`) is
+//! written to the caller-supplied diagnostic buffer so the error
+//! message can name every link, not just "cycle detected".
+//!
+//! The walker is allocation-light: it owns a single growable stack
+//! of prefab names for cycle detection and nothing else. It does not
+//! parse, does not touch the ECS, and does not resolve `@ref`s —
+//! callers layer those concerns on top of the yielded entries.
+
+const std = @import("std");
+const jsonc = @import("jsonc");
+const Value = jsonc.Value;
+const uf = @import("unified_format.zig");
+
+/// Error set for a tree walk. `PrefabCycle` carries no payload —
+/// the offending chain is reported through `WalkContext.cycle_chain`
+/// so the caller can format a message that names every link.
+pub const WalkError = error{
+    /// A prefab reference re-entered a prefab already being
+    /// expanded on the current branch. See `cycle_chain`.
+    PrefabCycle,
+    /// The walk nested deeper than `max_depth` — a runaway tree or
+    /// a `children`/component-field structure with no natural base.
+    DepthExceeded,
+    OutOfMemory,
+};
+
+/// How a particular entity entry was reached. Consumers that treat
+/// the two structural birth-places differently (save/load tags only
+/// prefab-tree descendants as `PrefabChild`; gizmo registration may
+/// skip component-field entities) branch on this.
+pub const Origin = enum {
+    /// The walk's starting entry.
+    root,
+    /// Reached through an entity's `children` array.
+    child,
+    /// Reached through `prefab.root.children` of a referenced prefab.
+    prefab_child,
+    /// Reached through an entity entry nested inside a component
+    /// field (the `Room.movement_nodes` pattern).
+    component_field,
+};
+
+/// One visit handed to the caller's `visit` callback.
+pub fn Node(comptime VisitError: type) type {
+    _ = VisitError;
+    return struct {
+        /// The entity entry's JSONC object — its `components` /
+        /// `overrides` / `prefab` / `children` keys.
+        obj: Value.Object,
+        /// The raw `Value` the object came from (handy for callers
+        /// that re-dispatch into existing `Value`-keyed helpers).
+        value: Value,
+        /// How this entry was reached.
+        origin: Origin,
+        /// Nesting depth — `0` for the root entry.
+        depth: usize,
+        /// When `origin == .component_field`, the name of the
+        /// component whose field carried this entry (e.g.
+        /// `"Room"`); `null` otherwise. Lets a consumer attribute a
+        /// nested entity to its owning component.
+        component_name: ?[]const u8,
+        /// The resolved prefab object when this entry referenced a
+        /// `prefab` that was found, else `null`. Already unwrapped
+        /// past the `root` block.
+        prefab_root: ?Value.Object,
+    };
+}
+
+/// Per-walk mutable state: the cycle-detection stack and the
+/// diagnostic chain buffer. One `WalkContext` per top-level walk;
+/// callers `init` it, run the walk, then read `cycle_chain` if the
+/// walk returned `error.PrefabCycle`.
+pub const WalkContext = struct {
+    /// Prefab names currently being expanded, innermost last. A
+    /// reference to a name already here is a cycle.
+    stack: std.ArrayListUnmanaged([]const u8) = .empty,
+    /// Filled with the offending chain when a cycle is hit — the
+    /// stack at the point of detection plus the repeated name.
+    /// Borrowed slices into the walked tree / prefab registry; valid
+    /// as long as those outlive the context.
+    cycle_chain: std.ArrayListUnmanaged([]const u8) = .empty,
+    allocator: std.mem.Allocator,
+    /// Hard recursion cap — a malformed tree (or a cycle the prefab
+    /// resolver fails to surface) can't run away.
+    max_depth: usize = 64,
+
+    pub fn init(allocator: std.mem.Allocator) WalkContext {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(self: *WalkContext) void {
+        self.stack.deinit(self.allocator);
+        self.cycle_chain.deinit(self.allocator);
+    }
+
+    /// Render the recorded cycle chain as `A -> B -> A`. The
+    /// returned slice is owned by `out_alloc`. Empty when no cycle
+    /// was recorded.
+    pub fn formatCycleChain(self: *const WalkContext, out_alloc: std.mem.Allocator) ![]const u8 {
+        if (self.cycle_chain.items.len == 0) return out_alloc.dupe(u8, "");
+        var buf: std.ArrayListUnmanaged(u8) = .empty;
+        errdefer buf.deinit(out_alloc);
+        for (self.cycle_chain.items, 0..) |name, i| {
+            if (i != 0) try buf.appendSlice(out_alloc, " -> ");
+            try buf.appendSlice(out_alloc, name);
+        }
+        return buf.toOwnedSlice(out_alloc);
+    }
+};
+
+/// A prefab resolver: maps a prefab name to its parsed `Value`, or
+/// `null` when the name is unknown. `PrefabCache.get` satisfies this
+/// directly; tests pass a closure over a static table.
+pub const Resolver = struct {
+    ctx: *anyopaque,
+    getFn: *const fn (ctx: *anyopaque, name: []const u8) ?Value,
+
+    pub fn get(self: Resolver, name: []const u8) ?Value {
+        return self.getFn(self.ctx, name);
+    }
+};
+
+/// Walk the entity tree rooted at `root_value`, invoking `visitor`
+/// once per entity entry in the normative pre-order. `visitor` must
+/// expose `pub fn visit(self, node) VisitError!void` where `node` is
+/// `Node(VisitError)`.
+///
+/// `resolver` resolves `prefab` references so the walk can descend
+/// into prefab subtrees; pass a resolver that always returns `null`
+/// to walk only the inline structure (no prefab expansion).
+///
+/// Returns `error.PrefabCycle` (with `ctx.cycle_chain` populated) on
+/// a referenced-prefab cycle, or any error the visitor raises.
+pub fn walk(
+    ctx: *WalkContext,
+    resolver: Resolver,
+    root_value: Value,
+    visitor: anytype,
+) (WalkError || @TypeOf(visitor).VisitError)!void {
+    try walkEntry(ctx, resolver, root_value, .root, 0, null, visitor);
+}
+
+fn walkEntry(
+    ctx: *WalkContext,
+    resolver: Resolver,
+    entity_value: Value,
+    origin: Origin,
+    depth: usize,
+    component_name: ?[]const u8,
+    visitor: anytype,
+) (WalkError || @TypeOf(visitor).VisitError)!void {
+    const VisitError = @TypeOf(visitor).VisitError;
+    if (depth > ctx.max_depth) return error.DepthExceeded;
+
+    const obj = entity_value.asObject() orelse return;
+
+    // Resolve a `prefab` reference, if any. A reference to a prefab
+    // already on the expansion stack is a cycle — record the full
+    // chain and bail before recursing.
+    var prefab_root: ?Value.Object = null;
+    var pushed_prefab: bool = false;
+    if (obj.getString("prefab")) |prefab_name| {
+        for (ctx.stack.items) |on_stack| {
+            if (std.mem.eql(u8, on_stack, prefab_name)) {
+                ctx.cycle_chain.clearRetainingCapacity();
+                try ctx.cycle_chain.appendSlice(ctx.allocator, ctx.stack.items);
+                try ctx.cycle_chain.append(ctx.allocator, prefab_name);
+                return error.PrefabCycle;
+            }
+        }
+        if (resolver.get(prefab_name)) |prefab_val| {
+            if (prefab_val.asObject()) |pobj| {
+                prefab_root = uf.rootObject(pobj);
+                try ctx.stack.append(ctx.allocator, prefab_name);
+                pushed_prefab = true;
+            }
+        }
+    }
+    defer if (pushed_prefab) {
+        _ = ctx.stack.pop();
+    };
+
+    // Pre-order: yield this entry before descending.
+    const node: Node(VisitError) = .{
+        .obj = obj,
+        .value = entity_value,
+        .origin = origin,
+        .depth = depth,
+        .component_name = component_name,
+        .prefab_root = prefab_root,
+    };
+    try visitor.visit(node);
+
+    // ── 1. prefab-defined children ──────────────────────────────
+    if (prefab_root) |proot| {
+        if (proot.getArray("children")) |children| {
+            for (children.items) |child_val| {
+                try walkEntry(ctx, resolver, child_val, .prefab_child, depth + 1, null, visitor);
+            }
+        }
+    }
+
+    // ── 2. entity entries nested in component fields ────────────
+    // Prefab components first, then the entry's own patch — the
+    // entry-side patch is walked too because an `overrides` block
+    // can introduce nested entities of its own.
+    if (prefab_root) |proot| {
+        if (proot.getObject("components")) |pc| {
+            try walkComponentFields(ctx, resolver, pc, depth, visitor);
+        }
+    }
+    if (uf.entityPatch(obj, NoopLog{})) |patch| {
+        try walkComponentFields(ctx, resolver, patch, depth, visitor);
+    }
+
+    // ── 3. the entry's own children array ───────────────────────
+    if (obj.getArray("children")) |children| {
+        for (children.items) |child_val| {
+            try walkEntry(ctx, resolver, child_val, .child, depth + 1, null, visitor);
+        }
+    }
+}
+
+/// Walk every entity entry nested inside a component object's array
+/// fields. A field is "entity-bearing" when its first array element
+/// looks like an entity entry (`isEntityLike`).
+fn walkComponentFields(
+    ctx: *WalkContext,
+    resolver: Resolver,
+    components: Value.Object,
+    depth: usize,
+    visitor: anytype,
+) (WalkError || @TypeOf(visitor).VisitError)!void {
+    for (components.entries) |entry| {
+        const comp_obj = entry.value.asObject() orelse continue;
+        for (comp_obj.entries) |field| {
+            const arr = field.value.asArray() orelse continue;
+            if (arr.items.len == 0) continue;
+            if (!isEntityLike(arr.items[0])) continue;
+            for (arr.items) |item| {
+                if (!isEntityLike(item)) continue;
+                try walkEntry(ctx, resolver, item, .component_field, depth + 1, entry.key, visitor);
+            }
+        }
+    }
+}
+
+/// Whether a `Value` looks like an entity definition — it has a
+/// `prefab` string or a `components` object. Mirrors
+/// `component_apply.isEntityLike`; kept here so the walker has no
+/// dependency on the component-apply machinery (which is generic
+/// over `GameType`).
+pub fn isEntityLike(value: Value) bool {
+    const obj = value.asObject() orelse return false;
+    return obj.getString("prefab") != null or obj.getObject("components") != null;
+}
+
+/// A `log`-shaped no-op — `uf.entityPatch` takes a logger to emit
+/// deprecation warnings, but a pure structural walk should stay
+/// silent (the instantiation pass already warns once per file).
+const NoopLog = struct {
+    pub fn warn(_: NoopLog, comptime _: []const u8, _: anytype) void {}
+    pub fn err(_: NoopLog, comptime _: []const u8, _: anytype) void {}
+};

--- a/src/jsonc/tree_walker.zig
+++ b/src/jsonc/tree_walker.zig
@@ -349,7 +349,7 @@ fn effectiveComponents(
         var value = pe.value;
         for (ov.entries) |oe| {
             if (std.mem.eql(u8, oe.key, pe.key) and oe.value != .null_value) {
-                value = uf.mergeValues(pe.value, oe.value, a);
+                value = try uf.mergeValues(pe.value, oe.value, a);
                 break;
             }
         }

--- a/src/jsonc/unified_format.zig
+++ b/src/jsonc/unified_format.zig
@@ -81,6 +81,15 @@ pub fn entityPatch(entity_obj: Value.Object, log: anytype) ?Value.Object {
     return null;
 }
 
+/// The registry key for a prefab/scene file: its `"name"` field
+/// when present, otherwise the caller-supplied filename basename.
+/// Lets a file be referenced by a name that diverges from its
+/// path — and is the value collisions are checked against
+/// (RFC #560, #561).
+pub fn effectiveName(file_obj: Value.Object, basename: []const u8) []const u8 {
+    return file_obj.getString("name") orelse basename;
+}
+
 /// Warn once if a scene file still declares the dropped `"assets"`
 /// field. Under the unified format assets are inferred from sprite
 /// references (RFC #563); the field is ignored.

--- a/src/jsonc/unified_format.zig
+++ b/src/jsonc/unified_format.zig
@@ -14,8 +14,23 @@
 //! See RFC-UNIFY-SCENES-AND-PREFABS.md.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const jsonc = @import("jsonc");
 const Value = jsonc.Value;
+
+// Persistent allocator for the process-lifetime `warned` set. On
+// `wasm32-emscripten` `std.heap.page_allocator` resolves to
+// `WasmAllocator` and bypasses emscripten's `_emscripten_resize_heap`
+// / `updateMemoryViews()`, reintroducing the stale-`HEAPU32`
+// memory-growth hazard this codebase deliberately avoids. Use
+// `c_allocator` on emscripten (libc malloc routes through emscripten's
+// resize path), keep `page_allocator` on desktop. Mirrors the
+// `persistent_allocator` / `intern_backing_allocator` convention in
+// `prefab_cache.zig` and `deserializer.zig`.
+const warned_allocator: std.mem.Allocator = if (builtin.target.os.tag == .emscripten)
+    std.heap.c_allocator
+else
+    std.heap.page_allocator;
 
 // One-time deprecation-warning dedup, keyed by the comptime message
 // literal. A legacy prefab spawned N times — or a scene with N
@@ -27,7 +42,7 @@ var warned: ?std.StringHashMap(void) = null;
 
 fn warnOnce(log: anytype, comptime msg: []const u8) void {
     if (warned == null) {
-        warned = std.StringHashMap(void).init(std.heap.page_allocator);
+        warned = std.StringHashMap(void).init(warned_allocator);
     }
     const gop = warned.?.getOrPut(msg) catch return;
     if (gop.found_existing) return;

--- a/src/jsonc/unified_format.zig
+++ b/src/jsonc/unified_format.zig
@@ -121,7 +121,10 @@ pub fn mergeValues(base: Value, patch: Value, arena: std.mem.Allocator) error{Ou
     const patch_obj = patch.asObject() orelse return patch;
 
     var entries: std.ArrayListUnmanaged(Value.Object.Entry) = .empty;
-    try entries.appendSlice(arena, base_obj.entries);
+    // Pre-size for the worst case (every patch key is new) so the
+    // hot loop below appends without reallocating mid-merge.
+    try entries.ensureTotalCapacity(arena, base_obj.entries.len + patch_obj.entries.len);
+    entries.appendSliceAssumeCapacity(base_obj.entries);
 
     for (patch_obj.entries) |pe| {
         for (entries.items) |*existing| {
@@ -135,7 +138,7 @@ pub fn mergeValues(base: Value, patch: Value, arena: std.mem.Allocator) error{Ou
                 break;
             }
         } else {
-            try entries.append(arena, pe);
+            entries.appendAssumeCapacity(pe);
         }
     }
     return .{ .object = .{ .entries = entries.items } };

--- a/src/jsonc/unified_format.zig
+++ b/src/jsonc/unified_format.zig
@@ -1,0 +1,91 @@
+//! Unified scene/prefab format accessors (RFC #560, ticket #561).
+//!
+//! The unified format wraps a file's entity content in an explicit
+//! `"root"` block, lists file-level entities under `"children"`
+//! (not `"entities"`), and names a prefab reference's patch data
+//! `"overrides"` (not `"components"`). Legacy spellings are still
+//! accepted during the migration window; each logs a one-time
+//! deprecation warning so the #572 migrator has a checklist.
+//!
+//! These accessors are the single place that bridges the two
+//! shapes — the loader calls them instead of reading raw keys, so
+//! `"root"`-wrapped and legacy files walk the exact same code path.
+//!
+//! See RFC-UNIFY-SCENES-AND-PREFABS.md.
+
+const std = @import("std");
+const jsonc = @import("jsonc");
+const Value = jsonc.Value;
+
+// One-time deprecation-warning dedup, keyed by the comptime message
+// literal. A legacy prefab spawned N times — or a scene with N
+// legacy references — then warns once, not N times. Unguarded on
+// purpose: scene loading is single-threaded and the worst case of a
+// race is one duplicate warning line. Never freed (process-lifetime
+// set); keys are string literals so there is nothing to dupe.
+var warned: ?std.StringHashMap(void) = null;
+
+fn warnOnce(log: anytype, comptime msg: []const u8) void {
+    if (warned == null) {
+        warned = std.StringHashMap(void).init(std.heap.page_allocator);
+    }
+    const gop = warned.?.getOrPut(msg) catch return;
+    if (gop.found_existing) return;
+    log.warn(msg, .{});
+}
+
+/// Unwrap the explicit `"root"` block. Unified files put the root
+/// entity's `components`/`children`/`ref` inside `"root"`; legacy
+/// files keep them at the file's top level. Returns the object that
+/// carries the root entity content either way.
+pub fn rootObject(file_obj: Value.Object) Value.Object {
+    return file_obj.getObject("root") orelse file_obj;
+}
+
+/// The file-level entity list for a scene file. Unified:
+/// `root.children`. Legacy: a top-level `"entities"` array (warned).
+/// A legacy file already using a top-level `"children"` is honored
+/// too, so a half-migrated file still loads.
+pub fn fileChildren(file_obj: Value.Object, log: anytype) ?Value.Array {
+    if (file_obj.getObject("root")) |root| {
+        return root.getArray("children");
+    }
+    if (file_obj.getArray("entities")) |entities| {
+        warnOnce(log, "[unified-format] legacy \"entities\" key: wrap the entity array in a \"root\" block and rename it to \"children\" (RFC #560)");
+        return entities;
+    }
+    return file_obj.getArray("children");
+}
+
+/// The component patch for an entity entry. Inline entries (no
+/// `"prefab"`) carry `"components"`. Reference entries (`"prefab"`
+/// set) carry `"overrides"`; a legacy `"components"` on a reference
+/// is accepted as a synonym and warned. When both are present,
+/// `"overrides"` wins.
+pub fn entityPatch(entity_obj: Value.Object, log: anytype) ?Value.Object {
+    if (entity_obj.getString("prefab") == null) {
+        // Inline entity — components are the only patch source.
+        return entity_obj.getObject("components");
+    }
+    // Reference entry — overrides, with a legacy `components` fallback.
+    if (entity_obj.getObject("overrides")) |overrides| {
+        if (entity_obj.getObject("components") != null) {
+            warnOnce(log, "[unified-format] prefab reference has both \"overrides\" and \"components\"; \"overrides\" wins — remove \"components\" (RFC #560)");
+        }
+        return overrides;
+    }
+    if (entity_obj.getObject("components")) |legacy| {
+        warnOnce(log, "[unified-format] legacy \"components\" on a prefab reference: rename it to \"overrides\" (RFC #560)");
+        return legacy;
+    }
+    return null;
+}
+
+/// Warn once if a scene file still declares the dropped `"assets"`
+/// field. Under the unified format assets are inferred from sprite
+/// references (RFC #563); the field is ignored.
+pub fn warnLegacyAssets(file_obj: Value.Object, log: anytype) void {
+    if (file_obj.get("assets") != null) {
+        warnOnce(log, "[unified-format] legacy \"assets\" key is ignored — assets are inferred from sprite references (RFC #560, #563)");
+    }
+}

--- a/src/jsonc/unified_format.zig
+++ b/src/jsonc/unified_format.zig
@@ -34,10 +34,29 @@ else
 
 // One-time deprecation-warning dedup, keyed by the comptime message
 // literal. A legacy prefab spawned N times — or a scene with N
-// legacy references — then warns once, not N times. Unguarded on
-// purpose: scene loading is single-threaded and the worst case of a
-// race is one duplicate warning line. Never freed (process-lifetime
-// set); keys are string literals so there is nothing to dupe.
+// legacy references — then warns once, not N times. Never freed
+// (process-lifetime set); keys are string literals so there is
+// nothing to dupe.
+//
+// Unguarded on purpose. Gemini-review on #573 asked why this isn't
+// behind a `std.Thread.Mutex` — the answer is two-fold:
+//
+//  1. Scene loading runs on the main thread on every supported
+//     platform (desktop, mobile, wasm). `warnOnce` has no other
+//     callers, so there is no concurrent reader/writer to race
+//     against today.
+//  2. The dedup set's *capacity* is bounded by the number of
+//     distinct comptime message literals in this file (currently
+//     three). `StringHashMap` only rehashes when crossing a load
+//     factor on `put`, and three entries never reach the initial
+//     allocation's threshold — so the table's backing buffer is
+//     written once and then only read. Even a hypothetical second
+//     thread emitting one of those same three messages would observe
+//     a stable buffer and at worst produce one duplicate log line.
+//
+// If a future change adds a parallel asset pipeline, or adds many
+// more distinct deprecation messages (re-introducing the rehash
+// case), add a `std.Thread.Mutex` here before flipping that switch.
 var warned: ?std.StringHashMap(void) = null;
 
 fn warnOnce(log: anytype, comptime msg: []const u8) void {
@@ -61,9 +80,17 @@ pub fn rootObject(file_obj: Value.Object) Value.Object {
 /// `root.children`. Legacy: a top-level `"entities"` array (warned).
 /// A legacy file already using a top-level `"children"` is honored
 /// too, so a half-migrated file still loads.
+///
+/// Partial-migration safety: if `"root"` is present but carries no
+/// `"children"` array, we still consult the legacy top-level
+/// `"entities"` / `"children"` keys before giving up — otherwise a
+/// scene that adds the `"root"` wrapper before moving its entity
+/// list silently loads as empty (#573).
 pub fn fileChildren(file_obj: Value.Object, log: anytype) ?Value.Array {
     if (file_obj.getObject("root")) |root| {
-        return root.getArray("children");
+        if (root.getArray("children")) |children| return children;
+        // `root` is present but empty — fall through to legacy keys
+        // (warned) so a half-migrated file still loads its entities.
     }
     if (file_obj.getArray("entities")) |entities| {
         warnOnce(log, "[unified-format] legacy \"entities\" key: wrap the entity array in a \"root\" block and rename it to \"children\" (RFC #560)");

--- a/src/jsonc/unified_format.zig
+++ b/src/jsonc/unified_format.zig
@@ -112,14 +112,16 @@ pub fn warnLegacyAssets(file_obj: Value.Object, log: anytype) void {
 ///
 /// The returned tree's entry arrays come from `arena`; leaf values
 /// (strings, numbers) are shared with `base`/`patch`, so the result
-/// must not outlive either input. On allocation failure it degrades
-/// to `patch` (whole-component replacement — the pre-#562 behavior).
-pub fn mergeValues(base: Value, patch: Value, arena: std.mem.Allocator) Value {
+/// must not outlive either input. Allocation failure is propagated
+/// as `error.OutOfMemory` — silently degrading to whole-component
+/// replacement would drop the prefab's inherited fields and violate
+/// the accepted deep-merge semantics (RFC #562).
+pub fn mergeValues(base: Value, patch: Value, arena: std.mem.Allocator) error{OutOfMemory}!Value {
     const base_obj = base.asObject() orelse return patch;
     const patch_obj = patch.asObject() orelse return patch;
 
     var entries: std.ArrayListUnmanaged(Value.Object.Entry) = .empty;
-    entries.appendSlice(arena, base_obj.entries) catch return patch;
+    try entries.appendSlice(arena, base_obj.entries);
 
     for (patch_obj.entries) |pe| {
         for (entries.items) |*existing| {
@@ -127,13 +129,13 @@ pub fn mergeValues(base: Value, patch: Value, arena: std.mem.Allocator) Value {
                 const both_objects =
                     existing.value.asObject() != null and pe.value.asObject() != null;
                 existing.value = if (both_objects)
-                    mergeValues(existing.value, pe.value, arena)
+                    try mergeValues(existing.value, pe.value, arena)
                 else
                     pe.value;
                 break;
             }
         } else {
-            entries.append(arena, pe) catch return patch;
+            try entries.append(arena, pe);
         }
     }
     return .{ .object = .{ .entries = entries.items } };
@@ -143,12 +145,15 @@ pub fn mergeValues(base: Value, patch: Value, arena: std.mem.Allocator) Value {
 /// override deep-merged onto the prefab's same-named component when
 /// the prefab declares one, otherwise the override value as-is.
 /// Callers handle a `null` override (component removal) first.
+///
+/// Propagates `error.OutOfMemory` from the underlying merge — the
+/// caller must not fall back to whole-component replacement.
 pub fn mergedOverride(
     prefab_components: ?Value.Object,
     key: []const u8,
     override_value: Value,
     arena: std.mem.Allocator,
-) Value {
+) error{OutOfMemory}!Value {
     const pc = prefab_components orelse return override_value;
     const base = pc.get(key) orelse return override_value;
     return mergeValues(base, override_value, arena);

--- a/src/jsonc/unified_format.zig
+++ b/src/jsonc/unified_format.zig
@@ -98,3 +98,58 @@ pub fn warnLegacyAssets(file_obj: Value.Object, log: anytype) void {
         warnOnce(log, "[unified-format] legacy \"assets\" key is ignored — assets are inferred from sprite references (RFC #560, #563)");
     }
 }
+
+// ── Override merge (RFC #562) ───────────────────────────────────
+
+/// Deep-merge `patch` onto `base`, returning a new `Value`.
+///
+/// Objects merge recursively — keys only in `base` are kept, keys
+/// only in `patch` are added, and a key in both recurses when both
+/// sides are objects. Arrays and scalars in `patch` replace
+/// outright (no element-wise list merge). A JSONC `null` in `patch`
+/// is carried through as a value — component-level removal is
+/// handled by the caller before this is reached.
+///
+/// The returned tree's entry arrays come from `arena`; leaf values
+/// (strings, numbers) are shared with `base`/`patch`, so the result
+/// must not outlive either input. On allocation failure it degrades
+/// to `patch` (whole-component replacement — the pre-#562 behavior).
+pub fn mergeValues(base: Value, patch: Value, arena: std.mem.Allocator) Value {
+    const base_obj = base.asObject() orelse return patch;
+    const patch_obj = patch.asObject() orelse return patch;
+
+    var entries: std.ArrayListUnmanaged(Value.Object.Entry) = .empty;
+    entries.appendSlice(arena, base_obj.entries) catch return patch;
+
+    for (patch_obj.entries) |pe| {
+        for (entries.items) |*existing| {
+            if (std.mem.eql(u8, existing.key, pe.key)) {
+                const both_objects =
+                    existing.value.asObject() != null and pe.value.asObject() != null;
+                existing.value = if (both_objects)
+                    mergeValues(existing.value, pe.value, arena)
+                else
+                    pe.value;
+                break;
+            }
+        } else {
+            entries.append(arena, pe) catch return patch;
+        }
+    }
+    return .{ .object = .{ .entries = entries.items } };
+}
+
+/// The effective value to apply for an overridden component: the
+/// override deep-merged onto the prefab's same-named component when
+/// the prefab declares one, otherwise the override value as-is.
+/// Callers handle a `null` override (component removal) first.
+pub fn mergedOverride(
+    prefab_components: ?Value.Object,
+    key: []const u8,
+    override_value: Value,
+    arena: std.mem.Allocator,
+) Value {
+    const pc = prefab_components orelse return override_value;
+    const base = pc.get(key) orelse return override_value;
+    return mergeValues(base, override_value, arena);
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -227,6 +227,13 @@ pub const JsoncSceneBridgeWithGizmos = @import("jsonc_scene_bridge.zig").JsoncSc
 // the piece they need without going through the full bridge.
 pub const jsonc_deserializer = @import("jsonc/deserializer.zig");
 
+// ── Entity-tree walker (RFC #569) ──
+// The single shared traversal for every entity-tree consumer —
+// crosses both `children` and prefab refs nested in component
+// fields, with prefab-cycle detection. Re-exported so specs and
+// downstream tooling (asset inference, editors) use one walker.
+pub const tree_walker = @import("jsonc/tree_walker.zig");
+
 // ── Scene Value & JSONC Parser ──
 pub const SceneValue = jsonc_mod.Value;
 pub const JsoncParser = jsonc_mod.JsoncParser;

--- a/test/font_loader_test.zig
+++ b/test/font_loader_test.zig
@@ -26,9 +26,20 @@ const font_types_mod = engine.font_types_mod;
 /// double-free. `upload` returns a sentinel `FontId` so the round-
 /// trip can assert on a known value.
 const MockBackend = struct {
-    var decode_calls: u32 = 0;
+    // `decodeFn` runs on any of the catalog's worker threads (3 of them,
+    // round-robin), so its counters must be atomic — the second test
+    // dispatches two registrations that can land on different workers
+    // and race a non-atomic `+= 1`, which is what caused the
+    // intermittent `decode_calls == 1` failure on macOS (issue #583).
+    // `uploadFn` / `unloadFn` run on the main thread inside `pump()` /
+    // `release()`, so plain `var` is fine for those.
+    var decode_calls: std.atomic.Value(u32) = std.atomic.Value(u32).init(0);
     var upload_calls: u32 = 0;
     var unload_calls: u32 = 0;
+    /// Last `pixel_height` seen by `decodeFn`. Only the first test
+    /// reads this, and that test issues a single registration → single
+    /// decode call, so a plain `var` is race-free for the asserting
+    /// thread. Kept non-atomic to match the type the caller asserts on.
     var last_pixel_height: f32 = 0;
     /// One slot per upload so the second round-trip can assert that
     /// the catalog handed back the second sentinel, not the first.
@@ -40,7 +51,7 @@ const MockBackend = struct {
     const sentinel_b: engine.FontId = .{ .index = 22, .generation = 5 };
 
     fn reset() void {
-        decode_calls = 0;
+        decode_calls.store(0, .seq_cst);
         upload_calls = 0;
         unload_calls = 0;
         last_pixel_height = 0;
@@ -56,7 +67,7 @@ const MockBackend = struct {
     ) anyerror!engine.DecodedFont {
         _ = file_type;
         _ = data;
-        decode_calls += 1;
+        _ = decode_calls.fetchAdd(1, .seq_cst);
         last_pixel_height = params.pixel_height;
 
         const bitmap = try allocator.alloc(u8, 1);
@@ -165,7 +176,7 @@ test "font loader: registerFont → acquire → pump → ready → release round
     try testing.expectEqual(engine.AssetState.ready, entry.state);
     try testing.expect(entry.resource != null);
     try testing.expectEqual(MockBackend.sentinel_a, entry.resource.?.font);
-    try testing.expectEqual(@as(u32, 1), MockBackend.decode_calls);
+    try testing.expectEqual(@as(u32, 1), MockBackend.decode_calls.load(.seq_cst));
     try testing.expectEqual(@as(u32, 1), MockBackend.upload_calls);
     try testing.expectEqual(@as(f32, 18.0), MockBackend.last_pixel_height);
     try testing.expect(catalog.isReady("title"));
@@ -224,7 +235,7 @@ test "font loader: two registrations with different pixel_height keep params ind
 
     try testing.expect(catalog.isReady("body"));
     try testing.expect(catalog.isReady("display"));
-    try testing.expectEqual(@as(u32, 2), MockBackend.decode_calls);
+    try testing.expectEqual(@as(u32, 2), MockBackend.decode_calls.load(.seq_cst));
     try testing.expectEqual(@as(u32, 2), MockBackend.upload_calls);
 
     // The two entries carry distinct `FontId`s — the catalog produced

--- a/test/font_loader_test.zig
+++ b/test/font_loader_test.zig
@@ -36,11 +36,13 @@ const MockBackend = struct {
     var decode_calls: std.atomic.Value(u32) = std.atomic.Value(u32).init(0);
     var upload_calls: u32 = 0;
     var unload_calls: u32 = 0;
-    /// Last `pixel_height` seen by `decodeFn`. Only the first test
-    /// reads this, and that test issues a single registration → single
-    /// decode call, so a plain `var` is race-free for the asserting
-    /// thread. Kept non-atomic to match the type the caller asserts on.
-    var last_pixel_height: f32 = 0;
+    /// Last `pixel_height` seen by `decodeFn`. The second test
+    /// dispatches two registrations whose `decodeFn` invocations can
+    /// land on different worker threads and write this concurrently,
+    /// so the slot must be atomic — even though only the first test
+    /// reads it. Zig has no built-in atomic float, so the `f32` bits
+    /// are carried inside an atomic `u32` via `@bitCast`.
+    var last_pixel_height: std.atomic.Value(u32) = std.atomic.Value(u32).init(@bitCast(@as(f32, 0.0)));
     /// One slot per upload so the second round-trip can assert that
     /// the catalog handed back the second sentinel, not the first.
     var last_uploaded_id: engine.FontId = engine.FontId.invalid;
@@ -54,7 +56,7 @@ const MockBackend = struct {
         decode_calls.store(0, .seq_cst);
         upload_calls = 0;
         unload_calls = 0;
-        last_pixel_height = 0;
+        last_pixel_height.store(@bitCast(@as(f32, 0.0)), .seq_cst);
         last_uploaded_id = engine.FontId.invalid;
         last_unloaded_id = engine.FontId.invalid;
     }
@@ -68,7 +70,7 @@ const MockBackend = struct {
         _ = file_type;
         _ = data;
         _ = decode_calls.fetchAdd(1, .seq_cst);
-        last_pixel_height = params.pixel_height;
+        last_pixel_height.store(@bitCast(params.pixel_height), .seq_cst);
 
         const bitmap = try allocator.alloc(u8, 1);
         bitmap[0] = 0xFF;
@@ -178,7 +180,7 @@ test "font loader: registerFont → acquire → pump → ready → release round
     try testing.expectEqual(MockBackend.sentinel_a, entry.resource.?.font);
     try testing.expectEqual(@as(u32, 1), MockBackend.decode_calls.load(.seq_cst));
     try testing.expectEqual(@as(u32, 1), MockBackend.upload_calls);
-    try testing.expectEqual(@as(f32, 18.0), MockBackend.last_pixel_height);
+    try testing.expectEqual(@as(f32, 18.0), @as(f32, @bitCast(MockBackend.last_pixel_height.load(.seq_cst))));
     try testing.expect(catalog.isReady("title"));
 
     // release on a `.ready` entry triggers `vtable.free`, which calls

--- a/test/jsonc/unified_format_test.zig
+++ b/test/jsonc/unified_format_test.zig
@@ -226,3 +226,48 @@ test "overrides leave un-mentioned prefab components intact" {
     try testing.expectEqual(@as(i32, 3), game.ecs_backend.getComponent(e, Marker).?.id);
     try testing.expectEqual(@as(f32, 80), game.ecs_backend.getComponent(e, Health).?.current);
 }
+
+// ── Registry: effective name + collision detection (RFC #561) ───
+
+test "registry: prefab resolves by its name field, not the file basename" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    // Embedded as basename "widget_file", but the file declares
+    // its own registry name — references must use that name.
+    try Bridge.addEmbeddedPrefab(&game, "widget_file",
+        \\{ "name": "fancy_widget",
+        \\  "root": { "components": { "Marker": { "id": 42 } } } }
+    , PREFAB_DIR);
+    try Bridge.loadSceneFromSource(&game,
+        \\{ "root": { "children": [ { "prefab": "fancy_widget" } ] } }
+    , PREFAB_DIR);
+
+    try testing.expectEqual(@as(i32, 42), soleMarker(&game).id);
+}
+
+test "registry: duplicate name field is a load-time error" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    try Bridge.addEmbeddedPrefab(&game, "first_file",
+        \\{ "name": "shared", "root": { "components": { "Marker": { "id": 1 } } } }
+    , PREFAB_DIR);
+    try testing.expectError(error.DuplicatePrefabName, Bridge.addEmbeddedPrefab(&game, "second_file",
+        \\{ "name": "shared", "root": { "components": { "Marker": { "id": 2 } } } }
+    , PREFAB_DIR));
+}
+
+test "registry: a name field colliding with another file's basename errors" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    // First file has no "name" — effective name is its basename "alpha".
+    try Bridge.addEmbeddedPrefab(&game, "alpha",
+        \\{ "root": { "components": { "Marker": { "id": 1 } } } }
+    , PREFAB_DIR);
+    // Second file's "name" collides with that basename.
+    try testing.expectError(error.DuplicatePrefabName, Bridge.addEmbeddedPrefab(&game, "beta",
+        \\{ "name": "alpha", "root": { "components": { "Marker": { "id": 2 } } } }
+    , PREFAB_DIR));
+}

--- a/test/jsonc/unified_format_test.zig
+++ b/test/jsonc/unified_format_test.zig
@@ -1,0 +1,228 @@
+//! Loader acceptance tests for the unified scene/prefab format
+//! (RFC #560, ticket #561).
+//!
+//! Pins that the loader walks both shapes down the same code path:
+//!
+//!  - the unified `"root"` wrapper at the file top,
+//!  - `"overrides"` (not `"components"`) on a prefab reference,
+//!  - and the legacy spellings — top-level `"entities"`,
+//!    `"components"` on a reference, a dropped `"assets"` field —
+//!    still load during the migration window.
+//!
+//! Cross-compatibility matters most: a unified scene referencing a
+//! legacy prefab (and vice-versa) must resolve, since files migrate
+//! one at a time.
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+const core = @import("labelle-core");
+
+// Two trivial components so a test can assert both "the override
+// won" and "the un-mentioned prefab component survived."
+const Marker = struct {
+    pub const save = core.Saveable(.saveable, @This(), .{});
+    id: i32 = 0,
+};
+
+const Health = struct {
+    pub const save = core.Saveable(.saveable, @This(), .{});
+    current: f32 = 0,
+};
+
+const TestComponents = engine.ComponentRegistry(.{
+    .Marker = Marker,
+    .Health = Health,
+});
+
+const MockEcs = core.MockEcsBackend(u32);
+const TestGame = engine.game_mod.GameConfig(
+    core.StubRender(MockEcs.Entity),
+    MockEcs,
+    engine.input_mod.StubInput,
+    engine.audio_mod.StubAudio,
+    engine.gui_mod.StubGui,
+    void,
+    core.StubLogSink,
+    TestComponents,
+    &.{},
+    void,
+);
+
+const Bridge = engine.JsoncSceneBridge(TestGame, TestComponents);
+
+// A path with no `prefabs/` directory, so the prefab cache never
+// finds a filesystem fallback — every prefab in these tests must
+// come from `addEmbeddedPrefab`.
+const PREFAB_DIR = "/tmp/labelle-nonexistent-561";
+
+fn boot(scene_jsonc: []const u8) !TestGame {
+    var game = TestGame.init(testing.allocator);
+    errdefer game.deinit();
+    try Bridge.loadSceneFromSource(&game, scene_jsonc, PREFAB_DIR);
+    return game;
+}
+
+/// Sorted `Marker.id` values of every entity carrying a `Marker`.
+fn markerIds(game: *TestGame, buf: []i32) []i32 {
+    var view = game.ecs_backend.view(.{Marker}, .{});
+    defer view.deinit();
+    var n: usize = 0;
+    while (view.next()) |e| : (n += 1) {
+        buf[n] = game.ecs_backend.getComponent(e, Marker).?.id;
+    }
+    const ids = buf[0..n];
+    std.mem.sort(i32, ids, {}, std.sort.asc(i32));
+    return ids;
+}
+
+/// The single entity carrying a `Marker` (fails if not exactly one).
+fn soleMarker(game: *TestGame) Marker {
+    var view = game.ecs_backend.view(.{Marker}, .{});
+    defer view.deinit();
+    const e = view.next().?;
+    std.debug.assert(view.next() == null);
+    return game.ecs_backend.getComponent(e, Marker).?.*;
+}
+
+// ── Unified "root" wrapper ──────────────────────────────────────
+
+test "unified: root wrapper, children load as entities" {
+    var game = try boot(
+        \\{ "root": { "children": [
+        \\  { "components": { "Marker": { "id": 1 } } },
+        \\  { "components": { "Marker": { "id": 2 } } }
+        \\] } }
+    );
+    defer game.deinit();
+
+    var buf: [8]i32 = undefined;
+    try testing.expectEqualSlices(i32, &.{ 1, 2 }, markerIds(&game, &buf));
+}
+
+test "unified: nested children under the root wrapper load" {
+    var game = try boot(
+        \\{ "root": { "children": [
+        \\  { "components": { "Marker": { "id": 1 } },
+        \\    "children": [ { "components": { "Marker": { "id": 2 } } } ] }
+        \\] } }
+    );
+    defer game.deinit();
+
+    var buf: [8]i32 = undefined;
+    try testing.expectEqualSlices(i32, &.{ 1, 2 }, markerIds(&game, &buf));
+}
+
+// ── Legacy shapes still accepted ────────────────────────────────
+
+test "legacy: top-level entities array still loads" {
+    var game = try boot(
+        \\{ "entities": [ { "components": { "Marker": { "id": 9 } } } ] }
+    );
+    defer game.deinit();
+
+    try testing.expectEqual(@as(i32, 9), soleMarker(&game).id);
+}
+
+test "legacy: dropped assets field is ignored, scene still loads" {
+    var game = try boot(
+        \\{ "assets": ["rooms", "props"],
+        \\  "entities": [ { "components": { "Marker": { "id": 8 } } } ] }
+    );
+    defer game.deinit();
+
+    try testing.expectEqual(@as(i32, 8), soleMarker(&game).id);
+}
+
+// ── Prefab references: overrides vs. legacy components ──────────
+
+test "unified: reference with overrides patches a unified prefab" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    try Bridge.addEmbeddedPrefab(&game, "widget",
+        \\{ "root": { "components": { "Marker": { "id": 100 } } } }
+    , PREFAB_DIR);
+    try Bridge.loadSceneFromSource(&game,
+        \\{ "root": { "children": [
+        \\  { "prefab": "widget", "overrides": { "Marker": { "id": 7 } } }
+        \\] } }
+    , PREFAB_DIR);
+
+    try testing.expectEqual(@as(i32, 7), soleMarker(&game).id);
+}
+
+test "legacy: reference with components still patches a legacy prefab" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    try Bridge.addEmbeddedPrefab(&game, "legacy_widget",
+        \\{ "components": { "Marker": { "id": 200 } } }
+    , PREFAB_DIR);
+    try Bridge.loadSceneFromSource(&game,
+        \\{ "entities": [
+        \\  { "prefab": "legacy_widget", "components": { "Marker": { "id": 5 } } }
+        \\] }
+    , PREFAB_DIR);
+
+    try testing.expectEqual(@as(i32, 5), soleMarker(&game).id);
+}
+
+// ── Cross-compatibility (files migrate one at a time) ───────────
+
+test "cross: unified scene + overrides references a legacy prefab" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    try Bridge.addEmbeddedPrefab(&game, "legacy_prefab",
+        \\{ "components": { "Marker": { "id": 300 } } }
+    , PREFAB_DIR);
+    try Bridge.loadSceneFromSource(&game,
+        \\{ "root": { "children": [
+        \\  { "prefab": "legacy_prefab", "overrides": { "Marker": { "id": 11 } } }
+        \\] } }
+    , PREFAB_DIR);
+
+    try testing.expectEqual(@as(i32, 11), soleMarker(&game).id);
+}
+
+test "cross: legacy scene + components references a unified prefab" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    try Bridge.addEmbeddedPrefab(&game, "unified_prefab",
+        \\{ "root": { "components": { "Marker": { "id": 400 } } } }
+    , PREFAB_DIR);
+    try Bridge.loadSceneFromSource(&game,
+        \\{ "entities": [
+        \\  { "prefab": "unified_prefab", "components": { "Marker": { "id": 13 } } }
+        \\] }
+    , PREFAB_DIR);
+
+    try testing.expectEqual(@as(i32, 13), soleMarker(&game).id);
+}
+
+// ── Merge behavior (unchanged by the rename — RFC #562 formalizes) ──
+
+test "overrides leave un-mentioned prefab components intact" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    try Bridge.addEmbeddedPrefab(&game, "two_comp",
+        \\{ "root": { "components": {
+        \\  "Marker": { "id": 50 },
+        \\  "Health": { "current": 80 }
+        \\} } }
+    , PREFAB_DIR);
+    try Bridge.loadSceneFromSource(&game,
+        \\{ "root": { "children": [
+        \\  { "prefab": "two_comp", "overrides": { "Marker": { "id": 3 } } }
+        \\] } }
+    , PREFAB_DIR);
+
+    var view = game.ecs_backend.view(.{ Marker, Health }, .{});
+    defer view.deinit();
+    const e = view.next().?;
+    try testing.expectEqual(@as(i32, 3), game.ecs_backend.getComponent(e, Marker).?.id);
+    try testing.expectEqual(@as(f32, 80), game.ecs_backend.getComponent(e, Health).?.current);
+}


### PR DESCRIPTION
## Umbrella PR for RFC #560 — Unify Scenes and Prefabs

This is the integration surface for the unification work. The leaf PRs below all target `feat/unify-scenes-prefabs` (this PR's head); as they merge in, this PR's diff grows. When the branch holds everything, this PR merges to `main` as a single reviewed unit.

## Current state (2026-05-25)

Already merged into `feat/unify-scenes-prefabs`:
- **#579** — RFC text (+627/-0). Lands the unified format spec with examples, override merge semantics, the authoring/instantiating framing on §B2, the shared-walker requirement, the pre-flight collision audit requirement, and the resolved "flat-list sugar rejected" decision.

Still open against `feat/unify-scenes-prefabs`, in landing order:

| # | Title | LOC | State | Round-1 fix-up |
|---|---|---|---|---|
| [#575](https://github.com/labelle-toolkit/labelle-engine/pull/575) | Collision audit (RFC-COLLISION-AUDIT.md only) | +92 | doc-only | implementation tracked separately by #581 |
| [#573](https://github.com/labelle-toolkit/labelle-engine/pull/573) | Loader accepts the unified prefab/scene format | +707 | CLEAN | `11a5d5e` — 4 bot findings addressed, 2 dismissed |
| ↳ [#577](https://github.com/labelle-toolkit/labelle-engine/pull/577) | Eager filesystem registry scan | +414 | CLEAN | `d6b9889` — 2 fixed, 1 dismissed, +1 regression spec |
| ↳ [#574](https://github.com/labelle-toolkit/labelle-engine/pull/574) | Deep-merge override semantics | +528 | CLEAN | `c5ba08b` — 2 fixed, 1 dismissed |
| &nbsp;&nbsp;↳ [#576](https://github.com/labelle-toolkit/labelle-engine/pull/576) | Shared tree walker + cycle detection | +958 | CLEAN | `9b1d609` — 3 fixed, 2 dismissed, +1 regression spec |

Cross-repo PRs depending on this stack (their integration branches live in their own repos):

- [labelle-cli#216](https://github.com/labelle-toolkit/labelle-cli/pull/216) — Write `.initial_prefab` from `--scene` plumbing
- [labelle-assembler#156](https://github.com/labelle-toolkit/labelle-assembler/pull/156) — Rename `project.labelle .initial_scene` → `.initial_prefab`

## Landing order (recommended)

1. `#575` resolves (either implementation lands here, or it's converted to docs-only + #581 tracks the implementation).
2. `#573` lands → integration gets the loader foundation.
3. `#577` and `#574` land in parallel (both stacked on #573).
4. `#576` lands (stacked on #574).
5. This umbrella PR merges to `main`.
6. cross-repo cli#216 + assembler#156 land afterward (they depend on the engine API this PR establishes).

## Follow-up issues filed today (don't block this PR)

- [#580](https://github.com/labelle-toolkit/labelle-engine/issues/580) — negative test for §B2 in the unified loader (gates merging into a maintainable test surface).
- [#581](https://github.com/labelle-toolkit/labelle-engine/issues/581) — implement the collision audit referenced by #575 (currently doc-only). Should land before #573 if possible.
- [labelle-cli#228](https://github.com/labelle-toolkit/labelle-cli/issues/228) — smoke test for the `.initial_prefab` plumbing.

## Test plan (umbrella)

- [x] RFC text reviewed and bot findings addressed (#579 + commit `1828531`)
- [ ] All 4 leaf implementation PRs merged with round-1 fix-up commits
- [ ] Round-2 bot review on the fix-up commits resolved (run after this comment lands)
- [ ] Collision audit (#581) green against `flying-platform-labelle` and `bouncing-ball`
- [ ] §B2 negative test (#580) added to the loader's test surface
- [ ] Cross-repo PRs (cli#216, assembler#156) rebased/retargeted and green
- [ ] Full `zig build test` + `zig build spec` green on the integration branch tip

## Why an umbrella PR

The unification spans 4 repos, ~3,300 LOC of engine changes alone, and changes a load-bearing file format. The leaf PRs are individually reviewable (each is ~100–960 lines) but reviewers also need a place to evaluate "does the unification, viewed as a whole, do what the RFC says." This PR is that surface — when it merges, the entire unification lands in one commit on main.