### PR TITLE
fix(io_helper): replace removed std.Thread.Mutex with std.atomic.Mutex

### DIFF
--- a/src/io_helper.zig
+++ b/src/io_helper.zig
@@ -19,7 +19,11 @@ const is_wasm_emscripten = builtin.target.os.tag == .emscripten;
 var _threaded: if (is_wasm_emscripten) void else std.Io.Threaded = if (is_wasm_emscripten) {} else undefined;
 var _io: std.Io = undefined;
 var _initialized: bool = false;
-var _init_lock: std.Thread.Mutex = .{};
+// std.Thread.Mutex was removed in Zig 0.16. std.Io.Mutex requires an
+// Io param to lock/unlock, but here we're guarding Io's own init —
+// chicken-and-egg. std.atomic.Mutex is the right primitive: a one-shot
+// init runs once per process, contention is brief, spin is fine.
+var _init_lock: std.atomic.Mutex = .unlocked;
 
 pub fn io() std.Io {
     if (is_wasm_emscripten) {
@@ -42,7 +46,7 @@ pub fn io() std.Io {
         return std.testing.io_instance.io();
     }
     if (@atomicLoad(bool, &_initialized, .acquire)) return _io;
-    _init_lock.lock();
+    while (!_init_lock.tryLock()) {}
     defer _init_lock.unlock();
     if (!_initialized) {
         _threaded = std.Io.Threaded.init(std.heap.page_allocator, .{});


### PR DESCRIPTION
## Diagnosis

Zig 0.16 removed `std.Thread.Mutex` (no longer declared in `std/Thread.zig`). The engine's own `zig build test` masked this — `io()` short-circuits in test mode via `if (builtin.is_test) return std.testing.io_instance.io();`, so the broken type declaration on line 22 was never semantically evaluated.

Downstream **game** builds (non-test) reach `_init_lock.lock()` through scene/prefab loading and fail with:

```
src/io_helper.zig:22:27: error: root source file struct 'Thread' has no member named 'Mutex'
```

This is why all of today's open PRs that depend on building a real game project failed CI:

- labelle-cli #232 / #233 / #234 — Versions Integration Test
- labelle-assembler #210 — Examples integration test  
- flying-platform-labelle #479 — test-game

…all hit this against engine `main`.

## Fix

`std.Io.Mutex` would be the natural replacement but its `lock()` takes an `Io` parameter — chicken-and-egg since this lock guards `Io`'s own init. `std.atomic.Mutex` is the right primitive: spin-only `tryLock` + `unlock`, no allocations, no Io dependency. Contention is brief and one-shot (first `io()` call per process), so a spin loop is fine.

Diff is 5 lines.

## Verification

- `zig build test` from engine root: clean.
- Force-evaluated `io_helper.zig` as a non-test root module standalone: produces a clean 1.87MB binary. Pre-fix, this same standalone build fails with the `std.Thread.Mutex` error; post-fix, it succeeds.

Downstream CI re-runs will be triggered once this merges into main.