### PR TITLE
feat(loader): accept wrapper-flat + bundle + meta forms (RFC #596 prep)

### DIFF
--- a/src/jsonc/component_apply.zig
+++ b/src/jsonc/component_apply.zig
@@ -172,18 +172,27 @@ pub fn ComponentApply(comptime GameType: type, comptime Components: type) type {
             return Value{ .object = .{ .entries = filtered.toOwnedSlice(allocator) catch obj.entries } };
         }
 
-        /// Check if a `Value` looks like an entity definition. An
-        /// entity carries one of: a `prefab` string (reference
-        /// mode), a `components` object (wrapped inline form), or
-        /// any PascalCase key (flat form, RFC #596 Axis 2). Mirrors
-        /// `tree_walker.isEntityLike`.
+        /// Check if a `Value` looks like an entity definition.
+        /// Recognized by STRUCTURAL keys only:
+        ///   - `prefab` string → reference-mode entity,
+        ///   - `children` array → entity with nested children,
+        ///   - `components` object → wrapped inline entity.
+        ///
+        /// PascalCase keys alone are NOT sufficient: arbitrary
+        /// component-value data can carry PascalCase fields (e.g.
+        /// `FireConfig: [{ Type: "magic" }]`), and the flat-inline
+        /// RFC #596 entity shape is only loaded from contexts where
+        /// the caller already knows the value is an entity (file
+        /// top-level, `children:` array items, bundle items). Here
+        /// — called from `stripEntityArrayFields` and
+        /// `spawnAndLinkNestedEntities` on COMPONENT VALUE arrays —
+        /// only structural keys can disambiguate entities from data.
+        /// Mirrors `tree_walker.isEntityLike`.
         pub fn isEntityLike(value: Value) bool {
             const obj = value.asObject() orelse return false;
             if (obj.getString("prefab") != null) return true;
+            if (obj.getArray("children") != null) return true;
             if (obj.getObject("components") != null) return true;
-            for (obj.entries) |e| {
-                if (uf.isPascalCase(e.key)) return true;
-            }
             return false;
         }
     };

--- a/src/jsonc/component_apply.zig
+++ b/src/jsonc/component_apply.zig
@@ -23,6 +23,7 @@ const core = @import("labelle-core");
 const Position = core.Position;
 const deserializer = @import("deserializer.zig");
 const ref_resolver_mod = @import("ref_resolver.zig");
+const uf = @import("unified_format.zig");
 
 pub fn ComponentApply(comptime GameType: type, comptime Components: type) type {
     const Entity = GameType.EntityType;
@@ -135,6 +136,19 @@ pub fn ComponentApply(comptime GameType: type, comptime Components: type) type {
                     return;
                 }
             }
+
+            // RFC #596 Axis 4: unknown PascalCase keys on an entity
+            // are treated as components, but we warn-once so typos
+            // (`Posiiton`) surface visibly. Lowercase names that
+            // reach here (e.g. legacy embedded structural keys that
+            // bypassed the structural / component split) are
+            // silently ignored — they're not authoring mistakes the
+            // RFC catches. Position / Sprite / Shape are handled
+            // above and returned before reaching this gate, so the
+            // built-in components don't false-warn.
+            if (uf.isPascalCase(name)) {
+                uf.warnUnknownComponent(game.log, name);
+            }
         }
 
         /// Strip fields that contain entity-like arrays from a
@@ -158,11 +172,19 @@ pub fn ComponentApply(comptime GameType: type, comptime Components: type) type {
             return Value{ .object = .{ .entries = filtered.toOwnedSlice(allocator) catch obj.entries } };
         }
 
-        /// Check if a `Value` looks like an entity definition (has
-        /// either a `prefab` string or a `components` object).
+        /// Check if a `Value` looks like an entity definition. An
+        /// entity carries one of: a `prefab` string (reference
+        /// mode), a `components` object (wrapped inline form), or
+        /// any PascalCase key (flat form, RFC #596 Axis 2). Mirrors
+        /// `tree_walker.isEntityLike`.
         pub fn isEntityLike(value: Value) bool {
             const obj = value.asObject() orelse return false;
-            return obj.getString("prefab") != null or obj.getObject("components") != null;
+            if (obj.getString("prefab") != null) return true;
+            if (obj.getObject("components") != null) return true;
+            for (obj.entries) |e| {
+                if (uf.isPascalCase(e.key)) return true;
+            }
+            return false;
         }
     };
 }

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -296,7 +296,7 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             // prefab tree, so the prefab itself outlives `pc_arena`.
             var pc_arena = std.heap.ArenaAllocator.init(game.allocator);
             defer pc_arena.deinit();
-            const prefab_components = (uf.prefabComponents(prefab_root, pc_arena.allocator()) catch null) orelse return null;
+            const prefab_components = (uf.prefabComponents(prefab_root, pc_arena.allocator(), game.log) catch null) orelse return null;
 
             const entity = game.createEntity();
             game.trackSceneEntity(entity);
@@ -412,7 +412,7 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             // tools can re-parse the file for `meta`, the runtime
             // never reads it. Object top-level rides the existing
             // single-root pipeline.
-            const top = uf.classifyTopLevel(scene_value) orelse return;
+            const top = uf.classifyTopLevel(scene_value) orelse return error.InvalidFormat;
             switch (top) {
                 .single_root => |scene_obj| {
                     if (scene_obj.getArray("include")) |include_arr| {
@@ -461,7 +461,7 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
 
             // Mirrors `loadSceneFile`'s post-parse dispatch — see
             // the RFC #596 comments there.
-            const top = uf.classifyTopLevel(scene_value) orelse return;
+            const top = uf.classifyTopLevel(scene_value) orelse return error.InvalidFormat;
             switch (top) {
                 .single_root => |scene_obj| {
                     if (scene_obj.getArray("include")) |include_arr| {
@@ -556,7 +556,7 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                         // prefab sources land in the cache unchecked,
                         // so re-validate here at every resolution.
                         try uf.rejectB2Violation(proot, game.log, "resolved prefab root");
-                        prefab_components = try uf.prefabComponents(proot, merge_arena.allocator());
+                        prefab_components = try uf.prefabComponents(proot, merge_arena.allocator(), game.log);
                         prefab_children = proot.getArray("children");
                     }
                 }
@@ -898,7 +898,7 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                                         // lives in `merge_arena` (above)
                                         // so it shares the apply / merge
                                         // pipeline's lifetime.
-                                        child_prefab_comps = try uf.prefabComponents(proot, merge_arena.allocator());
+                                        child_prefab_comps = try uf.prefabComponents(proot, merge_arena.allocator(), game.log);
                                         child_prefab_children = proot.getArray("children");
                                     }
                                 }

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -287,7 +287,16 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                 };
             }
 
-            const prefab_components = prefab_root.getObject("components") orelse return null;
+            // RFC #596: prefab components may sit in the explicit
+            // `"components"` wrapper or as flat PascalCase keys at
+            // the root. The synthesized view (flat case) lives in a
+            // local arena bound to this spawn — its entries slice is
+            // walked twice (apply + nested-spawn) but never escapes
+            // the function. Leaf values are shared with the cache's
+            // prefab tree, so the prefab itself outlives `pc_arena`.
+            var pc_arena = std.heap.ArenaAllocator.init(game.allocator);
+            defer pc_arena.deinit();
+            const prefab_components = (uf.prefabComponents(prefab_root, pc_arena.allocator()) catch null) orelse return null;
 
             const entity = game.createEntity();
             game.trackSceneEntity(entity);
@@ -397,32 +406,43 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             var parser = JsoncParser.init(parse_alloc, source);
             const scene_value = try parser.parse();
 
