### PR TITLE
release: v1.50.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xe8a81a8dc7f48c87,
     .name = .engine,
-    .version = "1.49.0",
+    .version = "1.50.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{


### PR DESCRIPTION
Cut **v1.50.0** — immersive-mode routed through the labelle-core AndroidBackendContext seam (#620 / #310 Stage 2). Pairs with labelle-core ≥ v1.17.0; generated Android apps need both.