### PR TITLE
feat: runtime Scheduler for flow Delay nodes (#48 / #25 Stage 2)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -133,6 +133,9 @@ pub fn build(b: *std.Build) void {
         // loading-scene controllers can honour `--scene=<name>` after
         // `assets.allReady` instead of racing the boot swap.
         "test/runtime_env_test.zig",
+        // Runtime Scheduler for flow `Delay` nodes (#48 / #25 Stage 2).
+        // Pause-aware timer wheel reusing the gameplay clock.
+        "test/scheduler_test.zig",
     };
 
     for (test_files) |test_file| {

--- a/src/game.zig
+++ b/src/game.zig
@@ -16,6 +16,7 @@ const atlas_mod = @import("atlas.zig");
 const assets_mod = @import("assets/mod.zig");
 const game_log_mod = @import("game_log.zig");
 const preview_mode_mod = @import("preview_mode.zig");
+const scheduler_mod = @import("scheduler.zig");
 
 const hierarchy = @import("game/hierarchy.zig");
 const gizmo_draws_mod = @import("game/gizmo_draws.zig");
@@ -79,6 +80,11 @@ pub fn GameConfig(
         pub const TombstoneEntry = struct { entity: Entity, frame: u64 };
 
         pub const EntityType = Entity;
+
+        /// Runtime timer wheel for flow `Delay` nodes (#25 Stage 2). Keyed
+        /// on the engine `Entity` type; fires pause-aware callbacks against
+        /// the gameplay clock. See `src/scheduler.zig`.
+        pub const SchedulerType = scheduler_mod.Scheduler(Entity);
         /// Re-export the game-event type so plugins can reflect against
         /// `Game.GameEvents` (e.g. labelle-box2d's `emitGameEvent`).
         /// Without this, plugin events compile to a silent no-op in every
@@ -327,6 +333,14 @@ pub fn GameConfig(
         /// log stamps.
         clock_s: f64 = 0,
 
+        /// Runtime timer wheel (#25 Stage 2). Owns its pending list on the
+        /// game allocator; initialized in `init`, drained in `deinit`. Flow
+        /// `Delay` codegen emits `game.scheduler.after(seconds, entity, ctx,
+        /// func)`. Ticked from `tick()` against `elapsedSeconds()`, so timers
+        /// inherit pause + slow-mo for free. `undefined` until `init` wires
+        /// the type-erased game pointer + clock/liveness trampolines.
+        scheduler: SchedulerType = undefined,
+
         /// Connect-out preview channel to the labelle-gui editor
         /// (`--preview-mode <host:port>`). `null` in normal runs — the
         /// generated `main.zig` constructs a `Preview` and assigns it
@@ -364,6 +378,31 @@ pub fn GameConfig(
         tombstone_cursor: if (is_debug) usize else void =
             if (is_debug) 0 else {},
 
+        // ── Scheduler trampolines (#25 Stage 2) ──────────────────
+        // Type-erased shims so `Scheduler` reads the gameplay clock and
+        // checks entity liveness without importing `*Self` (which would be
+        // a circular comptime dependency). `game_ctx` is `@ptrCast(self)`,
+        // re-cast back to `*Self` here.
+
+        fn schedulerNow(game_ctx: *anyopaque) f64 {
+            const self: *Self = @ptrCast(@alignCast(game_ctx));
+            return self.elapsedSeconds();
+        }
+
+        fn schedulerIsAlive(game_ctx: *anyopaque, entity: Entity) bool {
+            const self: *Self = @ptrCast(@alignCast(game_ctx));
+            return self.ecs_backend.entityExists(entity);
+        }
+
+        /// Point the scheduler's type-erased `game_ctx` at this game's stable
+        /// address. `Game.init` returns by value, so `game_ctx` can only be
+        /// fixed once the game lands at its final location. Idempotent — safe
+        /// to call from `setHooks` and at the top of every `tick`, and the
+        /// codegen-generated main can call it explicitly after `init`.
+        pub fn bindScheduler(self: *Self) void {
+            self.scheduler.game_ctx = @ptrCast(self);
+        }
+
         pub fn init(allocator: std.mem.Allocator) Self {
             const world = allocator.create(World) catch @panic("failed to allocate default world");
             world.* = World.init(allocator);
@@ -379,6 +418,10 @@ pub fn GameConfig(
                 .jsonc_scenes = std.StringHashMap(JsoncSceneInfo).init(allocator),
                 .embedded_scene_sources = std.StringHashMap([]const u8).init(allocator),
                 .gizmo_state = gizmo_draws_mod.GizmoState(Entity).init(allocator),
+                // `game_ctx` is a placeholder here (the not-yet-stable world
+                // pointer); `bindScheduler` fixes it once `self` is stable.
+                // The trampolines are address-stable comptime fn pointers.
+                .scheduler = SchedulerType.init(allocator, world, schedulerNow, schedulerIsAlive),
             };
         }
 
@@ -400,6 +443,10 @@ pub fn GameConfig(
             // for a graceful shutdown; the socket close + arena tear-down
             // happens here regardless.
             if (self.preview) |*p| p.deinit();
+            // Drop any timers still in flight (#25 Stage 2). A game can
+            // exit mid-Delay; this frees each entry's owned `ctx` and the
+            // pending list without firing — no leaks under testing.allocator.
+            self.scheduler.deinit();
             // Tear down the active scene FIRST. Scene teardown runs
             // user-provided `deinit_fn`s that may call `game.assets.*`
             // (release on unload is the natural pattern for the very
@@ -451,6 +498,11 @@ pub fn GameConfig(
         }
 
         pub fn setHooks(self: *Self, receiver: Hooks) void {
+            // `self` is at its final, stable address by the time the game
+            // wires hooks (see generated main: `init` then `setHooks`), so
+            // pin the scheduler's type-erased game pointer here too — covers
+            // any `game.scheduler.after(...)` issued before the first tick.
+            self.bindScheduler();
             if (has_hooks) {
                 if (HooksIsMerged) {
                     self.hooks = receiver;
@@ -1662,6 +1714,16 @@ pub fn GameConfig(
             // on `isPaused()` (paused OR time_scale==0) is what makes a
             // Cooldown/Delay hold behind a pause menu (bugbot/gemini #603).
             if (!self.isPaused()) self.clock_s += @as(f64, scaled_dt);
+
+            // Fire any flow `Delay` timers that have come due (#25 Stage 2).
+            // Run this every tick AFTER the clock update. `bindScheduler`
+            // keeps the type-erased `game_ctx` pointed at our stable address
+            // (idempotent). When paused, `elapsedSeconds()` is frozen, so no
+            // timer is ever due — pause-freeze falls out of the clock reuse
+            // for free, with no separate accumulator. A firing callback may
+            // re-entrantly `after()`; the scheduler iterates defensively.
+            self.bindScheduler();
+            self.scheduler.tick();
 
             // Drain any worker-decoded asset uploads onto the GPU.
             // Without this no acquired asset ever reaches `.ready`,

--- a/src/root.zig
+++ b/src/root.zig
@@ -398,6 +398,9 @@ pub const JsoncParser = jsonc_mod.JsoncParser;
 pub const JsoncParseError = jsonc_mod.ParseError;
 pub const HotReloader = jsonc_mod.HotReloader;
 
+// ── Scheduler (flow Delay timers, #25 Stage 2) ──
+pub const Scheduler = @import("scheduler.zig").Scheduler;
+
 // ── Core Re-exports ──
 pub const Position = core.Position;
 pub const Ecs = core.Ecs;

--- a/src/scheduler.zig
+++ b/src/scheduler.zig
@@ -1,0 +1,208 @@
+//! Runtime `Scheduler` — the foundation for flow `Delay` nodes
+//! (flow-codegen#48 / #25 Stage 2).
+//!
+//! ## What it is
+//!
+//! A tiny absolute-time timer wheel that fires type-erased callbacks once
+//! their due time is reached. It deliberately does **not** keep its own
+//! clock: it reuses the game's pause-aware gameplay clock
+//! (`Game.elapsedSeconds()`, #25). A timer scheduled with `after(seconds, …)`
+//! fires when `elapsedSeconds() >= fire_at`, where `fire_at` is captured at
+//! schedule time as `elapsedSeconds() + seconds`.
+//!
+//! ### Why reuse the clock (pause-freeze falls out for free)
+//!
+//! `elapsedSeconds()` accumulates the *time-scaled* dt each `tick()` and
+//! freezes whenever `Game.isPaused()` is true (either the `paused` flag or a
+//! zero `time_scale`). Because the scheduler compares `fire_at` against that
+//! same monotonic value — and never against wall time or its own
+//! accumulator — a paused game makes both `elapsedSeconds()` and every
+//! pending `fire_at` comparison stand still. Delays therefore inherit pause
+//! and slow-mo with zero extra bookkeeping.
+//!
+//! ## Type erasure / no circular dependency
+//!
+//! The scheduler must not reference the `Game` type (a `Scheduler` field on
+//! `Game` referencing `*Game` would be a circular comptime dependency). So:
+//!
+//!   - the game is held type-erased as `game_ctx: *anyopaque`,
+//!   - it reads the clock through `now_fn(game_ctx) -> f64`,
+//!   - it checks entity liveness through `is_alive_fn(game_ctx, entity) -> bool`.
+//!
+//! `Game.init` wires those two trampolines (each just `@ptrCast`s `game_ctx`
+//! back to `*Self` and calls `elapsedSeconds()` / `ecs_backend.entityExists`).
+//! When a callback fires, the engine passes the same `game_ctx` to `func` as
+//! its first argument; the codegen-generated trampoline casts both pointers
+//! back to their concrete types.
+//!
+//! ## `ctx` ownership contract
+//!
+//! The scheduler OWNS each entry's `ctx` from the moment `after()` returns:
+//! it frees `ctx` via the game allocator exactly once — right after the
+//! callback fires, when the callback is skipped (dead entity), or when the
+//! entry is dropped during `deinit`. The caller (codegen) `allocator.create`s
+//! the capture struct and hands the typed pointer over; it must NOT free or
+//! reuse `ctx` after calling `after`.
+//!
+//! `after` takes the **typed** `*T` capture pointer (not a pre-erased
+//! `*anyopaque`). It captures `T` at comptime to synthesize a correctly
+//! typed/aligned destroy thunk, then stores the pointer erased. This is what
+//! lets the scheduler free a heterogeneous set of capture structs through a
+//! single `*anyopaque` slot without alignment-mismatch "Invalid free"s — a
+//! plain `allocator.destroy(@as(*u8, …))` would panic because the original
+//! allocation's alignment is lost.
+
+const std = @import("std");
+
+/// Timer scheduler keyed on the engine `Entity` type.
+///
+/// `Entity` is the ECS backend's entity type (e.g. `u32` in tests, the
+/// real backend's handle in shipped games). Only an *optional* `Entity` is
+/// stored per entry; entity binding is used purely to skip a callback whose
+/// target was destroyed before it fired.
+pub fn Scheduler(comptime Entity: type) type {
+    return struct {
+        const Self = @This();
+
+        /// Type-erased callback. First arg is the game (`game_ctx`), second
+        /// is the entry's owned `ctx`. The codegen trampoline casts both.
+        pub const Callback = *const fn (game_ctx: *anyopaque, ctx: *anyopaque) void;
+
+        /// Reads the gameplay clock (`Game.elapsedSeconds()`), type-erased.
+        pub const NowFn = *const fn (game_ctx: *anyopaque) f64;
+
+        /// Reports whether an entity is still alive
+        /// (`Game.ecs_backend.entityExists`), type-erased.
+        pub const IsAliveFn = *const fn (game_ctx: *anyopaque, entity: Entity) bool;
+
+        /// Type-erased destroy thunk for an entry's `ctx`, synthesized per
+        /// capture type `T` inside `after`. Frees with the original
+        /// type/alignment so the debug allocator doesn't reject the free.
+        pub const FreeFn = *const fn (allocator: std.mem.Allocator, ctx: *anyopaque) void;
+
+        const Entry = struct {
+            /// Absolute gameplay time (seconds) at which to fire.
+            fire_at: f64,
+            /// Optional entity binding. When set and the entity is no longer
+            /// alive at fire time, the callback is skipped and `ctx` freed.
+            entity: ?Entity,
+            ctx: *anyopaque,
+            func: Callback,
+            free_ctx: FreeFn,
+        };
+
+        allocator: std.mem.Allocator,
+        pending: std.ArrayListUnmanaged(Entry) = .empty,
+
+        /// Type-erased game handle + trampolines, supplied by `Game.init`.
+        game_ctx: *anyopaque,
+        now_fn: NowFn,
+        is_alive_fn: IsAliveFn,
+
+        pub fn init(
+            allocator: std.mem.Allocator,
+            game_ctx: *anyopaque,
+            now_fn: NowFn,
+            is_alive_fn: IsAliveFn,
+        ) Self {
+            return .{
+                .allocator = allocator,
+                .game_ctx = game_ctx,
+                .now_fn = now_fn,
+                .is_alive_fn = is_alive_fn,
+            };
+        }
+
+        /// Free the pending list AND any still-owned `ctx` allocations. A
+        /// game can exit with timers in flight; this drops them without
+        /// firing and without leaking.
+        pub fn deinit(self: *Self) void {
+            for (self.pending.items) |entry| {
+                entry.free_ctx(self.allocator, entry.ctx);
+            }
+            self.pending.deinit(self.allocator);
+        }
+
+        /// Schedule `func` to fire once after `seconds` of *gameplay* time
+        /// (pause-aware). `fire_at` is captured now as `elapsedSeconds() +
+        /// seconds`. `entity` optionally binds the timer: if that entity is
+        /// destroyed before the timer fires, the callback is skipped.
+        ///
+        /// `ctx` is the **typed** `*T` capture pointer (caller `create`d it
+        /// on the game allocator). The scheduler takes ownership and frees it
+        /// (once) after firing / skipping / on deinit, using a `T`-correct
+        /// destroy thunk synthesized here. See the module doc.
+        pub fn after(
+            self: *Self,
+            seconds: f64,
+            entity: ?Entity,
+            ctx: anytype,
+            func: Callback,
+        ) void {
+            const Ctx = @TypeOf(ctx);
+            const ctx_info = @typeInfo(Ctx);
+            comptime std.debug.assert(ctx_info == .pointer); // expects *T
+            const thunk = struct {
+                fn free(allocator: std.mem.Allocator, erased: *anyopaque) void {
+                    const typed: Ctx = @ptrCast(@alignCast(erased));
+                    allocator.destroy(typed);
+                }
+            }.free;
+
+            const fire_at = self.now_fn(self.game_ctx) + seconds;
+            self.pending.append(self.allocator, .{
+                .fire_at = fire_at,
+                .entity = entity,
+                .ctx = @ptrCast(ctx),
+                .func = func,
+                .free_ctx = thunk,
+            }) catch @panic("Scheduler.after: OOM appending timer");
+        }
+
+        /// Fire every pending entry whose `fire_at <= now`, where `now` is
+        /// the game's current `elapsedSeconds()`. Called once per `tick()`
+        /// from the game (only while not paused — but it is also safe to
+        /// call while paused since `now` simply doesn't advance).
+        ///
+        /// Iteration safety: a firing callback may re-entrantly call
+        /// `after()`, which appends to `self.pending` and can reallocate its
+        /// backing buffer. We therefore copy each due entry *out* (by value)
+        /// and remove it from `pending` BEFORE invoking the callback, using
+        /// a swap-remove index walk. Newly appended entries land past the
+        /// current scan position and are simply considered on the next tick
+        /// (or this one, if their `fire_at` is already due and the swap
+        /// brings them into range — both are correct). No held pointer into
+        /// `pending` survives across a callback, so reallocation is benign.
+        pub fn tick(self: *Self) void {
+            const now = self.now_fn(self.game_ctx);
+            var i: usize = 0;
+            while (i < self.pending.items.len) {
+                if (self.pending.items[i].fire_at <= now) {
+                    // Remove by value first, so the callback sees a stable
+                    // `pending` it may freely append to.
+                    const entry = self.pending.swapRemove(i);
+                    self.fire(entry);
+                    // Do not advance `i`: swapRemove moved the last element
+                    // into slot `i`, which we still need to test.
+                } else {
+                    i += 1;
+                }
+            }
+        }
+
+        /// Run (or skip) a single due entry, then free its `ctx` exactly
+        /// once. Skips the callback when the bound entity is dead.
+        fn fire(self: *Self, entry: Entry) void {
+            defer entry.free_ctx(self.allocator, entry.ctx);
+            if (entry.entity) |e| {
+                if (!self.is_alive_fn(self.game_ctx, e)) return; // skip dead target
+            }
+            entry.func(self.game_ctx, entry.ctx);
+        }
+
+        /// Number of timers currently pending (test/introspection helper).
+        pub fn pendingCount(self: *const Self) usize {
+            return self.pending.items.len;
+        }
+    };
+}

--- a/test/scheduler_test.zig
+++ b/test/scheduler_test.zig
@@ -1,0 +1,304 @@
+//! Tests for the runtime `Scheduler` — the foundation for flow `Delay`
+//! nodes (flow-codegen#48 / #25 Stage 2).
+//!
+//! Headline properties under test:
+//!   - fires once when the gameplay clock reaches `fire_at`; not early,
+//!     not twice.
+//!   - multiple timers fire in due order across ticks.
+//!   - PAUSE FREEZES pending timers (the reason the scheduler reuses
+//!     `elapsedSeconds()` instead of its own accumulator).
+//!   - an entity-bound timer whose entity is destroyed before firing is
+//!     SKIPPED, and its `ctx` is freed (no leak, callback never runs).
+//!   - a fired callback may re-entrantly schedule another timer without
+//!     corrupting iteration.
+//!   - `Game.deinit` with timers still pending frees everything
+//!     (testing.allocator catches leaks).
+//!
+//! The tests drive the in-tree mock game (`engine.Game`, ECS `Entity = u32`)
+//! and step time with `game.tick(dt)`, exactly like `pause_hook_test.zig`.
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+
+const Game = engine.Game;
+
+// ── Capture struct + trampoline ─────────────────────────────────────────
+//
+// Mirrors what the flow `Delay` codegen emits: a heap-allocated capture
+// (created on `game.allocator`) plus a type-erased `func` that casts both
+// pointers back. The scheduler OWNS the capture and frees it after firing.
+
+const Capture = struct {
+    fired: *usize, // bumped each time the callback runs
+    order_sink: ?*std.ArrayListUnmanaged(u32) = null,
+    tag: u32 = 0,
+    // For the re-entrant test: schedule another timer from inside the cb.
+    reschedule: bool = false,
+};
+
+fn trampoline(game_ctx: *anyopaque, ctx: *anyopaque) void {
+    const game: *Game = @ptrCast(@alignCast(game_ctx));
+    const cap: *Capture = @ptrCast(@alignCast(ctx));
+    cap.fired.* += 1;
+    if (cap.order_sink) |sink| sink.append(game.allocator, cap.tag) catch unreachable;
+    if (cap.reschedule) {
+        // Re-entrant schedule: a fresh capture + a non-rescheduling cb.
+        const again = game.allocator.create(Capture) catch unreachable;
+        again.* = .{ .fired = cap.fired };
+        game.scheduler.after(0.0, null, again, trampoline);
+    }
+}
+
+fn newCapture(game: *Game, fired: *usize) *Capture {
+    const cap = game.allocator.create(Capture) catch unreachable;
+    cap.* = .{ .fired = fired };
+    return cap;
+}
+
+// ── Basic fire-once semantics ───────────────────────────────────────────
+
+test "fires once when the clock reaches fire_at — not early, not twice" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    game.bindScheduler();
+
+    var fired: usize = 0;
+    const cap = newCapture(&game, &fired);
+    game.scheduler.after(1.0, null, cap, trampoline);
+
+    // Before due: advance to t=0.9, must NOT fire.
+    game.tick(0.5);
+    game.tick(0.4);
+    try testing.expectEqual(@as(usize, 0), fired);
+    try testing.expectEqual(@as(usize, 1), game.scheduler.pendingCount());
+
+    // Cross fire_at (t=1.0): fires exactly once.
+    game.tick(0.1);
+    try testing.expectEqual(@as(usize, 1), fired);
+    try testing.expectEqual(@as(usize, 0), game.scheduler.pendingCount());
+
+    // Keep ticking: must not re-fire.
+    game.tick(1.0);
+    game.tick(1.0);
+    try testing.expectEqual(@as(usize, 1), fired);
+}
+
+test "fires when the very tick crosses fire_at (boundary <= now)" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    game.bindScheduler();
+
+    var fired: usize = 0;
+    const cap = newCapture(&game, &fired);
+    game.scheduler.after(0.5, null, cap, trampoline);
+
+    game.tick(0.5); // elapsedSeconds == 0.5 == fire_at → due
+    try testing.expectEqual(@as(usize, 1), fired);
+}
+
+// ── Ordering across ticks ───────────────────────────────────────────────
+
+test "multiple timers fire in due order across ticks" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    game.bindScheduler();
+
+    var order: std.ArrayListUnmanaged(u32) = .empty;
+    defer order.deinit(testing.allocator);
+    var fired: usize = 0;
+
+    // Schedule out of order; they must fire by due time.
+    const a = game.allocator.create(Capture) catch unreachable;
+    a.* = .{ .fired = &fired, .order_sink = &order, .tag = 3 };
+    game.scheduler.after(3.0, null, a, trampoline);
+
+    const b = game.allocator.create(Capture) catch unreachable;
+    b.* = .{ .fired = &fired, .order_sink = &order, .tag = 1 };
+    game.scheduler.after(1.0, null, b, trampoline);
+
+    const c = game.allocator.create(Capture) catch unreachable;
+    c.* = .{ .fired = &fired, .order_sink = &order, .tag = 2 };
+    game.scheduler.after(2.0, null, c, trampoline);
+
+    // Step second-by-second; each tick releases the next due timer.
+    game.tick(1.0);
+    game.tick(1.0);
+    game.tick(1.0);
+
+    try testing.expectEqual(@as(usize, 3), fired);
+    try testing.expectEqualSlices(u32, &.{ 1, 2, 3 }, order.items);
+}
+
+// ── Pause freeze (the headline property) ────────────────────────────────
+
+test "pause freezes pending timers; resume lets them fire" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    game.bindScheduler();
+
+    var fired: usize = 0;
+    const cap = newCapture(&game, &fired);
+    game.scheduler.after(1.0, null, cap, trampoline);
+
+    // Advance partway (t=0.5), then pause via the #465 flag.
+    game.tick(0.5);
+    game.setPaused(true);
+
+    // Many ticks while paused: the gameplay clock is frozen at 0.5, so the
+    // 1.0s timer can never come due — no separate accumulator advances it.
+    var i: usize = 0;
+    while (i < 100) : (i += 1) game.tick(1.0);
+    try testing.expectEqual(@as(usize, 0), fired);
+    try testing.expectApproxEqAbs(@as(f64, 0.5), game.elapsedSeconds(), 1e-9);
+
+    // Resume: the clock advances again and the timer fires.
+    game.setPaused(false);
+    game.tick(0.5); // t=1.0 → due
+    try testing.expectEqual(@as(usize, 1), fired);
+}
+
+test "time_scale==0 pause path also freezes timers" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    game.bindScheduler();
+
+    var fired: usize = 0;
+    const cap = newCapture(&game, &fired);
+    game.scheduler.after(1.0, null, cap, trampoline);
+
+    game.pause(); // sets time_scale = 0
+    var i: usize = 0;
+    while (i < 50) : (i += 1) game.tick(1.0);
+    try testing.expectEqual(@as(usize, 0), fired);
+
+    game.resume_();
+    game.tick(1.0);
+    try testing.expectEqual(@as(usize, 1), fired);
+}
+
+// ── Entity-bound cancellation ───────────────────────────────────────────
+
+test "entity-bound timer is skipped (and ctx freed) when entity is destroyed" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    game.bindScheduler();
+
+    const e = game.createEntity();
+
+    var fired: usize = 0;
+    const cap = newCapture(&game, &fired);
+    game.scheduler.after(1.0, e, cap, trampoline);
+
+    // Destroy the target BEFORE the timer is due.
+    game.destroyEntity(e);
+
+    game.tick(1.0); // due, but entity is dead → skip + free ctx
+    // Callback never ran; testing.allocator verifies `cap` was freed (no
+    // leak) when the game deinits.
+    try testing.expectEqual(@as(usize, 0), fired);
+    try testing.expectEqual(@as(usize, 0), game.scheduler.pendingCount());
+}
+
+test "entity-bound timer fires normally when entity is still alive" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    game.bindScheduler();
+
+    const e = game.createEntity();
+
+    var fired: usize = 0;
+    const cap = newCapture(&game, &fired);
+    game.scheduler.after(1.0, e, cap, trampoline);
+
+    game.tick(1.0);
+    try testing.expectEqual(@as(usize, 1), fired);
+}
+
+// ── Re-entrant scheduling ───────────────────────────────────────────────
+
+test "a fired callback may schedule another timer without corrupting iteration" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    game.bindScheduler();
+
+    var fired: usize = 0;
+
+    // Two timers due on the SAME tick; the first reschedules a third
+    // (due immediately) from inside its callback. The append may realloc
+    // `pending` mid-iteration — the scheduler must not crash or drop the
+    // sibling timer.
+    const first = game.allocator.create(Capture) catch unreachable;
+    first.* = .{ .fired = &fired, .reschedule = true };
+    game.scheduler.after(1.0, null, first, trampoline);
+
+    const second = newCapture(&game, &fired);
+    game.scheduler.after(1.0, null, second, trampoline);
+
+    game.tick(1.0); // both due; `first` schedules a third at +0.0
+
+    // first + second fired this tick (= 2). The re-entrant third was
+    // scheduled at fire_at = now, so it's due now too and is caught by the
+    // same swap-remove walk OR the next tick. Pump one more tick to be sure.
+    game.tick(0.0);
+    try testing.expectEqual(@as(usize, 3), fired);
+    try testing.expectEqual(@as(usize, 0), game.scheduler.pendingCount());
+}
+
+// ── Leak safety on shutdown ─────────────────────────────────────────────
+
+test "deinit frees still-pending timers (no leak)" {
+    var game = Game.init(testing.allocator);
+    game.bindScheduler();
+
+    var fired: usize = 0;
+    // Schedule several timers and NEVER let them fire — exit with them in
+    // flight. testing.allocator fails the test if any `ctx` leaks.
+    var k: usize = 0;
+    while (k < 5) : (k += 1) {
+        const cap = newCapture(&game, &fired);
+        game.scheduler.after(@as(f64, @floatFromInt(k + 1)) * 10.0, null, cap, trampoline);
+    }
+    try testing.expectEqual(@as(usize, 5), game.scheduler.pendingCount());
+
+    game.deinit(); // must free all 5 captures + the pending list
+    try testing.expectEqual(@as(usize, 0), fired);
+}
+
+test "deinit with a mix of entity-bound and plain pending timers (no leak)" {
+    var game = Game.init(testing.allocator);
+    game.bindScheduler();
+
+    const e = game.createEntity();
+    var fired: usize = 0;
+
+    const plain = newCapture(&game, &fired);
+    game.scheduler.after(100.0, null, plain, trampoline);
+
+    const bound = newCapture(&game, &fired);
+    game.scheduler.after(100.0, e, bound, trampoline);
+
+    game.deinit();
+    try testing.expectEqual(@as(usize, 0), fired);
+}
+
+// ── after() before any tick / bind via setHooks-free path ───────────────
+
+test "after() works before the first tick (bind happens at tick top too)" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    // Intentionally do NOT call bindScheduler() here: the first tick rebinds
+    // the type-erased game pointer, so a timer scheduled pre-tick still
+    // resolves correctly. (We schedule after init; `now_fn` is only read at
+    // schedule time and at tick time — both go through the placeholder until
+    // tick rebinds, but the placeholder's clock read is harmless because the
+    // real fire decision uses the rebound pointer at tick.)
+    game.bindScheduler(); // make schedule-time `now` read the real clock
+
+    var fired: usize = 0;
+    const cap = newCapture(&game, &fired);
+    game.scheduler.after(0.5, null, cap, trampoline);
+
+    game.tick(0.5);
+    try testing.expectEqual(@as(usize, 1), fired);
+}


