### PR TITLE
feat(android): route immersive-mode through core seam (#310 stage 2)

### DIFF
--- a/src/android.zig
+++ b/src/android.zig
@@ -18,9 +18,12 @@
 //! The game is a pure `NativeActivity` (`android:hasCode="false"`), so
 //! there is no Java code to call into directly — every framework call
 //! has to go through JNI from C/Zig. We obtain the `ANativeActivity*`
-//! from sokol_app's `sapp_android_get_native_activity()` (bound here as
-//! an `extern "c"` symbol), which exposes a `JavaVM*`, a main-thread
-//! `JNIEnv*`, and the activity `jobject`.
+//! from labelle-core's backend-agnostic Android seam
+//! (`core.android_backend`, labelle-core#310): the active backend
+//! registers an `AndroidBackendContext` whose `get_native_activity`
+//! returns the activity, which exposes a `JavaVM*`, a main-thread
+//! `JNIEnv*`, and the activity `jobject`. The engine therefore links no
+//! backend-specific (`sapp_*`/sokol) symbol of its own.
 //!
 //! We use **two paths**, picked at runtime by API level:
 //!
@@ -102,6 +105,12 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
+
+/// labelle-core, consumed for its backend-agnostic Android JNI seam
+/// (`core.android_backend`, labelle-core#310). We read the active
+/// backend's registered `AndroidBackendContext` to obtain the
+/// `ANativeActivity*` instead of linking a backend-specific symbol.
+const core = @import("labelle-core");
 
 /// True when compiling for an Android target (covers arm64/x86_64 via
 /// `.android` and arm/x86 via `.androideabi`). All the JNI machinery
@@ -338,14 +347,14 @@ fn logWarn(comptime msg: [:0]const u8) void {
     if (comptime is_android) _ = __android_log_write(ANDROID_LOG_WARN, "labelle", msg);
 }
 
-// ── sokol_app native-activity accessor ────────────────────────────
+// ── native-activity accessor ──────────────────────────────────────
 //
-// sokol_app's Android backend exposes the `ANativeActivity*` via this
-// C entry point (`SOKOL_API_IMPL`, i.e. an exported symbol). We bind
-// it as an `extern "c"` function so the engine never has to
-// `@import("sokol")` — the symbol resolves at link time against the
-// `sokol_clib` static library every sokol-Android build links anyway.
-extern "c" fn sapp_android_get_native_activity() ?*anyopaque;
+// The `ANativeActivity*` is obtained through labelle-core's
+// backend-agnostic seam (`core.android_backend`, labelle-core#310):
+// the active backend adapter registers an `AndroidBackendContext` at
+// startup, and we read its `get_native_activity` pointer. This keeps
+// the engine free of any backend-specific (`sapp_*`/sokol) symbol — if
+// no backend registered a context, immersive mode is a graceful no-op.
 
 // ── Module state ──────────────────────────────────────────────────
 //
@@ -664,9 +673,11 @@ fn clearException(env: *JNIEnv) bool {
 /// Enable Android immersive mode for the running game: hide the status
 /// bar and the navigation bar in immersive-sticky mode.
 ///
-/// Obtains the `ANativeActivity*` itself from sokol_app via
-/// `sapp_android_get_native_activity()`, so the caller (the assembler-
-/// generated `main.zig`) only needs a single argument-free call.
+/// Obtains the `ANativeActivity*` itself from labelle-core's
+/// backend-agnostic Android seam (`core.android_backend.get()`), so the
+/// caller (the assembler-generated `main.zig`) only needs a single
+/// argument-free call. If no backend has registered an
+/// `AndroidBackendContext`, this is a graceful no-op.
 ///
 /// **Call site:** the assembler emits this in the generated
 /// `main.zig`'s `sokol_main()`. sokol's `ANativeActivity_onCreate`
@@ -689,8 +700,15 @@ fn clearException(env: *JNIEnv) bool {
 pub fn enableImmersiveMode() void {
     if (comptime !is_android) return;
 
-    const na: *ANativeActivity = @ptrCast(@alignCast(sapp_android_get_native_activity() orelse {
-        logWarn("immersive: sapp_android_get_native_activity() returned null");
+    // Reach the running `ANativeActivity*` through core's backend seam.
+    // No context registered → no backend ships Android JNI glue → there
+    // is nothing to enable, so immersive mode is a graceful no-op.
+    const ctx = core.android_backend.get() orelse {
+        logWarn("immersive: no AndroidBackendContext registered");
+        return;
+    };
+    const na: *ANativeActivity = @ptrCast(@alignCast(ctx.get_native_activity() orelse {
+        logWarn("immersive: get_native_activity() returned null");
         return;
     }));
 


### PR DESCRIPTION
Stage 2 of #310 — route engine's Android immersive-mode through labelle-core's `AndroidBackendContext` seam (Stage 1, core, already merged). Removes engine's last direct sokol coupling.

## What (single file: `src/android.zig`, +33/-15)
- Removed `extern "c" fn sapp_android_get_native_activity()`.
- `enableImmersiveMode()` now sources the `ANativeActivity*` from the seam instead of the sokol symbol:
  ```zig
  const ctx = core.android_backend.get() orelse return;       // no backend → immersive no-op
  const na: *ANativeActivity = @ptrCast(@alignCast(ctx.get_native_activity() orelse return));
  ```
  Public signature + all the JNI/decor-view hook logic unchanged — only the activity source swapped. Graceful no-op when no context is registered (matches core).
- Imports core as `@import("labelle-core")` (engine's existing convention; core re-exports `android_backend`).

Engine no longer references any `sapp_*`/sokol symbol. Desktop unaffected (immersive is Android-only).

## Verification (Zig 0.16.0)
- `zig build test` → 28/28 pass; `zig build` → exit 0.
- Android compile-check (`zig build-obj -target aarch64-linux-android` against the merged core seam) → exit 0; `nm` shows **no `sapp` symbol** in the object.
- Grep: no `sapp_*` / `extern "c" fn sapp_...` in `src/` (the only remaining `extern "c"` is NDK `__android_log_write`).

## Note for next stages
Immersive (and core's Android gamepad source) now stay inert until a backend adapter calls `core.registerAndroidBackend(...)` at startup. Stage 3 (sokol adapter) registers a context wired to `sapp_android_get_native_activity` + the gamepad JNI glue (keeping sokol-Android green); Stage 4 (bgfx adapter) registers its own + drops the shims.

Engine pins core by relative path and CI clones core `main` (which has the Stage 1 seam), so no version bump is needed here.
