### PR TITLE
feat(loader): read engine-known meta keys from bundle file header (RFC #596 update)

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -284,6 +284,14 @@ pub fn GameConfig(
         game_state: []const u8 = "running",
         pending_state_change: ?[]const u8 = null,
         state_change_count: usize = 0,
+        /// Game-allocator-owned backing for `game_state` when the state
+        /// name came from a runtime-parsed source whose backing storage
+        /// has a shorter lifetime than the game (RFC #596 `meta.initial_state`
+        /// reads through the loader's `parse_arena`, which is freed before
+        /// the load returns). When set, `game_state` aliases this slice.
+        /// Freed on `deinit` and replaced (with the previous slice freed)
+        /// each time the loader applies a new `meta.initial_state`.
+        owned_initial_state: ?[]u8 = null,
         /// Time scale factor: 0 = paused, 0.5 = slow-mo, 1.0 = normal, 2.0 = fast.
         /// When paused (0), rendering and GUI continue but tick logic stops.
         time_scale: f32 = 1.0,
@@ -390,6 +398,9 @@ pub fn GameConfig(
                 self.allocator.free(name);
             }
             if (self.pending_scene_assets) |name| {
+                self.allocator.free(name);
+            }
+            if (self.owned_initial_state) |name| {
                 self.allocator.free(name);
             }
             // Clean up inactive worlds

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -379,16 +379,44 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                 //
                 // Dupe onto `game.allocator` and stash the owned backing
                 // on `game.owned_initial_state` so it lives as long as
-                // `game_state` itself. Free any prior owned slice first
-                // (a second `meta.initial_state` load supersedes it).
-                const owned = game.allocator.dupe(u8, state_name) catch {
+                // `game_state` itself.
+                //
+                // Ordering matters — `game.game_state` may alias the
+                // prior owned slot (set by an earlier `setState(owned)`
+                // call below). If we freed the old slot *before*
+                // `setState`, then `setState`'s `std.mem.eql(self.game_state, …)`
+                // probe would read freed memory (second-order UAF first
+                // caught on PR #599's first fix).
+                //
+                // So:
+                //   1. Short-circuit if we already own this exact state
+                //      name — no allocation, no free, no setState churn.
+                //   2. Dupe onto the game allocator.
+                //   3. Swap `owned_initial_state` to the fresh dupe
+                //      *before* `setState`. This way the field is
+                //      consistent even if `setState` early-returns.
+                //   4. Call `setState(new_owned)` — its `eql` probe reads
+                //      `game.game_state`, which still aliases the prior
+                //      owned slot (still live) or a default literal.
+                //      Safe either way.
+                //   5. *Now* free the previous owned slot. By this point
+                //      `game.game_state` has been reassigned to
+                //      `new_owned` (or unchanged if `setState`
+                //      early-returned because it equaled a literal — in
+                //      which case the old slot was null anyway, since a
+                //      live owned slot would have been caught by step 1).
+                if (game.owned_initial_state) |existing| {
+                    if (std.mem.eql(u8, existing, state_name)) return;
+                }
+                const new_owned = game.allocator.dupe(u8, state_name) catch {
                     // Out of memory — keep the previous state rather than
                     // crash the load. The directive is best-effort.
                     return;
                 };
-                if (game.owned_initial_state) |old| game.allocator.free(old);
-                game.owned_initial_state = owned;
-                game.setState(owned);
+                const old_owned = game.owned_initial_state;
+                game.owned_initial_state = new_owned;
+                game.setState(new_owned);
+                if (old_owned) |s| game.allocator.free(s);
             }
             // Future engine-known keys (`scripts`, `include`) dispatch here.
             // `name` and any other lowercase keys are authoring-only.

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -381,33 +381,58 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                 // on `game.owned_initial_state` so it lives as long as
                 // `game_state` itself.
                 //
-                // Ordering matters — `game.game_state` may alias the
-                // prior owned slot (set by an earlier `setState(owned)`
-                // call below). If we freed the old slot *before*
-                // `setState`, then `setState`'s `std.mem.eql(self.game_state, …)`
-                // probe would read freed memory (second-order UAF first
-                // caught on PR #599's first fix).
+                // PR #599 history (three fixes):
                 //
-                // So:
-                //   1. Short-circuit if we already own this exact state
-                //      name — no allocation, no free, no setState churn.
-                //   2. Dupe onto the game allocator.
-                //   3. Swap `owned_initial_state` to the fresh dupe
-                //      *before* `setState`. This way the field is
-                //      consistent even if `setState` early-returns.
-                //   4. Call `setState(new_owned)` — its `eql` probe reads
+                //  Fix #1: dupe meta.initial_state so the slice survives
+                //          parse_arena.deinit (first-order UAF).
+                //
+                //  Fix #2: reorder dupe/setState/free so the prior owned
+                //          slot is still live while setState's
+                //          `std.mem.eql(self.game_state, …)` probe runs
+                //          (second-order UAF when game.game_state aliased
+                //          the slot we'd just freed).
+                //
+                //  Fix #3 (here): drop the no-churn short-circuit that
+                //          fix #2 added. The short-circuit
+                //          `if (existing == state_name content) return;`
+                //          assumed `game.game_state` still aliased the
+                //          owned slot — but an external `setState(...)`
+                //          call between two `applyFileMetaDirectives`
+                //          invocations could have re-pointed
+                //          `game.game_state` elsewhere, leaving the
+                //          directive silently ignored (cursor MEDIUM:
+                //          game stayed in the wrong state).
+                //
+                // The new contract: always dupe, always free the prior.
+                // The dupe + free churn per scene load is negligible
+                // compared to the bug surface of a clever short-circuit.
+                //
+                // Ordering (preserves fix #2's UAF guarantee):
+                //
+                //   1. Dupe onto the game allocator — `new_owned`.
+                //   2. Swap `owned_initial_state` to the fresh dupe
+                //      *before* `setState`. The field is consistent even
+                //      if `setState` early-returns.
+                //   3. `setState(new_owned)`. Its `eql` probe reads
                 //      `game.game_state`, which still aliases the prior
                 //      owned slot (still live) or a default literal.
                 //      Safe either way.
-                //   5. *Now* free the previous owned slot. By this point
-                //      `game.game_state` has been reassigned to
-                //      `new_owned` (or unchanged if `setState`
-                //      early-returned because it equaled a literal — in
-                //      which case the old slot was null anyway, since a
-                //      live owned slot would have been caught by step 1).
-                if (game.owned_initial_state) |existing| {
-                    if (std.mem.eql(u8, existing, state_name)) return;
-                }
+                //   4. If `setState` short-circuited (because
+                //      `game.game_state` already content-equalled
+                //      `state_name`), `game.game_state` may still alias
+                //      the about-to-be-freed `old_owned`. Detect that
+                //      via pointer identity against `new_owned` and
+                //      explicitly re-point. Doing this only when the
+                //      pointer doesn't already match `new_owned` skips
+                //      the safe re-assign in the literal-aliasing case
+                //      where re-pointing to `new_owned` is also fine
+                //      (we just don't need to bother).
+                //
+                //      We do NOT re-fire state-change hooks here —
+                //      that's correct: the visible state value is
+                //      unchanged, we're only refreshing the backing
+                //      pointer.
+                //   5. Free the previous owned slot (no-op if null).
                 const new_owned = game.allocator.dupe(u8, state_name) catch {
                     // Out of memory — keep the previous state rather than
                     // crash the load. The directive is best-effort.
@@ -416,6 +441,16 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                 const old_owned = game.owned_initial_state;
                 game.owned_initial_state = new_owned;
                 game.setState(new_owned);
+                if (game.game_state.ptr != new_owned.ptr) {
+                    // setState short-circuited: game.game_state still
+                    // points at whatever it pointed at before (a literal
+                    // or, critically, `old_owned`). Re-point to
+                    // `new_owned` so the upcoming `free(old_owned)`
+                    // doesn't dangle game.game_state. Safe in the
+                    // literal-alias case too — the literal stays valid,
+                    // we just stop referencing it.
+                    game.game_state = new_owned;
+                }
                 if (old_owned) |s| game.allocator.free(s);
             }
             // Future engine-known keys (`scripts`, `include`) dispatch here.

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -345,6 +345,36 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
 
         // ── Top-level scene processing ─────────────────────────
 
+        /// Apply engine-known directives from a bundle file-header
+        /// `meta:` block (RFC #596). Today the only consumed key is
+        /// `initial_state` — `meta.initial_state: "<state>"` switches
+        /// the game's state machine to `<state>` BEFORE entities are
+        /// spawned, so state-gated scripts see the right state on the
+        /// first tick after the load.
+        ///
+        /// All other lowercase keys (`name`, `author`, `draft`, …) are
+        /// authoring-only and ignored silently — they're free-form
+        /// metadata for tools, not engine directives. `meta.scripts`
+        /// and `meta.include` are reserved by the RFC but currently
+        /// unused; once a consumer lands they'd join this dispatch.
+        ///
+        /// A non-object `meta:` value (e.g. `meta: "label"`) is also
+        /// ignored — the RFC documents `meta:` as a structured block,
+        /// but the loader doesn't error on malformed shapes here
+        /// because audit/tooling has a clearer error surface.
+        fn applyFileMetaDirectives(game: *GameType, file_meta: ?Value) void {
+            const meta_val = file_meta orelse return;
+            const meta_obj = meta_val.asObject() orelse return;
+            if (meta_obj.getString("initial_state")) |state_name| {
+                if (!std.mem.eql(u8, game.game_state, state_name)) {
+                    game.log.info("[scene] file-header meta.initial_state '{s}' → '{s}' (RFC #596)", .{ game.game_state, state_name });
+                }
+                game.setState(state_name);
+            }
+            // Future engine-known keys (`scripts`, `include`) dispatch here.
+            // `name` and any other lowercase keys are authoring-only.
+        }
+
         /// Process entities from a parsed scene, with two-pass ref
         /// resolution.
         fn processEntities(game: *GameType, entities_arr: Value.Array, prefab_cache: *PrefabCache, ref_ctx: *RefContext) LoadEntityError!void {
@@ -437,7 +467,11 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                     }
                 },
                 .bundle => |bundle| {
-                    _ = bundle.file_meta;
+                    // RFC #596: consume engine-known directives from
+                    // the bundle's file-header `meta:` block BEFORE
+                    // spawning entities, so state-gated scripts see
+                    // the requested initial state on their first tick.
+                    applyFileMetaDirectives(game, bundle.file_meta);
                     if (bundle.entities.len == 0) return;
                     var ref_ctx = RefContext.init(game.allocator, null);
                     defer ref_ctx.deinit();
@@ -479,7 +513,11 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                     }
                 },
                 .bundle => |bundle| {
-                    _ = bundle.file_meta;
+                    // Mirrors `loadSceneFile`'s bundle arm — file-
+                    // header meta directives (RFC #596) apply equally
+                    // to in-memory sources so embedded tests and hot-
+                    // reload paths see the same state-machine effect.
+                    applyFileMetaDirectives(game, bundle.file_meta);
                     if (bundle.entities.len == 0) return;
                     var ref_ctx = RefContext.init(game.allocator, null);
                     defer ref_ctx.deinit();

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -369,7 +369,26 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                 if (!std.mem.eql(u8, game.game_state, state_name)) {
                     game.log.info("[scene] file-header meta.initial_state '{s}' → '{s}' (RFC #596)", .{ game.game_state, state_name });
                 }
-                game.setState(state_name);
+                // `state_name` aliases into the loader's `parse_arena`,
+                // which is freed in the `defer` at the top of
+                // `loadSceneFile` / `loadSceneSource` before the load
+                // function returns. `setState` (see `state_mixin.zig`)
+                // stores its argument by reference into `game.game_state`,
+                // so handing the arena-slice in directly would leave
+                // `game_state` dangling after the arena teardown.
+                //
+                // Dupe onto `game.allocator` and stash the owned backing
+                // on `game.owned_initial_state` so it lives as long as
+                // `game_state` itself. Free any prior owned slice first
+                // (a second `meta.initial_state` load supersedes it).
+                const owned = game.allocator.dupe(u8, state_name) catch {
+                    // Out of memory — keep the previous state rather than
+                    // crash the load. The directive is best-effort.
+                    return;
+                };
+                if (game.owned_initial_state) |old| game.allocator.free(old);
+                game.owned_initial_state = owned;
+                game.setState(owned);
             }
             // Future engine-known keys (`scripts`, `include`) dispatch here.
             // `name` and any other lowercase keys are authoring-only.

