### PR TITLE
feat(profiler): built-in per-script / per-plugin frame profiler

### DIFF
--- a/scene/src/profiler.zig
+++ b/scene/src/profiler.zig
@@ -22,22 +22,55 @@ const std = @import("std");
 const builtin = @import("builtin");
 
 const is_wasm = builtin.cpu.arch == .wasm32 or builtin.os.tag == .emscripten;
+const is_windows = builtin.os.tag == .windows;
 
 const Timespec = extern struct { sec: i64, nsec: i64 };
 extern "c" fn clock_gettime(clk: c_int, tp: *Timespec) c_int;
-extern "c" fn getenv(name: [*:0]const u8) ?[*:0]const u8;
 
 /// Monotonic time in nanoseconds. Desktop only — returns 0 on wasm
 /// (profiling is not wired for the browser build).
 pub fn nowNs() u64 {
-    if (is_wasm) return 0;
-    const clk: c_int = switch (builtin.os.tag) {
-        .macos, .ios, .watchos, .tvos => 6, // _CLOCK_MONOTONIC
-        else => 1, // CLOCK_MONOTONIC (linux et al.)
-    };
-    var ts: Timespec = .{ .sec = 0, .nsec = 0 };
-    _ = clock_gettime(clk, &ts);
-    return @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+    if (comptime is_wasm) return 0;
+    // Windows has no `clock_gettime` to link against (MSVC/UCRT don't
+    // export it), so use the QueryPerformanceCounter path via ntdll —
+    // the same primitive `std.Io` uses internally.
+    if (comptime is_windows) {
+        const w = std.os.windows;
+        var qpf: w.LARGE_INTEGER = undefined;
+        var qpc: w.LARGE_INTEGER = undefined;
+        _ = w.ntdll.RtlQueryPerformanceFrequency(&qpf);
+        _ = w.ntdll.RtlQueryPerformanceCounter(&qpc);
+        const freq: u64 = @bitCast(qpf);
+        const count: u64 = @bitCast(qpc);
+        if (freq == 0) return 0;
+        // Split into whole-seconds + remainder to avoid overflow when
+        // multiplying the raw counter by ns_per_s.
+        const secs = count / freq;
+        const rem = count % freq;
+        return secs * std.time.ns_per_s + (rem * std.time.ns_per_s) / freq;
+    }
+    // POSIX with libc: use the libc `clock_gettime`. The `extern "c"`
+    // symbol is only referenced on this comptime branch, so non-libc
+    // targets never force an unresolved libc dependency.
+    if (comptime builtin.link_libc) {
+        const clk: c_int = switch (builtin.os.tag) {
+            .macos, .ios, .watchos, .tvos => 6, // _CLOCK_MONOTONIC
+            else => 1, // CLOCK_MONOTONIC (linux et al.)
+        };
+        var ts: Timespec = .{ .sec = 0, .nsec = 0 };
+        _ = clock_gettime(clk, &ts);
+        return @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+    }
+    // No libc: on Linux the monotonic clock is reachable via the raw
+    // syscall (vDSO-accelerated in std). Other no-libc POSIX targets
+    // have no portable clock here, so profiling stays off (0 disables
+    // recording downstream).
+    if (comptime builtin.os.tag == .linux) {
+        var ts: std.os.linux.timespec = undefined;
+        _ = std.os.linux.clock_gettime(.MONOTONIC, &ts);
+        return @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+    }
+    return 0;
 }
 
 /// Frames between log dumps while recording.
@@ -45,14 +78,24 @@ pub const dump_interval_frames: u64 = 120;
 /// Entries with a worst frame below this are omitted from the log dump.
 const report_threshold_ns: u64 = 100_000; // 0.1 ms
 
+extern "c" fn getenv(name: [*:0]const u8) ?[*:0]const u8;
+
 var _recording: ?bool = null;
 
 /// True when `LABELLE_PROFILE` is set and non-empty. The env read is
 /// cached so this is a cheap branch in the per-frame hot path.
