### PR TITLE
feat(loader): enforce §B2 — prefab references cannot have children (closes #586)

### DIFF
--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -391,6 +391,13 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             // `fileChildren` accepts the unified `root.children`
             // shape and the legacy top-level `entities` array.
             uf.warnLegacyAssets(scene_obj, game.log);
+            // RFC #560 §B2 at the file root: a reference-mode root
+            // (`"root": { "prefab": ..., ... }`) may not declare
+            // `"children"` — instantiating doesn't author. See
+            // RFC-UNIFY-SCENES-AND-PREFABS.md §Unified shape.
+            if (scene_obj.getObject("root")) |root_obj| {
+                try uf.rejectB2Violation(root_obj, game.log, "reference-mode root");
+            }
             if (uf.fileChildren(scene_obj, game.log)) |entities_arr| {
                 var ref_ctx = RefContext.init(game.allocator, null);
                 defer ref_ctx.deinit();
@@ -421,6 +428,13 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             }
 
             uf.warnLegacyAssets(scene_obj, game.log);
+            // RFC #560 §B2 at the file root: a reference-mode root
+            // (`"root": { "prefab": ..., ... }`) may not declare
+            // `"children"` — instantiating doesn't author. See
+            // RFC-UNIFY-SCENES-AND-PREFABS.md §Unified shape.
+            if (scene_obj.getObject("root")) |root_obj| {
+                try uf.rejectB2Violation(root_obj, game.log, "reference-mode root");
+            }
             if (uf.fileChildren(scene_obj, game.log)) |entities_arr| {
                 var ref_ctx = RefContext.init(game.allocator, null);
                 defer ref_ctx.deinit();
@@ -441,6 +455,17 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
         fn loadEntityInternal(game: *GameType, entity_val: Value, prefab_cache: *PrefabCache, depth: usize, parent_offset: Position, ref_ctx: ?*RefContext) LoadEntityError!Entity {
             if (depth > MAX_DEPTH) return error.IncludeDepthExceeded;
             const entity_obj = entity_val.asObject() orelse return error.InvalidFormat;
+
+            // RFC #560 §B2: reference-mode entries (those carrying a
+            // `"prefab"` field) may not also declare a `"children"`
+            // array — references instantiate, they do not author.
+            // Reject at every child-entry visit so a violation deep
+            // in a nested tree still surfaces as a load-time error
+            // rather than silent acceptance with the children
+            // ignored. See labelle-assembler#182 for the pre-build
+            // companion check (this is defense-in-depth for embedded
+            // sources, hand-edited save files, and third-party tools).
+            try uf.rejectB2Violation(entity_obj, game.log, "child entry");
 
             // Resolve prefab.
             var prefab_components: ?Value.Object = null;

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -249,6 +249,19 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             const prefab_obj = prefab_val.asObject() orelse return null;
             const prefab_root = uf.rootObject(prefab_obj);
 
+            // RFC #560 §B2: the resolved prefab's own root may not
+            // itself be a `{prefab + children}` shape. If the prefab
+            // file was authored as a reference-mode root carrying
+            // `"children"`, the file-root gates in
+            // `loadSceneFile`/`loadSceneSource` would have caught it
+            // for scenes, but `addEmbeddedPrefab` (and any third-party
+            // prefab source) parses without that gate — so re-check
+            // here at every use site rather than rely on the
+            // ingestion path. `spawnPrefabImpl` returns `?Entity`, so
+            // surface the violation as a logged error + null spawn
+            // (the helper already logged the diagnostic).
+            uf.rejectB2Violation(prefab_root, game.log, "resolved prefab root") catch return null;
+
             // Cycle gate. Walk a synthetic reference entry so the
             // shared walker pushes `name` onto its expansion stack
             // — that way a prefab that references itself (directly
@@ -288,9 +301,17 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             }
 
             // Handle nested entities (e.g. workstation storages).
+            // `spawnAndLinkNestedEntities` now propagates §B2
+            // violations; `spawnPrefabImpl` has no error channel, so
+            // log and bail (returning the partially-built entity is
+            // worse than returning null — the prefab content is
+            // malformed and shouldn't appear in the world).
             const entity_pos = game.getPosition(entity);
             for (prefab_components.entries) |entry| {
-                spawnAndLinkNestedEntities(game, entity, entry.key, entry.value, entity_pos, prefab_cache, 0, null);
+                spawnAndLinkNestedEntities(game, entity, entry.key, entry.value, entity_pos, prefab_cache, 0, null) catch |err| {
+                    game.log.err("[spawnPrefab] '{s}' nested-entity load failed: {s}", .{ name, @errorName(err) });
+                    return null;
+                };
             }
 
             // Fire onReady hooks.
@@ -478,6 +499,14 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                         // Unwrap the unified `root` block (a no-op
                         // on legacy prefabs that lack it).
                         const proot = uf.rootObject(pobj);
+                        // RFC #560 §B2: the resolved prefab's own
+                        // root may not itself be `{prefab + children}`.
+                        // The file-root gate only fires for scenes
+                        // loaded via `loadSceneFile`/`loadSceneSource`
+                        // — `addEmbeddedPrefab` and third-party
+                        // prefab sources land in the cache unchecked,
+                        // so re-validate here at every resolution.
+                        try uf.rejectB2Violation(proot, game.log, "resolved prefab root");
                         prefab_components = proot.getObject("components");
                         prefab_children = proot.getArray("children");
                     }
@@ -586,13 +615,13 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             if (scene_components) |sc| {
                 for (sc.entries, 0..) |entry, i| {
                     const effective = effective_overrides.?[i] orelse continue;
-                    spawnAndLinkNestedEntities(game, entity, entry.key, effective, entity_pos, prefab_cache, depth, ref_ctx);
+                    try spawnAndLinkNestedEntities(game, entity, entry.key, effective, entity_pos, prefab_cache, depth, ref_ctx);
                 }
             }
             if (prefab_components) |pc| {
                 for (pc.entries) |entry| {
                     if (!applied.contains(entry.key)) {
-                        spawnAndLinkNestedEntities(game, entity, entry.key, entry.value, entity_pos, prefab_cache, depth, ref_ctx);
+                        try spawnAndLinkNestedEntities(game, entity, entry.key, entry.value, entity_pos, prefab_cache, depth, ref_ctx);
                     }
                 }
             }
@@ -749,7 +778,7 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             prefab_cache: *PrefabCache,
             depth: usize,
             ref_ctx: ?*RefContext,
-        ) void {
+        ) LoadEntityError!void {
             const obj = comp_value.asObject() orelse return;
 
             // Arena for deep-merged override component values
@@ -759,6 +788,20 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
 
             for (obj.entries) |entry| {
                 const arr = entry.value.asArray() orelse continue;
+
+                // RFC #560 §B2: pre-scan for component-nested
+                // entries that smuggle `{prefab + children}` through
+                // a component array — the visit-time gate in
+                // `loadEntityInternal` doesn't fire on this walk
+                // path, so without this check a violation here loads
+                // silently. Propagate `error.InvalidFormat` so the
+                // top-level load returns the failure (matches the
+                // file-root and child-entry gates).
+                for (arr.items) |item| {
+                    if (!ApplyHelpers.isEntityLike(item)) continue;
+                    const item_obj = item.asObject() orelse continue;
+                    try uf.rejectB2Violation(item_obj, game.log, "component-nested entity");
+                }
 
                 // Count entity-like items.
                 var entity_count: usize = 0;
@@ -787,6 +830,22 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                                 if (prefab_cache.get(pname)) |pval| {
                                     if (pval.asObject()) |pobj| {
                                         const proot = uf.rootObject(pobj);
+                                        // RFC #560 §B2: re-validate
+                                        // the resolved prefab's own
+                                        // root for the
+                                        // `{prefab + children}` shape
+                                        // (mirrors the matching block
+                                        // in `loadEntityInternal`).
+                                        // Propagate the error so the
+                                        // top-level load fails — the
+                                        // child entity already exists,
+                                        // so an `errdefer` on the
+                                        // caller path would normally
+                                        // clean it up, but here we
+                                        // rely on the scene load's
+                                        // overall failure to surface
+                                        // the diagnostic.
+                                        try uf.rejectB2Violation(proot, game.log, "resolved prefab root");
                                         child_prefab_comps = proot.getObject("components");
                                         child_prefab_children = proot.getArray("children");
                                     }
@@ -923,7 +982,7 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                             if (child_scene_comps) |sc| {
                                 for (sc.entries, 0..) |e, i| {
                                     const effective = (child_effective orelse break)[i] orelse continue;
-                                    spawnAndLinkNestedEntities(game, child, e.key, effective, child_pos, prefab_cache, depth + 1, nested_ref_ctx);
+                                    try spawnAndLinkNestedEntities(game, child, e.key, effective, child_pos, prefab_cache, depth + 1, nested_ref_ctx);
                                 }
                             }
                             if (child_prefab_comps) |pc| {
@@ -935,7 +994,7 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                                         break :blk false;
                                     } else false;
                                     if (!already_set) {
-                                        spawnAndLinkNestedEntities(game, child, e.key, e.value, child_pos, prefab_cache, depth + 1, nested_ref_ctx);
+                                        try spawnAndLinkNestedEntities(game, child, e.key, e.value, child_pos, prefab_cache, depth + 1, nested_ref_ctx);
                                     }
                                 }
                             }

--- a/src/jsonc/unified_format.zig
+++ b/src/jsonc/unified_format.zig
@@ -141,6 +141,37 @@ pub fn warnLegacyAssets(file_obj: Value.Object, log: anytype) void {
     }
 }
 