-            const scene_obj = scene_value.asObject() orelse return;
-
-            // Process includes first — their entities are created
-            // before this file's own entities.
-            if (scene_obj.getArray("include")) |include_arr| {
-                for (include_arr.items) |include_val| {
-                    const include_path = include_val.asString() orelse continue;
-                    try loadSceneFile(game, include_path, prefab_cache, include_depth + 1);
-                }
-            }
-
-            // Process this file's entities with ref support.
-            // `fileChildren` accepts the unified `root.children`
-            // shape and the legacy top-level `entities` array.
-            uf.warnLegacyAssets(scene_obj, game.log);
-            // RFC #560 §B2 at the file root: a reference-mode root
-            // may not declare `"children"` — instantiating doesn't
-            // author. `uf.rootObject` returns the explicit `"root"`
-            // block when present (root-wrapped legacy v1.x shape)
-            // and the file object itself otherwise (flat top-level
-            // entity, RFC #594), so the gate fires for either shape.
-            try uf.rejectB2Violation(uf.rootObject(scene_obj), game.log, "reference-mode root");
-            if (uf.fileChildren(scene_obj, game.log)) |entities_arr| {
-                var ref_ctx = RefContext.init(game.allocator, null);
-                defer ref_ctx.deinit();
-                try processEntities(game, entities_arr, prefab_cache, &ref_ctx);
+            // RFC #596 Axis 3: a top-level Array is a bundle of
+            // sibling entities (no implicit root). The optional
+            // header (`{ meta: ... }` at index 0) is dropped here —
+            // tools can re-parse the file for `meta`, the runtime
+            // never reads it. Object top-level rides the existing
+            // single-root pipeline.
+            const top = uf.classifyTopLevel(scene_value) orelse return;
+            switch (top) {
+                .single_root => |scene_obj| {
+                    if (scene_obj.getArray("include")) |include_arr| {
+                        for (include_arr.items) |include_val| {
+                            const include_path = include_val.asString() orelse continue;
+                            try loadSceneFile(game, include_path, prefab_cache, include_depth + 1);
+                        }
+                    }
+                    uf.warnLegacyAssets(scene_obj, game.log);
+                    // RFC #560 §B2 at the file root: a reference-mode
+                    // root may not declare `"children"`.
+                    // `uf.rootObject` returns the explicit `"root"`
+                    // block when present (root-wrapped legacy v1.x
+                    // shape) and the file object itself otherwise
+                    // (flat top-level entity, RFC #594), so the
+                    // gate fires for either shape.
+                    try uf.rejectB2Violation(uf.rootObject(scene_obj), game.log, "reference-mode root");
+                    if (uf.fileChildren(scene_obj, game.log)) |entities_arr| {
+                        var ref_ctx = RefContext.init(game.allocator, null);
+                        defer ref_ctx.deinit();
+                        try processEntities(game, entities_arr, prefab_cache, &ref_ctx);
+                    }
+                },
+                .bundle => |bundle| {
+                    _ = bundle.file_meta;
+                    if (bundle.entities.len == 0) return;
+                    var ref_ctx = RefContext.init(game.allocator, null);
+                    defer ref_ctx.deinit();
+                    try processEntities(game, .{ .items = bundle.entities }, prefab_cache, &ref_ctx);
+                },
             }
         }
 
@@ -439,24 +459,32 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             var parser = JsoncParser.init(parse_alloc, source);
             const scene_value = try parser.parse();
 
-            const scene_obj = scene_value.asObject() orelse return;
-
-            if (scene_obj.getArray("include")) |include_arr| {
-                for (include_arr.items) |include_val| {
-                    const include_path = include_val.asString() orelse continue;
-                    try loadSceneFile(game, include_path, prefab_cache, 1);
-                }
-            }
-
-            uf.warnLegacyAssets(scene_obj, game.log);
-            // RFC #560 §B2 at the file root — see `loadSceneFile`
-            // for the dual-shape rationale (root-wrapped vs flat,
-            // RFC #594).
-            try uf.rejectB2Violation(uf.rootObject(scene_obj), game.log, "reference-mode root");
-            if (uf.fileChildren(scene_obj, game.log)) |entities_arr| {
-                var ref_ctx = RefContext.init(game.allocator, null);
-                defer ref_ctx.deinit();
-                try processEntities(game, entities_arr, prefab_cache, &ref_ctx);
+            // Mirrors `loadSceneFile`'s post-parse dispatch — see
+            // the RFC #596 comments there.
+            const top = uf.classifyTopLevel(scene_value) orelse return;
+            switch (top) {
+                .single_root => |scene_obj| {
+                    if (scene_obj.getArray("include")) |include_arr| {
+                        for (include_arr.items) |include_val| {
+                            const include_path = include_val.asString() orelse continue;
+                            try loadSceneFile(game, include_path, prefab_cache, 1);
+                        }
+                    }
+                    uf.warnLegacyAssets(scene_obj, game.log);
+                    try uf.rejectB2Violation(uf.rootObject(scene_obj), game.log, "reference-mode root");
+                    if (uf.fileChildren(scene_obj, game.log)) |entities_arr| {
+                        var ref_ctx = RefContext.init(game.allocator, null);
+                        defer ref_ctx.deinit();
+                        try processEntities(game, entities_arr, prefab_cache, &ref_ctx);
+                    }
+                },
+                .bundle => |bundle| {
+                    _ = bundle.file_meta;
+                    if (bundle.entities.len == 0) return;
+                    var ref_ctx = RefContext.init(game.allocator, null);
+                    defer ref_ctx.deinit();
+                    try processEntities(game, .{ .items = bundle.entities }, prefab_cache, &ref_ctx);
+                },
             }
         }
 
@@ -485,7 +513,31 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             // sources, hand-edited save files, and third-party tools).
             try uf.rejectB2Violation(entity_obj, game.log, "child entry");
 
-            // Resolve prefab.
+            // Merge / synthesized-view arena. `merge_arena` holds:
+            //   - the synthesized flat-form components view for both
+            //     the entity (RFC #596 Axis 2, `entityPatch`) and the
+            //     resolved prefab root (`prefabComponents`) when
+            //     neither carries an `overrides:` / `components:`
+            //     wrapper;
+            //   - the deep-merged override component values (RFC #562).
+            // Leaf values are shared with `entity_obj` / the prefab,
+            // so the arena's lifetime only needs to span this
+            // function's body.
+            var merge_arena = std.heap.ArenaAllocator.init(game.allocator);
+            defer merge_arena.deinit();
+
+            // `null`-as-removal is scoped to reference entries'
+            // `overrides` (RFC #562) — an inline entity's
+            // `components` have no removal semantics. Hoisted above
+            // `entityPatch` so the `is_reference` branch is
+            // already known when we classify the patch shape.
+            const is_reference = entity_obj.getString("prefab") != null;
+
+            // Resolve prefab. After RFC #596, a prefab's components
+            // may sit either inside an explicit `"components"`
+            // wrapper or as flat PascalCase keys at the root —
+            // `uf.prefabComponents` handles both, allocating the
+            // synthesized view into `merge_arena` in the flat case.
             var prefab_components: ?Value.Object = null;
             var prefab_children: ?Value.Array = null;
             var prefab_obj_opt: ?Value.Object = null;
@@ -504,20 +556,18 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                         // prefab sources land in the cache unchecked,
                         // so re-validate here at every resolution.
                         try uf.rejectB2Violation(proot, game.log, "resolved prefab root");
-                        prefab_components = proot.getObject("components");
+                        prefab_components = try uf.prefabComponents(proot, merge_arena.allocator());
                         prefab_children = proot.getArray("children");
                     }
                 }
             }
 
             // For a reference entry this is the `overrides` patch;