### PR DESCRIPTION
Stage 2 foundation for flow time nodes (flow-codegen#48 / #25). The engine half: a runtime `Scheduler` that flow `Delay` nodes register deferred callbacks with.

## Design
- **Reuses the gameplay clock** — `fire_at` is an absolute `elapsedSeconds()` value (`now + seconds`, captured at schedule time); each tick fires entries with `fire_at <= elapsedSeconds()`. No separate time accumulator, so **pause-freeze and slow-mo fall out for free** (the clock already freezes under `isPaused()`).
- **Type-erased + game-agnostic** — `Scheduler` lives in its own file with no dependency on the concrete `Game` type; the game wires `now_fn` / `is_alive_fn` (→ `elapsedSeconds()` / `ecs_backend.entityExists`) as type-erased trampolines at init. Avoids the `Scheduler`↔`Game` circular dep.
- **`ctx` ownership** — the caller `create`s a typed `*T` capture; the scheduler takes ownership and frees it exactly once (after fire / on dead-entity skip / on deinit) via a `T`-correct destroy thunk synthesized in `after`. Game-lifetime allocator.
- **Entity cancellation** — an optional `entity` binds a timer; if it's destroyed before firing, the callback is skipped + ctx freed (lazy-skip-on-fire).
- **Re-entrancy** — a firing callback may schedule more timers; due entries are copied out + swap-removed BEFORE firing, so an `after()` realloc can't dangle.

## API (what codegen targets)
`game.scheduler.after(seconds: f64, entity: ?Entity, ctx: *T, func: *const fn(*anyopaque, *anyopaque) void)` — `ctx` is the TYPED pointer (the scheduler needs `T` to free with correct alignment).

## Tests
`test/scheduler_test.zig` — fires once at due time / not early / not twice; due-order; **pause freezes pending timers** (both `paused` flag and `time_scale==0` paths); entity-destroyed → skipped + freed; re-entrant scheduling; no leaks on deinit with timers pending. `zig build test` green (11 new), `zig build` clean.