--- a/test/jsonc/unified_format_test.zig
+++ b/test/jsonc/unified_format_test.zig
@@ -1109,26 +1109,27 @@ test "rfc596: two consecutive meta.initial_state loads with SAME name — no dan
     try testing.expectEqualStrings("playing", game.getState());
 }
 
-test "rfc596: same-name reapply is a no-op (stable backing ptr)" {
-    // Pointer-identity probe that catches the pre-fix path
-    // deterministically. Pre-fix on the second call:
-    //   - dupe a fresh "playing" → owned2
-    //   - free owned1 (which game.game_state aliased — that's the
-    //     UAF read in setState's eql)
-    //   - assign game.game_state = owned2
-    //   → game.getState().ptr CHANGES across the two calls.
+test "rfc596: same-name reapply moves the backing pointer (post fix #3 contract)" {
+    // Pointer-identity probe of the NEW contract introduced by PR
+    // #599 fix #3: `applyFileMetaDirectives` always dupes a fresh
+    // backing slot and always frees the prior one, even when the
+    // state name is unchanged.
     //
-    // Post-fix:
-    //   - short-circuit at the `existing` eql probe — no allocation,
-    //     no free, no setState
-    //   → game.getState().ptr is STABLE across the two calls.
+    // Historical note — pre-fix-#3 this test asserted the OPPOSITE
+    // (pointer identity stable across same-name reapply), which was
+    // the documented contract of fix #2's no-churn short-circuit.
+    // That short-circuit was dropped in fix #3 because cursor
+    // surfaced a MEDIUM correctness bug: the short-circuit only
+    // probed `owned_initial_state == state_name`, not whether
+    // `game.game_state` was still in sync. An external `setState`
+    // between two loads with the same `meta.initial_state` would be
+    // silently ignored — game stuck at the external state. See the
+    // "recovers state after external setState" regression test
+    // below.
     //
-    // Asserting ptr identity is an implementation-detail check, but
-    // it's the exact property the no-churn short-circuit guarantees,
-    // and it surfaces the pre-fix's spurious realloc/free without
-    // needing sanitizer support (Zig's stock GPA does not actively
-    // trap reads on freed slots, so the eql probe's UAF read is
-    // silent on functional assertions alone).
+    // The dupe+free churn per scene load is negligible compared to
+    // the bug surface of the prior short-circuit. We now positively
+    // assert the new behavior: pointer MOVES on every call.
     var game = TestGame.init(testing.allocator);
     defer game.deinit();
 
@@ -1148,7 +1149,60 @@ test "rfc596: same-name reapply is a no-op (stable backing ptr)" {
     , PREFAB_DIR);
     const ptr_after = game.getState().ptr;
 
-    try testing.expectEqual(ptr_before, ptr_after);
+    // New contract: dupe+free churn means a fresh backing slot every
+    // time. Allocator MAY hand back the same address by coincidence
+    // (testing.allocator's GPA generally doesn't immediately reuse
+    // freed slots at the same size, but it's not a hard guarantee).
+    // We assert *inequality* as the documented contract; if the
+    // allocator ever does coincidentally reuse, this test will need
+    // a PoisonAllocator-backed value check instead. For now testing
+    // .allocator reliably hands back a different address.
+    try testing.expect(ptr_before != ptr_after);
+    try testing.expectEqualStrings("playing", game.getState());
+}
+
+test "rfc596: applyFileMetaDirectives recovers state after external setState (cursor MEDIUM regression)" {
+    // PR #599 fix #3 regression test. Pre-fix-#3 sequence:
+    //
+    //   1. Load bundle with meta.initial_state="playing"
+    //      → game.game_state = owned_initial_state = "playing"
+    //   2. game.setState("debug")
+    //      → game.game_state aliases the literal "debug"
+    //      → owned_initial_state still backs "playing"
+    //   3. Load same bundle again (meta.initial_state="playing")
+    //      → fix #2's short-circuit fires (owned == "playing")
+    //      → applyFileMetaDirectives returns immediately
+    //      → game.game_state STAYS as "debug" — directive silently
+    //        ignored.
+    //
+    // Post-fix-#3: no short-circuit. The dupe + setState path runs,
+    // and setState's eql("debug", "playing") fails, so setState
+    // reassigns and game.game_state ends up at "playing" as the
+    // directive demands.
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    try Bridge.loadSceneFromSource(&game,
+        \\[
+        \\  { "meta": { "initial_state": "playing" } },
+        \\  { "Marker": { "id": 1 } }
+        \\]
+    , PREFAB_DIR);
+    try testing.expectEqualStrings("playing", game.getState());
+
+    // External state mutation between loads.
+    game.setState("debug");
+    try testing.expectEqualStrings("debug", game.getState());
+
+    // Re-apply the same meta directive — must recover the demanded
+    // state, NOT silently leave the game in "debug".
+    try Bridge.loadSceneFromSource(&game,
+        \\[
+        \\  { "meta": { "initial_state": "playing" } },
+        \\  { "Marker": { "id": 2 } }
+        \\]
+    , PREFAB_DIR);
+
     try testing.expectEqualStrings("playing", game.getState());
 }
 

--- a/test/jsonc/unified_format_test.zig
+++ b/test/jsonc/unified_format_test.zig
@@ -946,3 +946,84 @@ test "rfc596: entity-level meta with initial_state does NOT change game_state" {
     try testing.expectEqualStrings("running", game.getState());
     try testing.expectEqual(@as(i32, 100), soleMarker(&game).id);
 }
+
+// A poisoning allocator wrapper: stamps freed regions with `0xDE`
+// before forwarding to the inner allocator. Used to force the
+// `meta.initial_state` UAF below to surface deterministically —
+// without it, freed arena memory still spells "playing" by accident
+// (GPA does not actively scribble on free) and the regression test
+// is a no-op.
+const PoisonAllocator = struct {
+    inner: std.mem.Allocator,
+
+    fn alloc(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ra: usize) ?[*]u8 {
+        const self: *PoisonAllocator = @ptrCast(@alignCast(ctx));
+        return self.inner.rawAlloc(len, alignment, ra);
+    }
+
+    fn resize(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) bool {
+        const self: *PoisonAllocator = @ptrCast(@alignCast(ctx));
+        return self.inner.rawResize(buf, alignment, new_len, ra);
+    }
+
+    fn remap(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, new_len: usize, ra: usize) ?[*]u8 {
+        const self: *PoisonAllocator = @ptrCast(@alignCast(ctx));
+        return self.inner.rawRemap(buf, alignment, new_len, ra);
+    }
+
+    fn free(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, ra: usize) void {
+        const self: *PoisonAllocator = @ptrCast(@alignCast(ctx));
+        @memset(buf, 0xDE);
+        self.inner.rawFree(buf, alignment, ra);
+    }
+
+    fn allocator(self: *PoisonAllocator) std.mem.Allocator {
+        return .{
+            .ptr = self,
+            .vtable = &.{
+                .alloc = alloc,
+                .resize = resize,
+                .remap = remap,
+                .free = free,
+            },
+        };
+    }
+};
+
+test "rfc596: bundle meta.initial_state survives parse_arena.deinit (UAF regression)" {
+    // Regression for a real use-after-free caught on PR #599:
+    // `applyFileMetaDirectives` (scene_loader.zig) reads `state_name`
+    // from the bundle header (`meta.initial_state`) — a slice into the
+    // loader's `parse_arena` — and passes it straight to `setState`,
+    // which stores by reference (`state_mixin.zig`: `self.game_state = new_state`).
+    // The arena is `defer`-freed before `loadSceneFile` /
+    // `loadSceneSource` returns, so `game.game_state` ended up
+    // dangling for any subsequent read.
+    //
+    // The happy-path tests above read `getState()` after `boot()`
+    // returns and happen to see the right bytes because freed memory
+    // still contains the original string — the UAF is latent. This
+    // test wraps the game allocator in `PoisonAllocator`, which
+    // stamps `0xDE` over every freed region. A slice into freed
+    // arena memory then observes poison, not "playing".
+    //
+    // Pre-fix: the assertion sees 0xDE bytes and fails.
+    // Post-fix: `applyFileMetaDirectives` dupes onto `game.allocator`
+    // and stores the owned backing on `game.owned_initial_state`,
+    // so the value survives the arena teardown.
+    var poison = PoisonAllocator{ .inner = testing.allocator };
+    var game = TestGame.init(poison.allocator());
+    defer game.deinit();
+    try Bridge.loadSceneFromSource(&game,
+        \\[
+        \\  { "meta": { "initial_state": "playing" } },
+        \\  { "Marker": { "id": 1 } }
+        \\]
+    , PREFAB_DIR);
+
+    // After load, the parse_arena has been freed and `PoisonAllocator`
+    // has overwritten its bytes with 0xDE. If `game.game_state` still
+    // aliased into the arena (pre-fix), this read would see poison.
+    try testing.expectEqualStrings("playing", game.getState());
+    try testing.expectEqual(@as(i32, 1), soleMarker(&game).id);
+}

--- a/test/jsonc/unified_format_test.zig
+++ b/test/jsonc/unified_format_test.zig
@@ -844,3 +844,105 @@ test "rfc596: flat-inline entity as a children[] item still works after tighteni
     try testing.expectEqual(@as(i32, 2), game.ecs_backend.getComponent(child, Marker).?.id);
     try testing.expectEqual(@as(f32, 50), game.ecs_backend.getComponent(child, Health).?.current);
 }