-            // for an inline entry, its own `components`.
-            const scene_components = uf.entityPatch(entity_obj, game.log);
-
-            // `null`-as-removal is scoped to reference entries'
-            // `overrides` (RFC #562) — an inline entity's
-            // `components` have no removal semantics.
-            const is_reference = entity_obj.getString("prefab") != null;
+            // for an inline entry, its own `components`. The flat
+            // form (RFC #596) synthesizes the view from the entity's
+            // PascalCase keys; the wrapped form returns the existing
+            // Object verbatim.
+            const scene_components = try uf.entityPatch(entity_obj, merge_arena.allocator(), game.log);
 
             // Create entity — destroy on error to prevent orphans.
             const entity = game.createEntity();
@@ -546,12 +596,11 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
             // component — patching only the fields it names — and a
             // `null` override removes the component (RFC #562).
             //
-            // The merge tree lives in `merge_arena`; its leaf
-            // strings are shared with the prefab/override inputs, so
-            // `@ref` names collected from a merged component stay
-            // valid into the pass-2 patch even after the arena frees.
-            var merge_arena = std.heap.ArenaAllocator.init(game.allocator);
-            defer merge_arena.deinit();
+            // The merge tree lives in `merge_arena` (declared above);
+            // its leaf strings are shared with the prefab/override
+            // inputs, so `@ref` names collected from a merged
+            // component stay valid into the pass-2 patch even after
+            // the arena frees.
 
             // `applied` records every override key — including
             // `null` removals — so the prefab blocks below skip them.
@@ -843,7 +892,13 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                                         // overall failure to surface
                                         // the diagnostic.
                                         try uf.rejectB2Violation(proot, game.log, "resolved prefab root");
-                                        child_prefab_comps = proot.getObject("components");
+                                        // RFC #596: flat prefab root has
+                                        // its components as PascalCase
+                                        // keys; the synthesized view
+                                        // lives in `merge_arena` (above)
+                                        // so it shares the apply / merge
+                                        // pipeline's lifetime.
+                                        child_prefab_comps = try uf.prefabComponents(proot, merge_arena.allocator());
                                         child_prefab_children = proot.getArray("children");
                                     }
                                 }
@@ -911,7 +966,11 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                             }
 
                             // Reference entry → `overrides`; inline → `components`.
-                            const child_scene_comps = uf.entityPatch(child_obj, game.log);
+                            // Flat shape (RFC #596) synthesizes the
+                            // view from PascalCase keys; the entries
+                            // slice lives in `merge_arena` (declared
+                            // at the top of `spawnAndLinkNestedEntities`).
+                            const child_scene_comps = try uf.entityPatch(child_obj, merge_arena.allocator(), game.log);
 
                             // `null`-as-removal is scoped to a
                             // reference entry's `overrides` (RFC #562).

