### PR TITLE
feat(input): ControllerManager — player↔controller mapping, debounced-lost, resume (#611)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -103,6 +103,10 @@ pub fn build(b: *std.Build) void {
         // Accessor methods on the game handle wrapping the unified
         // `InputInterface` for key-release / mouse-button polling (#208).
         "test/input_mixin_test.zig",
+        // #611 — ControllerManager player↔controller mapping: unassigned
+        // pool, assignment API, debounced-lost, guid/heuristic resume,
+        // opt-in policy helpers, and the auto-pause integration.
+        "test/controller_manager_test.zig",
         "test/spawn_from_prefab_test.zig",
         "test/jsonc/bridge_prefab_tags_test.zig",
         "test/save_load_two_phase_test.zig",

--- a/src/controller_manager.zig
+++ b/src/controller_manager.zig
@@ -539,9 +539,13 @@ pub fn ControllerManager(comptime max_controllers: usize, comptime max_players: 
         /// Reconstruct a `ControllerInfo` from a binding for pool re-entry.
         fn bindingInfo(self: *const Self, b: Binding) ControllerInfo {
             _ = self;
-            var info = b.bound_info;
-            info.controller_id = if (b.controller_id != NO_CONTROLLER) b.controller_id else b.bound_info.controller_id;
-            return info;
+            // Invariant: whenever `b.controller_id` is live (!= NO_CONTROLLER)
+            // it equals `b.bound_info.controller_id` — both are written
+            // together in `assign` and `restoreBinding`, and the only other
+            // writer (`onDisconnected`) clears `controller_id` to
+            // NO_CONTROLLER without touching `bound_info`. So `bound_info`
+            // already carries the right live id in every reachable state.
+            return b.bound_info;
         }
     };
 }

