### PR TITLE
feat(input): gamepad polling forwarders on the game handle

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -1356,6 +1356,10 @@ pub fn GameConfig(
         pub const isMouseButtonDown = InputMixin.isMouseButtonDown;
         pub const isMouseButtonPressed = InputMixin.isMouseButtonPressed;
         pub const isMouseButtonReleased = InputMixin.isMouseButtonReleased;
+        pub const isGamepadAvailable = InputMixin.isGamepadAvailable;
+        pub const isGamepadButtonDown = InputMixin.isGamepadButtonDown;
+        pub const isGamepadButtonPressed = InputMixin.isGamepadButtonPressed;
+        pub const getGamepadAxisValue = InputMixin.getGamepadAxisValue;
         pub const getTouchCount = InputMixin.getTouchCount;
         pub const getTouchX = InputMixin.getTouchX;
         pub const getTouchY = InputMixin.getTouchY;

--- a/src/game/input_mixin.zig
+++ b/src/game/input_mixin.zig
@@ -4,6 +4,8 @@ const Position = core.Position;
 const input_types = @import("../input_types.zig");
 const KeyboardKey = input_types.KeyboardKey;
 const MouseButton = input_types.MouseButton;
+const GamepadButton = input_types.GamepadButton;
+const GamepadAxis = input_types.GamepadAxis;
 
 /// Returns the input forwarding mixin for a given Game type.
 pub fn Mixin(comptime Game: type) type {
@@ -56,6 +58,33 @@ pub fn Mixin(comptime Game: type) type {
         /// Returns false if the backend doesn't report mouse-button edges.
         pub fn isMouseButtonReleased(_: *Game, button: MouseButton) bool {
             return Input.isMouseButtonReleased(@intCast(@intFromEnum(button)));
+        }
+
+        // ── Gamepad ──────────────────────────────────────────────
+
+        /// True when gamepad `id` is connected and usable this frame.
+        /// Returns false if the backend doesn't report gamepad state.
+        pub fn isGamepadAvailable(_: *Game, id: u32) bool {
+            return Input.isGamepadAvailable(id);
+        }
+
+        /// True while `button` on gamepad `id` is held down this frame.
+        /// Returns false if the backend doesn't report gamepad state.
+        pub fn isGamepadButtonDown(_: *Game, id: u32, button: GamepadButton) bool {
+            return Input.isGamepadButtonDown(id, @intCast(@intFromEnum(button)));
+        }
+
+        /// True on the frame `button` on gamepad `id` transitions from up to down.
+        /// Returns false if the backend doesn't report gamepad button edges.
+        pub fn isGamepadButtonPressed(_: *Game, id: u32, button: GamepadButton) bool {
+            return Input.isGamepadButtonPressed(id, @intCast(@intFromEnum(button)));
+        }
+
+        /// Current value of `axis` on gamepad `id`. Sticks report -1..1,
+        /// triggers report -1 (released) to 1 (fully pressed) on raylib.
+        /// Returns 0 if the backend doesn't report gamepad axes.
+        pub fn getGamepadAxisValue(_: *Game, id: u32, axis: GamepadAxis) f32 {
+            return Input.getGamepadAxisValue(id, @intCast(@intFromEnum(axis)));
         }
 
         // ── Touch ────────────────────────────────────────────────

--- a/test/input_mixin_test.zig
+++ b/test/input_mixin_test.zig
@@ -19,6 +19,8 @@ const core = engine.core;
 const game_mod = engine.game_mod;
 const KeyboardKey = engine.KeyboardKey;
 const MouseButton = engine.MouseButton;
+const GamepadButton = engine.GamepadButton;
+const GamepadAxis = engine.GamepadAxis;
 
 // ── Full controllable input stub ───────────────────────────────────────
 //
@@ -30,12 +32,20 @@ const FullInput = struct {
     var down_button: ?u32 = null;
     var pressed_button: ?u32 = null;
     var released_button: ?u32 = null;
+    var gamepad_available_id: ?u32 = null;
+    var gamepad_down: ?struct { id: u32, button: u32 } = null;
+    var gamepad_pressed: ?struct { id: u32, button: u32 } = null;
+    var gamepad_axis: ?struct { id: u32, axis: u32, value: f32 } = null;
 
     fn reset() void {
         released_key = null;
         down_button = null;
         pressed_button = null;
         released_button = null;
+        gamepad_available_id = null;
+        gamepad_down = null;
+        gamepad_pressed = null;
+        gamepad_axis = null;
     }
 
     // Required by InputInterface.
@@ -58,6 +68,23 @@ const FullInput = struct {
     }
     pub fn isMouseButtonReleased(button: u32) bool {
         return released_button != null and released_button.? == button;
+    }
+
+    // Gamepad wrappers the new accessors surface.
+    pub fn isGamepadAvailable(id: u32) bool {
+        return gamepad_available_id != null and gamepad_available_id.? == id;
+    }
+    pub fn isGamepadButtonDown(id: u32, button: u32) bool {
+        return gamepad_down != null and gamepad_down.?.id == id and gamepad_down.?.button == button;
+    }
+    pub fn isGamepadButtonPressed(id: u32, button: u32) bool {
+        return gamepad_pressed != null and gamepad_pressed.?.id == id and gamepad_pressed.?.button == button;
+    }
+    pub fn getGamepadAxisValue(id: u32, axis: u32) f32 {
+        if (gamepad_axis) |a| {
+            if (a.id == id and a.axis == axis) return a.value;
+        }
+        return 0;
     }
 };
 
@@ -143,6 +170,49 @@ test "isMouseButtonReleased reflects a release-edge, false otherwise" {
     try testing.expect(!game.isMouseButtonReleased(.left));
 }
 
+// ── Gamepad accessors reflect reported state ────────────────────────────
+
+test "isGamepadAvailable reflects a connected pad, false otherwise" {
+    FullInput.reset();
+    var game = FullGame.init(testing.allocator);
+    defer game.deinit();
+
+    FullInput.gamepad_available_id = 0;
+    try testing.expect(game.isGamepadAvailable(0));
+    try testing.expect(!game.isGamepadAvailable(1));
+}
+
+test "isGamepadButtonDown reflects a held face button, false otherwise" {
+    FullInput.reset();
+    var game = FullGame.init(testing.allocator);
+    defer game.deinit();
+
+    FullInput.gamepad_down = .{ .id = 0, .button = @intCast(@intFromEnum(GamepadButton.right_face_down)) };
+    try testing.expect(game.isGamepadButtonDown(0, .right_face_down));
+    try testing.expect(!game.isGamepadButtonDown(0, .right_face_up));
+    try testing.expect(!game.isGamepadButtonDown(1, .right_face_down));
+}
+
+test "isGamepadButtonPressed reflects a press-edge, false otherwise" {
+    FullInput.reset();
+    var game = FullGame.init(testing.allocator);
+    defer game.deinit();
+
+    FullInput.gamepad_pressed = .{ .id = 0, .button = @intCast(@intFromEnum(GamepadButton.left_trigger_1)) };
+    try testing.expect(game.isGamepadButtonPressed(0, .left_trigger_1));
+    try testing.expect(!game.isGamepadButtonPressed(0, .right_trigger_1));
+}
+
+test "getGamepadAxisValue reflects a reported axis, 0 otherwise" {
+    FullInput.reset();
+    var game = FullGame.init(testing.allocator);
+    defer game.deinit();
+
+    FullInput.gamepad_axis = .{ .id = 0, .axis = @intCast(@intFromEnum(GamepadAxis.left_x)), .value = 0.75 };
+    try testing.expectApproxEqAbs(@as(f32, 0.75), game.getGamepadAxisValue(0, .left_x), 0.0001);
+    try testing.expectApproxEqAbs(@as(f32, 0.0), game.getGamepadAxisValue(0, .left_y), 0.0001);
+}
+
 // ── Minimal backend → graceful false fallback ──────────────────────────
 
 test "accessors return false when the backend omits the optional methods" {
@@ -153,4 +223,8 @@ test "accessors return false when the backend omits the optional methods" {
     try testing.expect(!game.isMouseButtonDown(.left));
     try testing.expect(!game.isMouseButtonPressed(.left));
     try testing.expect(!game.isMouseButtonReleased(.left));
+    try testing.expect(!game.isGamepadAvailable(0));
+    try testing.expect(!game.isGamepadButtonDown(0, .right_face_down));
+    try testing.expect(!game.isGamepadButtonPressed(0, .right_face_down));
+    try testing.expectApproxEqAbs(@as(f32, 0.0), game.getGamepadAxisValue(0, .left_x), 0.0001);
 }


### PR DESCRIPTION
Adds gamepad polling to the engine input mixin (`src/game/input_mixin.zig` + re-exported on the Game handle), mirroring the key/mouse forwarders, delegating to the backend `InputInterface`: `isGamepadAvailable`/`isGamepadButtonDown`/`isGamepadButtonPressed`/`getGamepadAxisValue`. Full mixin test coverage; `zig build test` green (28/28). Enables the gamepad demo (assembler `feat/gamepad-example`). Part of epic #609.