+
+// ── RFC #596 update: file-header meta carries engine directives ──
+//
+// The bundle file-header `meta:` block is no longer a pure dump —
+// engine-known keys (`initial_state`, plus reserved `scripts` /
+// `include`) are applied to the load context BEFORE entities spawn.
+// Unknown lowercase keys (`name`, `author`, `draft`, …) remain
+// authoring-only and never reach the runtime. Entity-level `meta:`
+// is still stripped unchanged (regression pin).
+
+test "rfc596: bundle header with initial_state directive transitions game_state" {
+    // `meta.initial_state: "playing"` switches the game to "playing"
+    // before any entity spawns. `TestGame` defaults to "running"
+    // (set in `game.zig:284`), so any change here came from the
+    // file-header meta dispatch — not from a script, not from
+    // SceneEntry.initial_state (no SceneEntry exists at this code
+    // path: scenes loaded through `loadSceneFromSource` bypass the
+    // scene registry).
+    var game = try boot(
+        \\[
+        \\  { "meta": { "initial_state": "playing" } },
+        \\  { "Marker": { "id": 1 } }
+        \\]
+    );
+    defer game.deinit();
+
+    try testing.expectEqualStrings("playing", game.getState());
+    // Entity still spawned (directive runs alongside the entity load).
+    try testing.expectEqual(@as(i32, 1), soleMarker(&game).id);
+}
+
+test "rfc596: bundle header with free-form meta keys is ignored (no state change)" {
+    // `author`, `draft`, and other lowercase non-engine keys are
+    // valid free-form authoring metadata. They MUST NOT affect the
+    // engine — the loader ignores them silently (no warn, no error).
+    var game = try boot(
+        \\[
+        \\  { "meta": { "author": "alexandre", "draft": true, "version": 3 } },
+        \\  { "Marker": { "id": 7 } }
+        \\]
+    );
+    defer game.deinit();
+
+    // Default game_state untouched.
+    try testing.expectEqualStrings("running", game.getState());
+    try testing.expectEqual(@as(i32, 7), soleMarker(&game).id);
+}
+
+test "rfc596: bundle header with mixed engine + free-form meta applies engine key only" {
+    // `meta.initial_state` is consumed; `meta.author` is ignored.
+    // Both coexisting in the same header is the documented shape.
+    var game = try boot(
+        \\[
+        \\  { "meta": { "initial_state": "playing", "author": "A", "name": "Demo" } },
+        \\  { "Marker": { "id": 42 } }
+        \\]
+    );
+    defer game.deinit();
+
+    try testing.expectEqualStrings("playing", game.getState());
+    try testing.expectEqual(@as(i32, 42), soleMarker(&game).id);
+}
+
+test "rfc596: bundle without header leaves game_state at default (regression)" {
+    // Pin the no-header path: a bundle whose first element is an
+    // entity (no `meta:`-only file header) MUST NOT trigger the
+    // directive dispatch. The default game_state ("running") is
+    // preserved.
+    var game = try boot(
+        \\[
+        \\  { "Marker": { "id": 1 } },
+        \\  { "Marker": { "id": 2 } }
+        \\]
+    );
+    defer game.deinit();
+
+    try testing.expectEqualStrings("running", game.getState());
+    var buf: [8]i32 = undefined;
+    try testing.expectEqualSlices(i32, &.{ 1, 2 }, markerIds(&game, &buf));
+}
+
+test "rfc596: entity-level meta with initial_state does NOT change game_state" {
+    // Entity-scope `meta:` is authoring-only — it's stripped at
+    // load and never consulted for engine directives. The asymmetric
+    // semantics rationale: only the file-header `meta:` carries
+    // engine directives; per-entity `meta:` is opaque label data.
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    try Bridge.addEmbeddedPrefab(&game, "widget",
+        \\{ "root": { "components": { "Marker": { "id": 100 } } } }
+    , PREFAB_DIR);
+    try Bridge.loadSceneFromSource(&game,
+        \\{ "children": [
+        \\  { "prefab": "widget", "meta": { "initial_state": "playing" } }
+        \\] }
+    , PREFAB_DIR);
+
+    // Game stayed at the default — entity-meta is opaque to the engine.
+    try testing.expectEqualStrings("running", game.getState());
+    try testing.expectEqual(@as(i32, 100), soleMarker(&game).id);
+}