+/// RFC §B2 gate: a reference-mode entry (one that carries a
+/// `"prefab"` field) is *instantiating*, not *authoring*. Appending a
+/// `"children"` array at the call site would silently re-author the
+/// referenced recipe — exactly the surprise §B2 forbids. Inline mode
+/// (`"components"` + `"children"`) is the place that legitimately
+/// nests; if a use site needs to grow a prefab's content, the growth
+/// becomes a wrapper prefab in its own file (RFC §Examples #3).
+///
+/// Returns `error.InvalidFormat` if `entry_obj` has both `"prefab"`
+/// and `"children"` set. The error message names RFC §B2 explicitly
+/// so a reader landing on a load-time failure can find the spec.
+///
+/// `site_label` is the human-readable site name — currently
+/// `"reference-mode root"` (file-root violation) or
+/// `"child entry"` (nested violation). Callers pre-classify so the
+/// log line tells the author *where* in the file to look.
+///
+/// The assembler rejects this shape pre-build at `codegen/scan.zig`
+/// (labelle-assembler#182); this gate is the engine-side complement,
+/// catching content that bypassed the assembler (embedded sources in
+/// tests, hand-edited save files, third-party tools).
+pub fn rejectB2Violation(entry_obj: Value.Object, log: anytype, site_label: []const u8) error{InvalidFormat}!void {
+    if (entry_obj.getString("prefab") == null) return;
+    if (entry_obj.getArray("children") == null) return;
+    log.err(
+        "[unified-format] RFC §B2 violation at {s}: a prefab reference cannot also declare \"children\" — references instantiate, they do not author. Move the extra entities into a wrapper prefab (RFC #560 §B2).",
+        .{site_label},
+    );
+    return error.InvalidFormat;
+}
+
 // ── Override merge (RFC #562) ───────────────────────────────────
 
 /// Deep-merge `patch` onto `base`, returning a new `Value`.