--- a/src/jsonc/tree_walker.zig
+++ b/src/jsonc/tree_walker.zig
@@ -289,7 +289,7 @@ fn walkEntry(
         // views into `merge_arena` so the cycle walk sees the same
         // effective component tree the loader will instantiate.
         const prefab_components: ?Value.Object =
-            if (prefab_root) |proot| try uf.prefabComponents(proot, merge_arena.allocator()) else null;
+            if (prefab_root) |proot| try uf.prefabComponents(proot, merge_arena.allocator(), NoopLog{}) else null;
         const patch = try uf.entityPatch(obj, merge_arena.allocator(), NoopLog{});
         if (try effectiveComponents(merge_arena, prefab_components, patch)) |eff| {
             try walkComponentFields(ctx, merge_arena, resolver, eff, depth, visitor);
@@ -404,19 +404,23 @@ fn walkComponentFields(
     }
 }
 
-/// Whether a `Value` looks like an entity definition — it has a
-/// `prefab` string, a `components` object (wrapped form), or any
-/// PascalCase key (flat form, RFC #596 Axis 2). Mirrors
+/// Whether a `Value` looks like an entity definition — recognized
+/// by STRUCTURAL keys only (`prefab`, `children`, `components`).
+/// PascalCase content alone is NOT sufficient (component-value
+/// arrays may carry data objects with PascalCase keys); the
+/// flat-inline RFC #596 entity shape is only valid at sites where
+/// the caller already treats items as entities (`children:`
+/// arrays, bundle items). Used here from `walkComponentFields`
+/// over component-value arrays, where only structural keys can
+/// disambiguate entities from data. Mirrors
 /// `component_apply.isEntityLike`; kept here so the walker has no
 /// dependency on the component-apply machinery (which is generic
 /// over `GameType`).
 pub fn isEntityLike(value: Value) bool {
     const obj = value.asObject() orelse return false;
     if (obj.getString("prefab") != null) return true;
+    if (obj.getArray("children") != null) return true;
     if (obj.getObject("components") != null) return true;
-    for (obj.entries) |e| {
-        if (uf.isPascalCase(e.key)) return true;
-    }
     return false;
 }
 

--- a/src/jsonc/tree_walker.zig
+++ b/src/jsonc/tree_walker.zig
@@ -283,9 +283,14 @@ fn walkEntry(
     // (RFC #562, `uf.mergedOverride`), drops `null`-removed
     // components, and carries through override-only components.
     {
+        // RFC #596: both the prefab root and the entity entry may
+        // expose their components as flat PascalCase keys (no
+        // `"components"` / `"overrides"` wrapper). Synthesize the
+        // views into `merge_arena` so the cycle walk sees the same
+        // effective component tree the loader will instantiate.
         const prefab_components: ?Value.Object =
-            if (prefab_root) |proot| proot.getObject("components") else null;
-        const patch = uf.entityPatch(obj, NoopLog{});
+            if (prefab_root) |proot| try uf.prefabComponents(proot, merge_arena.allocator()) else null;
+        const patch = try uf.entityPatch(obj, merge_arena.allocator(), NoopLog{});
         if (try effectiveComponents(merge_arena, prefab_components, patch)) |eff| {
             try walkComponentFields(ctx, merge_arena, resolver, eff, depth, visitor);
         }
@@ -400,13 +405,19 @@ fn walkComponentFields(
 }
 
 /// Whether a `Value` looks like an entity definition — it has a
-/// `prefab` string or a `components` object. Mirrors
+/// `prefab` string, a `components` object (wrapped form), or any
+/// PascalCase key (flat form, RFC #596 Axis 2). Mirrors
 /// `component_apply.isEntityLike`; kept here so the walker has no
 /// dependency on the component-apply machinery (which is generic
 /// over `GameType`).
 pub fn isEntityLike(value: Value) bool {
     const obj = value.asObject() orelse return false;
-    return obj.getString("prefab") != null or obj.getObject("components") != null;
+    if (obj.getString("prefab") != null) return true;
+    if (obj.getObject("components") != null) return true;
+    for (obj.entries) |e| {
+        if (uf.isPascalCase(e.key)) return true;
+    }
+    return false;
 }
 
 /// A `log`-shaped no-op — `uf.entityPatch` takes a logger to emit

--- a/src/jsonc/unified_format.zig
+++ b/src/jsonc/unified_format.zig
@@ -402,8 +402,18 @@ fn synthesizeFlatComponents(entity_obj: Value.Object, allocator: std.mem.Allocat
 /// per RFC #596; the loader spawns its children with no inherited
 /// components. `allocator` is used only to synthesize the flat
 /// view; mirrors `entityPatch`'s arena contract.
-pub fn prefabComponents(prefab_root: Value.Object, allocator: std.mem.Allocator) error{OutOfMemory}!?Value.Object {
-    if (prefab_root.getObject("components")) |c| return c;
+///
+/// If both an explicit `"components"` wrapper AND flat PascalCase
+/// keys appear at `prefab_root`, the wrapper wins (back-compat) and
+/// we warn once — same dual-shape rule `entityPatch` enforces on
+/// inline entries.
+pub fn prefabComponents(prefab_root: Value.Object, allocator: std.mem.Allocator, log: anytype) error{OutOfMemory}!?Value.Object {
+    if (prefab_root.getObject("components")) |c| {
+        if (hasPascalCaseKey(prefab_root)) {
+            warnOnce(log, "[unified-format] prefab root has both a \"components\" wrapper and flat PascalCase keys — wrapper wins. Drop one shape (RFC #596).");
+        }
+        return c;
+    }
     return try synthesizeFlatComponents(prefab_root, allocator);
 }
 

--- a/src/jsonc/unified_format.zig
+++ b/src/jsonc/unified_format.zig
@@ -1,22 +1,41 @@
-//! Unified scene/prefab format accessors (RFC #560 + RFC #594).
+//! Unified scene/prefab format accessors (RFC #560 + RFC #594 + RFC #596).
 //!
 //! The unified format lists file-level entities under `"children"`
 //! (not `"entities"`) and names a prefab reference's patch data
 //! `"overrides"` (not `"components"`). The file's entity content
 //! lives either inside an explicit `"root"` wrapper (v1.0 — v1.x)
 //! or directly at the file top level (RFC #594, recommended from
-//! v1.47 onward, only shape in v2.0). Pre-#560 legacy spellings
-//! are still accepted during the migration window and each logs a
-//! one-time deprecation warning so the #572 migrator has a checklist.
+//! v1.47 onward, only shape in v2.0). RFC #596 extends this further
+//! with three new axes:
+//!
+//!   - **Wrapper-flat components.** PascalCase keys at the entity
+//!     scope are components directly — no `overrides:` /
+//!     `components:` wrapper. Lowercase keys (`prefab`, `children`,
+//!     `meta`, `ref`) stay structural. Dual-accept during v1.x.
+//!   - **File-as-array bundles.** The file's top-level JSON value
+//!     can be an Array of sibling entities — no implicit root. An
+//!     optional header element (only-`meta` object at index 0)
+//!     carries file-level metadata.
+//!   - **`meta:` field.** Free-form authoring-only data at entity
+//!     and file-header scope; stripped at load, never reaches
+//!     runtime.
+//!   - **Unknown PascalCase → warn-once.** Forward-compat with
+//!     cross-repo plugin authoring; typos still surface visibly.
+//!
+//! Pre-#560 legacy spellings are still accepted during the
+//! migration window and each logs a one-time deprecation warning so
+//! the #572 migrator has a checklist.
 //!
 //! These accessors are the single place that bridges the shapes —
 //! the loader calls them instead of reading raw keys, so flat,
-//! `"root"`-wrapped, and legacy files all walk the exact same code
-//! path. Per RFC #594 "Loader changes", during v1.x both the
-//! root-wrapped and flat shapes are first-class and warning-free;
-//! v2.0 drops the root-wrapped path alongside the other legacy paths.
+//! `"root"`-wrapped, bundle, and legacy files all walk the exact
+//! same code path. Per RFC #594 "Loader changes", during v1.x
+//! every shape is first-class and warning-free (only outright
+//! legacy patterns warn); v2.0 drops the wrapper / root-wrapped /
+//! file-object-no-root paths.
 //!
-//! See RFC-UNIFY-SCENES-AND-PREFABS.md and RFC-FLATTEN-ROOT.md.
+//! See RFC-UNIFY-SCENES-AND-PREFABS.md, RFC-FLATTEN-ROOT.md, and
+//! RFC-FLATTEN-WRAPPERS-AND-BUNDLES.md.
 
 const std = @import("std");
 const builtin = @import("builtin");
@@ -73,6 +92,62 @@ fn warnOnce(log: anytype, comptime msg: []const u8) void {
     log.warn(msg, .{});
 }
 
+// Separate dedup set for runtime-formatted warnings (unknown
+// component names, file-specific diagnostics). Keys are duped into
+// `warned_allocator` because the format strings are runtime-built
+// and would otherwise dangle. Same threading rationale as `warned`
+// above — load is single-threaded today.
+var warned_runtime: ?std.StringHashMap(void) = null;
+
+/// Warn-once for a runtime-formatted message. The first call with a
+/// given `key` logs `msg`; later calls with an equal `key` are
+/// suppressed. `key` is duped into the process-lifetime allocator on
+/// first sight so the caller's buffer can free safely.
+fn warnOnceKey(log: anytype, key: []const u8, comptime fmt: []const u8, args: anytype) void {
+    if (warned_runtime == null) {
+        warned_runtime = std.StringHashMap(void).init(warned_allocator);
+    }
+    const gop = warned_runtime.?.getOrPut(key) catch return;
+    if (gop.found_existing) return;
+    // Dupe the key so the caller can free its scratch buffer. The
+    // hashmap stores the duped pointer; nothing frees it (this is a
+    // process-lifetime dedup set).
+    const owned = warned_allocator.dupe(u8, key) catch {
+        _ = warned_runtime.?.remove(key);
+        return;
+    };
+    gop.key_ptr.* = owned;
+    log.warn(fmt, args);
+}
+
+/// True if `name` looks PascalCase: starts with an ASCII uppercase
+/// letter. RFC #596's case convention — PascalCase keys at the
+/// entity scope are components, lowercase keys are structural
+/// (`prefab`, `children`, `meta`, `ref`). Empty or non-ASCII-start
+/// names return false (treated as structural so we don't accidentally
+/// classify e.g. an explicit-`null` key as a component).
+pub fn isPascalCase(name: []const u8) bool {
+    if (name.len == 0) return false;
+    return name[0] >= 'A' and name[0] <= 'Z';
+}
+
+/// Warn once that an unknown PascalCase component appeared on an
+/// entity (RFC #596 Axis 4). The component is treated as a no-op
+/// override / declaration so authoring against a not-yet-loaded
+/// plugin still works — but the warning catches typos like
+/// `Posiiton` visibly. Audit promotes this to a finding.
+///
+/// Deduped by component name across the whole process; a typo in
+/// 50 scene entries warns once, not 50 times.
+pub fn warnUnknownComponent(log: anytype, name: []const u8) void {
+    // 256B scratch covers any realistic component name. If a name
+    // overruns we drop the warning rather than allocate — a name
+    // long enough to overrun is already obviously broken.
+    var buf: [256]u8 = undefined;
+    const key = std.fmt.bufPrint(&buf, "unknown-component:{s}", .{name}) catch return;
+    warnOnceKey(log, key, "[unified-format] unknown component '{s}' on entity — treated as no-op (RFC #596). If this is a typo, fix it; if it's a forward-compat reference to a not-yet-loaded plugin, ignore this warning.", .{name});
+}
+
 /// Unwrap the explicit `"root"` block. The unified format ships two
 /// shapes during the v1.x deprecation window (RFC #594):
 ///
@@ -124,28 +199,212 @@ pub fn fileChildren(file_obj: Value.Object, log: anytype) ?Value.Array {
     return file_obj.getArray("children");
 }
 
-/// The component patch for an entity entry. Inline entries (no
-/// `"prefab"`) carry `"components"`. Reference entries (`"prefab"`
-/// set) carry `"overrides"`; a legacy `"components"` on a reference
-/// is accepted as a synonym and warned. When both are present,
-/// `"overrides"` wins.
-pub fn entityPatch(entity_obj: Value.Object, log: anytype) ?Value.Object {
-    if (entity_obj.getString("prefab") == null) {
-        // Inline entity — components are the only patch source.
-        return entity_obj.getObject("components");
+/// The result of parsing a file's top-level shape.
+///
+/// RFC #596 Axis 3 introduces the **bundle** shape — the file's
+/// top-level JSON value is an Array of sibling entities, no
+/// implicit root. The first array element MAY be a "file header"
+/// (an object whose only entity-shape key is `meta:`) carrying
+/// file-level metadata; the loader treats it as metadata, not an
+/// entity.
+///
+/// Existing single-root files (object top-level) ride the
+/// `.single_root` variant unchanged.
+pub const TopLevel = union(enum) {
+    /// File top-level is a single Object — the existing single-root
+    /// shape (RFC #560 / #594). Process via `rootObject` /
+    /// `fileChildren` as before.
+    single_root: Value.Object,
+    /// File top-level is an Array of sibling entities. `entities`
+    /// excludes the optional file-header element; `file_meta` holds
+    /// the header's `meta` value (or null when no header present).
+    bundle: Bundle,
+
+    pub const Bundle = struct {
+        entities: []Value,
+        file_meta: ?Value,
+    };
+};
+
+/// Classify the file's top-level value. Object → single-root;
+/// Array → bundle (RFC #596 Axis 3). Anything else (string,
+/// number, …) is malformed — returns `null` so the caller can
+/// surface `error.InvalidFormat` without this helper having to
+/// know the loader's error type.
+///
+/// The bundle header is detected by inspecting the first array
+/// element only: if it's an object whose ONLY keys are `meta` (no
+/// `prefab`, no `children`, no PascalCase, no `components` /
+/// `overrides` legacy wrappers — none of the entity-shape keys),
+/// it's the header. Anything else at index 0 is an entity. Empty
+/// arrays `[]` are valid zero-entity bundles (no warning).
+pub fn classifyTopLevel(file_val: Value) ?TopLevel {
+    switch (file_val) {
+        .object => |o| return .{ .single_root = o },
+        .array => |a| {
+            if (a.items.len == 0) {
+                return .{ .bundle = .{ .entities = &.{}, .file_meta = null } };
+            }
+            // Header detection: index 0 is an object whose only
+            // recognized key is `meta` (no entity-shape keys).
+            if (a.items[0].asObject()) |first_obj| {
+                if (isFileHeader(first_obj)) {
+                    return .{ .bundle = .{
+                        .entities = a.items[1..],
+                        .file_meta = first_obj.get("meta"),
+                    } };
+                }
+            }
+            return .{ .bundle = .{ .entities = a.items, .file_meta = null } };
+        },
+        else => return null,
     }
-    // Reference entry — overrides, with a legacy `components` fallback.
-    if (entity_obj.getObject("overrides")) |overrides| {
-        if (entity_obj.getObject("components") != null) {
-            warnOnce(log, "[unified-format] prefab reference has both \"overrides\" and \"components\"; \"overrides\" wins — remove \"components\" (RFC #560)");
+}
+
+/// True if `obj` is a file-level metadata header — an object that
+/// contains `meta:` and NO entity-shape keys. Entity-shape keys are
+/// `prefab`, `children`, `components`, `overrides` (legacy), or any
+/// PascalCase key (RFC #596). A header MAY also be `{}` (empty
+/// object), but that's not a useful header and we treat it as an
+/// entity (the existing `loadEntityInternal` will reject `{}` as
+/// malformed).
+fn isFileHeader(obj: Value.Object) bool {
+    if (obj.get("meta") == null) return false;
+    for (obj.entries) |e| {
+        if (std.mem.eql(u8, e.key, "meta")) continue;
+        // Any entity-shape key disqualifies — this is an entity
+        // that happens to carry a `meta` field, not a file header.
+        if (std.mem.eql(u8, e.key, "prefab")) return false;
+        if (std.mem.eql(u8, e.key, "children")) return false;
+        if (std.mem.eql(u8, e.key, "components")) return false;
+        if (std.mem.eql(u8, e.key, "overrides")) return false;
+        if (std.mem.eql(u8, e.key, "ref")) return false;
+        if (isPascalCase(e.key)) return false;
+        // Other lowercase keys (e.g. unknown future structural
+        // keys) are tolerated on the header — `meta`-shaped side
+        // data.
+    }
+    return true;
+}
+
+/// The component patch for an entity entry. Three shapes ride this
+/// accessor (RFC #560 / #594 / #596):
+///
+///   - **Wrapped (v1.0 — v1.x):** inline entries carry
+///     `"components": { ... }`; reference entries carry
+///     `"overrides": { ... }`. A legacy `"components"` on a
+///     reference is accepted as a synonym and warned. When
+///     `"overrides"` and `"components"` both appear on a reference,
+///     `"overrides"` wins.
+///   - **Flat (RFC #596 Axis 2):** PascalCase keys at the entity
+///     scope are the components directly — no `overrides:` /
+///     `components:` wrapper. Lowercase keys (`prefab`, `children`,
+///     `meta`, `ref`) stay structural. Mode (inline vs reference)
+///     is determined by whether `prefab` is present, exactly as in
+///     the wrapped form.
+///   - **Mixed (defense-in-depth):** if both an explicit wrapper
+///     AND PascalCase keys at the entity scope exist, the wrapper
+///     wins (back-compat) and we warn once. Authoring tools should
+///     never produce this; the migrator either lifts the wrapper or
+///     leaves it alone, but a hand-edited file could land here.
+///
+/// `allocator` is used only when synthesizing the flat-form
+/// components view (the wrapped paths just return the existing
+/// Object verbatim). Callers pass their per-scene arena; the
+/// synthesized Object's `entries` slice lives in that arena and
+/// must not outlive it. Leaf values are shared with `entity_obj`.
+pub fn entityPatch(entity_obj: Value.Object, allocator: std.mem.Allocator, log: anytype) error{OutOfMemory}!?Value.Object {
+    const is_reference = entity_obj.getString("prefab") != null;
+
+    // Wrapped form takes precedence — back-compat for v1.x and the
+    // dual-accept matrix during the deprecation window.
+    if (is_reference) {
+        if (entity_obj.getObject("overrides")) |overrides| {
+            if (entity_obj.getObject("components") != null) {
+                warnOnce(log, "[unified-format] prefab reference has both \"overrides\" and \"components\"; \"overrides\" wins — remove \"components\" (RFC #560)");
+            }
+            if (hasPascalCaseKey(entity_obj)) {
+                warnOnce(log, "[unified-format] reference entry has both an \"overrides\" wrapper and flat PascalCase keys — \"overrides\" wins. Drop one shape (RFC #596).");
+            }
+            return overrides;
         }
-        return overrides;
+        if (entity_obj.getObject("components")) |legacy| {
+            warnOnce(log, "[unified-format] legacy \"components\" on a prefab reference: rename it to \"overrides\" (RFC #560)");
+            if (hasPascalCaseKey(entity_obj)) {
+                warnOnce(log, "[unified-format] reference entry has both a \"components\" wrapper and flat PascalCase keys — wrapper wins. Drop one shape (RFC #596).");
+            }
+            return legacy;
+        }
+    } else {
+        if (entity_obj.getObject("components")) |components| {
+            if (hasPascalCaseKey(entity_obj)) {
+                warnOnce(log, "[unified-format] inline entity has both a \"components\" wrapper and flat PascalCase keys — wrapper wins. Drop one shape (RFC #596).");
+            }
+            return components;
+        }
     }
-    if (entity_obj.getObject("components")) |legacy| {
-        warnOnce(log, "[unified-format] legacy \"components\" on a prefab reference: rename it to \"overrides\" (RFC #560)");
-        return legacy;
+
+    // Flat form (RFC #596 Axis 2): synthesize a components view
+    // from the PascalCase keys at the entity scope. Lowercase keys
+    // are structural and skipped. An entity with no PascalCase keys
+    // returns null (no components to apply) — matches the wrapped
+    // path's "no `components`/`overrides`" return.
+    return try synthesizeFlatComponents(entity_obj, allocator);
+}
+
+/// Whether `entity_obj` has at least one PascalCase key at its top
+/// level. Used to detect the flat shape without allocating a
+/// synthetic Object — and to warn when wrapped + flat are mixed.
+fn hasPascalCaseKey(entity_obj: Value.Object) bool {
+    for (entity_obj.entries) |e| {
+        if (isPascalCase(e.key)) return true;
     }
-    return null;
+    return false;
+}
+
+/// Build a `Value.Object` whose entries are the entity's PascalCase
+/// keys — the components view for the flat shape (RFC #596 Axis 2).
+/// `meta` and other lowercase keys are skipped. Returns `null` when
+/// there are no PascalCase keys at all (parity with the wrapped
+/// path's "no components" return; lets the caller treat an entity
+/// with only `prefab` and `meta` as a no-op spawn).
+///
+/// Entries slice lives in `allocator` (caller's arena). Leaf values
+/// are shared with `entity_obj`, so the synthesized Object must not
+/// outlive `entity_obj`.
+fn synthesizeFlatComponents(entity_obj: Value.Object, allocator: std.mem.Allocator) error{OutOfMemory}!?Value.Object {
+    var count: usize = 0;
+    for (entity_obj.entries) |e| {
+        if (isPascalCase(e.key)) count += 1;
+    }
+    if (count == 0) return null;
+
+    const entries = try allocator.alloc(Value.Object.Entry, count);
+    var i: usize = 0;
+    for (entity_obj.entries) |e| {
+        if (isPascalCase(e.key)) {
+            entries[i] = e;
+            i += 1;
+        }
+    }
+    return Value.Object{ .entries = entries };
+}
+
+/// The components view of a resolved prefab root. Two shapes:
+///
+///   - **Wrapped (today):** `prefab_root.components` is the
+///     components Object.
+///   - **Flat (RFC #596):** PascalCase keys at `prefab_root` ARE the
+///     components.
+///
+/// Returns `null` if neither shape has any components — a prefab
+/// with only `children` (or only structural keys) is well-formed
+/// per RFC #596; the loader spawns its children with no inherited
+/// components. `allocator` is used only to synthesize the flat
+/// view; mirrors `entityPatch`'s arena contract.
+pub fn prefabComponents(prefab_root: Value.Object, allocator: std.mem.Allocator) error{OutOfMemory}!?Value.Object {
+    if (prefab_root.getObject("components")) |c| return c;
+    return try synthesizeFlatComponents(prefab_root, allocator);
 }
 
 /// The registry key for a prefab/scene file: its `"name"` field

--- a/test/jsonc/unified_format_test.zig
+++ b/test/jsonc/unified_format_test.zig
@@ -30,9 +30,25 @@ const Health = struct {
     current: f32 = 0,
 };
 
+// A component whose data field is an array of structs that themselves
+// use PascalCase keys. Pins that `isEntityLike` does NOT classify
+// these inner data objects as entities — they're component-value
+// data, not entity definitions (RFC #596 cursor MED).
+const FireSpellEntry = struct {
+    pub const save = core.Saveable(.saveable, @This(), .{});
+    Type: i32 = 0,
+    DamageMultiplier: i32 = 0,
+};
+
+const FireSpell = struct {
+    pub const save = core.Saveable(.saveable, @This(), .{});
+    entries: []const FireSpellEntry = &.{},
+};
+
 const TestComponents = engine.ComponentRegistry(.{
     .Marker = Marker,
     .Health = Health,
+    .FireSpell = FireSpell,
 });
 
 const MockEcs = core.MockEcsBackend(u32);
@@ -731,4 +747,100 @@ test "rfc596: flat prefab with PascalCase components resolves via reference" {
     const e = view.next().?;
     try testing.expectEqual(@as(i32, 5), game.ecs_backend.getComponent(e, Marker).?.id);
     try testing.expectEqual(@as(f32, 75), game.ecs_backend.getComponent(e, Health).?.current);
+}
+
+// ── Regression tests for PR #597 review findings ───────────────
+
+test "rfc596: malformed top-level value (string) returns error.InvalidFormat" {
+    // Gemini HIGH (#597): `classifyTopLevel` returns null for any
+    // scalar at the file top level; the loader must surface
+    // `error.InvalidFormat` instead of silently succeeding.
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+    try testing.expectError(error.InvalidFormat, Bridge.loadSceneFromSource(&game, "\"malformed\"", PREFAB_DIR));
+}
+
+test "rfc596: malformed top-level value (number) returns error.InvalidFormat" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+    try testing.expectError(error.InvalidFormat, Bridge.loadSceneFromSource(&game, "42", PREFAB_DIR));
+}
+
+test "rfc596: malformed top-level value (bool) returns error.InvalidFormat" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+    try testing.expectError(error.InvalidFormat, Bridge.loadSceneFromSource(&game, "true", PREFAB_DIR));
+}
+
+test "rfc596: malformed top-level value (null) returns error.InvalidFormat" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+    try testing.expectError(error.InvalidFormat, Bridge.loadSceneFromSource(&game, "null", PREFAB_DIR));
+}
+
+test "rfc596: component-value data with PascalCase keys does NOT spawn phantom entities" {
+    // Cursor MED (#597): `isEntityLike` was broadened to recognize
+    // any object with a PascalCase key as an entity, but it's
+    // called from `stripEntityArrayFields` and
+    // `spawnAndLinkNestedEntities` on COMPONENT VALUE arrays —
+    // component data that happens to carry PascalCase fields (e.g.
+    // `{ Type: 1, DamageMultiplier: 2 }`) would be falsely tagged
+    // as entities → stripped from component data → spawned as
+    // phantom entities.
+    //
+    // The fix tightens `isEntityLike` to recognize entities by
+    // structural keys only (`prefab` / `children` / `components`).
+    var game = try boot(
+        \\{ "children": [
+        \\  { "Marker": { "id": 1 },
+        \\    "FireSpell": { "entries": [
+        \\      { "Type": 11, "DamageMultiplier": 22 },
+        \\      { "Type": 33, "DamageMultiplier": 44 }
+        \\    ] } }
+        \\] }
+    );
+    defer game.deinit();
+
+    // Exactly ONE entity — no phantoms spawned from FireSpell.entries.
+    var buf: [8]i32 = undefined;
+    try testing.expectEqualSlices(i32, &.{1}, markerIds(&game, &buf));
+
+    // FireSpell component preserved intact: both entries present.
+    var view = game.ecs_backend.view(.{FireSpell}, .{});
+    defer view.deinit();
+    const e = view.next().?;
+    const fs = game.ecs_backend.getComponent(e, FireSpell).?.*;
+    try testing.expectEqual(@as(usize, 2), fs.entries.len);
+    try testing.expectEqual(@as(i32, 11), fs.entries[0].Type);
+    try testing.expectEqual(@as(i32, 22), fs.entries[0].DamageMultiplier);
+    try testing.expectEqual(@as(i32, 33), fs.entries[1].Type);
+    try testing.expectEqual(@as(i32, 44), fs.entries[1].DamageMultiplier);
+}
+
+test "rfc596: flat-inline entity as a children[] item still works after tightening isEntityLike" {
+    // Sanity gate for the cursor MED fix: tightening `isEntityLike`
+    // to structural-keys-only must NOT break the legitimate flat-
+    // inline RFC #596 shape — flat-inline entities are still
+    // spawned via `children:` array items (where the caller knows
+    // every item is an entity by definition, no `isEntityLike`
+    // filter required).
+    var game = try boot(
+        \\{ "children": [
+        \\  { "Marker": { "id": 2 }, "Health": { "current": 50 } }
+        \\] }
+    );
+    defer game.deinit();
+
+    // The flat-inline child spawns with BOTH components — proving
+    // the tightened predicate still admits the RFC #596 Axis 2
+    // shape when reached through a `children:` array (no
+    // `isEntityLike` filter on that path).
+    var buf: [8]i32 = undefined;
+    try testing.expectEqualSlices(i32, &.{2}, markerIds(&game, &buf));
+
+    var view = game.ecs_backend.view(.{ Marker, Health }, .{});
+    defer view.deinit();
+    const child = view.next().?;
+    try testing.expectEqual(@as(i32, 2), game.ecs_backend.getComponent(child, Marker).?.id);
+    try testing.expectEqual(@as(f32, 50), game.ecs_backend.getComponent(child, Health).?.current);
 }

--- a/test/jsonc/unified_format_test.zig
+++ b/test/jsonc/unified_format_test.zig
@@ -500,3 +500,235 @@ test "flat: dual-acceptance — root-wrapped form still loads unchanged" {
     var buf: [8]i32 = undefined;
     try testing.expectEqualSlices(i32, &.{ 1, 2 }, markerIds(&game, &buf));
 }
+
+// ── RFC #596: wrapper-flat + bundle + meta forms ────────────────
+//
+// RFC #596 extends the dual-accept matrix with three more axes:
+//
+//   1. Wrapper-flat components — PascalCase keys at the entity
+//      scope ARE components, no `overrides:` / `components:`
+//      wrapper required.
+//   2. File-as-array bundles — top-level Array is a list of sibling
+//      entities (no implicit root), with an optional `{ meta: ... }`
+//      file-header element at index 0.
+//   3. `meta:` field at entity and file-header scope — stripped at
+//      load, never reaches runtime, never propagates.
+//   4. Unknown PascalCase keys warn-once (forward-compat with
+//      cross-repo plugin authoring; typos still surface).
+//
+// All axes are dual-accept during v1.x; wrapped forms keep working
+// throughout. The §B2 gate fires at every shape.
+
+test "rfc596: flat reference — PascalCase override sibling of prefab key" {
+    // `{ "prefab": "x", "Marker": { ... } }` — no `overrides`
+    // wrapper. The PascalCase key IS the override (RFC #596 Axis 2).
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    try Bridge.addEmbeddedPrefab(&game, "widget",
+        \\{ "root": { "components": { "Marker": { "id": 100 } } } }
+    , PREFAB_DIR);
+    try Bridge.loadSceneFromSource(&game,
+        \\{ "children": [
+        \\  { "prefab": "widget", "Marker": { "id": 42 } }
+        \\] }
+    , PREFAB_DIR);
+
+    try testing.expectEqual(@as(i32, 42), soleMarker(&game).id);
+}
+
+test "rfc596: flat inline — PascalCase keys declare an inline entity" {
+    // `{ "Marker": { ... } }` — no `components` wrapper. The
+    // PascalCase key IS the inline component (RFC #596 Axis 2).
+    var game = try boot(
+        \\{ "children": [
+        \\  { "Marker": { "id": 7 } },
+        \\  { "Marker": { "id": 8 } }
+        \\] }
+    );
+    defer game.deinit();
+
+    var buf: [8]i32 = undefined;
+    try testing.expectEqualSlices(i32, &.{ 7, 8 }, markerIds(&game, &buf));
+}
+
+test "rfc596: bundle scene — top-level Array spawns N siblings" {
+    // RFC #596 Axis 3: file-as-array. No implicit root entity, no
+    // shared parent — every array element is a sibling.
+    var game = try boot(
+        \\[
+        \\  { "Marker": { "id": 1 } },
+        \\  { "Marker": { "id": 2 } },
+        \\  { "Marker": { "id": 3 } }
+        \\]
+    );
+    defer game.deinit();
+
+    var buf: [8]i32 = undefined;
+    try testing.expectEqualSlices(i32, &.{ 1, 2, 3 }, markerIds(&game, &buf));
+}
+
+test "rfc596: bundle header — only-meta object at index 0 is file-meta, not entity" {
+    // The first array element with ONLY `meta:` (no entity-shape
+    // keys) is the file header — treated as authoring metadata, not
+    // an entity. The other elements spawn normally.
+    var game = try boot(
+        \\[
+        \\  { "meta": { "name": "Production Colony Demo", "author": "alexandre" } },
+        \\  { "Marker": { "id": 10 } },
+        \\  { "Marker": { "id": 11 } }
+        \\]
+    );
+    defer game.deinit();
+
+    var buf: [8]i32 = undefined;
+    try testing.expectEqualSlices(i32, &.{ 10, 11 }, markerIds(&game, &buf));
+}
+
+test "rfc596: empty bundle [] is valid, zero entities" {
+    // Empty bundles are valid per the RFC's Q2 resolution —
+    // authoring workflows benefit (new file → `[]` → add entities).
+    var game = try boot("[]");
+    defer game.deinit();
+
+    var buf: [8]i32 = undefined;
+    try testing.expectEqualSlices(i32, &.{}, markerIds(&game, &buf));
+}
+
+test "rfc596: meta on an entity is stripped — never reaches runtime" {
+    // The `meta:` key is dropped at load. The entity spawns with
+    // its components; `meta` is not a component, not attached to
+    // the entity, not visible to gameplay code. The test passes if
+    // (a) loading succeeds, and (b) `Marker` is applied normally —
+    // no spurious warning, no extra entity.
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    try Bridge.addEmbeddedPrefab(&game, "widget",
+        \\{ "root": { "components": { "Marker": { "id": 100 } } } }
+    , PREFAB_DIR);
+    try Bridge.loadSceneFromSource(&game,
+        \\{ "children": [
+        \\  { "prefab": "widget", "meta": { "label": "main kitchen", "tags": ["debug"] } }
+        \\] }
+    , PREFAB_DIR);
+
+    // The widget spawned with the prefab's default Marker.id=100;
+    // `meta` is gone, no second entity was created from it.
+    try testing.expectEqual(@as(i32, 100), soleMarker(&game).id);
+}
+
+test "rfc596: meta does NOT propagate from prefab file to scene reference" {
+    // RFC §"Authoring-only / No propagation": a prefab file's
+    // file-level meta is local to the prefab. A scene that
+    // references it without its own `meta:` gets no meta on the
+    // spawned entity (and the prefab's meta is NOT silently
+    // attached as a component).
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    // Prefab in flat shape with its own meta block.
+    try Bridge.addEmbeddedPrefab(&game, "labeled",
+        \\{ "Marker": { "id": 50 },
+        \\  "meta": { "author": "A", "version": 3 } }
+    , PREFAB_DIR);
+    // Scene reference has no `meta:` of its own.
+    try Bridge.loadSceneFromSource(&game,
+        \\[ { "prefab": "labeled" } ]
+    , PREFAB_DIR);
+
+    // Spawn succeeded with the prefab's Marker only. If `meta`
+    // were applied as a component, the apply-component pipeline
+    // would have warned (`uf.warnUnknownComponent` only fires for
+    // PascalCase keys, but `meta` is lowercase — it's structural)
+    // — but more importantly, only ONE marker exists at id=50, no
+    // second entity, no error.
+    try testing.expectEqual(@as(i32, 50), soleMarker(&game).id);
+}
+
+test "rfc596: unknown PascalCase component (typo) warns but does not crash" {
+    // RFC #596 Axis 4: unknown PascalCase keys are treated as
+    // components, but the loader warns-once instead of erroring.
+    // Forward-compat: write the prefab before the plugin lands.
+    // Catches typos like `Posiiton` visibly.
+    //
+    // The test asserts behavior — load succeeds and the known
+    // sibling component still applies. The warning is observed
+    // out-of-band (StubLogSink swallows it, but the warn-once dedup
+    // set in `unified_format.zig` is the truthful signal — exercised
+    // by the load path).
+    var game = try boot(
+        \\{ "children": [
+        \\  { "Marker": { "id": 42 }, "Posiiton": { "x": 0, "y": 0 } }
+        \\] }
+    );
+    defer game.deinit();
+
+    // `Marker` applied normally; the typo'd component was ignored
+    // (no entity-side effect, no crash).
+    try testing.expectEqual(@as(i32, 42), soleMarker(&game).id);
+}
+
+test "rfc596: wrapped 'overrides' form still works (dual-accept regression)" {
+    // The RFC promises dual-accept during v1.x — adding the flat
+    // path MUST NOT break wrapped scenes. This test is the
+    // regression pin for that promise: the same scene shape as
+    // pre-RFC-596 keeps resolving cleanly.
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    try Bridge.addEmbeddedPrefab(&game, "widget",
+        \\{ "root": { "components": { "Marker": { "id": 100 } } } }
+    , PREFAB_DIR);
+    try Bridge.loadSceneFromSource(&game,
+        \\{ "children": [
+        \\  { "prefab": "widget", "overrides": { "Marker": { "id": 9 } } }
+        \\] }
+    , PREFAB_DIR);
+
+    try testing.expectEqual(@as(i32, 9), soleMarker(&game).id);
+}
+
+test "rfc596: §B2 still fires on a flat bundle element with {prefab + children}" {
+    // The §B2 gate (RFC #560: no `children` on a reference) must
+    // catch the violation in the bundle shape too. The file-root
+    // gate doesn't apply (a bundle has no root), but the per-entry
+    // gate inside `loadEntityInternal` fires on every visit.
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+    try Bridge.addEmbeddedPrefab(&game, "door",
+        \\{ "components": { "Marker": { "id": 1 } } }
+    , PREFAB_DIR);
+
+    const src =
+        \\[
+        \\  { "prefab": "door",
+        \\    "children": [ { "Marker": { "id": 99 } } ] }
+        \\]
+    ;
+    try testing.expectError(error.InvalidFormat, Bridge.loadSceneFromSource(&game, src, PREFAB_DIR));
+}
+
+test "rfc596: flat prefab with PascalCase components resolves via reference" {
+    // RFC #596 Axis 2 applied to prefabs: a prefab file can drop
+    // its `components:` wrapper too. The flat references resolve
+    // through the cache identically.
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    // Prefab in fully flat form — no `root`, no `components`.
+    try Bridge.addEmbeddedPrefab(&game, "flat_widget",
+        \\{ "Marker": { "id": 200 }, "Health": { "current": 75 } }
+    , PREFAB_DIR);
+    try Bridge.loadSceneFromSource(&game,
+        \\[
+        \\  { "prefab": "flat_widget", "Marker": { "id": 5 } }
+        \\]
+    , PREFAB_DIR);
+
+    var view = game.ecs_backend.view(.{ Marker, Health }, .{});
+    defer view.deinit();
+    const e = view.next().?;
+    try testing.expectEqual(@as(i32, 5), game.ecs_backend.getComponent(e, Marker).?.id);
+    try testing.expectEqual(@as(f32, 75), game.ecs_backend.getComponent(e, Health).?.current);
+}


### PR DESCRIPTION
Implements the loader side of RFC #596 (PR https://github.com/labelle-toolkit/labelle-engine/pull/596) — extends the unified-format dual-accept matrix with four more axes on top of yesterday's #594 wrapper-flat work.

## Axes implemented (all in the loader)

1. **Wrapper-flat components (Axis 2).** Within an entity object, PascalCase keys are components and lowercase keys are structural — no `overrides:` / `components:` wrapper required. `uf.entityPatch` / `uf.prefabComponents` synthesize the view from PascalCase keys (entries slice in caller's arena; leaf values shared with the source). Mixed wrapped+flat warns once, wrapper wins.

2. **File-as-array bundles (Axis 3).** `uf.classifyTopLevel` returns a `TopLevel.bundle` when the file's top-level is an Array. Optional `{ meta: ... }` header at index 0 — detected by the no-entity-shape-keys rule — is captured separately, not spawned as an entity. Empty bundles `[]` are valid zero-entity loads. `loadSceneFile` / `loadSceneSource` switch on the classified top-level.

3. **`meta:` field (Axis 4 structural).** Lowercase, structural — never reaches runtime. The flat-form `entityPatch` automatically skips it (not PascalCase). File-header `meta` is captured in `TopLevel.bundle.file_meta` for tooling but unused by the engine.

4. **Unknown PascalCase warn-once (Axis 4 components).** `applyComponent` falls through to `uf.warnUnknownComponent` when no registered name matches AND the key is PascalCase. Forward-compat with cross-repo plugin authoring; typos like `Posiiton` warn visibly without crashing the load. Deduped by component name across the whole process.

## Dual-accept

Every wrapped / legacy shape continues to work through v1.x. v2.0 (engine#592) drops the wrapper / root-wrapped / file-object-no-root paths.

## §B2 verification

The `{prefab + children}` rejection (RFC #560 §B2) fires on every new shape:

- **Single-root, wrapped:** file-root gate in `loadSceneFile` / `loadSceneSource` (unchanged).
- **Single-root, flat:** same gate — `uf.rootObject` returns the file object itself for flat scenes (RFC #594 behavior preserved).
- **Bundle:** file-root gate is skipped (a bundle has no root), but the per-entry gate in `loadEntityInternal` fires on every bundle element — covered by the new `rfc596: §B2 still fires on a flat bundle element with {prefab + children}` test.
- **Resolved-prefab root (flat or wrapped):** unchanged — the cache walks every prefab through `rejectB2Violation`.

## Tests (`test/jsonc/unified_format_test.zig`)

- `rfc596: flat reference — PascalCase override sibling of prefab key`
- `rfc596: flat inline — PascalCase keys declare an inline entity`
- `rfc596: bundle scene — top-level Array spawns N siblings`
- `rfc596: bundle header — only-meta object at index 0 is file-meta, not entity`
- `rfc596: empty bundle [] is valid, zero entities`
- `rfc596: meta on an entity is stripped — never reaches runtime`
- `rfc596: meta does NOT propagate from prefab file to scene reference`
- `rfc596: unknown PascalCase component (typo) warns but does not crash`
- `rfc596: wrapped 'overrides' form still works (dual-accept regression)`
- `rfc596: §B2 still fires on a flat bundle element with {prefab + children}`
- `rfc596: flat prefab with PascalCase components resolves via reference`

Build + spec green; all 479 tests pass.

## Out of scope

- Migrator transforms — separate PR (cli#…).
- Audit findings — separate PR.
- Assembler-side handling — separate PR.

## Test plan
- [ ] `zig build` (engine root)
- [ ] `zig build test` — 479/479 pass locally
- [ ] `zig build spec` — 28/28 pass locally
- [ ] Verify existing wrapped + flat (RFC #594) scenes still load
- [ ] Smoke-test on flying-platform-labelle to confirm no regressions