--- a/src/controller_manager.zig
+++ b/src/controller_manager.zig
@@ -1,0 +1,552 @@
+//! `ControllerManager` — game-facing player↔controller mapping
+//! (labelle-engine#611, Phase 2 of the gamepad epic #609).
+//!
+//! ## Mechanism, not policy
+//!
+//! Raw engine `gamepad_connected`/`gamepad_disconnected` events are at the
+//! wrong altitude: they say "slot 1 vanished", not "Player 2 lost their
+//! pad". **When a connected controller becomes a player is a per-game
+//! decision** (single-player, press-A-to-join couch co-op, fixed GUID
+//! seats, drop-in/drop-out). The engine must NOT hardcode any of these.
+//!
+//! This module provides the *mechanism* — an unassigned pool, an
+//! assignment API, and player-level events — and ships the two common
+//! policies (auto-bind / join-on-button) as **opt-in helpers** that a game
+//! can call, never as default behaviour.
+//!
+//! What stays engine-owned (because it needs the stable identity the
+//! engine resolves over the core#18 `GamepadEvent` contract):
+//!
+//!   - **debounced-lost** — a configurable grace window before a transient
+//!     disconnect (endemic Bluetooth churn on Android TV) counts as a real
+//!     `player_controller_lost`. If the same stable id (`guid`) reappears
+//!     inside the window, the binding is treated as continuous — no
+//!     lost/restored churn, no pause-dialog flicker.
+//!   - **identity-based resume** — a replug rebinds to the *same* player
+//!     via `guid`. On backends with no stable key (raylib reports `null`),
+//!     a documented heuristic kicks in: the next controller to appear
+//!     resumes the most-recently-vacated player (note the multi-pad
+//!     ambiguity — see `resumeVacated`).
+//!
+//! ## Push/pull shape (zero allocations, fully testable)
+//!
+//! The manager is a pure state machine over fixed-size arrays — no
+//! allocator, COPY-friendly, embeddable directly in `Game`. Drive it with:
+//!
+//!   - `onConnected(ev)` / `onDisconnected(slot)` — feed drained
+//!     `core.GamepadEvent`s.
+//!   - `advance(now_seconds)` — let the debounce clock expire pending-lost
+//!     entries (call once per tick with the gameplay clock).
+//!   - `assign(controller, player)` / `unassign(player)` and the query API.
+//!   - `drainEvents(out)` — pull the `ManagerEvent`s produced since the
+//!     last drain; the host turns each into an engine event.
+//!
+//! `Game` wires all of this automatically when the project's `GameEvents`
+//! carries the controller variants (see `src/game.zig`), but the type is
+//! self-contained so it unit-tests without a `Game`.
+
+const std = @import("std");
+const core = @import("labelle-core");
+
+/// Sentinel for "no player". Returned by `playerFor` when a controller is
+/// unassigned, and used internally to mark empty binding slots.
+pub const NO_PLAYER: u32 = std.math.maxInt(u32);
+
+/// Sentinel for "no controller". Returned by `controllerFor` when a player
+/// has no controller currently bound.
+pub const NO_CONTROLLER: u32 = std.math.maxInt(u32);
+
+/// Configuration for a `ControllerManager`. All durations are in seconds,
+/// measured against the same clock the host feeds to `advance` (the
+/// engine's pause-aware `game.elapsedSeconds()`).
+pub const Config = struct {
+    /// Grace window before a disconnect of an *assigned* controller becomes
+    /// `player_controller_lost`. A transient Bluetooth blip shorter than
+    /// this never fires a lost event. `0` disables debouncing (a disconnect
+    /// is reported immediately). Default 0.2s — comfortably covers TV BT
+    /// re-pairing without feeling laggy.
+    debounce_lost_seconds: f64 = 0.2,
+};
+
+/// Output of the manager's state machine. The host drains these via
+/// `drainEvents` and re-emits each as the corresponding engine event.
+/// COPY-only (no borrowed memory) — `name` is inline, like
+/// `core.GamepadEvent`.
+pub const ManagerEvent = union(enum) {
+    /// A connected-but-unbound controller entered the unassigned pool —
+    /// the game's cue to decide whether/how it becomes a player.
+    controller_available: ControllerInfo,
+    /// An unassigned controller was removed (unplugged while in the pool).
+    controller_removed: struct { controller_id: u32 },
+    /// The game assigned a controller to a player (via `assign` or an
+    /// opt-in helper). Emitted only *after* the game decides.
+    player_joined: struct { player: u32, controller_id: u32 },
+    /// An assigned controller has been gone longer than the debounce
+    /// window — the player has truly lost their pad. A game can gate
+    /// `Controller.advance` / raise a "reconnect Player N" prompt on this.
+    player_controller_lost: struct { player: u32 },
+    /// A previously-lost (or debouncing) player got their controller back
+    /// — same `guid` replug, or the raylib resume heuristic. Carries the
+    /// (possibly new) backing controller id.
+    player_controller_restored: struct { player: u32, controller_id: u32 },
+};
+
+/// Identity snapshot of a pooled / bound controller. COPY-only.
+pub const ControllerInfo = struct {
+    controller_id: u32,
+    name: [core.gamepad.NAME_CAPACITY:0]u8 = [_:0]u8{0} ** core.gamepad.NAME_CAPACITY,
+    name_len: u8 = 0,
+    guid: ?[16]u8 = null,
+    source_class: core.GamepadSourceClass = .unknown,
+    type_hint: core.GamepadTypeHint = .unknown,
+
+    pub fn nameSlice(self: *const ControllerInfo) []const u8 {
+        return self.name[0..self.name_len];
+    }
+
+    fn fromEvent(ev: core.GamepadEvent) ControllerInfo {
+        return .{
+            .controller_id = ev.slot,
+            .name = ev.name,
+            .name_len = ev.name_len,
+            .guid = ev.guid,
+            .source_class = ev.source_class,
+            .type_hint = ev.type_hint,
+        };
+    }
+};
+
+/// `ControllerManager(max_controllers, max_players)` — fixed-capacity
+/// player↔controller mapping. Capacities are comptime so the whole thing
+/// is a flat, allocation-free value embeddable in `Game`.
+///
+/// `max_controllers` bounds both the unassigned pool and the number of
+/// distinct controller ids tracked at once; `max_players` bounds the
+/// player binding table. The toolkit default (`DefaultControllerManager`)
+/// uses 8 / 8 — plenty for couch co-op.
+pub fn ControllerManager(comptime max_controllers: usize, comptime max_players: usize) type {
+    return struct {
+        const Self = @This();
+
+        pub const capacity_controllers = max_controllers;
+        pub const capacity_players = max_players;
+
+        /// State of one tracked controller binding to a player. Lives in a
+        /// dense array indexed by player id (`0..max_players`).
+        const Binding = struct {
+            /// `true` when this player slot is in use (assigned at least
+            /// once and not fully released).
+            active: bool = false,
+            /// The controller id currently backing this player, or
+            /// `NO_CONTROLLER` while the controller is gone (debouncing or
+            /// lost).
+            controller_id: u32 = NO_CONTROLLER,
+            /// Stable identity captured at assign time, used to rebind on
+            /// replug. `null` when the backend reported no guid.
+            guid: ?[16]u8 = null,
+            /// `true` between a disconnect and either its debounce
+            /// expiry (→ lost) or a same-guid reconnect (→ continuous).
+            debouncing: bool = false,
+            /// Gameplay-clock deadline at which `debouncing` becomes a real
+            /// `player_controller_lost`. Only meaningful while `debouncing`.
+            lost_deadline: f64 = 0,
+            /// `true` once we have emitted `player_controller_lost` and are
+            /// waiting for a reconnect to restore. Distinct from
+            /// `debouncing`: a lost player no longer has a pending deadline.
+            lost: bool = false,
+            /// Clock time the controller vacated (disconnect). Drives the
+            /// raylib resume heuristic (most-recently-vacated wins).
+            vacated_at: f64 = 0,
+            /// Identity snapshot captured at assign time, so a player whose
+            /// controller is released (via `unassign`, or replaced) can
+            /// return the *right* `ControllerInfo` (name/guid/class) to the
+            /// pool — the live `controller_id` may have changed on replug.
+            bound_info: ControllerInfo = .{ .controller_id = NO_CONTROLLER },
+        };
+
+        /// One entry in the unassigned pool.
+        const PoolEntry = struct {
+            in_use: bool = false,
+            info: ControllerInfo = .{ .controller_id = NO_CONTROLLER },
+        };
+
+        pub const event_capacity = (max_controllers + max_players) * 2 + 8;
+
+        config: Config = .{},
+        bindings: [max_players]Binding = [_]Binding{.{}} ** max_players,
+        pool: [max_controllers]PoolEntry = [_]PoolEntry{.{}} ** max_controllers,
+
+        /// Ring of pending output events drained by the host. Sized to
+        /// comfortably cover a frame's churn; surplus is dropped with a
+        /// debug log rather than silently (should never happen in practice).
+        out: [event_capacity]ManagerEvent = undefined,
+        out_len: usize = 0,
+
+        /// Last clock value seen via `advance` — captured so `onDisconnected`
+        /// can stamp `vacated_at` / set the debounce deadline against the
+        /// current time without the caller threading `now` through every
+        /// feed call.
+        last_now: f64 = 0,
+
+        // ── Construction ──────────────────────────────────────────────
+
+        pub fn init(config: Config) Self {
+            return .{ .config = config };
+        }
+
+        // ── Event feed (host → manager) ───────────────────────────────
+
+        /// Feed a drained connect event. Resolves identity-based resume
+        /// first (a replug of an assigned controller restores the binding,
+        /// cancelling any in-flight debounce / firing `restored`); otherwise
+        /// the controller lands in the unassigned pool and
+        /// `controller_available` fires so the game can decide.
+        pub fn onConnected(self: *Self, ev: core.GamepadEvent) void {
+            // 1. Same-guid resume: a controller the game previously assigned
+            //    came back. Rebind to its player regardless of slot churn
+            //    (Linux returns a different `js*` on replug).
+            if (ev.guid) |g| {
+                if (self.findPlayerByGuid(g)) |player| {
+                    self.restoreBinding(player, ev.slot);
+                    return;
+                }
+            }
+
+            // 2. raylib heuristic: no stable key anywhere. If some player is
+            //    waiting for a controller (debouncing or lost), the next
+            //    controller to appear resumes the most-recently-vacated one.
+            //    Multi-pad ambiguity: with two pads down, the first replug
+            //    grabs the more-recently-vacated player — documented and
+            //    accepted (raylib gives us nothing better).
+            if (ev.guid == null) {
+                if (self.mostRecentlyVacated()) |player| {
+                    self.restoreBinding(player, ev.slot);
+                    return;
+                }
+            }
+
+            // 3. Brand-new controller → unassigned pool + availability event.
+            self.addToPool(ControllerInfo.fromEvent(ev));
+        }
+
+        /// Feed a drained disconnect event for `slot`. If the controller is
+        /// assigned, this starts the debounce window (or fires `lost`
+        /// immediately when debounce is disabled). If it was merely pooled,
+        /// it leaves the pool and `controller_removed` fires.
+        pub fn onDisconnected(self: *Self, slot: u32) void {
+            // Assigned controller? Begin debounce / mark vacated.
+            if (self.findPlayerByController(slot)) |player| {
+                const b = &self.bindings[player];
+                b.controller_id = NO_CONTROLLER;
+                b.vacated_at = self.last_now;
+                if (self.config.debounce_lost_seconds <= 0) {
+                    // No grace window — report lost right away.
+                    b.lost = true;
+                    b.debouncing = false;
+                    self.push(.{ .player_controller_lost = .{ .player = player } });
+                } else {
+                    b.debouncing = true;
+                    b.lost = false;
+                    b.lost_deadline = self.last_now + self.config.debounce_lost_seconds;
+                }
+                return;
+            }
+
+            // Pooled (unassigned) controller? Drop it from the pool.
+            if (self.removeFromPool(slot)) {
+                self.push(.{ .controller_removed = .{ .controller_id = slot } });
+            }
+        }
+
+        /// Advance the debounce clock to `now` (gameplay seconds). Any
+        /// pending-lost binding whose deadline has passed fires
+        /// `player_controller_lost`. Call once per tick.
+        pub fn advance(self: *Self, now: f64) void {
+            self.last_now = now;
+            for (&self.bindings, 0..) |*b, i| {
+                if (b.active and b.debouncing and now >= b.lost_deadline) {
+                    b.debouncing = false;
+                    b.lost = true;
+                    self.push(.{ .player_controller_lost = .{ .player = @intCast(i) } });
+                }
+            }
+        }
+
+        // ── Assignment API (game → manager) ───────────────────────────
+
+        pub const AssignError = error{
+            PlayerOutOfRange,
+            ControllerNotAvailable,
+        };
+
+        /// Bind `controller` (which must currently be in the unassigned
+        /// pool) to `player`. Emits `player_joined`. Removes the controller
+        /// from the pool. If `player` already had a (live) controller, the
+        /// old one is released back to the pool first.
+        pub fn assign(self: *Self, controller: u32, player: u32) AssignError!void {
+            if (player >= max_players) return error.PlayerOutOfRange;
+            const idx = self.poolIndex(controller) orelse return error.ControllerNotAvailable;
+            const info = self.pool[idx].info;
+            self.pool[idx].in_use = false;
+
+            // If this player held a different, still-live controller, return
+            // it to the pool so it can be reassigned.
+            const b = &self.bindings[player];
+            if (b.active and b.controller_id != NO_CONTROLLER and b.controller_id != controller) {
+                self.addToPool(self.bindingInfo(b.*));
+            }
+
+            b.* = .{
+                .active = true,
+                .controller_id = controller,
+                .guid = info.guid,
+                .bound_info = info,
+            };
+            self.push(.{ .player_joined = .{ .player = player, .controller_id = controller } });
+        }
+
+        /// Release `player`'s binding entirely. The controller (if still
+        /// present) returns to the unassigned pool with a fresh
+        /// `controller_available`. No-op for an inactive player.
+        pub fn unassign(self: *Self, player: u32) void {
+            if (player >= max_players) return;
+            const b = &self.bindings[player];
+            if (!b.active) return;
+            const live = b.controller_id != NO_CONTROLLER;
+            const info = self.bindingInfo(b.*);
+            b.* = .{};
+            if (live) self.addToPool(info);
+        }
+
+        /// The player a controller is bound to, or `NO_PLAYER`.
+        pub fn playerFor(self: *const Self, controller: u32) u32 {
+            return self.findPlayerByController(controller) orelse NO_PLAYER;
+        }
+
+        /// The controller currently backing a player, or `NO_CONTROLLER`
+        /// (also `NO_CONTROLLER` while the player is debouncing/lost).
+        pub fn controllerFor(self: *const Self, player: u32) u32 {
+            if (player >= max_players) return NO_CONTROLLER;
+            const b = self.bindings[player];
+            if (!b.active) return NO_CONTROLLER;
+            return b.controller_id;
+        }
+
+        /// `true` when the player slot is in use (assigned and not
+        /// unassigned), even if its controller is currently lost.
+        pub fn isPlayerActive(self: *const Self, player: u32) bool {
+            if (player >= max_players) return false;
+            return self.bindings[player].active;
+        }
+
+        /// `true` when an active player's controller is currently absent
+        /// (debouncing or fully lost) — useful to gate gameplay / show a
+        /// reconnect prompt.
+        pub fn isPlayerWaiting(self: *const Self, player: u32) bool {
+            if (player >= max_players) return false;
+            const b = self.bindings[player];
+            return b.active and (b.debouncing or b.lost);
+        }
+
+        // ── Pool query / iteration ────────────────────────────────────
+
+        /// Number of controllers waiting in the unassigned pool.
+        pub fn availableCount(self: *const Self) usize {
+            var n: usize = 0;
+            for (self.pool) |e| {
+                if (e.in_use) n += 1;
+            }
+            return n;
+        }
+
+        /// Snapshot the unassigned controllers into `out`, returning the
+        /// count written (capped at `out.len`). Order is pool-slot order.
+        pub fn availableControllers(self: *const Self, out: []ControllerInfo) usize {
+            var n: usize = 0;
+            for (self.pool) |e| {
+                if (!e.in_use) continue;
+                if (n >= out.len) break;
+                out[n] = e.info;
+                n += 1;
+            }
+            return n;
+        }
+
+        /// `true` when `controller` is in the unassigned pool.
+        pub fn isAvailable(self: *const Self, controller: u32) bool {
+            return self.poolIndex(controller) != null;
+        }
+
+        // ── Output drain (manager → host) ─────────────────────────────
+
+        /// Drain the events produced since the last call into `out`,
+        /// returning the count written. Drops surplus beyond `out.len`
+        /// (host should size `out` to the manager's `event_capacity`).
+        pub fn drainEvents(self: *Self, out: []ManagerEvent) usize {
+            const n = @min(out.len, self.out_len);
+            for (0..n) |i| out[i] = self.out[i];
+            self.out_len = 0;
+            return n;
+        }
+
+        // ── Opt-in policy helpers (NOT default behaviour) ─────────────
+
+        /// **Opt-in policy.** Bind every currently-unassigned controller to
+        /// the next free player slot, in pool order. A single-player or
+        /// "fill seats as pads appear" game can call this each tick after
+        /// `advance`. Returns the number of new assignments made. Does
+        /// nothing on its own unless the game chooses to call it.
+        pub fn autoBindFreeSlots(self: *Self) usize {
+            var assigned: usize = 0;
+            for (&self.pool) |*e| {
+                if (!e.in_use) continue;
+                const player = self.firstFreePlayer() orelse break;
+                const controller = e.info.controller_id;
+                self.assign(controller, player) catch break;
+                assigned += 1;
+            }
+            return assigned;
+        }
+
+        /// **Opt-in policy.** "Press A to join": bind the unassigned
+        /// controller `controller` to the next free player slot. Call from a
+        /// game's button handler when an *unassigned* pad's join button is
+        /// pressed. Returns the player it joined as, or `null` if the
+        /// controller isn't available / there's no free slot.
+        pub fn joinOnButton(self: *Self, controller: u32) ?u32 {
+            if (!self.isAvailable(controller)) return null;
+            const player = self.firstFreePlayer() orelse return null;
+            self.assign(controller, player) catch return null;
+            return player;
+        }
+
+        // ── Internals ─────────────────────────────────────────────────
+
+        fn push(self: *Self, ev: ManagerEvent) void {
+            if (self.out_len >= self.out.len) {
+                // Should not happen for realistic churn; drop rather than
+                // overwrite so the oldest events still dispatch.
+                return;
+            }
+            self.out[self.out_len] = ev;
+            self.out_len += 1;
+        }
+
+        fn addToPool(self: *Self, info: ControllerInfo) void {
+            // Idempotent on controller_id — a duplicate connect for an
+            // already-pooled id updates its info without a second event.
+            if (self.poolIndex(info.controller_id)) |idx| {
+                self.pool[idx].info = info;
+                return;
+            }
+            for (&self.pool) |*e| {
+                if (!e.in_use) {
+                    e.in_use = true;
+                    e.info = info;
+                    self.push(.{ .controller_available = info });
+                    return;
+                }
+            }
+            // Pool full — drop (no event). Realistically unreachable at the
+            // default capacity.
+        }
+
+        fn removeFromPool(self: *Self, controller: u32) bool {
+            if (self.poolIndex(controller)) |idx| {
+                self.pool[idx].in_use = false;
+                return true;
+            }
+            return false;
+        }
+
+        fn poolIndex(self: *const Self, controller: u32) ?usize {
+            for (self.pool, 0..) |e, i| {
+                if (e.in_use and e.info.controller_id == controller) return i;
+            }
+            return null;
+        }
+
+        fn findPlayerByController(self: *const Self, controller: u32) ?u32 {
+            if (controller == NO_CONTROLLER) return null;
+            for (self.bindings, 0..) |b, i| {
+                if (b.active and b.controller_id == controller) return @intCast(i);
+            }
+            return null;
+        }
+
+        fn findPlayerByGuid(self: *const Self, guid: [16]u8) ?u32 {
+            for (self.bindings, 0..) |b, i| {
+                if (!b.active) continue;
+                if (b.guid) |bg| {
+                    if (std.mem.eql(u8, &bg, &guid)) return @intCast(i);
+                }
+            }
+            return null;
+        }
+
+        /// Most-recently-vacated active player still waiting for a
+        /// controller (debouncing or lost). Drives the raylib resume
+        /// heuristic. `null` if no player is waiting.
+        fn mostRecentlyVacated(self: *const Self) ?u32 {
+            var best: ?u32 = null;
+            var best_t: f64 = -std.math.inf(f64);
+            for (self.bindings, 0..) |b, i| {
+                if (!b.active) continue;
+                if (!(b.debouncing or b.lost)) continue;
+                if (b.vacated_at >= best_t) {
+                    best_t = b.vacated_at;
+                    best = @intCast(i);
+                }
+            }
+            return best;
+        }
+
+        /// Rebind `player` to `controller` after a reconnect (guid match or
+        /// heuristic). Cancels any debounce; fires `player_controller_restored`
+        /// only when the player had visibly lost its controller (so a
+        /// within-window blip stays silent — no churn).
+        fn restoreBinding(self: *Self, player: u32, controller: u32) void {
+            const b = &self.bindings[player];
+            const was_visibly_lost = b.lost;
+            const was_debouncing = b.debouncing;
+            b.controller_id = controller;
+            b.debouncing = false;
+            b.lost = false;
+            b.lost_deadline = 0;
+            // Refresh the live controller id on the bound info too.
+            b.bound_info.controller_id = controller;
+            // Emit `restored` whenever the binding had actually vacated —
+            // both the visibly-lost case AND a within-window debounce
+            // reconnect surface as restored so the game can clear a prompt.
+            // The KEY no-churn guarantee is: a transient drop never fired
+            // `lost` in the first place (advance hasn't expired it), so the
+            // pair the game sees is at most {restored}, never {lost,restored}.
+            if (was_visibly_lost or was_debouncing) {
+                self.push(.{ .player_controller_restored = .{
+                    .player = player,
+                    .controller_id = controller,
+                } });
+            }
+        }
+
+        fn firstFreePlayer(self: *const Self) ?u32 {
+            for (self.bindings, 0..) |b, i| {
+                if (!b.active) return @intCast(i);
+            }
+            return null;
+        }
+
+        /// Reconstruct a `ControllerInfo` from a binding for pool re-entry.
+        fn bindingInfo(self: *const Self, b: Binding) ControllerInfo {
+            _ = self;
+            var info = b.bound_info;
+            info.controller_id = if (b.controller_id != NO_CONTROLLER) b.controller_id else b.bound_info.controller_id;
+            return info;
+        }
+    };
+}
+
+/// Toolkit default capacities (8 controllers / 8 players) — enough for
+/// couch co-op without an allocator. Games that need more can instantiate
+/// `ControllerManager(N, M)` directly.
+pub const DefaultControllerManager = ControllerManager(8, 8);

