### PR TITLE
fix: re-export GameEvents from GameConfig so plugin emit gates pass (#601)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xe8a81a8dc7f48c87,
     .name = .engine,
-    .version = "1.48.0",
+    .version = "1.48.1",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{

--- a/src/game.zig
+++ b/src/game.zig
@@ -44,7 +44,7 @@ pub fn GameConfig(
     comptime LogSinkImpl: type,
     comptime ComponentsType: type,
     comptime GizmoCategoriesSlice: anytype,
-    comptime GameEvents: type,
+    comptime GameEventsParam: type,
 ) type {
     // Validate renderer satisfies the contract
     _ = core.RenderInterface(RenderImpl);
@@ -58,8 +58,8 @@ pub fn GameConfig(
     const Children = ChildrenComponent(Entity);
     const PrefabChildT = PrefabChild(Entity);
     const EnginePayload = hooks_types.HookPayload(Entity);
-    const has_events = GameEvents != void;
-    const Payload = if (has_events) core.MergeHookPayloads(.{ EnginePayload, GameEvents }) else EnginePayload;
+    const has_events = GameEventsParam != void;
+    const Payload = if (has_events) core.MergeHookPayloads(.{ EnginePayload, GameEventsParam }) else EnginePayload;
     const has_hooks = Hooks != void;
     const HooksIsMerged = has_hooks and @typeInfo(Hooks) == .pointer and @hasDecl(@typeInfo(Hooks).pointer.child, "emit");
     const HooksField = if (!has_hooks)
@@ -68,7 +68,7 @@ pub fn GameConfig(
         ?Hooks
     else
         ?HookDispatcher(Payload, Hooks, .{});
-    const EventBuffer = if (has_events) std.ArrayList(GameEvents) else void;
+    const EventBuffer = if (has_events) std.ArrayList(GameEventsParam) else void;
 
     return struct {
         const Self = @This();
@@ -79,6 +79,12 @@ pub fn GameConfig(
         pub const TombstoneEntry = struct { entity: Entity, frame: u64 };
 
         pub const EntityType = Entity;
+        /// Re-export the game-event union so plugins can gate their
+        /// dual-emit on `@hasDecl(Game, "GameEvents")` + reflect against
+        /// `Game.GameEvents` (e.g. labelle-box2d's `emitGameEvent`).
+        /// Without this, plugin events compile to a silent no-op in every
+        /// assembled game (labelle-engine#601).
+        pub const GameEvents = GameEventsParam;
         pub const EcsBackend = EcsImpl;
         pub const SpriteComp = Sprite;
         pub const ShapeComp = Shape;


### PR DESCRIPTION
Fixes #601. `GameConfig` took `GameEvents` as a comptime param but exposed only `EntityType`/`EcsBackend`/… on the returned struct — not `GameEvents`. So labelle-box2d's `emitGameEvent` gate `@hasDecl(Game, "GameEvents")` was always false and **plugin collision/sensor events compiled to a no-op in every assembled game** (only legacy `on_collision_*` callbacks worked). The unit test missed it by calling `game.emit(...)` directly.

Renames the param to `GameEventsParam` (a decl can't share the param name — it shadows) and adds `pub const GameEvents = GameEventsParam`. `zig build test` green. Bumps 1.48.0 → 1.48.1.

Verified end-to-end: with this fix, bouncing-ball's flow prints `hits: 1, 2, 3…` on collisions. Unblocks flow-codegen#20.