### PR TITLE
feat(window): engine-owned fullscreen API (v1.52.0)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -75,6 +75,7 @@ pub fn build(b: *std.Build) void {
         "test/form_binder_test.zig",
         "test/script_runner_test.zig",
         "test/game_log_test.zig",
+        "test/fullscreen_api_test.zig",
         "test/save_policy_test.zig",
         "test/save_load_mixin_test.zig",
         "test/jsonc/bridge_leak_test.zig",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xe8a81a8dc7f48c87,
     .name = .engine,
-    .version = "1.51.0",
+    .version = "1.52.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{

--- a/src/game.zig
+++ b/src/game.zig
@@ -326,6 +326,16 @@ pub fn GameConfig(
 
         // Game state
         running: bool = true,
+        /// Desired fullscreen state, owned by the engine. Scripts flip it
+        /// via `setFullscreen`/`toggleFullscreen`; the generated frame
+        /// loop drains `takeFullscreenRequest()` and applies the value to
+        /// the window backend. The engine never imports a window module —
+        /// same cooperative split as `running`/`isRunning`/`requestQuit`.
+        fullscreen: bool = false,
+        /// Set whenever `fullscreen` changes; cleared by the one-shot
+        /// `takeFullscreenRequest()` drain so the backend toggle fires
+        /// exactly once per change instead of every frame.
+        fullscreen_dirty: bool = false,
         frame_number: u64 = 0,
         /// Current game state (e.g. "menu", "playing", "paused").
         /// Set via setState() or queueStateChange(). Default is "running".
@@ -1806,6 +1816,47 @@ pub fn GameConfig(
 
         pub fn isRunning(self: *const Self) bool {
             return self.running;
+        }
+
+        // ── Fullscreen ──
+        //
+        // The engine owns the *desired* fullscreen flag; the actual
+        // platform window call (sokol `sapp.toggleFullscreen`, raylib
+        // `ToggleFullscreen`, …) lives in the generated `main.zig` frame
+        // loop, which polls `takeFullscreenRequest()` and forwards the
+        // value to `window.setFullscreen`. Keeping the call out of the
+        // library is what lets the engine stay backend-agnostic — the
+        // same reason `quit()` only flips `running` and lets the frame
+        // loop call `window.requestQuit()`.
+
+        /// Request a fullscreen / windowed switch. No-op if already in the
+        /// requested mode. Takes effect on the next frame, when the
+        /// generated main drains `takeFullscreenRequest()`.
+        pub fn setFullscreen(self: *Self, on: bool) void {
+            if (self.fullscreen == on) return;
+            self.fullscreen = on;
+            self.fullscreen_dirty = true;
+        }
+
+        /// Flip between fullscreen and windowed.
+        pub fn toggleFullscreen(self: *Self) void {
+            self.setFullscreen(!self.fullscreen);
+        }
+
+        /// The engine's desired fullscreen state. This is the value a
+        /// settings UI should bind a checkbox to — it reflects the latest
+        /// `setFullscreen`/`toggleFullscreen` call, not a backend query.
+        pub fn isFullscreen(self: *const Self) bool {
+            return self.fullscreen;
+        }
+
+        /// Frame-loop drain (generated main only): returns the new
+        /// fullscreen value exactly once after it changes, else `null`.
+        /// The caller forwards a non-null result to the window backend.
+        pub fn takeFullscreenRequest(self: *Self) ?bool {
+            if (!self.fullscreen_dirty) return null;
+            self.fullscreen_dirty = false;
+            return self.fullscreen;
         }
 
         // ── Time scale ──

--- a/test/fullscreen_api_test.zig
+++ b/test/fullscreen_api_test.zig
@@ -1,0 +1,63 @@
+//! Tests for the engine-owned fullscreen request API on `Game`:
+//! `setFullscreen` / `toggleFullscreen` / `isFullscreen` /
+//! `takeFullscreenRequest`.
+//!
+//! The engine holds only the *desired* fullscreen flag; the generated
+//! `main.zig` frame loop drains `takeFullscreenRequest()` and forwards a
+//! non-null result to the window backend (`window.setFullscreen` in
+//! backends/{sokol,raylib,bgfx}/src/window.zig). That keeps the library
+//! backend-agnostic — same split as `quit()`/`isRunning()`/`requestQuit`.
+//!
+//! These tests cover the flag + one-shot-drain semantics in isolation,
+//! using the in-tree `Game = GameWith(void)` (MockEcsBackend + StubRender,
+//! no real window).
+
+const std = @import("std");
+const testing = std.testing;
+
+const engine = @import("engine");
+const Game = engine.Game;
+
+test "fullscreen: defaults to windowed with no pending request" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    try testing.expect(!game.isFullscreen());
+    try testing.expectEqual(@as(?bool, null), game.takeFullscreenRequest());
+}
+
+test "fullscreen: setFullscreen flips state and queues a one-shot request" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    game.setFullscreen(true);
+    try testing.expect(game.isFullscreen());
+
+    // The request drains exactly once — the backend toggle must fire on
+    // the change, not every frame.
+    try testing.expectEqual(@as(?bool, true), game.takeFullscreenRequest());
+    try testing.expectEqual(@as(?bool, null), game.takeFullscreenRequest());
+}
+
+test "fullscreen: setting the current mode is a no-op (no request queued)" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    // Already windowed → nothing to apply.
+    game.setFullscreen(false);
+    try testing.expectEqual(@as(?bool, null), game.takeFullscreenRequest());
+}
+
+test "fullscreen: toggle alternates and each change drains once" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    game.toggleFullscreen();
+    try testing.expect(game.isFullscreen());
+    try testing.expectEqual(@as(?bool, true), game.takeFullscreenRequest());
+
+    game.toggleFullscreen();
+    try testing.expect(!game.isFullscreen());
+    try testing.expectEqual(@as(?bool, false), game.takeFullscreenRequest());
+    try testing.expectEqual(@as(?bool, null), game.takeFullscreenRequest());
+}


### PR DESCRIPTION
Adds `game.setFullscreen(bool)` / `toggleFullscreen()` / `isFullscreen()` + a one-shot `takeFullscreenRequest()` drain.

## Design
The engine owns only the *desired* fullscreen flag. The generated `main.zig` frame loop drains `takeFullscreenRequest()` once per change and forwards the value to the backend window module (`window.setFullscreen` — sokol/raylib/bgfx, shipped in labelle-assembler). This keeps the library backend-agnostic, mirroring the existing `quit()`/`isRunning()`/`requestQuit` cooperative split.

## Pairs with
- labelle-assembler: `window.setFullscreen`/`isFullscreen` + frame-loop drain.
- labelle-gfx: removes the old no-op `Fullscreen` stub.
- Consumer: flying-platform-labelle main-menu Options → Fullscreen checkbox.

## Tests
`test/fullscreen_api_test.zig` — flag + one-shot-drain semantics on the in-tree `GameWith(void)`. `zig build test` green.

## Verified
End-to-end against flying-platform-labelle (sokol desktop): checkbox toggles real fullscreen, exit 0, no panic, no leaks.