+///
+/// The env lookup goes through libc `getenv` when libc is linked (the
+/// case for every shipped desktop build — raylib pulls in libc). Without
+/// libc there is no library-accessible environ block in Zig 0.16
+/// (`std.os.environ` was removed and the block is threaded through
+/// `main` only), so the profiler stays off rather than forcing an
+/// unresolved `getenv` symbol at link time on no-libc builds.
 pub fn recording() bool {
     if (_recording) |v| return v;
     const v = blk: {
-        if (is_wasm) break :blk false;
+        if (comptime is_wasm) break :blk false;
+        if (comptime !builtin.link_libc) break :blk false;
         if (getenv("LABELLE_PROFILE")) |raw| break :blk std.mem.span(raw).len > 0;
         break :blk false;
     };

--- a/scene/src/profiler.zig
+++ b/scene/src/profiler.zig
@@ -1,0 +1,110 @@
+//! Lightweight per-script / per-plugin frame profiler.
+//!
+//! Revives the `profile[]` / `plugin_profile[]` scaffolding that was
+//! stubbed during the Zig 0.16 migration (`std.time.Timer` removal).
+//! Timing uses a monotonic clock (`nowNs`). The profiler is *compiled
+//! into every build* — including ReleaseFast, which is where perf
+//! actually matters — but only **records** when `recording()` is true,
+//! gated on the `LABELLE_PROFILE` env var. When off, the per-frame cost
+//! is a single cached-bool branch.
+//!
+//! Two surfaces:
+//!   * per-entry `Stat`s are exposed via the Game's `script_profile_ptr`
+//!     / `plugin_profile_ptr` for a live debug overlay (future work);
+//!   * `report()` logs a sorted ranking every `dump_interval_frames`,
+//!     which works **headless** (CI / no-window perf runs) — this is the
+//!     surface that makes at-scale dip-hunting a flip-a-flag operation.
+//!
+//! Enable: `LABELLE_PROFILE=1 <game>` (or `labelle run ... ` with the
+//! profiling flag once the CLI wires it). Look for `info(profiler)` lines.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+const is_wasm = builtin.cpu.arch == .wasm32 or builtin.os.tag == .emscripten;
+
+const Timespec = extern struct { sec: i64, nsec: i64 };
+extern "c" fn clock_gettime(clk: c_int, tp: *Timespec) c_int;
+extern "c" fn getenv(name: [*:0]const u8) ?[*:0]const u8;
+
+/// Monotonic time in nanoseconds. Desktop only — returns 0 on wasm
+/// (profiling is not wired for the browser build).
+pub fn nowNs() u64 {
+    if (is_wasm) return 0;
+    const clk: c_int = switch (builtin.os.tag) {
+        .macos, .ios, .watchos, .tvos => 6, // _CLOCK_MONOTONIC
+        else => 1, // CLOCK_MONOTONIC (linux et al.)
+    };
+    var ts: Timespec = .{ .sec = 0, .nsec = 0 };
+    _ = clock_gettime(clk, &ts);
+    return @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
+}
+
+/// Frames between log dumps while recording.
+pub const dump_interval_frames: u64 = 120;
+/// Entries with a worst frame below this are omitted from the log dump.
+const report_threshold_ns: u64 = 100_000; // 0.1 ms
+
+var _recording: ?bool = null;
+
+/// True when `LABELLE_PROFILE` is set and non-empty. The env read is
+/// cached so this is a cheap branch in the per-frame hot path.
+pub fn recording() bool {
+    if (_recording) |v| return v;
+    const v = blk: {
+        if (is_wasm) break :blk false;
+        if (getenv("LABELLE_PROFILE")) |raw| break :blk std.mem.span(raw).len > 0;
+        break :blk false;
+    };
+    _recording = v;
+    return v;
+}
+
+/// Rolling timing for one entry over the current dump window. `last_ns`
+/// is kept across windows for the live overlay; worst/sum/samples reset
+/// each dump.
+pub const Stat = struct {
+    last_ns: u64 = 0,
+    worst_ns: u64 = 0,
+    sum_ns: u64 = 0,
+    samples: u64 = 0,
+
+    pub fn record(self: *Stat, ns: u64) void {
+        self.last_ns = ns;
+        if (ns > self.worst_ns) self.worst_ns = ns;
+        self.sum_ns += ns;
+        self.samples += 1;
+    }
+
+    pub fn avgNs(self: Stat) u64 {
+        return if (self.samples == 0) 0 else self.sum_ns / self.samples;
+    }
+
+    pub fn resetWindow(self: *Stat) void {
+        self.worst_ns = 0;
+        self.sum_ns = 0;
+        self.samples = 0;
+    }
+};
+
+pub const Row = struct { name: []const u8, worst_ns: u64, avg_ns: u64 };
+
+/// Log a ranking of `rows` (sorted worst-first) under `label`, skipping
+/// entries below the threshold. `rows` is sorted in place. Emitted via
+/// `std.log.scoped(.profiler)` so it surfaces on stderr headless.
+pub fn report(comptime label: []const u8, rows: []Row) void {
+    std.mem.sort(Row, rows, {}, struct {
+        fn gt(_: void, a: Row, b: Row) bool {
+            return a.worst_ns > b.worst_ns;
+        }
+    }.gt);
+    const log = std.log.scoped(.profiler);
+    for (rows) |r| {
+        if (r.worst_ns < report_threshold_ns) continue;
+        log.info("[" ++ label ++ "] {s}: worst={d:6.2}ms avg={d:6.2}ms", .{
+            r.name,
+            @as(f64, @floatFromInt(r.worst_ns)) / 1e6,
+            @as(f64, @floatFromInt(r.avg_ns)) / 1e6,
+        });
+    }
+}

--- a/scene/src/root.zig
+++ b/scene/src/root.zig
@@ -14,6 +14,7 @@ pub const component = @import("component.zig");
 pub const script = @import("script.zig");
 pub const gizmo = @import("gizmo.zig");
 pub const system = @import("system.zig");
+pub const profiler = @import("profiler.zig");
 
 // ── Types ──
 pub const RefInfo = types.RefInfo;

--- a/scene/src/system.zig
+++ b/scene/src/system.zig
@@ -33,15 +33,21 @@ pub fn SystemRegistry(comptime plugin_modules: anytype) type {
         const std = @import("std");
         const std_time = std.time;
         const builtin = @import("builtin");
-        pub const profiling_enabled = builtin.mode == .Debug;
+        const profiler = @import("profiler.zig");
+        // Compiled into every build (incl. ReleaseFast); recording is gated
+        // at runtime by `profiler.recording()` (`LABELLE_PROFILE`). Public
+        // because the generated `main.zig` reads it to expose the array.
+        pub const profiling_enabled = true;
 
-        /// Plugin system profiling entry.
+        /// Plugin system timing (tick + postTick), rolling over the dump
+        /// window. Exposed via `Game.plugin_profile_ptr` for a live overlay.
         pub const PluginProfileEntry = struct {
             name: []const u8,
-            tick_ns: u64 = 0,
-            post_tick_ns: u64 = 0,
-            draw_gui_ns: u64 = 0,
+            tick: profiler.Stat = .{},
+            post_tick: profiler.Stat = .{},
         };
+        /// Frames since the last profiler log dump (advances only while recording).
+        var prof_frame_counter: u64 = 0;
 
         pub const plugin_system_count: usize = countPluginSystems();
 
@@ -91,6 +97,7 @@ pub fn SystemRegistry(comptime plugin_modules: anytype) type {
         /// Respects game_states — skips plugins not active in the current state.
         pub fn tick(game: anytype, dt: f32) void {
             const current_state = getGameState(game);
+            const rec = profiler.recording();
             comptime var pidx: usize = 0;
             inline for (info.@"struct".fields) |field| {
                 const mod = @field(plugin_modules, field.name);
@@ -98,21 +105,44 @@ pub fn SystemRegistry(comptime plugin_modules: anytype) type {
                     const Sys = @field(mod, "Systems");
                     if (@hasDecl(Sys, "tick")) {
                         if (isStateAllowed(Sys, current_state)) {
-                            const timer: ?usize = null; // std.time.Timer removed in 0.16 — see #TBD
-                            Sys.tick(game, dt);
-                            if (timer) |_| plugin_profile[pidx].tick_ns = 0;
-                        } else if (profiling_enabled) {
-                            plugin_profile[pidx].tick_ns = 0;
+                            if (rec) {
+                                const t0 = profiler.nowNs();
+                                Sys.tick(game, dt);
+                                plugin_profile[pidx].tick.record(profiler.nowNs() - t0);
+                            } else {
+                                Sys.tick(game, dt);
+                            }
                         }
                     }
                     pidx += 1;
                 }
             }
+            // tick() runs once per frame before postTick(): drive the dump here.
+            if (rec) {
+                prof_frame_counter += 1;
+                if (prof_frame_counter >= profiler.dump_interval_frames) {
+                    dumpProfile();
+                    prof_frame_counter = 0;
+                }
+            }
+        }
+
+        /// Log a worst-first ranking of per-plugin tick times over the
+        /// window, then reset. Called from `tick` while recording.
+        fn dumpProfile() void {
+            var rows: [plugin_system_count]profiler.Row = undefined;
+            for (&plugin_profile, 0..) |*e, i| {
+                rows[i] = .{ .name = e.name, .worst_ns = e.tick.worst_ns, .avg_ns = e.tick.avgNs() };
+                e.tick.resetWindow();
+                e.post_tick.resetWindow();
+            }
+            profiler.report("plugin", &rows);
         }
 
         /// Call postTick() on all plugin systems that declare it.
         pub fn postTick(game: anytype, dt: f32) void {
             const current_state = getGameState(game);
+            const rec = profiler.recording();
             comptime var pidx: usize = 0;
             inline for (info.@"struct".fields) |field| {
                 const mod = @field(plugin_modules, field.name);
@@ -120,11 +150,13 @@ pub fn SystemRegistry(comptime plugin_modules: anytype) type {
                     const Sys = @field(mod, "Systems");
                     if (@hasDecl(Sys, "postTick")) {
                         if (isStateAllowed(Sys, current_state)) {
-                            const timer: ?usize = null; // std.time.Timer removed in 0.16 — see #TBD
-                            Sys.postTick(game, dt);
-                            if (timer) |_| plugin_profile[pidx].post_tick_ns = 0;
-                        } else if (profiling_enabled) {
-                            plugin_profile[pidx].post_tick_ns = 0;
+                            if (rec) {
+                                const t0 = profiler.nowNs();
+                                Sys.postTick(game, dt);
+                                plugin_profile[pidx].post_tick.record(profiler.nowNs() - t0);
+                            } else {
+                                Sys.postTick(game, dt);
+                            }
                         }
                     }
                     pidx += 1;
@@ -142,11 +174,7 @@ pub fn SystemRegistry(comptime plugin_modules: anytype) type {
                     const Sys = @field(mod, "Systems");
                     if (@hasDecl(Sys, "drawGui")) {
                         if (isStateAllowed(Sys, current_state)) {
-                            const timer: ?usize = null; // std.time.Timer removed in 0.16 — see #TBD
                             Sys.drawGui(game);
-                            if (timer) |_| plugin_profile[pidx].draw_gui_ns = 0;
-                        } else if (profiling_enabled) {
-                            plugin_profile[pidx].draw_gui_ns = 0;
                         }
                     }
                     pidx += 1;

--- a/src/root.zig
+++ b/src/root.zig
@@ -326,6 +326,12 @@ pub const ComponentPayload = hooks_types_mod.ComponentPayload;
 pub const MergeHooks = core.MergeHooks;
 pub const MergeHookPayloads = core.MergeHookPayloads;
 
+// ── Profiler ──
+/// Per-script / per-plugin frame profiler (lives in the scene module so
+/// both the ScriptRunner and the SystemRegistry can reach it). Enable at
+/// runtime with `LABELLE_PROFILE=1`; ranks tick costs to the log.
+pub const profiler = scene_mod.profiler;
+
 // ── Scene System ──
 pub const Scene = scene_mod.Scene;
 pub const PrefabRegistry = scene_mod.PrefabRegistry;

--- a/src/script_runner.zig
+++ b/src/script_runner.zig
@@ -13,6 +13,7 @@
 /// Scene scripts (init/update/deinit with opaque ptrs) are not processed here —
 /// they go through ScriptRegistry and SceneLoader as before.
 const std = @import("std");
+const profiler = @import("scene").profiler;
 
 pub fn ScriptRunner(
     comptime AllScripts: type,
@@ -22,13 +23,20 @@ pub fn ScriptRunner(
     return struct {
         const Self = @This();
         const builtin = @import("builtin");
-        pub const profiling_enabled = builtin.mode == .Debug;
+        // Compiled into every build (incl. ReleaseFast — that's where perf
+        // matters); recording is gated at runtime by `profiler.recording()`
+        // (the `LABELLE_PROFILE` env var), so the off-path is one branch.
+        // Kept as a public decl because the generated `main.zig` reads it to
+        // decide whether to expose the profile array to the Game.
+        pub const profiling_enabled = true;
 
-        /// Profiling data — timing per script per phase. Only in debug builds.
+        /// Per-script timing (tick + drawGui), rolling over the current
+        /// dump window. Exposed via `Game.script_profile_ptr` for a live
+        /// overlay; ranked + logged by `dumpProfile`.
         pub const ProfileEntry = struct {
             name: []const u8,
-            tick_ns: u64 = 0,
-            draw_gui_ns: u64 = 0,
+            tick: profiler.Stat = .{},
+            draw_gui: profiler.Stat = .{},
         };
 
         pub const script_count: usize = blk: {
@@ -46,6 +54,9 @@ pub fn ScriptRunner(
         allocator: std.mem.Allocator,
         profile: if (profiling_enabled) [script_count]ProfileEntry else void =
             if (profiling_enabled) initProfile() else {},
+        /// Frames since the last profiler log dump (only advances while
+        /// recording). See `tick`.
+        prof_frame_counter: u64 = 0,
 
         fn initProfile() [script_count]ProfileEntry {
             comptime {
@@ -175,50 +186,64 @@ pub fn ScriptRunner(
         pub fn tick(self: *Self, game: anytype, dt: f32) void {
             const current_state = getGameState(game);
             const decls = @typeInfo(AllScripts).@"struct".decls;
+            // Read the runtime profiling flag once per frame (cached env).
+            const rec = profiler.recording();
             comptime var profile_idx: usize = 0;
             inline for (decls) |d| {
                 const mod = @field(AllScripts, d.name);
                 if (comptime isGameScript(mod)) {
                     if (comptime isFnDecl(mod, "tick")) {
                         if (isStateAllowedCached(mod, current_state)) {
-                            if (profiling_enabled) {
-                                const timer: ?usize = null; // Timer removed in 0.16; profiling stubbed
+                            if (rec) {
+                                const t0 = profiler.nowNs();
                                 dispatchTickCall(mod.tick, game, self, d.name, dt);
-                                if (timer != null) {
-                                    self.profile[profile_idx].tick_ns = 0;
-                                }
+                                self.profile[profile_idx].tick.record(profiler.nowNs() - t0);
                             } else {
                                 dispatchTickCall(mod.tick, game, self, d.name, dt);
                             }
-                        } else if (profiling_enabled) {
-                            self.profile[profile_idx].tick_ns = 0;
                         }
                     }
                     profile_idx += 1;
                 }
             }
+            if (rec) {
+                self.prof_frame_counter += 1;
+                if (self.prof_frame_counter >= profiler.dump_interval_frames) {
+                    self.dumpProfile();
+                    self.prof_frame_counter = 0;
+                }
+            }
+        }
+
+        /// Log a worst-first ranking of per-script tick times over the
+        /// window, then reset the window. Called from `tick` every
+        /// `profiler.dump_interval_frames` while recording.
+        fn dumpProfile(self: *Self) void {
+            var rows: [script_count]profiler.Row = undefined;
+            for (&self.profile, 0..) |*e, i| {
+                rows[i] = .{ .name = e.name, .worst_ns = e.tick.worst_ns, .avg_ns = e.tick.avgNs() };
+                e.tick.resetWindow();
+            }
+            profiler.report("script", &rows);
         }
 
         pub fn drawGui(self: *Self, game: anytype) void {
             const current_state = getGameState(game);
             const decls = @typeInfo(AllScripts).@"struct".decls;
+            const rec = profiler.recording();
             comptime var profile_idx: usize = 0;
             inline for (decls) |d| {
                 const mod = @field(AllScripts, d.name);
                 if (comptime isGameScript(mod)) {
                     if (comptime isFnDecl(mod, "drawGui")) {
                         if (isStateAllowedCached(mod, current_state)) {
-                            if (profiling_enabled) {
-                                const timer: ?usize = null; // Timer removed in 0.16; profiling stubbed
+                            if (rec) {
+                                const t0 = profiler.nowNs();
                                 dispatchCall(mod.drawGui, game, self, d.name);
-                                if (timer != null) {
-                                    self.profile[profile_idx].draw_gui_ns = 0;
-                                }
+                                self.profile[profile_idx].draw_gui.record(profiler.nowNs() - t0);
                             } else {
                                 dispatchCall(mod.drawGui, game, self, d.name);
                             }
-                        } else if (profiling_enabled) {
-                            self.profile[profile_idx].draw_gui_ns = 0;
                         }
                     }
                     profile_idx += 1;

--- a/src/script_runner.zig
+++ b/src/script_runner.zig
@@ -223,6 +223,7 @@ pub fn ScriptRunner(
             for (&self.profile, 0..) |*e, i| {
                 rows[i] = .{ .name = e.name, .worst_ns = e.tick.worst_ns, .avg_ns = e.tick.avgNs() };
                 e.tick.resetWindow();
+                e.draw_gui.resetWindow();
             }
             profiler.report("script", &rows);
         }


### PR DESCRIPTION
## What
Revives the `profile[]`/`plugin_profile[]` scaffolding that was stubbed during the Zig 0.16 `std.time.Timer` removal, turning it into a working frame profiler.

- New `scene/src/profiler.zig`: monotonic `nowNs()` (clock_gettime via @extern), a cached `recording()` gate on the `LABELLE_PROFILE` env var, a rolling `Stat` (worst/avg), and a worst-first `report()` to the log.
- Un-stubs the timing in `ScriptRunner` (tick/drawGui) and `SystemRegistry` (tick/postTick), feeding the existing per-entry arrays (already exposed via `Game.script_profile_ptr`/`plugin_profile_ptr` for a future overlay).
- `profiling_enabled` flipped from `builtin.mode == .Debug` to always compiled-in, so **ReleaseFast can be profiled** (recording stays gated at runtime; off-path is ~one branch). Lives in the `scene` module so both the engine `ScriptRunner` and the `scene` `SystemRegistry` can reach it; re-exported as `engine.profiler`.

## Use
`LABELLE_PROFILE=1 <game>` → logs `info(profiler)` `[script]/[plugin] <name>: worst=Xms avg=Yms` rankings every ~120 frames. Works headless (stderr).

## Why
Hunting at-scale FPS dips required hand-instrumenting the runners repeatedly; this makes it flip-a-flag and CI-able. Used it to attribute the scheduler and needs_decay dips.

## Test
`zig build` + `zig build test` pass. Companion CLI flag `labelle run --profile` in a separate labelle-cli PR.

Follow-up: an imgui debug-overlay panel (data already exposed for it).