### PR TITLE
release: labelle-engine v1.49.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xe8a81a8dc7f48c87,
     .name = .engine,
-    .version = "1.48.1",
+    .version = "1.49.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{


### PR DESCRIPTION
Version bump to 1.49.0 for release (captures the merged controller work). Temp core/dep commit-pins left as-is (functionally fine post core-unify #259); pin->tag hygiene tracked as a follow-up.