### PR TITLE
fix(prefab): tag runtime spawnPrefab entities as PrefabInstance (release v1.51.0)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xe8a81a8dc7f48c87,
     .name = .engine,
-    .version = "1.50.0",
+    .version = "1.51.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -340,6 +340,17 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
                 }
             }
 
+            // Tag the root (+ children) as a prefab instance so save/load
+            // Phase 1 can reinstantiate it — same step the scene-load path
+            // (`loadEntityInternal`) performs via `tagAsPrefabInstance`.
+            // Without this, a runtime-`spawnPrefab`'d entity carries no
+            // `PrefabInstance`, so on load only its saveable game components
+            // come back and its non-saveable prefab visuals (Sprite, etc.)
+            // are lost — `spawnPrefab`'s own docstring promises this tagging.
+            game.tagAsPrefabInstance(entity, name) catch |err| {
+                game.log.err("[spawnPrefab] tagAsPrefabInstance('{s}') failed: {s}", .{ name, @errorName(err) });
+            };
+
             return entity;
         }
 


### PR DESCRIPTION
Runtime `game.spawnPrefab` never tagged entities with `PrefabInstance` (only the scene-load path did), so runtime-spawned prefabs could not be reinstantiated by save/load Phase 1 — on load their non-saveable visuals (Sprite, prefab children) were lost while saveable game components returned. Surfaced in flying-platform-labelle: a runtime-built ship carcase loaded invisible. Fix adds the same `tagAsPrefabInstance(entity, name)` the scene path uses, fulfilling `spawnPrefab`'s docstring. Bumps version to 1.51.0. 28/28 tests pass.