--- a/src/game.zig
+++ b/src/game.zig
@@ -17,6 +17,7 @@ const assets_mod = @import("assets/mod.zig");
 const game_log_mod = @import("game_log.zig");
 const preview_mode_mod = @import("preview_mode.zig");
 const scheduler_mod = @import("scheduler.zig");
+const controller_manager_mod = @import("controller_manager.zig");
 
 const hierarchy = @import("game/hierarchy.zig");
 const gizmo_draws_mod = @import("game/gizmo_draws.zig");
@@ -368,6 +369,26 @@ pub fn GameConfig(
         /// inherit pause + slow-mo for free. `undefined` until `init` wires
         /// the type-erased game pointer + clock/liveness trampolines.
         scheduler: SchedulerType = undefined,
+
+        /// Player↔controller mapping layer (#611). `void` (zero-size,
+        /// elided) unless the project's `GameEvents` carries a player-level
+        /// controller variant — then it's a `DefaultControllerManager` the
+        /// engine feeds drained gamepad events and drains player-level
+        /// events out of, each tick (see `scanInputEvents` / `tick`). The
+        /// game reaches the assignment API via `game.controllerManager()`.
+        controller_manager: ControllerManagerType = if (controller_events_wanted)
+            ControllerManagerType.init(.{})
+        else {},
+
+        /// Opt-in: when `true`, an active player losing its controller (a
+        /// real `player_controller_lost`, past the debounce window) drives
+        /// `setPaused(true)` so plugin-gated work (`Controller.advance`,
+        /// #465) halts and the game can raise a "reconnect Player N"
+        /// prompt. Cleared back to running when every player is whole again
+        /// (a `player_controller_restored` leaves nobody waiting). OFF by
+        /// default — the engine never forces a pause. Toggle with
+        /// `setAutoPauseOnControllerLost`.
+        auto_pause_on_controller_lost: bool = false,
 
         /// Connect-out preview channel to the labelle-gui editor
         /// (`--preview-mode <host:port>`). `null` in normal runs — the
@@ -1478,6 +1499,67 @@ pub fn GameConfig(
             return self.paused or self.time_scale == 0;
         }
 
+        // ── ControllerManager game-facing API (#611) ─────────────────
+        //
+        // Thin forwarders over the embedded `controller_manager` so game
+        // scripts and plugins reach the assignment/query API without poking
+        // the field directly. Available only when the project's
+        // `GameEvents` carries a player-level controller variant — calling
+        // any of these in a game that doesn't is a compile error (the
+        // manager field is `void`), which is the intended guard rail.
+
+        /// Mutable handle to the embedded `ControllerManager`. Use for the
+        /// full API (iteration, `availableControllers`, opt-in helpers like
+        /// `autoBindFreeSlots` / `joinOnButton`). Requires a controller
+        /// event in `GameEvents`.
+        pub fn controllerManager(self: *Self) *ControllerManagerType {
+            comptime if (!controller_events_wanted)
+                @compileError("controllerManager() requires a player-level controller event " ++
+                    "(engine.player_joined / controller_available / ...) in GameEvents");
+            return &self.controller_manager;
+        }
+
+        /// Assign an unassigned `controller` to `player`. Emits
+        /// `player_joined` on the next `dispatchEvents`. Errors if the
+        /// player id is out of range or the controller isn't in the pool.
+        pub fn assignController(self: *Self, controller: u32, player: u32) !void {
+            comptime if (!controller_events_wanted)
+                @compileError("assignController() requires a player-level controller event in GameEvents");
+            try self.controller_manager.assign(controller, player);
+            self.drainControllerManagerEvents();
+        }
+
+        /// Release a player's controller binding, returning the controller
+        /// (if still present) to the unassigned pool.
+        pub fn unassignPlayer(self: *Self, player: u32) void {
+            comptime if (!controller_events_wanted)
+                @compileError("unassignPlayer() requires a player-level controller event in GameEvents");
+            self.controller_manager.unassign(player);
+            self.drainControllerManagerEvents();
+        }
+
+        /// The player a controller is bound to, or `NO_PLAYER`.
+        pub fn playerForController(self: *Self, controller: u32) u32 {
+            comptime if (!controller_events_wanted)
+                @compileError("playerForController() requires a player-level controller event in GameEvents");
+            return self.controller_manager.playerFor(controller);
+        }
+
+        /// The controller currently backing a player, or `NO_CONTROLLER`.
+        pub fn controllerForPlayer(self: *Self, player: u32) u32 {
+            comptime if (!controller_events_wanted)
+                @compileError("controllerForPlayer() requires a player-level controller event in GameEvents");
+            return self.controller_manager.controllerFor(player);
+        }
+
+        /// Toggle the opt-in auto-pause policy (#465 precedent): when on, a
+        /// real `player_controller_lost` drives `setPaused(true)`, and the
+        /// game resumes once every player is whole again. OFF by default —
+        /// the engine never forces a pause.
+        pub fn setAutoPauseOnControllerLost(self: *Self, enabled: bool) void {
+            self.auto_pause_on_controller_lost = enabled;
+        }
+
         pub fn unloadCurrentScene(self: *Self) void {
             if (has_events) self.event_buffer.clearRetainingCapacity();
             if (self.current_scene_name) |name| {
@@ -1769,7 +1851,31 @@ pub fn GameConfig(
         const mouse_events_wanted = engineEventWanted("engine__mouse_button_pressed") or
             engineEventWanted("engine__mouse_button_released");
         const gamepad_events_wanted = engineEventWanted("engine__gamepad_connected") or
-            engineEventWanted("engine__gamepad_disconnected");
+            engineEventWanted("engine__gamepad_disconnected") or
+            // The ControllerManager consumes the SAME drained gamepad
+            // events, so any project that listens to a player-level event
+            // forces the drain on too — even if it never listens to the raw
+            // `gamepad_*` pair (#611).
+            controller_events_wanted;
+
+        /// True when the project's `GameEvents` carries any
+        /// `ControllerManager` player-level variant. Gates the manager's
+        /// state machine + output drain so an unused game pays nothing
+        /// (the whole `controller_manager` field + per-tick work folds
+        /// away). Mirrors the `gamepad_events_wanted` gate.
+        const controller_events_wanted = engineEventWanted("engine__controller_available") or
+            engineEventWanted("engine__controller_removed") or
+            engineEventWanted("engine__player_joined") or
+            engineEventWanted("engine__player_controller_lost") or
+            engineEventWanted("engine__player_controller_restored");
+
+        /// The concrete `ControllerManager` type for this game (toolkit
+        /// default capacities). `void` when no controller event is wanted —
+        /// the field then has zero size and all wiring folds away.
+        pub const ControllerManagerType = if (controller_events_wanted)
+            controller_manager_mod.DefaultControllerManager
+        else
+            void;
 
         /// Scan the unified `InputInterface` for input edges and emit
         /// the matching engine events into the buffer. Every query goes
@@ -1823,6 +1929,17 @@ pub fn GameConfig(
                 }
             }
 
+        }
+
+        /// Drain gamepad hotplug events (core#18) and the
+        /// `ControllerManager` (#611). Split OUT of `scanInputEvents`
+        /// because it MUST run every frame, INCLUDING while paused: when
+        /// the opt-in auto-pause gates the game on a lost controller, the
+        /// reconnect that lifts the pause arrives as a gamepad event — if we
+        /// only scanned in the active-frame body (past the pause gate) the
+        /// game would deadlock paused forever. Keyboard/mouse scanning stays
+        /// gameplay-only in `scanInputEvents`.
+        fn scanGamepadEvents(self: *Self) void {
             // ── Gamepad connect / disconnect (drained queue, core#18) ──
             //
             // Drain hotplug events from a single source — picked at
@@ -1862,8 +1979,86 @@ pub fn GameConfig(
                             .{ .id = ev.slot },
                         ),
                     }
+                    // The ControllerManager consumes the SAME drained
+                    // events (#611). Feed it here so a project listening to
+                    // a player-level event but NOT the raw `gamepad_*` pair
+                    // still drives the mapping layer.
+                    if (comptime controller_events_wanted) {
+                        switch (ev.kind) {
+                            .connected => self.controller_manager.onConnected(ev),
+                            .disconnected => self.controller_manager.onDisconnected(ev.slot),
+                        }
+                    }
                 }
             }
