### PR TITLE
feat(screenshot): add engine.requestedScreenshot() env-var helper (#227)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xe8a81a8dc7f48c87,
     .name = .engine,
-    .version = "1.44.0",
+    .version = "1.45.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{

--- a/src/root.zig
+++ b/src/root.zig
@@ -28,6 +28,7 @@ pub const atlas_mod = @import("atlas.zig");
 pub const assets_mod = @import("assets/mod.zig");
 pub const preview_mode_mod = @import("preview_mode.zig");
 pub const preview_capture_mod = @import("preview_capture.zig");
+pub const screenshot_request_mod = @import("screenshot_request.zig");
 pub const jsonc_mod = @import("jsonc");
 
 // ── Android runtime helpers ──
@@ -350,6 +351,18 @@ pub const preview_binary_magic = preview_mode_mod.binary_magic;
 // `Preview.beginFrameStreamIOSurface` / `publishFrameIOSurface` /
 // `endFrameStreamIOSurface` triple.
 pub const preview_iosurface_mod = preview_mode_mod.preview_iosurface;
+
+// ── Out-of-band screenshot request (labelle-cli#227) ──
+// Read by the assembler-generated `main.zig`'s frame loop after the
+// game enters its main loop — when `LABELLE_SCREENSHOT_PATH` is set
+// (by `labelle run --screenshot=<path>`), the loop fires
+// `window.takeScreenshot(req.path)` once after `req.after_sec`.
+//
+// The helper itself is environment-driven so the assembler template
+// stays argv-agnostic — no new pass-through wiring through every
+// platform template, just one `getenv` per run.
+pub const ScreenshotRequest = screenshot_request_mod.Request;
+pub const requestedScreenshot = screenshot_request_mod.parse;
 
 // ── JSONC Scene Bridge ──
 pub const JsoncSceneBridge = @import("jsonc_scene_bridge.zig").JsoncSceneBridge;

--- a/src/root.zig
+++ b/src/root.zig
@@ -363,6 +363,11 @@ pub const preview_iosurface_mod = preview_mode_mod.preview_iosurface;
 // platform template, just one `getenv` per run.
 pub const ScreenshotRequest = screenshot_request_mod.Request;
 pub const requestedScreenshot = screenshot_request_mod.parse;
+/// Monotonic ns counter the screenshot timing block reads each frame
+/// to decide whether `after_sec` has elapsed. Lives next to
+/// `requestedScreenshot` because `std.time.nanoTimestamp` is gone in
+/// Zig 0.16 — see screenshot_request.zig for the libc fallback.
+pub const nowNs = screenshot_request_mod.nowNs;
 
 // ── JSONC Scene Bridge ──
 pub const JsoncSceneBridge = @import("jsonc_scene_bridge.zig").JsoncSceneBridge;

--- a/src/screenshot_request.zig
+++ b/src/screenshot_request.zig
@@ -47,17 +47,16 @@ pub fn nowNs() i128 {
         .windows => 1, // unused — Windows path below
         else => 1,
     };
-    if (comptime builtin.os.tag == .windows) {
-        // QueryPerformanceCounter would be the right call here, but
-        // Windows already provides `std.posix.clock_gettime`-equivalent
-        // wiring through MSVCRT for libc-linked builds — and the
-        // assembler-generated game always links libc. Fall through.
-        var ts: Timespec = undefined;
-        _ = clock_gettime(clk_id, &ts);
-        return @as(i128, ts.sec) * std.time.ns_per_s + @as(i128, ts.nsec);
+    // Zero-initialize so a `clock_gettime` failure can't yield garbage
+    // ns (uninitialized stack would let the assembler frame loop's
+    // `after_sec` check fire at random times — never, or immediately).
+    // Per spec, 0 is a valid CLOCK_MONOTONIC reading, so falling back
+    // to 0 just means the elapsed-time delta is conservative until the
+    // clock starts ticking, which beats undefined behavior.
+    var ts: Timespec = .{ .sec = 0, .nsec = 0 };
+    if (clock_gettime(clk_id, &ts) != 0) {
+        return 0;
     }
-    var ts: Timespec = undefined;
-    _ = clock_gettime(clk_id, &ts);
     return @as(i128, ts.sec) * std.time.ns_per_s + @as(i128, ts.nsec);
 }
 

--- a/src/screenshot_request.zig
+++ b/src/screenshot_request.zig
@@ -30,6 +30,37 @@ const builtin = @import("builtin");
 // `LABELLE_SCREENSHOT_PATH` isn't a thing in those environments anyway.
 extern "c" fn getenv(name: [*:0]const u8) ?[*:0]const u8;
 
+/// Monotonic ns counter for the assembler-generated frame loop's
+/// "fire after N seconds" check. `std.time.nanoTimestamp` was removed
+/// in Zig 0.16; libc `clock_gettime(CLOCK_MONOTONIC)` is the portable
+/// replacement (matches what `preview_mode_test`/`preview_iosurface_test`
+/// already use elsewhere in the engine).
+const Timespec = extern struct { sec: i64, nsec: i64 };
+const CLOCK_MONOTONIC: c_int = 6; // macOS value; Linux is 1 — picked
+// up below at runtime via `posix.CLOCK.MONOTONIC` when available.
+extern "c" fn clock_gettime(clk: c_int, tp: *Timespec) c_int;
+
+pub fn nowNs() i128 {
+    const clk_id: c_int = switch (builtin.os.tag) {
+        .macos, .ios, .watchos, .tvos => 6, // _CLOCK_MONOTONIC
+        .linux => 1, // CLOCK_MONOTONIC
+        .windows => 1, // unused — Windows path below
+        else => 1,
+    };
+    if (comptime builtin.os.tag == .windows) {
+        // QueryPerformanceCounter would be the right call here, but
+        // Windows already provides `std.posix.clock_gettime`-equivalent
+        // wiring through MSVCRT for libc-linked builds — and the
+        // assembler-generated game always links libc. Fall through.
+        var ts: Timespec = undefined;
+        _ = clock_gettime(clk_id, &ts);
+        return @as(i128, ts.sec) * std.time.ns_per_s + @as(i128, ts.nsec);
+    }
+    var ts: Timespec = undefined;
+    _ = clock_gettime(clk_id, &ts);
+    return @as(i128, ts.sec) * std.time.ns_per_s + @as(i128, ts.nsec);
+}
+
 fn getEnv(comptime name: [:0]const u8) ?[:0]const u8 {
     if (comptime !builtin.link_libc and builtin.os.tag != .linux and
         builtin.os.tag != .macos and builtin.os.tag != .windows)

--- a/src/screenshot_request.zig
+++ b/src/screenshot_request.zig
@@ -1,0 +1,95 @@
+/// Out-of-band screenshot capture request, surfaced to the generated
+/// `main.zig` so it can call the active backend's `takeScreenshot`
+/// path once the right frame arrives.
+///
+/// The CLI (`labelle run --screenshot=<path> [--after=<dur>]`) sets the
+/// `LABELLE_SCREENSHOT_PATH` (+ optional `LABELLE_SCREENSHOT_AFTER_SEC`)
+/// env vars on the spawned game process; this module reads them at
+/// startup. No flag → `parse()` returns `null` and the codegen-emitted
+/// runtime branch optimizes away.
+///
+/// Why an env var, not a CLI argv pass-through: the assembler-generated
+/// `main.zig` already owns argv parsing for `--preview-mode <host:port>`
+/// and ad-hoc game args. A new argv flag would mean either threading
+/// the parse through every generator template (raylib desktop/wasm,
+/// sokol desktop/mobile, Android, iOS) or stealing a bare positional
+/// token that the user might also want to forward to their game.
+/// `getenv` lives outside the argv parser entirely; the template hole
+/// is one runtime branch.
+
+const std = @import("std");
+
+pub const Request = struct {
+    /// Output path the backend writes to. Raylib's `TakeScreenshot`
+    /// picks the format from the extension (.png/.bmp/.tga), so the
+    /// CLI passes this through unchanged.
+    ///
+    /// Pointer lifetime: program-lifetime — backed by the libc env
+    /// block, which the kernel maps for the whole process. The
+    /// generated `main.zig` does not free it. Sentinel-terminated so
+    /// it can be handed directly to raylib's `[*:0]` API.
+    path: [:0]const u8,
+
+    /// Wait this many seconds (wall-clock from the first frame the
+    /// game enters its main loop) before firing the screenshot. The
+    /// default is 0 — fire on the first frame — so smoke tests that
+    /// just want a frame can omit `--after`.
+    after_sec: f32 = 0.0,
+};
+
+/// Read the screenshot env vars and return a `Request` if
+/// `LABELLE_SCREENSHOT_PATH` is set. Cheap (two `getenv` calls + one
+/// `parseFloat`) so the codegen calls it unconditionally per run.
+///
+/// Errors in `LABELLE_SCREENSHOT_AFTER_SEC` (non-numeric, negative)
+/// degrade to `after_sec = 0` rather than crashing the game — the user
+/// asked for a screenshot, not a hard failure.
+pub fn parse() ?Request {
+    const path_z = std.posix.getenv("LABELLE_SCREENSHOT_PATH") orelse return null;
+    if (path_z.len == 0) return null;
+
+    // `getenv` returns `[]const u8` without the sentinel. The libc
+    // env block IS NUL-terminated though — the slice just trims the
+    // NUL. Re-attach the sentinel via `ptrCast` so callers that need
+    // a `[*:0]const u8` (raylib) don't have to re-allocate.
+    const path_ptr: [*:0]const u8 = @ptrCast(path_z.ptr);
+    const path: [:0]const u8 = path_ptr[0..path_z.len :0];
+
+    var after_sec: f32 = 0.0;
+    if (std.posix.getenv("LABELLE_SCREENSHOT_AFTER_SEC")) |after_str| {
+        if (after_str.len > 0) {
+            after_sec = std.fmt.parseFloat(f32, after_str) catch 0.0;
+            if (after_sec < 0) after_sec = 0;
+        }
+    }
+
+    return .{ .path = path, .after_sec = after_sec };
+}
+
+// ── Tests ──
+
+const expect = @import("zspec").expect;
+
+test {
+    @import("zspec").runAll(@This());
+}
+
+pub const ScreenshotRequest = struct {
+    pub const env_absent = struct {
+        test "returns null when LABELLE_SCREENSHOT_PATH unset" {
+            // No good way to clear the env var portably from a unit
+            // test here (std.posix.unsetenv lacks a 0.16 wrapper), so
+            // this spec just documents the contract.
+            // Functional verification lives in the integration smoke
+            // (bouncing-ball / flying-platform).
+            try expect.equal(true, true);
+        }
+    };
+
+    pub const after_default = struct {
+        test "default after_sec is 0" {
+            const req = Request{ .path = "/tmp/x.png" };
+            try expect.equal(req.after_sec, 0.0);
+        }
+    };
+};

--- a/src/screenshot_request.zig
+++ b/src/screenshot_request.zig
@@ -18,6 +18,27 @@
 /// is one runtime branch.
 
 const std = @import("std");
+const builtin = @import("builtin");
+
+// libc `getenv` — works on every target the assembler-generated game
+// links against (raylib, sokol, sdl all pull libc in). Zig 0.16 removed
+// `std.posix.getenv` and the `std.process.Environ.getPosix` replacement
+// needs a pre-constructed `Environ` value the game's `main.zig` doesn't
+// have on hand. Calling libc directly keeps the helper self-contained.
+//
+// On freestanding / no-libc targets this falls back to returning null —
+// `LABELLE_SCREENSHOT_PATH` isn't a thing in those environments anyway.
+extern "c" fn getenv(name: [*:0]const u8) ?[*:0]const u8;
+
+fn getEnv(comptime name: [:0]const u8) ?[:0]const u8 {
+    if (comptime !builtin.link_libc and builtin.os.tag != .linux and
+        builtin.os.tag != .macos and builtin.os.tag != .windows)
+    {
+        return null;
+    }
+    const raw = getenv(name.ptr) orelse return null;
+    return std.mem.span(raw);
+}
 
 pub const Request = struct {
     /// Output path the backend writes to. Raylib's `TakeScreenshot`
@@ -45,18 +66,11 @@ pub const Request = struct {
 /// degrade to `after_sec = 0` rather than crashing the game — the user
 /// asked for a screenshot, not a hard failure.
 pub fn parse() ?Request {
-    const path_z = std.posix.getenv("LABELLE_SCREENSHOT_PATH") orelse return null;
-    if (path_z.len == 0) return null;
-
-    // `getenv` returns `[]const u8` without the sentinel. The libc
-    // env block IS NUL-terminated though — the slice just trims the
-    // NUL. Re-attach the sentinel via `ptrCast` so callers that need
-    // a `[*:0]const u8` (raylib) don't have to re-allocate.
-    const path_ptr: [*:0]const u8 = @ptrCast(path_z.ptr);
-    const path: [:0]const u8 = path_ptr[0..path_z.len :0];
+    const path = getEnv("LABELLE_SCREENSHOT_PATH") orelse return null;
+    if (path.len == 0) return null;
 
     var after_sec: f32 = 0.0;
-    if (std.posix.getenv("LABELLE_SCREENSHOT_AFTER_SEC")) |after_str| {
+    if (getEnv("LABELLE_SCREENSHOT_AFTER_SEC")) |after_str| {
         if (after_str.len > 0) {
             after_sec = std.fmt.parseFloat(f32, after_str) catch 0.0;
             if (after_sec < 0) after_sec = 0;


### PR DESCRIPTION
## Summary

- Adds `engine.ScreenshotRequest` + `engine.requestedScreenshot()` helper that reads `LABELLE_SCREENSHOT_PATH` (+ optional `LABELLE_SCREENSHOT_AFTER_SEC`) at startup and returns a `ScreenshotRequest { path, after_sec }` (or null when unset).
- Pairs with [labelle-assembler#TBD](https://github.com/labelle-toolkit/labelle-assembler) (template wiring) and [labelle-cli#227](https://github.com/labelle-toolkit/labelle-cli/issues/227) (CLI flag).
- Bumps engine to **1.45.0** — additive helper, no API changes.

## Rationale

Env-var instead of argv keeps the assembler templates argv-agnostic. Two `getenv` calls + one `parseFloat` per run; absent env vars → `null` return → codegen branch is a no-op the optimizer collapses.

## Test plan

- [x] `zig build` ok
- [x] `zig build test` — 28 tests pass (no regressions)
- [ ] Smoke verify end-to-end after the matching CLI + assembler PRs land