### PR TITLE
feat: surface isKeyReleased + isMouseButton{Down,Pressed,Released} on the game mixin (#208)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ usage/*/.labelle/
 
 # Screenshots from CI tests
 screenshot_*.png
+
+# Zig fetched package cache
+zig-pkg/

--- a/build.zig
+++ b/build.zig
@@ -100,6 +100,9 @@ pub fn build(b: *std.Build) void {
         // `Game.tick` through the unified `InputInterface`, dual-emitted
         // on the buffered event path so flows can listen via `OnEvent`.
         "test/input_events_test.zig",
+        // Accessor methods on the game handle wrapping the unified
+        // `InputInterface` for key-release / mouse-button polling (#208).
+        "test/input_mixin_test.zig",
         "test/spawn_from_prefab_test.zig",
         "test/jsonc/bridge_prefab_tags_test.zig",
         "test/save_load_two_phase_test.zig",

--- a/src/game.zig
+++ b/src/game.zig
@@ -1308,10 +1308,14 @@ pub fn GameConfig(
         // ── Input (mixin) ────────────────────────────────────────
         pub const isKeyDown = InputMixin.isKeyDown;
         pub const isKeyPressed = InputMixin.isKeyPressed;
+        pub const isKeyReleased = InputMixin.isKeyReleased;
         pub const getMouseX = InputMixin.getMouseX;
         pub const getMouseY = InputMixin.getMouseY;
         pub const getMouse = InputMixin.getMouse;
         pub const getMouseWheelMove = InputMixin.getMouseWheelMove;
+        pub const isMouseButtonDown = InputMixin.isMouseButtonDown;
+        pub const isMouseButtonPressed = InputMixin.isMouseButtonPressed;
+        pub const isMouseButtonReleased = InputMixin.isMouseButtonReleased;
         pub const getTouchCount = InputMixin.getTouchCount;
         pub const getTouchX = InputMixin.getTouchX;
         pub const getTouchY = InputMixin.getTouchY;

--- a/src/game/input_mixin.zig
+++ b/src/game/input_mixin.zig
@@ -3,6 +3,7 @@ const core = @import("labelle-core");
 const Position = core.Position;
 const input_types = @import("../input_types.zig");
 const KeyboardKey = input_types.KeyboardKey;
+const MouseButton = input_types.MouseButton;
 
 /// Returns the input forwarding mixin for a given Game type.
 pub fn Mixin(comptime Game: type) type {
@@ -15,6 +16,12 @@ pub fn Mixin(comptime Game: type) type {
 
         pub fn isKeyPressed(_: *Game, key: KeyboardKey) bool {
             return Input.isKeyPressed(@intCast(@intFromEnum(key)));
+        }
+
+        /// True on the frame `key` transitions from down to up.
+        /// Returns false if the backend doesn't report key-release edges.
+        pub fn isKeyReleased(_: *Game, key: KeyboardKey) bool {
+            return Input.isKeyReleased(@intCast(@intFromEnum(key)));
         }
 
         pub fn getMouseX(_: *Game) f32 {
@@ -31,6 +38,24 @@ pub fn Mixin(comptime Game: type) type {
 
         pub fn getMouseWheelMove(_: *Game) f32 {
             return Input.getMouseWheelMove();
+        }
+
+        /// True while `button` is held down this frame.
+        /// Returns false if the backend doesn't report mouse-button state.
+        pub fn isMouseButtonDown(_: *Game, button: MouseButton) bool {
+            return Input.isMouseButtonDown(@intCast(@intFromEnum(button)));
+        }
+
+        /// True on the frame `button` transitions from up to down.
+        /// Returns false if the backend doesn't report mouse-button edges.
+        pub fn isMouseButtonPressed(_: *Game, button: MouseButton) bool {
+            return Input.isMouseButtonPressed(@intCast(@intFromEnum(button)));
+        }
+
+        /// True on the frame `button` transitions from down to up.
+        /// Returns false if the backend doesn't report mouse-button edges.
+        pub fn isMouseButtonReleased(_: *Game, button: MouseButton) bool {
+            return Input.isMouseButtonReleased(@intCast(@intFromEnum(button)));
         }
 
         // ── Touch ────────────────────────────────────────────────

--- a/test/input_mixin_test.zig
+++ b/test/input_mixin_test.zig
@@ -1,0 +1,156 @@
+//! Tests for the input ACCESSOR methods surfaced on the game handle
+//! (labelle-gui#208). These wrap the unified `InputInterface` so flow
+//! reporter nodes can poll key-release and mouse-button state directly:
+//!
+//!   isKeyReleased / isMouseButtonDown
+//!   isMouseButtonPressed / isMouseButtonReleased
+//!
+//! Each delegates to the matching (optional) `InputInterface` method,
+//! which falls back to `false` when the backend omits it. The tests
+//! drive two stubs: a FULL one that reports state, and a MINIMAL one
+//! that defines only the required `isKeyDown`/`isKeyPressed` to exercise
+//! the graceful `false` fallback path.
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+
+const core = engine.core;
+const game_mod = engine.game_mod;
+const KeyboardKey = engine.KeyboardKey;
+const MouseButton = engine.MouseButton;
+
+// ── Full controllable input stub ───────────────────────────────────────
+//
+// State is process-global because the interface dispatches to *type*
+// decls (static fns), not an instance — mirrors the real backends.
+// Reset between tests via `FullInput.reset()`.
+const FullInput = struct {
+    var released_key: ?u32 = null;
+    var down_button: ?u32 = null;
+    var pressed_button: ?u32 = null;
+    var released_button: ?u32 = null;
+
+    fn reset() void {
+        released_key = null;
+        down_button = null;
+        pressed_button = null;
+        released_button = null;
+    }
+
+    // Required by InputInterface.
+    pub fn isKeyDown(_: u32) bool {
+        return false;
+    }
+    pub fn isKeyPressed(_: u32) bool {
+        return false;
+    }
+
+    // Optional wrappers the new accessors surface.
+    pub fn isKeyReleased(key: u32) bool {
+        return released_key != null and released_key.? == key;
+    }
+    pub fn isMouseButtonDown(button: u32) bool {
+        return down_button != null and down_button.? == button;
+    }
+    pub fn isMouseButtonPressed(button: u32) bool {
+        return pressed_button != null and pressed_button.? == button;
+    }
+    pub fn isMouseButtonReleased(button: u32) bool {
+        return released_button != null and released_button.? == button;
+    }
+};
+
+// ── Minimal stub (only the required methods) ───────────────────────────
+//
+// Omits all the optional methods so the InputInterface `@hasDecl` guards
+// take the graceful `false` fallback path.
+const MinimalInput = struct {
+    pub fn isKeyDown(_: u32) bool {
+        return false;
+    }
+    pub fn isKeyPressed(_: u32) bool {
+        return false;
+    }
+};
+
+const EmptyComponents = struct {
+    pub fn has(comptime _: []const u8) bool {
+        return false;
+    }
+    pub fn names() []const []const u8 {
+        return &.{};
+    }
+};
+
+fn GameWith(comptime Input: type) type {
+    return game_mod.GameConfig(
+        core.StubRender(core.MockEcsBackend(u32).Entity),
+        core.MockEcsBackend(u32),
+        Input,
+        engine.StubAudio,
+        engine.StubGui,
+        void,
+        core.StubLogSink,
+        EmptyComponents,
+        &.{},
+        void,
+    );
+}
+
+const FullGame = GameWith(FullInput);
+const MinimalGame = GameWith(MinimalInput);
+
+// ── Full backend reflects reported state ───────────────────────────────
+
+test "isKeyReleased reflects a released key, false otherwise" {
+    FullInput.reset();
+    var game = FullGame.init(testing.allocator);
+    defer game.deinit();
+
+    FullInput.released_key = @intFromEnum(KeyboardKey.space);
+    try testing.expect(game.isKeyReleased(.space));
+    try testing.expect(!game.isKeyReleased(.a));
+}
+
+test "isMouseButtonDown reflects a held button, false otherwise" {
+    FullInput.reset();
+    var game = FullGame.init(testing.allocator);
+    defer game.deinit();
+
+    FullInput.down_button = @intFromEnum(MouseButton.left);
+    try testing.expect(game.isMouseButtonDown(.left));
+    try testing.expect(!game.isMouseButtonDown(.right));
+}
+
+test "isMouseButtonPressed reflects a press-edge, false otherwise" {
+    FullInput.reset();
+    var game = FullGame.init(testing.allocator);
+    defer game.deinit();
+
+    FullInput.pressed_button = @intFromEnum(MouseButton.right);
+    try testing.expect(game.isMouseButtonPressed(.right));
+    try testing.expect(!game.isMouseButtonPressed(.left));
+}
+
+test "isMouseButtonReleased reflects a release-edge, false otherwise" {
+    FullInput.reset();
+    var game = FullGame.init(testing.allocator);
+    defer game.deinit();
+
+    FullInput.released_button = @intFromEnum(MouseButton.middle);
+    try testing.expect(game.isMouseButtonReleased(.middle));
+    try testing.expect(!game.isMouseButtonReleased(.left));
+}
+
+// ── Minimal backend → graceful false fallback ──────────────────────────
+
+test "accessors return false when the backend omits the optional methods" {
+    var game = MinimalGame.init(testing.allocator);
+    defer game.deinit();
+
+    try testing.expect(!game.isKeyReleased(.space));
+    try testing.expect(!game.isMouseButtonDown(.left));
+    try testing.expect(!game.isMouseButtonPressed(.left));
+    try testing.expect(!game.isMouseButtonReleased(.left));
+}


### PR DESCRIPTION
Surfaces four input accessors on the game handle so flow input reporter nodes (labelle-gui#208) can read key-release + mouse-button state — the gap the first reporter PR (flow-codegen#51) flagged.

## What
`src/game/input_mixin.zig` adds, mirroring `isKeyDown`/`isKeyPressed`'s exact wrapper shape (`Input.<m>(@intCast(@intFromEnum(x)))`):
- `isKeyReleased(KeyboardKey) bool`
- `isMouseButtonDown(MouseButton) bool`
- `isMouseButtonPressed(MouseButton) bool`
- `isMouseButtonReleased(MouseButton) bool`

These were already on the unified `InputInterface` (`labelle-core`, optional methods with `false` fallback) — this just surfaces them on `game`. Re-exported via `game.zig`'s input block. No event/scan changes.

## Tests
`test/input_mixin_test.zig`: a controllable stub asserts each accessor reflects state; a minimal stub (only the required `isKeyDown`/`isKeyPressed`) exercises the graceful `false`-fallback. `zig build test` green; `zig build` clean. (Also gitignored the `zig-pkg/` build cache.)

Unblocks the `IsKeyReleased`/`IsMouseButton*` reporter nodes (flow-codegen, parallel PR). Parent: labelle-gui#208.