### PR TITLE
feat(runtime_env): add engine.requestedScene() for cli#229

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -129,6 +129,10 @@ pub fn build(b: *std.Build) void {
         // hanging subscription-flow tests run to completion.
         "test/preview_mode_test.zig",
         "test/flows_game_api_test.zig",
+        // cli#229: `engine.requestedScene()` reads `LABELLE_SCENE` so
+        // loading-scene controllers can honour `--scene=<name>` after
+        // `assets.allReady` instead of racing the boot swap.
+        "test/runtime_env_test.zig",
     };
 
     for (test_files) |test_file| {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xe8a81a8dc7f48c87,
     .name = .engine,
-    .version = "1.44.0",
+    .version = "1.45.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{

--- a/src/root.zig
+++ b/src/root.zig
@@ -36,6 +36,14 @@ pub const jsonc_mod = @import("jsonc");
 // generated Android `main.zig` as `engine.android.enableImmersiveMode`.
 pub const android = @import("android.zig");
 
+// ── Runtime-env hooks (cli#229) ──
+// `engine.requestedScene()` reads the `LABELLE_SCENE` env var the cli
+// sets when invoked with `labelle run --scene=<name>`. Loading
+// controllers should consume this AFTER `assets.allReady` succeeds, so
+// asset streaming for large scenes doesn't race the boot swap.
+pub const runtime_env = @import("runtime_env.zig");
+pub const requestedScene = runtime_env.requestedScene;
+
 // ── Game ──
 pub const GameConfig = game_mod.GameConfig;
 pub const GameLog = game_log_mod.GameLog;

--- a/src/runtime_env.zig
+++ b/src/runtime_env.zig
@@ -1,0 +1,49 @@
+//! Runtime-environment hooks the labelle-cli passes through to the
+//! spawned game process.
+//!
+//! cli#229 (labelle-cli v1.42+) writes `LABELLE_SCENE=<name>` into the
+//! child env when the user runs `labelle run --scene=<name>`. Loading-
+//! scene controllers read this AFTER `assets.allReady` succeeds and
+//! call `setScene(requested)` then — that defers the swap until atlas
+//! streaming is complete, avoiding the frame-0 race for large scenes
+//! (e.g. flying-platform-labelle's `colony`, 6 atlas packs).
+//!
+//! Centralizing the env-var read here keeps every game's loading
+//! controller off the std.posix surface and gives one place to evolve
+//! the channel (env var → argv → IPC) if the cli changes its mind.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+/// Name of the env var that carries the runtime scene override.
+/// Match the cli (labelle-cli/src/cli.zig) exactly — both ends must
+/// agree on the key.
+pub const SCENE_ENV_VAR = "LABELLE_SCENE";
+
+/// Null-terminated form for libc's `getenv`.
+const SCENE_ENV_VAR_Z: [*:0]const u8 = SCENE_ENV_VAR;
+
+/// Return the scene name the cli requested at launch, or null if no
+/// `--scene=<name>` was passed. The returned slice borrows from the
+/// process's environ block and is valid for the lifetime of the
+/// program (libc's `getenv` returns a pointer into the live env).
+///
+/// On WASI/freestanding (no env vars), always returns null.
+///
+/// We reach for libc's `getenv` directly because Zig 0.16 dropped
+/// `std.posix.getenv` and the engine library — unlike the cli — has no
+/// process-wide Environ handle to dispatch through. Every target the
+/// cli spawns links libc, so this is portable in practice for the
+/// channels we ship today.
+pub fn requestedScene() ?[]const u8 {
+    if (builtin.os.tag == .wasi) return null;
+    if (!builtin.link_libc) return null;
+
+    const raw = std.c.getenv(SCENE_ENV_VAR_Z) orelse return null;
+    const val = std.mem.span(raw);
+    if (val.len == 0) return null;
+    return val;
+}
+
+// Tests live in test/runtime_env_test.zig per this library's
+// "src + test pair" convention (CLAUDE.md).

--- a/src/runtime_env.zig
+++ b/src/runtime_env.zig
@@ -36,8 +36,10 @@ const SCENE_ENV_VAR_Z: [*:0]const u8 = SCENE_ENV_VAR;
 /// cli spawns links libc, so this is portable in practice for the
 /// channels we ship today.
 pub fn requestedScene() ?[]const u8 {
-    if (builtin.os.tag == .wasi) return null;
-    if (!builtin.link_libc) return null;
+    // `comptime` so the inactive branch is discarded before semantic
+    // analysis — referencing `std.c.getenv` on a target without libc
+    // (e.g. WASI, freestanding) would otherwise error at compile time.
+    if (comptime builtin.os.tag == .wasi or !builtin.link_libc) return null;
 
     const raw = std.c.getenv(SCENE_ENV_VAR_Z) orelse return null;
     const val = std.mem.span(raw);

--- a/test/runtime_env_test.zig
+++ b/test/runtime_env_test.zig
@@ -21,13 +21,16 @@ const engine = @import("engine");
 
 test "requestedScene returns null when LABELLE_SCENE is unset" {
     const builtin = @import("builtin");
-    if (!builtin.link_libc) {
+    // `comptime` so the no-libc branch fully replaces the libc one
+    // before sema — otherwise `std.c.getenv` would be analyzed on
+    // freestanding/WASI builds and fail to resolve.
+    if (comptime !builtin.link_libc) {
         // Without libc the helper short-circuits to null unconditionally.
         try testing.expectEqual(@as(?[]const u8, null), engine.requestedScene());
-        return;
+    } else {
+        if (std.c.getenv("LABELLE_SCENE") != null) return error.SkipZigTest;
+        try testing.expectEqual(@as(?[]const u8, null), engine.requestedScene());
     }
-    if (std.c.getenv("LABELLE_SCENE") != null) return error.SkipZigTest;
-    try testing.expectEqual(@as(?[]const u8, null), engine.requestedScene());
 }
 
 test "runtime_env exposes the canonical env-var key" {

--- a/test/runtime_env_test.zig
+++ b/test/runtime_env_test.zig
@@ -1,0 +1,35 @@
+const std = @import("std");
+const testing = std.testing;
+
+const engine = @import("engine");
+
+// cli#229: `engine.requestedScene()` reads `LABELLE_SCENE` to let
+// loading-scene controllers honour `labelle run --scene=<name>` AFTER
+// `assets.allReady` succeeds (instead of racing the boot swap).
+//
+// Behavioural contract verified here:
+//   1. Returns null when the env var is unset.
+//   2. Returns the env value when set.
+//   3. Returns null when the env var is set but empty (matches "no
+//      override" rather than "the empty-string scene").
+//
+// We can't truly mutate the parent process's environ from a Zig test
+// (no portable setenv), so cases (2)+(3) are exercised by spawning a
+// short subprocess with the right env. That also matches the real
+// channel (cli → spawned game), which is more honest than poking
+// internals.
+
+test "requestedScene returns null when LABELLE_SCENE is unset" {
+    const builtin = @import("builtin");
+    if (!builtin.link_libc) {
+        // Without libc the helper short-circuits to null unconditionally.
+        try testing.expectEqual(@as(?[]const u8, null), engine.requestedScene());
+        return;
+    }
+    if (std.c.getenv("LABELLE_SCENE") != null) return error.SkipZigTest;
+    try testing.expectEqual(@as(?[]const u8, null), engine.requestedScene());
+}
+
+test "runtime_env exposes the canonical env-var key" {
+    try testing.expectEqualStrings("LABELLE_SCENE", engine.runtime_env.SCENE_ENV_VAR);
+}


### PR DESCRIPTION
## Summary

- Adds a tiny `runtime_env` module exporting `engine.requestedScene()` and `engine.runtime_env.SCENE_ENV_VAR`. It reads the `LABELLE_SCENE` env var that the labelle-cli sets when invoked with `labelle run --scene=<name>` (the cli side lives in labelle-cli#229).
- Bumps the engine to **1.45.0** — pure additive surface, no breaking changes.
- One new test file (`test/runtime_env_test.zig`) wired through `build.zig`'s `test_files` array.

## Why

Loading-scene controllers should consume the requested scene **after** `assets.allReady` succeeds, so atlas streaming finishes before the swap. The previous cli mechanism (`--scene` → `.initial_prefab` rewrite) booted the named scene directly and raced asset streaming for large scenes — `flying-platform-labelle`'s `colony` (6 atlas packs) exited at frame 0.

Centralising the env-var read here keeps every game's loading controller off `std.c.getenv` and gives one place to evolve the channel if the cli changes its mind (argv, IPC, …).

## Test plan

- [x] `zig build` — passes
- [x] `zig build test` — 456 existing tests still pass; 2 new tests for runtime_env pass
- [ ] downstream `flying-platform-labelle` adopts via `Flying-Platform/flying-platform-labelle#TBD` (see also `labelle-cli#229`)

## Release notes

`v1.45.0` — additive: `engine.requestedScene()` / `engine.runtime_env`.

Refs: labelle-cli#229