--- a/test/jsonc/unified_format_test.zig
+++ b/test/jsonc/unified_format_test.zig
@@ -1027,3 +1027,163 @@ test "rfc596: bundle meta.initial_state survives parse_arena.deinit (UAF regress
     try testing.expectEqualStrings("playing", game.getState());
     try testing.expectEqual(@as(i32, 1), soleMarker(&game).id);
 }
+
+test "rfc596: two consecutive meta.initial_state loads with different names — no second-order UAF" {
+    // Second-order UAF caught on PR #599's first fix:
+    //
+    //   const owned = dupe(state_name);
+    //   if (old) |o| free(o);          // game.game_state still aliases `o`
+    //   game.owned_initial_state = owned;
+    //   game.setState(owned);          // setState reads game.game_state in eql — UAF
+    //
+    // The first call leaves `game.game_state` aliasing the first
+    // owned slot. The second call frees that slot *before* setState,
+    // and PoisonAllocator stamps it with 0xDE. setState's
+    // `std.mem.eql(self.game_state, new_state)` then probes freed
+    // memory.
+    //
+    // Pre-fix on a debug build: a `[]const u8` comparison against a
+    // 0xDE-stamped buffer may early-mismatch (no crash) or read
+    // freed bytes (UB, potentially crash under sanitizers). The
+    // assertion below — that game.game_state reads back as "paused"
+    // — would also fail, because under poison the second setState
+    // can mis-decide and the field can end up pointing wherever the
+    // poison left it.
+    //
+    // Post-fix the eql probe runs against the still-live old slot
+    // (or default literal), setState assigns game.game_state =
+    // new_owned, and we free old_owned afterwards.
+    var poison = PoisonAllocator{ .inner = testing.allocator };
+    var game = TestGame.init(poison.allocator());
+    defer game.deinit();
+
+    try Bridge.loadSceneFromSource(&game,
+        \\[
+        \\  { "meta": { "initial_state": "playing" } },
+        \\  { "Marker": { "id": 1 } }
+        \\]
+    , PREFAB_DIR);
+    try testing.expectEqualStrings("playing", game.getState());
+
+    try Bridge.loadSceneFromSource(&game,
+        \\[
+        \\  { "meta": { "initial_state": "paused" } },
+        \\  { "Marker": { "id": 2 } }
+        \\]
+    , PREFAB_DIR);
+    try testing.expectEqualStrings("paused", game.getState());
+}
+
+test "rfc596: two consecutive meta.initial_state loads with SAME name — no dangle, no churn" {
+    // If the same state name is applied twice in a row, the
+    // owned-slot short-circuit should fire (post-fix). Pre-fix's
+    // ordering would still free + dupe + setState — and even if
+    // the dupe happens to land at the same address (it won't under
+    // PoisonAllocator + testing.allocator), the early-return inside
+    // setState (eql with freed-then-poisoned bytes) leaves
+    // game.game_state permanently aliasing the freed slot.
+    //
+    // Post-fix: second call short-circuits at the eql probe of
+    // `existing` (the still-live owned slot from the first call)
+    // against `state_name` — no free, no dupe, no setState. The
+    // value read back is still "playing".
+    var poison = PoisonAllocator{ .inner = testing.allocator };
+    var game = TestGame.init(poison.allocator());
+    defer game.deinit();
+
+    try Bridge.loadSceneFromSource(&game,
+        \\[
+        \\  { "meta": { "initial_state": "playing" } },
+        \\  { "Marker": { "id": 1 } }
+        \\]
+    , PREFAB_DIR);
+
+    try Bridge.loadSceneFromSource(&game,
+        \\[
+        \\  { "meta": { "initial_state": "playing" } },
+        \\  { "Marker": { "id": 2 } }
+        \\]
+    , PREFAB_DIR);
+
+    // game.game_state must still read "playing" — not poison.
+    try testing.expectEqualStrings("playing", game.getState());
+}
+
+test "rfc596: same-name reapply is a no-op (stable backing ptr)" {
+    // Pointer-identity probe that catches the pre-fix path
+    // deterministically. Pre-fix on the second call:
+    //   - dupe a fresh "playing" → owned2
+    //   - free owned1 (which game.game_state aliased — that's the
+    //     UAF read in setState's eql)
+    //   - assign game.game_state = owned2
+    //   → game.getState().ptr CHANGES across the two calls.
+    //
+    // Post-fix:
+    //   - short-circuit at the `existing` eql probe — no allocation,
+    //     no free, no setState
+    //   → game.getState().ptr is STABLE across the two calls.
+    //
+    // Asserting ptr identity is an implementation-detail check, but
+    // it's the exact property the no-churn short-circuit guarantees,
+    // and it surfaces the pre-fix's spurious realloc/free without
+    // needing sanitizer support (Zig's stock GPA does not actively
+    // trap reads on freed slots, so the eql probe's UAF read is
+    // silent on functional assertions alone).
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    try Bridge.loadSceneFromSource(&game,
+        \\[
+        \\  { "meta": { "initial_state": "playing" } },
+        \\  { "Marker": { "id": 1 } }
+        \\]
+    , PREFAB_DIR);
+    const ptr_before = game.getState().ptr;
+
+    try Bridge.loadSceneFromSource(&game,
+        \\[
+        \\  { "meta": { "initial_state": "playing" } },
+        \\  { "Marker": { "id": 2 } }
+        \\]
+    , PREFAB_DIR);
+    const ptr_after = game.getState().ptr;
+
+    try testing.expectEqual(ptr_before, ptr_after);
+    try testing.expectEqualStrings("playing", game.getState());
+}
+
+test "rfc596: meta.initial_state matching pre-set non-owned literal — no free of literal" {
+    // If a prior code path (comptime codegen, manual `setState`)
+    // left `game.game_state` aliasing a string literal whose value
+    // happens to equal the bundle's `meta.initial_state`, the
+    // loader must not attempt to free the literal — and the field
+    // must still read back correctly after the call.
+    //
+    // Post-fix walk:
+    //   - `owned_initial_state` is null on entry → short-circuit
+    //     does NOT fire.
+    //   - We dupe `new_owned`.
+    //   - `owned_initial_state = new_owned`.
+    //   - `setState(new_owned)`: eql(literal, new_owned) → true →
+    //     early-return. `game.game_state` keeps aliasing the literal.
+    //   - `old_owned` is null → no free attempt.
+    //
+    // No literal is freed, no UAF, value reads correctly.
+    var poison = PoisonAllocator{ .inner = testing.allocator };
+    var game = TestGame.init(poison.allocator());
+    defer game.deinit();
+
+    // Force game.game_state to a literal "playing" *before* the
+    // meta-directive load. This mimics the comptime-codegen path
+    // (and is also what a script could do).
+    game.setState("playing");
+
+    try Bridge.loadSceneFromSource(&game,
+        \\[
+        \\  { "meta": { "initial_state": "playing" } },
+        \\  { "Marker": { "id": 1 } }
+        \\]
+    , PREFAB_DIR);
+
+    try testing.expectEqualStrings("playing", game.getState());
+}


