### PR TITLE
feat: engine input events (key/mouse-button/gamepad) for flows

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -96,6 +96,10 @@ pub fn build(b: *std.Build) void {
         // the buffered event path so flows can listen to lifecycle
         // hooks as Event-node variants.
         "test/engine_events_test.zig",
+        // labelle-gui#208 — engine-hosted input events scanned in
+        // `Game.tick` through the unified `InputInterface`, dual-emitted
+        // on the buffered event path so flows can listen via `OnEvent`.
+        "test/input_events_test.zig",
         "test/spawn_from_prefab_test.zig",
         "test/jsonc/bridge_prefab_tags_test.zig",
         "test/save_load_two_phase_test.zig",

--- a/src/game.zig
+++ b/src/game.zig
@@ -1756,65 +1756,62 @@ pub fn GameConfig(
         /// state is still current; buffered events drain via
         /// `dispatchEvents` the same frame.
         fn scanInputEvents(self: *Self) void {
-            // The keyboard scan unrolls `emitEngineEvent` (itself an
-            // `inline for` over the payload fields) across the full
-            // `KeyboardKey` enum (~100 keys), which blows past the
-            // default 1000-branch comptime budget. Raise it.
-            @setEvalBranchQuota(20_000);
+            // Each category's emit calls are gated at comptime (so an
+            // unused one folds away), but the per-element scans are plain
+            // RUNTIME `for`s over the comptime enum-value slices — NOT
+            // `inline for`. Unrolling ~114 keys would inline
+            // `emitEngineEvent` (itself an `inline for` over payload
+            // fields) once per key, bloating the binary and needing a big
+            // `@setEvalBranchQuota`; a runtime loop has one call site per
+            // category (gemini #606).
 
             // ── Keyboard ──
             if (comptime keyboard_events_wanted) {
-                inline for (comptime std.enums.values(input_types.KeyboardKey)) |k| {
-                    // Skip the `key_null = 0` sentinel — not a real key.
-                    if (comptime k != .key_null) {
-                        const code: u32 = @intCast(@intFromEnum(k));
-                        if (comptime engineEventWanted("engine__key_pressed")) {
-                            if (Self.Input.isKeyPressed(code))
-                                self.emitEngineEvent("engine__key_pressed", .{ .key = code });
-                        }
-                        if (comptime engineEventWanted("engine__key_released")) {
-                            if (Self.Input.isKeyReleased(code))
-                                self.emitEngineEvent("engine__key_released", .{ .key = code });
-                        }
-                    }
+                const pressed_wanted = comptime engineEventWanted("engine__key_pressed");
+                const released_wanted = comptime engineEventWanted("engine__key_released");
+                for (std.enums.values(input_types.KeyboardKey)) |k| {
+                    if (k == .key_null) continue; // sentinel, not a real key
+                    const code: u32 = @intCast(@intFromEnum(k));
+                    if (pressed_wanted and Self.Input.isKeyPressed(code))
+                        self.emitEngineEvent("engine__key_pressed", .{ .key = code });
+                    if (released_wanted and Self.Input.isKeyReleased(code))
+                        self.emitEngineEvent("engine__key_released", .{ .key = code });
                 }
             }
 
             // ── Mouse buttons ──
             if (comptime mouse_events_wanted) {
-                inline for (comptime std.enums.values(input_types.MouseButton)) |b| {
+                const pressed_wanted = comptime engineEventWanted("engine__mouse_button_pressed");
+                const released_wanted = comptime engineEventWanted("engine__mouse_button_released");
+                for (std.enums.values(input_types.MouseButton)) |b| {
                     const code: u32 = @intCast(@intFromEnum(b));
-                    if (comptime engineEventWanted("engine__mouse_button_pressed")) {
-                        if (Self.Input.isMouseButtonPressed(code))
-                            self.emitEngineEvent("engine__mouse_button_pressed", .{
-                                .button = code,
-                                .x = Self.Input.getMouseX(),
-                                .y = Self.Input.getMouseY(),
-                            });
-                    }
-                    if (comptime engineEventWanted("engine__mouse_button_released")) {
-                        if (Self.Input.isMouseButtonReleased(code))
-                            self.emitEngineEvent("engine__mouse_button_released", .{
-                                .button = code,
-                                .x = Self.Input.getMouseX(),
-                                .y = Self.Input.getMouseY(),
-                            });
-                    }
+                    if (pressed_wanted and Self.Input.isMouseButtonPressed(code))
+                        self.emitEngineEvent("engine__mouse_button_pressed", .{
+                            .button = code,
+                            .x = Self.Input.getMouseX(),
+                            .y = Self.Input.getMouseY(),
+                        });
+                    if (released_wanted and Self.Input.isMouseButtonReleased(code))
+                        self.emitEngineEvent("engine__mouse_button_released", .{
+                            .button = code,
+                            .x = Self.Input.getMouseX(),
+                            .y = Self.Input.getMouseY(),
+                        });
                 }
             }
 
             // ── Gamepad connect / disconnect (engine-side edge diff) ──
             if (comptime gamepad_events_wanted) {
-                comptime var gi: u32 = 0;
-                inline while (gi < max_tracked_gamepads) : (gi += 1) {
+                const conn_wanted = comptime engineEventWanted("engine__gamepad_connected");
+                const disc_wanted = comptime engineEventWanted("engine__gamepad_disconnected");
+                var gi: u32 = 0;
+                while (gi < max_tracked_gamepads) : (gi += 1) {
                     const now = Self.Input.isGamepadAvailable(gi);
                     const was = self.prev_gamepad_connected[gi];
                     if (now and !was) {
-                        if (comptime engineEventWanted("engine__gamepad_connected"))
-                            self.emitEngineEvent("engine__gamepad_connected", .{ .id = gi });
+                        if (conn_wanted) self.emitEngineEvent("engine__gamepad_connected", .{ .id = gi });
                     } else if (!now and was) {
-                        if (comptime engineEventWanted("engine__gamepad_disconnected"))
-                            self.emitEngineEvent("engine__gamepad_disconnected", .{ .id = gi });
+                        if (disc_wanted) self.emitEngineEvent("engine__gamepad_disconnected", .{ .id = gi });
                     }
                     self.prev_gamepad_connected[gi] = now;
                 }

--- a/src/game.zig
+++ b/src/game.zig
@@ -20,7 +20,15 @@ const scheduler_mod = @import("scheduler.zig");
 
 const hierarchy = @import("game/hierarchy.zig");
 const gizmo_draws_mod = @import("game/gizmo_draws.zig");
+const input_types = @import("input_types.zig");
 const builtin = @import("builtin");
+
+/// Number of gamepad slots the engine diffs for connect/disconnect
+/// events each frame. Matches raylib's typical `MAX_GAMEPADS` cap (4);
+/// the unified `InputInterface.isGamepadAvailable` is polled for slots
+/// `0..max_tracked_gamepads`. The per-slot previous-availability state
+/// lives in `Game.prev_gamepad_connected`.
+const max_tracked_gamepads = 4;
 
 // Mixin modules — domain-specific method groups
 const visuals_mixin = @import("game/visuals.zig");
@@ -323,6 +331,16 @@ pub fn GameConfig(
         /// `GamePaused` component into `setPaused` — and the engine
         /// just stores + dispatches the bool.
         paused: bool = false,
+
+        /// Per-slot gamepad availability as observed on the PREVIOUS
+        /// `tick`. There is no "connected-this-frame" edge query in the
+        /// input backends, so `tick`'s gamepad scan diffs the current
+        /// `Input.isGamepadAvailable(id)` against this to synthesize
+        /// `engine.gamepad_connected` / `engine.gamepad_disconnected`
+        /// edges. Tiny ([max_tracked_gamepads]bool), so it stays
+        /// unconditionally even when no flow listens — only the scan
+        /// loop is comptime-gated. labelle-gui#208.
+        prev_gamepad_connected: [max_tracked_gamepads]bool = .{false} ** max_tracked_gamepads,
 
         /// Monotonic gameplay clock in seconds, accumulated from the
         /// *time-scaled* dt each `tick()` — so it freezes while paused
@@ -1707,6 +1725,102 @@ pub fn GameConfig(
             return self.clock_s;
         }
 
+        // ── Input events (labelle-gui#208) ───────────────────────
+        //
+        // Comptime gates mirroring `emitEngineEvent`'s `@hasField`
+        // check, grouped per input category. When the project's
+        // `GameEvents` doesn't carry a category's variants, the whole
+        // scan loop for that category folds away — an unused game pays
+        // NOTHING per frame (no enum iteration, no backend polling).
+
+        /// True when `GameEvents` declares `field` (the qualified
+        /// `engine__<name>` tag). Same gate `emitEngineEvent` uses.
+        inline fn engineEventWanted(comptime field: []const u8) bool {
+            if (!has_events) return false;
+            if (@typeInfo(GameEvents) != .@"union") return false;
+            return @hasField(GameEvents, field);
+        }
+
+        const keyboard_events_wanted = engineEventWanted("engine__key_pressed") or
+            engineEventWanted("engine__key_released");
+        const mouse_events_wanted = engineEventWanted("engine__mouse_button_pressed") or
+            engineEventWanted("engine__mouse_button_released");
+        const gamepad_events_wanted = engineEventWanted("engine__gamepad_connected") or
+            engineEventWanted("engine__gamepad_disconnected");
+
+        /// Scan the unified `InputInterface` for input edges and emit
+        /// the matching engine events into the buffer. Every query goes
+        /// through `Self.Input` (the backend-agnostic wrapper) — never a
+        /// backend's native API — which is what keeps this portable
+        /// across raylib / sokol / SDL. Called from `tick` while input
+        /// state is still current; buffered events drain via
+        /// `dispatchEvents` the same frame.
+        fn scanInputEvents(self: *Self) void {
+            // The keyboard scan unrolls `emitEngineEvent` (itself an
+            // `inline for` over the payload fields) across the full
+            // `KeyboardKey` enum (~100 keys), which blows past the
+            // default 1000-branch comptime budget. Raise it.
+            @setEvalBranchQuota(20_000);
+
+            // ── Keyboard ──
+            if (comptime keyboard_events_wanted) {
+                inline for (comptime std.enums.values(input_types.KeyboardKey)) |k| {
+                    // Skip the `key_null = 0` sentinel — not a real key.
+                    if (comptime k != .key_null) {
+                        const code: u32 = @intCast(@intFromEnum(k));
+                        if (comptime engineEventWanted("engine__key_pressed")) {
+                            if (Self.Input.isKeyPressed(code))
+                                self.emitEngineEvent("engine__key_pressed", .{ .key = code });
+                        }
+                        if (comptime engineEventWanted("engine__key_released")) {
+                            if (Self.Input.isKeyReleased(code))
+                                self.emitEngineEvent("engine__key_released", .{ .key = code });
+                        }
+                    }
+                }
+            }
+
+            // ── Mouse buttons ──
+            if (comptime mouse_events_wanted) {
+                inline for (comptime std.enums.values(input_types.MouseButton)) |b| {
+                    const code: u32 = @intCast(@intFromEnum(b));
+                    if (comptime engineEventWanted("engine__mouse_button_pressed")) {
+                        if (Self.Input.isMouseButtonPressed(code))
+                            self.emitEngineEvent("engine__mouse_button_pressed", .{
+                                .button = code,
+                                .x = Self.Input.getMouseX(),
+                                .y = Self.Input.getMouseY(),
+                            });
+                    }
+                    if (comptime engineEventWanted("engine__mouse_button_released")) {
+                        if (Self.Input.isMouseButtonReleased(code))
+                            self.emitEngineEvent("engine__mouse_button_released", .{
+                                .button = code,
+                                .x = Self.Input.getMouseX(),
+                                .y = Self.Input.getMouseY(),
+                            });
+                    }
+                }
+            }
+
+            // ── Gamepad connect / disconnect (engine-side edge diff) ──
+            if (comptime gamepad_events_wanted) {
+                comptime var gi: u32 = 0;
+                inline while (gi < max_tracked_gamepads) : (gi += 1) {
+                    const now = Self.Input.isGamepadAvailable(gi);
+                    const was = self.prev_gamepad_connected[gi];
+                    if (now and !was) {
+                        if (comptime engineEventWanted("engine__gamepad_connected"))
+                            self.emitEngineEvent("engine__gamepad_connected", .{ .id = gi });
+                    } else if (!now and was) {
+                        if (comptime engineEventWanted("engine__gamepad_disconnected"))
+                            self.emitEngineEvent("engine__gamepad_disconnected", .{ .id = gi });
+                    }
+                    self.prev_gamepad_connected[gi] = now;
+                }
+            }
+        }
+
         pub fn tick(self: *Self, dt: f32) void {
             const scaled_dt = dt * self.time_scale;
             // Freeze the gameplay clock under EITHER pause path — the
@@ -1818,6 +1932,19 @@ pub fn GameConfig(
             self.emitHook(.{ .frame_end = .{ .frame_number = self.frame_number, .dt = scaled_dt } });
             // Engine `Events` dual-emit (#578).
             self.emitEngineEvent("engine__post_tick", .{ .frame_number = self.frame_number, .dt = scaled_dt });
+
+            // Input events (labelle-gui#208). Scan the unified
+            // `InputInterface` and buffer matching engine events. Placed
+            // here, at the tail of the active-frame body, so the events
+            // land in `event_buffer` alongside this frame's lifecycle
+            // events and drain together on the next `dispatchEvents`
+            // (called by the generated main loop right after `tick`) —
+            // i.e. they dispatch the SAME frame. Input state is current
+            // during `tick` (scripts already read it here). Each scan
+            // loop is comptime-gated, so an event-less game runs none of
+            // this.
+            self.scanInputEvents();
+
             self.frame_number += 1;
         }
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -261,6 +261,54 @@ pub const Events = struct {
     pub const pause_changed = struct {
         paused: bool,
     };
+
+    // ── Input events (labelle-gui#208, Option B) ─────────────────
+    // Engine-hosted input events scanned in `Game.tick` through the
+    // unified `InputInterface`. Flows handle them via
+    // `OnEvent { name: "engine.key_pressed" }` etc. `key`/`button` are
+    // backend-compatible raylib codes (see `input_types.zig`).
+
+    /// Fired when a key transitioned to down THIS frame (down-edge).
+    /// `key` is the raylib-compatible `KeyboardKey` code.
+    pub const key_pressed = struct {
+        key: u32,
+    };
+
+    /// Fired when a key transitioned to up this frame (up-edge).
+    /// `key` is the raylib-compatible `KeyboardKey` code.
+    pub const key_released = struct {
+        key: u32,
+    };
+
+    /// Fired on a mouse-button down-edge, carrying the cursor position
+    /// (screen coordinates, Y-down) at the moment of the press.
+    /// `button` is the raylib-compatible `MouseButton` code.
+    pub const mouse_button_pressed = struct {
+        button: u32,
+        x: f32,
+        y: f32,
+    };
+
+    /// Fired on a mouse-button up-edge, carrying the cursor position
+    /// (screen coordinates, Y-down) at the moment of the release.
+    /// `button` is the raylib-compatible `MouseButton` code.
+    pub const mouse_button_released = struct {
+        button: u32,
+        x: f32,
+        y: f32,
+    };
+
+    /// Fired the frame a gamepad slot became available (transitioned
+    /// from unavailable to available). `id` is the gamepad slot index.
+    pub const gamepad_connected = struct {
+        id: u32,
+    };
+
+    /// Fired the frame a gamepad slot became unavailable (transitioned
+    /// from available to unavailable). `id` is the gamepad slot index.
+    pub const gamepad_disconnected = struct {
+        id: u32,
+    };
 };
 
 // ── Hook Types ──

--- a/test/engine_events_test.zig
+++ b/test/engine_events_test.zig
@@ -133,6 +133,13 @@ test "engine.Events declares the expected variant set" {
     _ = engine.Events.scene_assets_release;
     _ = engine.Events.state_changed;
     _ = engine.Events.pause_changed;
+    // Input events (labelle-gui#208).
+    _ = engine.Events.key_pressed;
+    _ = engine.Events.key_released;
+    _ = engine.Events.mouse_button_pressed;
+    _ = engine.Events.mouse_button_released;
+    _ = engine.Events.gamepad_connected;
+    _ = engine.Events.gamepad_disconnected;
 }
 
 // ── Buffered-emit tests ────────────────────────────────────────────────

--- a/test/input_events_test.zig
+++ b/test/input_events_test.zig
@@ -1,0 +1,315 @@
+//! Tests for the engine-hosted INPUT EVENTS (labelle-gui#208, Option B).
+//!
+//! `Game.tick` scans the unified `InputInterface` and emits six engine
+//! events into the buffered event path:
+//!
+//!   engine__key_pressed / engine__key_released
+//!   engine__mouse_button_pressed / engine__mouse_button_released
+//!   engine__gamepad_connected / engine__gamepad_disconnected
+//!
+//! Each scan loop is comptime-gated on `@hasField(GameEvents, tag)`, so
+//! an event-less game (`GameEvents = void`) compiles fine and emits
+//! nothing — the scans fold away entirely.
+//!
+//! The tests below drive a CONTROLLABLE input stub (settable per-key /
+//! per-button / per-gamepad state) and a recorder hook, ticking the
+//! game and draining `dispatchEvents` to observe what fired.
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+
+const core = engine.core;
+const game_mod = engine.game_mod;
+
+// ── Controllable input stub ────────────────────────────────────────────
+//
+// Satisfies the `InputInterface(Impl)` contract (`isKeyDown` +
+// `isKeyPressed` are required; the rest are optional and we provide the
+// ones the scan uses). State is process-global because the interface
+// dispatches to *type* decls (static fns), not an instance — mirrors how
+// the real backends wrap a global window/input context. Reset between
+// tests via `TestInput.reset()`.
+const TestInput = struct {
+    var pressed_key: ?u32 = null;
+    var released_key: ?u32 = null;
+    var pressed_button: ?u32 = null;
+    var released_button: ?u32 = null;
+    var mouse_x: f32 = 0;
+    var mouse_y: f32 = 0;
+    var gamepad_available: [4]bool = .{ false, false, false, false };
+
+    fn reset() void {
+        pressed_key = null;
+        released_key = null;
+        pressed_button = null;
+        released_button = null;
+        mouse_x = 0;
+        mouse_y = 0;
+        gamepad_available = .{ false, false, false, false };
+    }
+
+    // Required by InputInterface.
+    pub fn isKeyDown(_: u32) bool {
+        return false;
+    }
+    pub fn isKeyPressed(key: u32) bool {
+        return pressed_key != null and pressed_key.? == key;
+    }
+
+    // Optional wrappers the scan relies on.
+    pub fn isKeyReleased(key: u32) bool {
+        return released_key != null and released_key.? == key;
+    }
+    pub fn getMouseX() f32 {
+        return mouse_x;
+    }
+    pub fn getMouseY() f32 {
+        return mouse_y;
+    }
+    pub fn isMouseButtonPressed(button: u32) bool {
+        return pressed_button != null and pressed_button.? == button;
+    }
+    pub fn isMouseButtonReleased(button: u32) bool {
+        return released_button != null and released_button.? == button;
+    }
+    pub fn isGamepadAvailable(gamepad: u32) bool {
+        if (gamepad >= gamepad_available.len) return false;
+        return gamepad_available[gamepad];
+    }
+};
+
+// ── GameEvents union with the six input variants ───────────────────────
+const InputGameEvents = union(enum) {
+    engine__key_pressed: engine.Events.key_pressed,
+    engine__key_released: engine.Events.key_released,
+    engine__mouse_button_pressed: engine.Events.mouse_button_pressed,
+    engine__mouse_button_released: engine.Events.mouse_button_released,
+    engine__gamepad_connected: engine.Events.gamepad_connected,
+    engine__gamepad_disconnected: engine.Events.gamepad_disconnected,
+};
+
+// ── Recorder hook ──────────────────────────────────────────────────────
+const InputRecorder = struct {
+    key_pressed_count: usize = 0,
+    key_released_count: usize = 0,
+    mouse_pressed_count: usize = 0,
+    mouse_released_count: usize = 0,
+    gamepad_connected_count: usize = 0,
+    gamepad_disconnected_count: usize = 0,
+
+    last_key: u32 = 0,
+    last_released_key: u32 = 0,
+    last_button: u32 = 0,
+    last_x: f32 = 0,
+    last_y: f32 = 0,
+    last_gamepad_connected: u32 = 0,
+    last_gamepad_disconnected: u32 = 0,
+
+    pub fn engine__key_pressed(self: *InputRecorder, info: anytype) void {
+        self.key_pressed_count += 1;
+        self.last_key = info.key;
+    }
+    pub fn engine__key_released(self: *InputRecorder, info: anytype) void {
+        self.key_released_count += 1;
+        self.last_released_key = info.key;
+    }
+    pub fn engine__mouse_button_pressed(self: *InputRecorder, info: anytype) void {
+        self.mouse_pressed_count += 1;
+        self.last_button = info.button;
+        self.last_x = info.x;
+        self.last_y = info.y;
+    }
+    pub fn engine__mouse_button_released(self: *InputRecorder, info: anytype) void {
+        self.mouse_released_count += 1;
+        self.last_button = info.button;
+        self.last_x = info.x;
+        self.last_y = info.y;
+    }
+    pub fn engine__gamepad_connected(self: *InputRecorder, info: anytype) void {
+        self.gamepad_connected_count += 1;
+        self.last_gamepad_connected = info.id;
+    }
+    pub fn engine__gamepad_disconnected(self: *InputRecorder, info: anytype) void {
+        self.gamepad_disconnected_count += 1;
+        self.last_gamepad_disconnected = info.id;
+    }
+};
+
+const EmptyComponents = struct {
+    pub fn has(comptime _: []const u8) bool {
+        return false;
+    }
+    pub fn names() []const []const u8 {
+        return &.{};
+    }
+};
+
+const InputGame = game_mod.GameConfig(
+    core.StubRender(core.MockEcsBackend(u32).Entity),
+    core.MockEcsBackend(u32),
+    TestInput,
+    engine.StubAudio,
+    engine.StubGui,
+    *InputRecorder,
+    core.StubLogSink,
+    EmptyComponents,
+    &.{},
+    InputGameEvents,
+);
+
+// raylib-compatible key/button codes (see src/input_types.zig).
+const KEY_SPACE: u32 = 32;
+const KEY_A: u32 = 65;
+const MOUSE_LEFT: u32 = 0;
+const MOUSE_RIGHT: u32 = 1;
+
+fn newGame(recorder: *InputRecorder) InputGame {
+    var game = InputGame.init(testing.allocator);
+    game.setHooks(recorder);
+    // Drain the buffered `game_init` (not a variant of this union, so it
+    // never buffers anyway) — keep the buffer clean for the assertions.
+    game.dispatchEvents();
+    recorder.* = .{};
+    return game;
+}
+
+// ── Keyboard ───────────────────────────────────────────────────────────
+
+test "key down-edge emits key_pressed with the right code" {
+    TestInput.reset();
+    var recorder = InputRecorder{};
+    var game = newGame(&recorder);
+    defer game.deinit();
+
+    TestInput.pressed_key = KEY_SPACE;
+    game.tick(0.016);
+    game.dispatchEvents();
+
+    try testing.expectEqual(@as(usize, 1), recorder.key_pressed_count);
+    try testing.expectEqual(KEY_SPACE, recorder.last_key);
+    try testing.expectEqual(@as(usize, 0), recorder.key_released_count);
+}
+
+test "key up-edge emits key_released with the right code" {
+    TestInput.reset();
+    var recorder = InputRecorder{};
+    var game = newGame(&recorder);
+    defer game.deinit();
+
+    TestInput.released_key = KEY_A;
+    game.tick(0.016);
+    game.dispatchEvents();
+
+    try testing.expectEqual(@as(usize, 1), recorder.key_released_count);
+    try testing.expectEqual(KEY_A, recorder.last_released_key);
+    try testing.expectEqual(@as(usize, 0), recorder.key_pressed_count);
+}
+
+test "key_null sentinel is never emitted" {
+    TestInput.reset();
+    var recorder = InputRecorder{};
+    var game = newGame(&recorder);
+    defer game.deinit();
+
+    // Force the scan to report key 0 (key_null) as pressed/released.
+    TestInput.pressed_key = 0;
+    TestInput.released_key = 0;
+    game.tick(0.016);
+    game.dispatchEvents();
+
+    // key_null (code 0) is skipped at comptime, so nothing fires.
+    try testing.expectEqual(@as(usize, 0), recorder.key_pressed_count);
+    try testing.expectEqual(@as(usize, 0), recorder.key_released_count);
+}
+
+// ── Mouse ──────────────────────────────────────────────────────────────
+
+test "mouse button down-edge emits with cursor x/y" {
+    TestInput.reset();
+    var recorder = InputRecorder{};
+    var game = newGame(&recorder);
+    defer game.deinit();
+
+    TestInput.pressed_button = MOUSE_LEFT;
+    TestInput.mouse_x = 123.5;
+    TestInput.mouse_y = 47.0;
+    game.tick(0.016);
+    game.dispatchEvents();
+
+    try testing.expectEqual(@as(usize, 1), recorder.mouse_pressed_count);
+    try testing.expectEqual(MOUSE_LEFT, recorder.last_button);
+    try testing.expectApproxEqAbs(@as(f32, 123.5), recorder.last_x, 0.001);
+    try testing.expectApproxEqAbs(@as(f32, 47.0), recorder.last_y, 0.001);
+}
+
+test "mouse button up-edge emits mouse_button_released with x/y" {
+    TestInput.reset();
+    var recorder = InputRecorder{};
+    var game = newGame(&recorder);
+    defer game.deinit();
+
+    TestInput.released_button = MOUSE_RIGHT;
+    TestInput.mouse_x = 5.0;
+    TestInput.mouse_y = 9.0;
+    game.tick(0.016);
+    game.dispatchEvents();
+
+    try testing.expectEqual(@as(usize, 1), recorder.mouse_released_count);
+    try testing.expectEqual(MOUSE_RIGHT, recorder.last_button);
+    try testing.expectApproxEqAbs(@as(f32, 5.0), recorder.last_x, 0.001);
+    try testing.expectApproxEqAbs(@as(f32, 9.0), recorder.last_y, 0.001);
+}
+
+// ── Gamepad ────────────────────────────────────────────────────────────
+
+test "gamepad false->true emits gamepad_connected once, not while held" {
+    TestInput.reset();
+    var recorder = InputRecorder{};
+    var game = newGame(&recorder);
+    defer game.deinit();
+
+    // First tick with slot 0 available: connect edge.
+    TestInput.gamepad_available[0] = true;
+    game.tick(0.016);
+    // Still available next tick: NO repeat.
+    game.tick(0.016);
+    game.dispatchEvents();
+
+    try testing.expectEqual(@as(usize, 1), recorder.gamepad_connected_count);
+    try testing.expectEqual(@as(u32, 0), recorder.last_gamepad_connected);
+    try testing.expectEqual(@as(usize, 0), recorder.gamepad_disconnected_count);
+}
+
+test "gamepad true->false emits gamepad_disconnected" {
+    TestInput.reset();
+    var recorder = InputRecorder{};
+    var game = newGame(&recorder);
+    defer game.deinit();
+
+    TestInput.gamepad_available[1] = true;
+    game.tick(0.016); // connect edge for slot 1
+    TestInput.gamepad_available[1] = false;
+    game.tick(0.016); // disconnect edge for slot 1
+    game.dispatchEvents();
+
+    try testing.expectEqual(@as(usize, 1), recorder.gamepad_connected_count);
+    try testing.expectEqual(@as(usize, 1), recorder.gamepad_disconnected_count);
+    try testing.expectEqual(@as(u32, 1), recorder.last_gamepad_disconnected);
+}
+
+// ── Zero-cost / comptime-gate safety ───────────────────────────────────
+
+// A game whose `GameEvents` lacks the input variants (here `void`) must
+// compile and emit nothing — the scan folds away. Exercises the same
+// `engine.Game` (GameEvents = void) used everywhere in the unit suite.
+test "GameEvents = void emits no input events and compiles" {
+    var game = engine.Game.init(testing.allocator);
+    defer game.deinit();
+
+    // Ticking with input state present must not crash or attempt any
+    // emission — the comptime gate eliminated every scan loop.
+    game.tick(0.016);
+    game.tick(0.016);
+    // No assertion: passing == compiles + runs with the scans gated out.
+}


### PR DESCRIPTION
Lets flows react to user input via the existing `OnEvent` (labelle-gui#208, Option B). Engine-only — the assembler auto-discovers `engine.Events`, so flows reach these with no codegen/assembler change.

## Events (added to `engine.Events`)
- `key_pressed { key: u32 }` / `key_released { key: u32 }`
- `mouse_button_pressed { button: u32, x: f32, y: f32 }` / `mouse_button_released { … }`
- `gamepad_connected { id: u32 }` / `gamepad_disconnected { id: u32 }`

A flow handles e.g. `OnEvent { name: "engine.key_pressed" }` and branches on `key`.

## Cross-backend by construction
The per-frame edge scan (`scanInputEvents`, run at the tail of `tick`) queries **only** the unified `InputInterface` (`Self.Input.isKeyPressed/isKeyReleased/isMouseButton*/getMouseX/Y/isGamepadAvailable`) — never a backend's native input/event API. raylib/sokol/SDL each implement that interface; optional methods fall back to `false`, so an event simply doesn't fire on a backend lacking support (e.g. gamepad on sokol/SDL). 

Keyboard/mouse edges reuse the backend's own pressed/released state (no engine bookkeeping). **Gamepad connect/disconnect** has no "this-frame" query, so the engine diffs `isGamepadAvailable(i)` against a `prev_gamepad_connected[4]` field and emits on transitions (fires once, not while held connected).

## Zero-cost when unused
Each scan category is wrapped in `if (comptime <cat>_wanted)` (mirroring `emitEngineEvent`'s `@hasField(GameEvents, tag)` gate), and each emit is per-tag gated — so a game whose flows don't listen has the entire enum scan **comptime-eliminated**. A `GameEvents = void` game compiles and emits nothing (tested).

## Timing
Emitted at the tail of `tick` (after `post_tick`); buffers with the frame's lifecycle events and drains on the main loop's post-`tick` `dispatchEvents` — same frame.

## Tests
`test/input_events_test.zig` (8, controllable input stub + recorder): key down/up-edge codes, `key_null` skipped, mouse press/release with x/y, gamepad connect fires once / disconnect, and `GameEvents = void` emits nothing + compiles. `zig build test` green; `zig build` clean.

Deferred (per #208): `mouse_moved` (high-frequency), gamepad buttons/axes, touch. Parent: labelle-gui#187 / #208.