--- a/test/jsonc/bridge_prefab_tags_test.zig
+++ b/test/jsonc/bridge_prefab_tags_test.zig
@@ -238,26 +238,31 @@ test "jsonc_scene_bridge: prefab children get PrefabChild tags on scene load" {
     try testing.expect(found_c1_gc0);
 }
 
-test "jsonc_scene_bridge: scene-declared children on a prefab do NOT get PrefabChild" {
-    // Regression guard for copilot L531/L608 on #485. A scene may
-    // over-declare children on top of a prefab (e.g. the scene adds
-    // decorations around a prefab-sourced room). Those scene-only
-    // children must NOT be tagged with `PrefabChild`, because the
-    // prefab definition doesn't own them — if the prefab later grows
-    // a new child at the same `children[N]` slot, Phase 1b on load
-    // would mis-map the saved scene-only child onto the new prefab
-    // child.
+test "jsonc_scene_bridge: scene-declared children on a prefab reference are a §B2 load-time error" {
+    // Reframed for RFC #560 §B2 enforcement (#586). The earlier
+    // regression — a scene "over-declaring" children on top of a
+    // prefab reference, and the bridge tagging only the prefab-owned
+    // ones with `PrefabChild` — described an *accepted* but
+    // ambiguous shape. RFC §B2 now forbids that shape outright:
+    // reference-mode entries instantiate, they do not author, so
+    // appending `children` at the call site is a load-time error.
     //
-    // Fix: the scene bridge calls `tagAsPrefabInstance` BETWEEN the
-    // prefab-declared children loop and the scene-declared children
-    // loop, so only prefab-owned children are within reach of the
-    // tagger's `getChildren` walk.
+    // The PrefabChild-vs-scene-child tagging distinction is moot
+    // because the violating scene can no longer load. The wrapper
+    // prefab pattern (RFC §Examples #3) is the supported way to
+    // grow a prefab's content at a use site: author a new file with
+    // inline `components` + `children`, and reference *that* by name.
+    //
+    // This test now pins the rejection so a future regression that
+    // re-accepts `{prefab + children}` would surface here as well as
+    // in `unified_format_test.zig`'s §B2 cases.
     var tmp_dir = testing.tmpDir(.{});
     defer tmp_dir.cleanup();
 
-    var fixture = try setupFixture(&tmp_dir, .{
-        // Prefab with one own child.
-        .room =
+    try tmp_dir.dir.createDir(std.testing.io, "prefabs", .default_dir);
+    try tmp_dir.dir.writeFile(std.testing.io, .{
+        .sub_path = "prefabs/room.jsonc",
+        .data =
         \\{
         \\  "components": { "Health": { "current": 100, "max": 100 } },
         \\  "children": [
@@ -265,8 +270,20 @@ test "jsonc_scene_bridge: scene-declared children on a prefab do NOT get PrefabC
         \\  ]
         \\}
         ,
-    },
-        // Scene adds TWO extra children on top of the prefab instance.
+    });
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const _len = try tmp_dir.dir.realPath(std.testing.io, &buf);
+    const dir_path = buf[0.._len];
+    const prefab_dir = try std.fmt.allocPrint(testing.allocator, "{s}/prefabs", .{dir_path});
+    defer testing.allocator.free(prefab_dir);
+
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    // Scene with the §B2-violating shape: a prefab reference that
+    // also declares `children`.
+    const scene_source =
         \\{
         \\  "entities": [
         \\    {
@@ -278,18 +295,11 @@ test "jsonc_scene_bridge: scene-declared children on a prefab do NOT get PrefabC
         \\    }
         \\  ]
         \\}
+    ;
+    try testing.expectError(
+        error.InvalidFormat,
+        Bridge.loadSceneFromSource(&game, scene_source, prefab_dir),
     );
-    defer fixture.deinit();
-
-    const PrefabChild = TestGame.PrefabChildComp;
-    var tagged_count: usize = 0;
-    var view = fixture.game.active_world.ecs_backend.view(.{PrefabChild}, .{});
-    defer view.deinit();
-    while (view.next()) |_| tagged_count += 1;
-
-    // Only the single prefab-declared child should carry PrefabChild;
-    // the two scene-added children must not.
-    try testing.expectEqual(@as(usize, 1), tagged_count);
 }
 
 test "jsonc_scene_bridge: PrefabInstance.path survives save/load round-trip" {

--- a/test/jsonc/unified_format_test.zig
+++ b/test/jsonc/unified_format_test.zig
@@ -300,6 +300,67 @@ test "unified: prefab root with children is a load-time error" {
     try testing.expectError(error.InvalidFormat, Bridge.loadSceneFromSource(&game, src, PREFAB_DIR));
 }
 
+// Defense-in-depth for content the file-root gate can't see: a
+// prefab parsed through `addEmbeddedPrefab` (or any third-party
+// source that lands in the prefab cache without traversing
+// `loadSceneFile`/`loadSceneSource`) whose own root is itself a
+// reference-mode `{prefab + children}` block. The scene-side
+// reference looks innocent, but the resolved prefab root is the
+// §B2 violation. The loader re-validates at every prefab
+// resolution site, so the scene-load fails even though the
+// scene file is well-formed.
+test "unified: resolved prefab root with {prefab + children} is a load-time error" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+    try Bridge.addEmbeddedPrefab(&game, "base",
+        \\{ "root": { "components": { "Marker": { "id": 1 } } } }
+    , PREFAB_DIR);
+    // `door` is itself reference-mode AND declares children — this
+    // is the shape the file-root gate would normally catch when the
+    // prefab is loaded as a scene, but `addEmbeddedPrefab` doesn't
+    // gate. The violation must surface at use-site instead.
+    try Bridge.addEmbeddedPrefab(&game, "door",
+        \\{ "root": {
+        \\  "prefab": "base",
+        \\  "children": [ { "components": { "Marker": { "id": 2 } } } ]
+        \\} }
+    , PREFAB_DIR);
+    const src =
+        \\{ "root": { "children": [ { "prefab": "door" } ] } }
+    ;
+    try testing.expectError(error.InvalidFormat, Bridge.loadSceneFromSource(&game, src, PREFAB_DIR));
+}
+
+// Defense-in-depth for entity-like objects smuggled into a
+// component array: the visit-time §B2 gate in `loadEntityInternal`
+// only fires when the walker traverses the `children` path, but
+// component-nested entities (e.g. a workstation's storages,
+// a room's furniture array) are spawned by
+// `spawnAndLinkNestedEntities` — a separate walk that also has
+// to reject `{prefab + children}` or the violation loads silently.
+test "unified: {prefab + children} in a component-nested entity array is a load-time error" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+    try Bridge.addEmbeddedPrefab(&game, "item",
+        \\{ "root": { "components": { "Marker": { "id": 1 } } } }
+    , PREFAB_DIR);
+    // The outer entity inlines a component whose value is an array
+    // of entity-like objects. One of them is reference-mode AND
+    // declares children — the §B2 violation we want to catch.
+    const src =
+        \\{ "root": { "children": [
+        \\  { "components": {
+        \\      "Marker": { "id": 0 },
+        \\      "Container": { "items": [
+        \\        { "prefab": "item",
+        \\          "children": [ { "components": { "Marker": { "id": 99 } } } ] }
+        \\      ] }
+        \\  } }
+        \\] } }
+    ;
+    try testing.expectError(error.InvalidFormat, Bridge.loadSceneFromSource(&game, src, PREFAB_DIR));
+}
+
 test "registry: a name field colliding with another file's basename errors" {
     var game = TestGame.init(testing.allocator);
     defer game.deinit();

--- a/test/jsonc/unified_format_test.zig
+++ b/test/jsonc/unified_format_test.zig
@@ -264,24 +264,12 @@ test "registry: duplicate name field is a load-time error" {
 // declare `children`. Inline mode authors; reference mode
 // instantiates — appending children at a use site would silently
 // re-author the recipe. The assembler rejects this shape pre-parse
-// (labelle-assembler#182), but the engine loader does NOT currently
-// enforce it directly — the existing `bridge_prefab_tags_test.zig`
-// regression guard explicitly exercises the violating shape, so
-// landing the engine-side gate is a separate contract change.
-//
-// See #586 for the loader gate + contract reconciliation. These
-// tests are kept skipped (not deleted) so they land alongside the
-// follow-up PR and start asserting once the gate is in.
+// (labelle-assembler#182); the engine loader enforces the same rule
+// at load time (#586) as defense-in-depth for content that bypassed
+// the assembler — embedded sources in tests, hand-edited save
+// files, third-party tools.
 
 test "unified: prefab reference with children is a load-time error" {
-    // TODO(#586): unskip once the loader gates `{prefab + children}`
-    // at child reference sites with `error.InvalidFormat`.
-    // The body below is the assertion the loader gate will satisfy;
-    // it is gated on a `comptime` flag so it doesn't dead-code-warn
-    // and so flipping the flag is the only edit needed on unskip.
-    const loader_enforces_b2 = false;
-    if (!loader_enforces_b2) return error.SkipZigTest;
-
     var game = TestGame.init(testing.allocator);
     defer game.deinit();
     try Bridge.addEmbeddedPrefab(&game, "door",
@@ -298,11 +286,6 @@ test "unified: prefab reference with children is a load-time error" {
 }
 
 test "unified: prefab root with children is a load-time error" {
-    // TODO(#586): unskip once the loader gates `{root: {prefab +
-    // children}}` at the file root with `error.InvalidFormat`.
-    const loader_enforces_b2 = false;
-    if (!loader_enforces_b2) return error.SkipZigTest;
-
     var game = TestGame.init(testing.allocator);
     defer game.deinit();
     try Bridge.addEmbeddedPrefab(&game, "door",


### PR DESCRIPTION
## Summary

RFC #560 §B2: a reference-mode entry (one carrying `"prefab"`) is **instantiating**, not **authoring** — appending `"children"` at the call site silently re-authors the recipe and is forbidden. The assembler already rejects this shape pre-build (labelle-assembler#182); this PR adds the matching engine-side gate so content that bypasses the assembler (embedded sources in tests, hand-edited save files, third-party tools) cannot quietly load a §B2-violating shape.

## What changed

- **New helper `uf.rejectB2Violation`** (`src/jsonc/unified_format.zig`) — returns `error.InvalidFormat` with a message that names RFC §B2 by name, plus a site label (`"reference-mode root"` vs. `"child entry"`) so the author knows where to look.
- **Two enforcement sites** in `src/jsonc/scene_loader.zig`:
  - `loadEntityInternal` — fires on every child-entry visit, so a violation nested deep in a prefab tree still surfaces at load time rather than silent acceptance with the `children` array ignored.
  - `loadSceneFile` / `loadSceneSource` — fires when the file itself has a reference-mode `"root"` block carrying `"children"` (`{"root": {"prefab": "...", "children": [...]}}`).
- **Error variant**: `error.InvalidFormat` (already in `LoadEntityError`, no widening). Tests assert this exact variant.

## Reconciliation with the existing regression test

`test/jsonc/bridge_prefab_tags_test.zig:241` ("scene-declared children on a prefab do NOT get PrefabChild") was the explicit guard for the now-rejected shape — it loaded a scene with `{prefab + children}` and checked that the scene-added children were *not* tagged as `PrefabChild`. With §B2 enforcement that scene no longer loads, so the tagging distinction is moot.

The test is **reframed**, not deleted: it now writes the same prefab + violating scene to disk and asserts `loadSceneFromSource` returns `error.InvalidFormat`. The pre-§B2 behavior it guarded (selective `PrefabChild` tagging) is no longer reachable through legal input; the supported way to grow a prefab's content at a use site is the wrapper-prefab pattern (RFC §Examples #3).

The previously-skipped negative tests in `test/jsonc/unified_format_test.zig` ("prefab reference with children", "prefab root with children") are unflagged — the `loader_enforces_b2 = false` + `error.SkipZigTest` gates were removed and they now assert `error.InvalidFormat`.

## Defense-in-depth, not duplication

The assembler-side check at `labelle-assembler/src/codegen/scan.zig` (landed in PR #182) **stays** — it is the first-line gate for assembled projects and the engine-side check is the safety net for everything else. Both should remain; do not remove the assembler check on the strength of this PR.

## Test plan

- [x] `zig build test` — all green, no skips.
- [x] `zig build spec` — all green.
- [x] Two §B2 negative tests in `unified_format_test.zig` now assert the rejection.
- [x] Reframed `bridge_prefab_tags_test.zig:241` asserts the rejection via the bridge.
- [ ] Bot review.