### PR DESCRIPTION
## Summary

RFC #596 (PR #596, SHA \`ae17556\`) was just updated to specify that a bundle file-header \`meta:\` block carries **documented engine directives**, not just opaque authoring labels. The first directive is \`initial_state\` — \`meta.initial_state: \"<state>\"\` switches the game's state machine to \`<state>\` BEFORE entities spawn, so state-gated scripts see the requested state on the first tick.

Today, the bundle arm of \`processSceneValue\` captured \`bundle.file_meta\` into the \`TopLevel.bundle\` union and immediately dropped it (\`_ = bundle.file_meta\` at \`src/jsonc/scene_loader.zig:483\`). PR #597 added the capture; this PR makes the engine actually consume the documented engine-known keys before dropping the rest.

## Change

A small \`applyFileMetaDirectives\` helper in \`src/jsonc/scene_loader.zig\`:

\`\`\`zig
fn applyFileMetaDirectives(game: *GameType, file_meta: ?Value) void {
    const meta_val = file_meta orelse return;
    const meta_obj = meta_val.asObject() orelse return;
    if (meta_obj.getString(\"initial_state\")) |state_name| {
        if (!std.mem.eql(u8, game.game_state, state_name)) {
            game.log.info(\"[scene] file-header meta.initial_state '{s}' → '{s}' (RFC #596)\", .{ game.game_state, state_name });
        }
        game.setState(state_name);
    }
    // Future engine-known keys (`scripts`, `include`) dispatch here.
    // `name` and any other lowercase keys are authoring-only.
}
\`\`\`

Wired into BOTH \`loadSceneFile\` and \`loadSceneSource\` in the \`.bundle\` arm so file-based loads and embedded/in-memory loads see identical behavior.

### What's consumed today

- \`meta.initial_state\` → \`game.setState(state_name)\`. Logs the transition for grep-ability.

### What's documented-but-reserved (no code yet)

- \`meta.scripts\` and \`meta.include\` are reserved by the RFC but unused by FP today (assembler examples use \`include\` separately). When a consumer lands they'd join the same dispatch in \`applyFileMetaDirectives\`.

### What's ignored silently

- \`meta.name\`, \`meta.author\`, \`meta.draft\`, and any other lowercase non-engine keys. They're valid free-form authoring metadata; loader doesn't warn, doesn't error.

### What's untouched

- Entity-level \`meta:\` is still stripped at the entity scope (no engine read). Per the RFC's asymmetric semantics rationale: only the file-header \`meta:\` carries engine directives; per-entity \`meta:\` is opaque label data.

## Test coverage

5 new tests in \`test/jsonc/unified_format_test.zig\`:

1. \`bundle header with initial_state directive transitions game_state\` — the headline behavior.
2. \`bundle header with free-form meta keys is ignored\` — author/draft/version don't touch state.
3. \`bundle header with mixed engine + free-form meta\` — engine key applied, others ignored.
4. \`bundle without header leaves game_state at default\` — regression pin: no-header bundles still default to \"running\".
5. \`entity-level meta with initial_state does NOT change game_state\` — regression pin: entity-meta is opaque to the engine.

## Verify

- \`zig build test\` — green (44/44 in unified_format_test, all other suites pass).
- \`zig build spec\` — green (28/28).

## Notes

- Surfacing \`file_meta\` did NOT require touching \`scene_loader\`'s signature — \`TopLevel.bundle.file_meta\` was already plumbed through by PR #597.
- The bundle arm and (potential future) single-root path are intentionally not yet unified — single-root files don't currently carry a top-level \`meta:\` block in the schema; the RFC reserves that shape for later.

## Test plan

- [x] \`zig build test\` green
- [x] \`zig build spec\` green
- [ ] Confirm flying-platform-labelle bundles with \`meta.initial_state\` transition state correctly (downstream consumer)