### PR TITLE
feat: scaled, pause-aware gameplay clock (game.elapsedSeconds)

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -1657,7 +1657,11 @@ pub fn GameConfig(
 
         pub fn tick(self: *Self, dt: f32) void {
             const scaled_dt = dt * self.time_scale;
-            self.clock_s += @as(f64, scaled_dt);
+            // Freeze the gameplay clock under EITHER pause path — the
+            // `paused` flag (#465) doesn't zero `time_scale`, so guarding
+            // on `isPaused()` (paused OR time_scale==0) is what makes a
+            // Cooldown/Delay hold behind a pause menu (bugbot/gemini #603).
+            if (!self.isPaused()) self.clock_s += @as(f64, scaled_dt);
 
             // Drain any worker-decoded asset uploads onto the GPU.
             // Without this no acquired asset ever reaches `.ready`,

--- a/src/game.zig
+++ b/src/game.zig
@@ -318,6 +318,15 @@ pub fn GameConfig(
         /// just stores + dispatches the bool.
         paused: bool = false,
 
+        /// Monotonic gameplay clock in seconds, accumulated from the
+        /// *time-scaled* dt each `tick()` — so it freezes while paused
+        /// (`time_scale == 0`) and slows under slow-mo. Read via
+        /// `elapsedSeconds()`; flow `Cooldown`/`Delay` nodes (#25) time
+        /// against it so gameplay timers don't advance on a pause menu.
+        /// Distinct from `game_log.elapsed_s`, which stays wall-time for
+        /// log stamps.
+        clock_s: f64 = 0,
+
         /// Connect-out preview channel to the labelle-gui editor
         /// (`--preview-mode <host:port>`). `null` in normal runs — the
         /// generated `main.zig` constructs a `Preview` and assigns it
@@ -1640,8 +1649,15 @@ pub fn GameConfig(
             self.setPaused(false);
         }
 
+        /// Seconds of gameplay time elapsed (time-scaled, pause-aware) —
+        /// the clock flow `Cooldown`/`Delay` nodes (#25) measure against.
+        pub fn elapsedSeconds(self: *const Self) f64 {
+            return self.clock_s;
+        }
+
         pub fn tick(self: *Self, dt: f32) void {
             const scaled_dt = dt * self.time_scale;
+            self.clock_s += @as(f64, scaled_dt);
 
             // Drain any worker-decoded asset uploads onto the GPU.
             // Without this no acquired asset ever reaches `.ready`,

--- a/test/pause_hook_test.zig
+++ b/test/pause_hook_test.zig
@@ -136,3 +136,24 @@ test "elapsedSeconds accumulates time-scaled dt and freezes while paused" {
     game.tick(1.0);
     try testing.expectApproxEqAbs(@as(f64, 1.25), game.elapsedSeconds(), 1e-6);
 }
+
+test "elapsedSeconds freezes under the paused flag even at full time_scale" {
+    // The `paused` flag (#465) is independent of `time_scale` — pausing
+    // through it leaves time_scale at 1.0, so the clock must gate on
+    // isPaused(), not just a zero scale (bugbot/gemini #603).
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    game.tick(0.5);
+    try testing.expectApproxEqAbs(@as(f64, 0.5), game.elapsedSeconds(), 1e-6);
+
+    game.setPaused(true); // does NOT touch time_scale (stays 1.0)
+    try testing.expect(game.isPaused());
+    try testing.expectEqual(@as(f32, 1.0), game.getTimeScale());
+    game.tick(1.0);
+    try testing.expectApproxEqAbs(@as(f64, 0.5), game.elapsedSeconds(), 1e-6); // frozen
+
+    game.setPaused(false);
+    game.tick(0.25);
+    try testing.expectApproxEqAbs(@as(f64, 0.75), game.elapsedSeconds(), 1e-6);
+}

--- a/test/pause_hook_test.zig
+++ b/test/pause_hook_test.zig
@@ -105,3 +105,34 @@ test "setPaused(false) when already false is a no-op" {
     try testing.expectEqual(@as(usize, 0), recorder.changes.items.len);
     try testing.expect(!game.isPaused());
 }
+
+// ── Gameplay clock (#25) ─────────────────────────────────────────────────
+
+test "elapsedSeconds starts at zero" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+    try testing.expectEqual(@as(f64, 0), game.elapsedSeconds());
+}
+
+test "elapsedSeconds accumulates time-scaled dt and freezes while paused" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    // Running at normal scale: the clock tracks dt.
+    game.tick(0.5);
+    try testing.expectApproxEqAbs(@as(f64, 0.5), game.elapsedSeconds(), 1e-6);
+    game.tick(0.25);
+    try testing.expectApproxEqAbs(@as(f64, 0.75), game.elapsedSeconds(), 1e-6);
+
+    // Paused (time_scale == 0): scaled dt is 0, so the clock holds —
+    // a Cooldown/Delay must not advance behind a pause menu.
+    game.pause();
+    game.tick(1.0);
+    try testing.expectApproxEqAbs(@as(f64, 0.75), game.elapsedSeconds(), 1e-6);
+
+    // Slow-mo (0.5×): the clock advances at half rate.
+    game.resume_();
+    game.setTimeScale(0.5);
+    game.tick(1.0);
+    try testing.expectApproxEqAbs(@as(f64, 1.25), game.elapsedSeconds(), 1e-6);
+}


### PR DESCRIPTION
Stage 1 dependency for flow time nodes (flow-codegen#47 / #25).

Adds a monotonic gameplay clock read via `game.elapsedSeconds() f64`:
- accumulates the **time-scaled** dt in `tick()` (`clock_s += dt * time_scale`), so it **freezes while paused** (`time_scale == 0`) and slows under slow-mo — gameplay timers shouldn't tick behind a pause menu.
- kept distinct from `game_log.elapsed_s` (which stays wall-time for log stamps).

Flow `Cooldown` (now) and `Delay` (Stage 2) lower to `game.elapsedSeconds()` comparisons.

Tests: clock starts at 0, accumulates dt, freezes when paused, advances at half-rate under 0.5× (in `test/pause_hook_test.zig`). `zig build test` green.