+
+            // Advance the manager's debounce clock and drain its
+            // player-level output into engine events (#611). The clock is
+            // the pause-aware gameplay clock, so a debounce window measured
+            // in seconds holds correctly behind a pause menu. Runs after the
+            // feed above so a connect+expire within one tick is consistent.
+            if (comptime controller_events_wanted) {
+                self.controller_manager.advance(self.elapsedSeconds());
+                self.drainControllerManagerEvents();
+            }
+        }
+
+        /// Pull the `ControllerManager`'s pending player-level events and
+        /// re-emit each as the matching engine event, applying the opt-in
+        /// auto-pause policy (#611). Folds away unless a controller event is
+        /// wanted.
+        fn drainControllerManagerEvents(self: *Self) void {
+            if (comptime !controller_events_wanted) return;
+            var evbuf: [ControllerManagerType.event_capacity]controller_manager_mod.ManagerEvent = undefined;
+            const m = self.controller_manager.drainEvents(&evbuf);
+            for (evbuf[0..m]) |mev| {
+                switch (mev) {
+                    .controller_available => |c| self.emitEngineEvent("engine__controller_available", .{
+                        .controller_id = c.controller_id,
+                        .name = c.name,
+                        .name_len = c.name_len,
+                        .guid = c.guid,
+                        .source_class = c.source_class,
+                        .type_hint = c.type_hint,
+                    }),
+                    .controller_removed => |c| self.emitEngineEvent("engine__controller_removed", .{
+                        .controller_id = c.controller_id,
+                    }),
+                    .player_joined => |p| self.emitEngineEvent("engine__player_joined", .{
+                        .player = p.player,
+                        .controller_id = p.controller_id,
+                    }),
+                    .player_controller_lost => |p| {
+                        self.emitEngineEvent("engine__player_controller_lost", .{ .player = p.player });
+                        // Opt-in auto-pause (#465 precedent): a real loss
+                        // gates the game until the controller is back.
+                        if (self.auto_pause_on_controller_lost) self.setPaused(true);
+                    },
+                    .player_controller_restored => |p| {
+                        self.emitEngineEvent("engine__player_controller_restored", .{
+                            .player = p.player,
+                            .controller_id = p.controller_id,
+                        });
+                        // Resume only once NO player is still waiting — with
+                        // multiple lost pads we stay paused until the last
+                        // one reconnects.
+                        if (self.auto_pause_on_controller_lost and !self.anyPlayerWaiting()) {
+                            self.setPaused(false);
+                        }
+                    },
+                }
+            }
+        }
+
+        /// `true` when any active player's controller is currently absent
+        /// (debouncing or lost). Drives the auto-pause resume gate.
+        fn anyPlayerWaiting(self: *const Self) bool {
+            if (comptime !controller_events_wanted) return false;
+            var p: u32 = 0;
+            while (p < ControllerManagerType.capacity_players) : (p += 1) {
+                if (self.controller_manager.isPlayerWaiting(p)) return true;
+            }
+            return false;
         }
 
         pub fn tick(self: *Self, dt: f32) void {
@@ -1908,6 +2103,13 @@ pub fn GameConfig(
             Input.updateGestures(dt);
             self.resolveAtlasSprites();
             self.renderer.sync(EcsImpl, self.ecs_backend);
+
+            // Gamepad hotplug + ControllerManager drain (core#18 / #611).
+            // Runs in the ALWAYS-RUN section, BEFORE the pause gate below,
+            // so a controller reconnect that should lift an opt-in
+            // auto-pause is still seen while the game is paused. Folds away
+            // entirely when no gamepad/controller event is wanted.
+            self.scanGamepadEvents();
 
             // Reconcile gizmos for runtime-created entities
             if (self.gizmo_reconcile_fn) |reconcile_fn| {

--- a/src/root.zig
+++ b/src/root.zig
@@ -335,6 +335,64 @@ pub const Events = struct {
     pub const gamepad_disconnected = struct {
         id: u32,
     };
+
+    // ── ControllerManager player↔controller events (#611) ─────────────
+    //
+    // Higher-altitude than the raw `gamepad_*` events above. The engine's
+    // `ControllerManager` (src/controller_manager.zig) consumes the drained
+    // gamepad events and emits these — the game listens to *players*, not
+    // hardware slots. `controller_available`/`controller_removed` surface
+    // the unassigned pool (the cue to decide); the `player_*` trio fires
+    // only *after* the game assigns. All four are flow-listenable via
+    // `OnEvent { name: "engine.<event>" }`. See the issue for the
+    // mechanism-not-policy rationale.
+
+    /// Fired when a connected-but-unbound controller enters the unassigned
+    /// pool — the game's cue to decide whether/how it becomes a player.
+    /// Carries the same identity fields as `gamepad_connected` (read the
+    /// name via `nameSlice()`).
+    pub const controller_available = struct {
+        controller_id: u32,
+        name: [core.gamepad.NAME_CAPACITY:0]u8 = [_:0]u8{0} ** core.gamepad.NAME_CAPACITY,
+        name_len: u8 = 0,
+        guid: ?[16]u8 = null,
+        source_class: core.GamepadSourceClass = .unknown,
+        type_hint: core.GamepadTypeHint = .unknown,
+
+        pub fn nameSlice(self: *const controller_available) []const u8 {
+            return self.name[0..self.name_len];
+        }
+    };
+
+    /// Fired when an unassigned controller leaves the pool (unplugged while
+    /// it was never bound to a player).
+    pub const controller_removed = struct {
+        controller_id: u32,
+    };
+
+    /// Fired when the game assigns a controller to a player (via the
+    /// `ControllerManager` assignment API or an opt-in policy helper).
+    /// Emitted only *after* the game decides — never auto-imposed.
+    pub const player_joined = struct {
+        player: u32,
+        controller_id: u32,
+    };
+
+    /// Fired when a player's assigned controller has been absent longer
+    /// than the configurable debounce window — a real loss, not a blip. A
+    /// transient drop that reconnects inside the window NEVER fires this.
+    /// Gate `Controller.advance` / raise a "reconnect Player N" prompt here.
+    pub const player_controller_lost = struct {
+        player: u32,
+    };
+
+    /// Fired when a previously-lost (or debouncing) player gets their
+    /// controller back — a same-`guid` replug, or the raylib resume
+    /// heuristic. `controller_id` is the (possibly new) backing controller.
+    pub const player_controller_restored = struct {
+        player: u32,
+        controller_id: u32,
+    };
 };
 
 // ── Hook Types ──
@@ -474,6 +532,20 @@ pub const HotReloader = jsonc_mod.HotReloader;
 
 // ── Scheduler (flow Delay timers, #25 Stage 2) ──
 pub const Scheduler = @import("scheduler.zig").Scheduler;
+
+// ── ControllerManager (player↔controller mapping, #611) ──
+// Game-facing layer over the raw gamepad events: unassigned pool +
+// assignment API + player-level events, with engine-owned debounced-lost
+// and identity-based resume. Mechanism, not policy — the two common
+// policies ship as opt-in helpers. See src/controller_manager.zig.
+pub const controller_manager_mod = @import("controller_manager.zig");
+pub const ControllerManager = controller_manager_mod.ControllerManager;
+pub const DefaultControllerManager = controller_manager_mod.DefaultControllerManager;
+pub const ControllerManagerConfig = controller_manager_mod.Config;
+pub const ControllerInfo = controller_manager_mod.ControllerInfo;
+pub const ControllerManagerEvent = controller_manager_mod.ManagerEvent;
+pub const NO_PLAYER = controller_manager_mod.NO_PLAYER;
+pub const NO_CONTROLLER = controller_manager_mod.NO_CONTROLLER;
 
 // ── Core Re-exports ──
 pub const Position = core.Position;

--- a/test/controller_manager_test.zig
+++ b/test/controller_manager_test.zig
@@ -1,0 +1,498 @@
+//! Tests for the `ControllerManager` — game-facing player↔controller
+//! mapping (labelle-engine#611).
+//!
+//! Two layers:
+//!   1. UNIT — drive `engine.ControllerManager` directly (no `Game`):
+//!      unassigned pool, assignment/query API, debounced-lost, guid resume,
+//!      raylib heuristic resume, opt-in policy helpers.
+//!   2. INTEGRATION — through `Game.tick`, with a `TestInput` backend that
+//!      injects `core.GamepadEvent`s (same pattern as
+//!      `input_events_test.zig`): the engine drains them, feeds the
+//!      manager, and re-emits player-level engine events; the opt-in
+//!      auto-pause is exercised end to end.
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+
+const core = engine.core;
+const game_mod = engine.game_mod;
+
+const Manager = engine.DefaultControllerManager;
+const ManagerEvent = engine.ControllerManagerEvent;
+
+// ── helpers ─────────────────────────────────────────────────────────────
+
+fn connectedGuid(slot: u32, name: []const u8, guid: [16]u8) core.GamepadEvent {
+    var ev = core.GamepadEvent.connected(slot, name);
+    ev.guid = guid;
+    return ev;
+}
+
+const G1: [16]u8 = .{ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 };
+const G2: [16]u8 = .{ 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 };
+
+/// Drain the manager and count events by tag.
+const Counts = struct {
+    available: usize = 0,
+    removed: usize = 0,
+    joined: usize = 0,
+    lost: usize = 0,
+    restored: usize = 0,
+    last_joined_player: u32 = 0,
+    last_joined_controller: u32 = 0,
+    last_lost_player: u32 = 0,
+    last_restored_player: u32 = 0,
+    last_restored_controller: u32 = 0,
+    last_available_controller: u32 = 0,
+};
+
+fn drain(m: *Manager) Counts {
+    var buf: [Manager.event_capacity]ManagerEvent = undefined;
+    const n = m.drainEvents(&buf);
+    var c = Counts{};
+    for (buf[0..n]) |ev| switch (ev) {
+        .controller_available => |x| {
+            c.available += 1;
+            c.last_available_controller = x.controller_id;
+        },
+        .controller_removed => c.removed += 1,
+        .player_joined => |x| {
+            c.joined += 1;
+            c.last_joined_player = x.player;
+            c.last_joined_controller = x.controller_id;
+        },
+        .player_controller_lost => |x| {
+            c.lost += 1;
+            c.last_lost_player = x.player;
+        },
+        .player_controller_restored => |x| {
+            c.restored += 1;
+            c.last_restored_player = x.player;
+            c.last_restored_controller = x.controller_id;
+        },
+    };
+    return c;
+}
+
+// ── Unassigned pool ──────────────────────────────────────────────────────
+
+test "a connect lands in the unassigned pool and fires controller_available" {
+    var m = Manager.init(.{});
+    m.onConnected(core.GamepadEvent.connected(0, "Pad A"));
+
+    const c = drain(&m);
+    try testing.expectEqual(@as(usize, 1), c.available);
+    try testing.expectEqual(@as(u32, 0), c.last_available_controller);
+    try testing.expectEqual(@as(usize, 1), m.availableCount());
+    try testing.expect(m.isAvailable(0));
+    // Unassigned → no player.
+    try testing.expectEqual(engine.NO_PLAYER, m.playerFor(0));
+}
+
+test "unplugging a pooled (unassigned) controller fires controller_removed" {
+    var m = Manager.init(.{});
+    m.onConnected(core.GamepadEvent.connected(0, "Pad A"));
+    _ = drain(&m);
+
+    m.onDisconnected(0);
+    const c = drain(&m);
+    try testing.expectEqual(@as(usize, 1), c.removed);
+    try testing.expectEqual(@as(usize, 0), m.availableCount());
+}
+
+test "availableControllers snapshots the pool" {
+    var m = Manager.init(.{});
+    m.onConnected(core.GamepadEvent.connected(0, "A"));
+    m.onConnected(core.GamepadEvent.connected(5, "B"));
+    _ = drain(&m);
+
+    var snap: [4]engine.ControllerInfo = undefined;
+    const n = m.availableControllers(&snap);
+    try testing.expectEqual(@as(usize, 2), n);
+    try testing.expectEqualStrings("A", snap[0].nameSlice());
+    try testing.expectEqual(@as(u32, 5), snap[1].controller_id);
+}
+
+// ── Assignment API ─────────────────────────────────────────────────────────
+
+test "assign binds a pooled controller to a player and fires player_joined" {
+    var m = Manager.init(.{});
+    m.onConnected(core.GamepadEvent.connected(2, "Pad"));
+    _ = drain(&m);
+
+    try m.assign(2, 0);
+    const c = drain(&m);
+    try testing.expectEqual(@as(usize, 1), c.joined);
+    try testing.expectEqual(@as(u32, 0), c.last_joined_player);
+    try testing.expectEqual(@as(u32, 2), c.last_joined_controller);
+
+    // Bidirectional query + pool removal.
+    try testing.expectEqual(@as(u32, 0), m.playerFor(2));
+    try testing.expectEqual(@as(u32, 2), m.controllerFor(0));
+    try testing.expect(!m.isAvailable(2));
+    try testing.expect(m.isPlayerActive(0));
+}
+
+test "assigning an unavailable controller errors" {
+    var m = Manager.init(.{});
+    try testing.expectError(error.ControllerNotAvailable, m.assign(9, 0));
+}
+
+test "assigning to an out-of-range player errors" {
+    var m = Manager.init(.{});
+    m.onConnected(core.GamepadEvent.connected(0, "P"));
+    _ = drain(&m);
+    try testing.expectError(error.PlayerOutOfRange, m.assign(0, 999));
+}
+
+test "unassign releases the controller back to the pool" {
+    var m = Manager.init(.{});
+    m.onConnected(core.GamepadEvent.connected(1, "P"));
+    _ = drain(&m);
+    try m.assign(1, 0);
+    _ = drain(&m);
+
+    m.unassign(0);
+    const c = drain(&m);
+    // Released controller re-enters the pool with a fresh availability.
+    try testing.expectEqual(@as(usize, 1), c.available);
+    try testing.expect(m.isAvailable(1));
+    try testing.expect(!m.isPlayerActive(0));
+    try testing.expectEqual(engine.NO_PLAYER, m.playerFor(1));
+}
+
+// ── Debounced-lost (engine-owned, the headline TV feature) ─────────────────
+
+test "a transient drop within the debounce window does NOT fire lost" {
+    var m = Manager.init(.{ .debounce_lost_seconds = 0.2 });
+    m.onConnected(connectedGuid(0, "Pad", G1));
+    _ = drain(&m);
+    try m.assign(0, 0);
+    _ = drain(&m);
+
+    // Drop at t=0, reconnect at t=0.1 (inside the 0.2s window).
+    m.advance(0.0);
+    m.onDisconnected(0);
+    m.advance(0.1);
+    m.onConnected(connectedGuid(0, "Pad", G1)); // same guid
+
+    const c = drain(&m);
+    // No lost (debounce never expired); a restored fires so a prompt can
+    // clear, but crucially NEVER the {lost, restored} churn pair.
+    try testing.expectEqual(@as(usize, 0), c.lost);
+    try testing.expectEqual(@as(usize, 1), c.restored);
+    try testing.expectEqual(@as(u32, 0), m.controllerFor(0)); // rebound
+    try testing.expect(!m.isPlayerWaiting(0));
+}
+
+test "a drop past the debounce window fires player_controller_lost" {
+    var m = Manager.init(.{ .debounce_lost_seconds = 0.2 });
+    m.onConnected(connectedGuid(0, "Pad", G1));
+    _ = drain(&m);
+    try m.assign(0, 0);
+    _ = drain(&m);
+
+    m.advance(0.0);
+    m.onDisconnected(0);
+    // Clock crosses the deadline with no reconnect.
+    m.advance(0.5);
+
+    const c = drain(&m);
+    try testing.expectEqual(@as(usize, 1), c.lost);
+    try testing.expectEqual(@as(u32, 0), c.last_lost_player);
+    try testing.expect(m.isPlayerWaiting(0));
+    try testing.expectEqual(engine.NO_CONTROLLER, m.controllerFor(0));
+}
+
+test "debounce disabled (0s) reports lost immediately on disconnect" {
+    var m = Manager.init(.{ .debounce_lost_seconds = 0 });
+    m.onConnected(connectedGuid(0, "Pad", G1));
+    _ = drain(&m);
+    try m.assign(0, 0);
+    _ = drain(&m);
+
+    m.advance(0.0);
+    m.onDisconnected(0);
+    const c = drain(&m);
+    try testing.expectEqual(@as(usize, 1), c.lost);
+}
+
+// ── Identity-based resume (guid) ──────────────────────────────────────────
+
+test "a same-guid replug after a real loss restores the SAME player" {
+    var m = Manager.init(.{ .debounce_lost_seconds = 0.2 });
+    m.onConnected(connectedGuid(3, "Pad", G1));
+    _ = drain(&m);
+    try m.assign(3, 1); // player 1
+    _ = drain(&m);
+
+    m.advance(0.0);
+    m.onDisconnected(3);
+    m.advance(1.0); // truly lost
+    try testing.expectEqual(@as(usize, 1), drain(&m).lost);
+
+    // Replug on a DIFFERENT slot (Linux returns a new js* index) but same guid.
+    m.onConnected(connectedGuid(9, "Pad", G1));
+    const c = drain(&m);
+    try testing.expectEqual(@as(usize, 1), c.restored);
+    try testing.expectEqual(@as(u32, 1), c.last_restored_player);
+    try testing.expectEqual(@as(u32, 9), c.last_restored_controller);
+    // Player 1 now backed by the new slot; no new pool entry.
+    try testing.expectEqual(@as(u32, 9), m.controllerFor(1));
+    try testing.expectEqual(@as(u32, 1), m.playerFor(9));
+    try testing.expectEqual(@as(usize, 0), m.availableCount());
+}
+
+test "a different-guid controller after a loss does NOT hijack the player; it pools" {
+    var m = Manager.init(.{ .debounce_lost_seconds = 0.2 });
+    m.onConnected(connectedGuid(0, "Pad1", G1));
+    _ = drain(&m);
+    try m.assign(0, 0);
+    _ = drain(&m);
+
+    m.advance(0.0);
+    m.onDisconnected(0);
+    m.advance(1.0);
+    _ = drain(&m);
+
+    // A genuinely different device (G2) connects — guid match fails, so it
+    // must NOT steal player 0; it joins the pool instead.
+    m.onConnected(connectedGuid(7, "Pad2", G2));
+    const c = drain(&m);
+    try testing.expectEqual(@as(usize, 0), c.restored);
+    try testing.expectEqual(@as(usize, 1), c.available);
+    try testing.expect(m.isPlayerWaiting(0)); // still waiting
+}
+
+// ── raylib heuristic resume (no stable key) ───────────────────────────────
+
+test "with no guid, the next controller resumes the most-recently-vacated player" {
+    var m = Manager.init(.{ .debounce_lost_seconds = 0.2 });
+    // Two players, neither with a guid (raylib).
+    m.onConnected(core.GamepadEvent.connected(0, "P0"));
+    m.onConnected(core.GamepadEvent.connected(1, "P1"));
+    _ = drain(&m);
+    try m.assign(0, 0);
+    try m.assign(1, 1);
+    _ = drain(&m);
+
+    // Player 0 vacates first (t=0), player 1 vacates later (t=0.1).
+    m.advance(0.0);
+    m.onDisconnected(0);
+    m.advance(0.1);
+    m.onDisconnected(1);
+    m.advance(1.0); // both lost
+    _ = drain(&m);
+
+    // Next no-guid controller resumes the MOST-recently-vacated → player 1.
+    m.onConnected(core.GamepadEvent.connected(4, "new"));
+    const c = drain(&m);
+    try testing.expectEqual(@as(usize, 1), c.restored);
+    try testing.expectEqual(@as(u32, 1), c.last_restored_player);
+    try testing.expectEqual(@as(u32, 4), m.controllerFor(1));
+    // Player 0 still waiting.
+    try testing.expect(m.isPlayerWaiting(0));
+}
+
+// ── Opt-in policy helpers ──────────────────────────────────────────────────
+
+test "autoBindFreeSlots binds every pooled controller to a free player" {
+    var m = Manager.init(.{});
+    m.onConnected(core.GamepadEvent.connected(0, "A"));
+    m.onConnected(core.GamepadEvent.connected(1, "B"));
+    _ = drain(&m);
+
+    const n = m.autoBindFreeSlots();
+    try testing.expectEqual(@as(usize, 2), n);
+    const c = drain(&m);
+    try testing.expectEqual(@as(usize, 2), c.joined);
+    try testing.expectEqual(@as(u32, 0), m.playerFor(0));
+    try testing.expectEqual(@as(u32, 1), m.playerFor(1));
+    try testing.expectEqual(@as(usize, 0), m.availableCount());
+}
+
+test "joinOnButton binds one pooled controller to the next free slot" {
+    var m = Manager.init(.{});
+    m.onConnected(core.GamepadEvent.connected(0, "A"));
+    m.onConnected(core.GamepadEvent.connected(1, "B"));
+    _ = drain(&m);
+
+    // Player 0 already taken by A.
+    try m.assign(0, 0);
+    _ = drain(&m);
+
+    const joined = m.joinOnButton(1);
+    try testing.expect(joined != null);
+    try testing.expectEqual(@as(u32, 1), joined.?); // next free slot
+    try testing.expectEqual(@as(u32, 1), m.playerFor(1));
+    try testing.expectEqual(@as(?u32, null), m.joinOnButton(99)); // not available
+}
+
+// ── INTEGRATION through Game.tick ──────────────────────────────────────────
+
+const TestInput = struct {
+    var pending: [16]core.GamepadEvent = undefined;
+    var pending_len: usize = 0;
+
+    fn reset() void {
+        pending_len = 0;
+    }
+    fn queue(ev: core.GamepadEvent) void {
+        pending[pending_len] = ev;
+        pending_len += 1;
+    }
+
+    pub fn isKeyDown(_: u32) bool {
+        return false;
+    }
+    pub fn isKeyPressed(_: u32) bool {
+        return false;
+    }
+    pub fn pollGamepadEvents(out: []core.GamepadEvent) usize {
+        const n = @min(out.len, pending_len);
+        for (0..n) |i| out[i] = pending[i];
+        pending_len = 0;
+        return n;
+    }
+};
+
+// GameEvents carrying the player-level controller variants → the engine
+// instantiates a ControllerManager and drives it.
+const ControllerGameEvents = union(enum) {
+    engine__controller_available: engine.Events.controller_available,
+    engine__controller_removed: engine.Events.controller_removed,
+    engine__player_joined: engine.Events.player_joined,
+    engine__player_controller_lost: engine.Events.player_controller_lost,
+    engine__player_controller_restored: engine.Events.player_controller_restored,
+};
+
+const Recorder = struct {
+    available: usize = 0,
+    joined: usize = 0,
+    lost: usize = 0,
+    restored: usize = 0,
+    last_available_controller: u32 = 0,
+    last_joined_player: u32 = 0,
+
+    pub fn engine__controller_available(self: *Recorder, info: anytype) void {
+        self.available += 1;
+        self.last_available_controller = info.controller_id;
+    }
+    pub fn engine__controller_removed(_: *Recorder, _: anytype) void {}
+    pub fn engine__player_joined(self: *Recorder, info: anytype) void {
+        self.joined += 1;
+        self.last_joined_player = info.player;
+    }
+    pub fn engine__player_controller_lost(self: *Recorder, _: anytype) void {
+        self.lost += 1;
+    }
+    pub fn engine__player_controller_restored(self: *Recorder, _: anytype) void {
+        self.restored += 1;
+    }
+};
+
+const EmptyComponents = struct {
+    pub fn has(comptime _: []const u8) bool {
+        return false;
+    }
+    pub fn names() []const []const u8 {
+        return &.{};
+    }
+};
+
+const ControllerGame = game_mod.GameConfig(
+    core.StubRender(core.MockEcsBackend(u32).Entity),
+    core.MockEcsBackend(u32),
+    TestInput,
+    engine.StubAudio,
+    engine.StubGui,
+    *Recorder,
+    core.StubLogSink,
+    EmptyComponents,
+    &.{},
+    ControllerGameEvents,
+);
+
+fn newGame(rec: *Recorder) ControllerGame {
+    var game = ControllerGame.init(testing.allocator);
+    game.setHooks(rec);
+    game.dispatchEvents();
+    rec.* = .{};
+    return game;
+}
+
+test "tick drains a connect into engine controller_available" {
+    TestInput.reset();
+    var rec = Recorder{};
+    var game = newGame(&rec);
+    defer game.deinit();
+
+    TestInput.queue(core.GamepadEvent.connected(0, "Pad"));
+    game.tick(0.016);
+    game.dispatchEvents();
+
+    try testing.expectEqual(@as(usize, 1), rec.available);
+    try testing.expectEqual(@as(u32, 0), rec.last_available_controller);
+    // The unassigned pool is reachable through the game handle.
+    try testing.expectEqual(@as(usize, 1), game.controllerManager().availableCount());
+}
+
+test "assignController through the game emits player_joined" {
+    TestInput.reset();
+    var rec = Recorder{};
+    var game = newGame(&rec);
+    defer game.deinit();
+
+    TestInput.queue(core.GamepadEvent.connected(0, "Pad"));
+    game.tick(0.016);
+    game.dispatchEvents();
+    rec = .{};
+
+    try game.assignController(0, 0);
+    game.dispatchEvents();
+
+    try testing.expectEqual(@as(usize, 1), rec.joined);
+    try testing.expectEqual(@as(u32, 0), rec.last_joined_player);
+    try testing.expectEqual(@as(u32, 0), game.playerForController(0));
+    try testing.expectEqual(@as(u32, 0), game.controllerForPlayer(0));
+}
+
+test "opt-in auto-pause: real loss pauses, same-guid replug resumes" {
+    TestInput.reset();
+    var rec = Recorder{};
+    var game = newGame(&rec);
+    defer game.deinit();
+    game.controllerManager().config.debounce_lost_seconds = 0.2;
+    game.setAutoPauseOnControllerLost(true);
+
+    // Connect + assign player 0.
+    TestInput.queue(connectedGuid(0, "Pad", G1));
+    game.tick(0.016);
+    game.dispatchEvents();
+    try game.assignController(0, 0);
+    game.dispatchEvents();
+    try testing.expect(!game.isPaused());
+
+    // Disconnect, then tick past the debounce window → lost → auto-pause.
+    TestInput.queue(core.GamepadEvent.disconnected(0));
+    game.tick(0.016); // feeds the disconnect; clock advances ~0.016s
+    // Within the window, no lost yet → still running.
+    try testing.expect(!game.isPaused());
+    try testing.expectEqual(@as(usize, 0), rec.lost);
+
+    // Advance the gameplay clock past 0.2s → lost fires → auto-pause kicks in.
+    var i: usize = 0;
+    while (i < 20) : (i += 1) game.tick(0.016);
+    game.dispatchEvents();
+    try testing.expectEqual(@as(usize, 1), rec.lost);
+    try testing.expect(game.isPaused());
+
+    // A same-guid replug, seen even WHILE PAUSED (gamepad drain runs in the
+    // always-run block), restores the binding and lifts the auto-pause.
+    TestInput.queue(connectedGuid(0, "Pad", G1));
+    game.tick(0.016);
+    game.dispatchEvents();
+    try testing.expectEqual(@as(usize, 1), rec.restored);
+    try testing.expect(!game.isPaused());
+}


### PR DESCRIPTION
## What

Phase 2 of the gamepad epic (#609): a **game-facing `ControllerManager`** on top of the raw core#18 gamepad events. Game code cares about *players*, not hardware slots — this layer maps controllers to players, survives reconnects, and tolerates the Bluetooth churn endemic on Android TV.

Closes #611.

> **Stacked PR.** Base is `feat/gamepad-drain` (engine#610, PR #613 — the enriched `GamepadEvent` drain), **not** `main`. Also depends on **labelle-core#19** for the `GamepadEvent` identity contract (`guid` / `source_class` / `type_hint`). Review/merge #613 first.

## Mechanism, not policy

When a connected controller becomes a player is a **per-game decision** (single-player, press-A-to-join couch co-op, fixed-GUID seats, drop-in/out). The engine never hardcodes it. The manager provides *mechanism*; the game owns *policy*. The two common policies ship as **opt-in helpers**, never default.

What stays engine-owned (needs the stable identity the engine resolves):
- **debounced-lost** — a transient BT blip must not slam up a pause dialog.
- **identity-based resume** — a replug rebinds to the *same* player.

## API exposed

**`engine.ControllerManager(max_controllers, max_players)`** (default `engine.DefaultControllerManager` = 8/8) — allocation-free fixed-capacity state machine:
- Feed: `onConnected(GamepadEvent)`, `onDisconnected(slot)`, `advance(now_seconds)`.
- Assignment: `assign(controller, player) !void`, `unassign(player)`, `playerFor(controller) u32`, `controllerFor(player) u32`.
- Query/iterate: `availableCount`, `availableControllers([]ControllerInfo) usize`, `isAvailable`, `isPlayerActive`, `isPlayerWaiting`.
- Output drain: `drainEvents([]ManagerEvent) usize`.
- **Opt-in policy helpers** (not default): `autoBindFreeSlots() usize`, `joinOnButton(controller) ?u32`.

**`Game` forwarders** (compile-error unless a player-level controller event is in `GameEvents`): `controllerManager() *ControllerManagerType`, `assignController(c, p) !void`, `unassignPlayer(p)`, `playerForController(c) u32`, `controllerForPlayer(p) u32`, `setAutoPauseOnControllerLost(bool)`.

**Engine `Events`** (flow `OnEvent`-listenable): `controller_available`, `controller_removed`, `player_joined`, `player_controller_lost`, `player_controller_restored`.

## Design decisions

- **Debounce.** `Config.debounce_lost_seconds` (default 0.2s, `0` disables). Measured against the engine's **pause-aware** `elapsedSeconds()`. A disconnect of an *assigned* controller starts the window; if the same `guid` returns inside it, the binding is treated as continuous and `lost` never fires — so the game sees at most `{restored}`, never the `{lost, restored}` churn pair.
- **Resume.** Same-`guid` replug rebinds to the same player regardless of slot churn (Linux returns a new `js*`). With **no stable key** (raylib → `guid == null`), the documented heuristic resumes the **most-recently-vacated** waiting player; with multiple pads down, the first replug grabs the more-recently-vacated one (multi-pad ambiguity, accepted — raylib offers nothing better).
- **Auto-pause (opt-in, #465 precedent).** A real `player_controller_lost` drives `setPaused(true)`; the game resumes once *every* player is whole again. To make this work, the gamepad+`ControllerManager` drain moved into `scanGamepadEvents`, run in the **always-run** tick section **before** the pause gate — otherwise the reconnect that lifts the pause would never be seen and the game would deadlock paused.
- **Zero-cost.** The manager field is `void` (zero-size) and all wiring folds away unless `GameEvents` carries a player-level controller variant — same comptime-gate pattern as the input events (#606/#610).

## Tests — `test/controller_manager_test.zig` (18)

Unit (manager directly) + integration (through `Game.tick` with an injected-event `TestInput`, same pattern as `input_events_test.zig`):
- Unassigned pool: available/removed, snapshot.
- Assignment + bidirectional query + error cases; unassign returns to pool.
- **Debounce**: transient drop within window does NOT fire lost; drop past window fires lost; `0s` reports immediately.
- **guid resume** across slot churn; a *different*-guid device does not hijack the player (pools instead).
- **raylib heuristic**: next no-guid controller resumes most-recently-vacated.
- Opt-in `autoBindFreeSlots` / `joinOnButton`.
- Integration: tick drains connect → `controller_available`; `assignController` → `player_joined`; end-to-end auto-pause (lose → pause → same-guid replug **while paused** → resume).

`zig build test` → **544/544 pass** (with build.zig.zon temporarily repointed to the local core checkout; path-pins reverted before commit, so the diff is clean).

## Non-goals
Button/axis state (Phase 3); detection plumbing (Phase 0/1).