### PR TITLE
feat(anim): engine-driven sprite animation + pause hook (v1.53.0)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -76,6 +76,7 @@ pub fn build(b: *std.Build) void {
         "test/script_runner_test.zig",
         "test/game_log_test.zig",
         "test/fullscreen_api_test.zig",
+        "test/engine_sprite_anim_test.zig",
         "test/save_policy_test.zig",
         "test/save_load_mixin_test.zig",
         "test/jsonc/bridge_leak_test.zig",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xe8a81a8dc7f48c87,
     .name = .engine,
-    .version = "1.52.0",
+    .version = "1.53.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{

--- a/src/game.zig
+++ b/src/game.zig
@@ -2205,7 +2205,11 @@ pub fn GameConfig(
             // per-frame game script. Lives in the always-run block (not the
             // gameplay-skip section) so it advances on `scaled_dt`, which a
             // `time_scale==0` hard pause already zeroes.
-            if (self.drive_sprite_animations and !self.sprite_animations_paused) {
+            // `scaled_dt != 0` skips the ECS walk entirely when time is
+            // frozen (a `time_scale==0` hard pause, which still runs this
+            // always-run block) — no frame can advance on a zero dt anyway.
+            // Slow-mo keeps a tiny non-zero dt, so it still animates.
+            if (self.drive_sprite_animations and !self.sprite_animations_paused and scaled_dt != 0) {
                 @import("sprite_animation_tick.zig").tick(self, scaled_dt);
             }
             self.resolveAtlasSprites();

--- a/src/game.zig
+++ b/src/game.zig
@@ -336,6 +336,18 @@ pub fn GameConfig(
         /// `takeFullscreenRequest()` drain so the backend toggle fires
         /// exactly once per change instead of every frame.
         fullscreen_dirty: bool = false,
+        /// Opt-in: when true the engine advances every `SpriteAnimation`
+        /// component itself each tick (on the time-scaled dt), so a game
+        /// no longer needs a `sprite_animation_tick` script of its own.
+        /// Off by default so existing projects that still drive animation
+        /// from a script don't double-advance. Set via
+        /// `setDriveSpriteAnimations`.
+        drive_sprite_animations: bool = false,
+        /// Freezes the engine-driven sprite-animation advance while set —
+        /// the hook a pause menu toggles so sprite cycling stops without
+        /// halting the rest of the script loop. Only meaningful alongside
+        /// `drive_sprite_animations`. Set via `setSpriteAnimationsPaused`.
+        sprite_animations_paused: bool = false,
         frame_number: u64 = 0,
         /// Current game state (e.g. "menu", "playing", "paused").
         /// Set via setState() or queueStateChange(). Default is "running".
@@ -1859,6 +1871,34 @@ pub fn GameConfig(
             return self.fullscreen;
         }
 
+        // ── Engine-driven sprite animation ──
+        //
+        // Opt-in: instead of the game shipping a `sprite_animation_tick`
+        // script that calls `spriteAnimationTick(game, dt)`, the engine
+        // can advance every `SpriteAnimation` itself in `tick()` on the
+        // time-scaled clock (see the always-run block). A game enables it
+        // once at startup and deletes its script; a pause menu freezes
+        // sprite cycling via `setSpriteAnimationsPaused` without having to
+        // gate a per-frame script.
+
+        /// Turn engine-driven sprite-animation advancement on/off. When on,
+        /// the game must NOT also run a `sprite_animation_tick` script, or
+        /// animations advance twice per frame.
+        pub fn setDriveSpriteAnimations(self: *Self, on: bool) void {
+            self.drive_sprite_animations = on;
+        }
+
+        /// Freeze (`true`) or resume (`false`) the engine-driven sprite
+        /// animation advance. No-op unless `drive_sprite_animations` is on.
+        pub fn setSpriteAnimationsPaused(self: *Self, paused: bool) void {
+            self.sprite_animations_paused = paused;
+        }
+
+        /// Whether engine-driven sprite animation is currently frozen.
+        pub fn spriteAnimationsPaused(self: *const Self) bool {
+            return self.sprite_animations_paused;
+        }
+
         // ── Time scale ──
 
         pub fn setTimeScale(self: *Self, scale: f32) void {
@@ -2156,6 +2196,18 @@ pub fn GameConfig(
             self.log.update(dt);
             Audio.update();
             Input.updateGestures(dt);
+            // Engine-driven sprite animation (opt-in via
+            // `drive_sprite_animations`). Advance every `SpriteAnimation`
+            // on the time-scaled dt BEFORE `resolveAtlasSprites` so the
+            // new frame's `sprite_name` is resolved to a `source_rect` the
+            // same frame. Frozen when `sprite_animations_paused` — that's
+            // how a pause menu stops sprite cycling without gating a
+            // per-frame game script. Lives in the always-run block (not the
+            // gameplay-skip section) so it advances on `scaled_dt`, which a
+            // `time_scale==0` hard pause already zeroes.
+            if (self.drive_sprite_animations and !self.sprite_animations_paused) {
+                @import("sprite_animation_tick.zig").tick(self, scaled_dt);
+            }
             self.resolveAtlasSprites();
             self.renderer.sync(EcsImpl, self.ecs_backend);
 

--- a/test/engine_sprite_anim_test.zig
+++ b/test/engine_sprite_anim_test.zig
@@ -1,0 +1,86 @@
+//! Tests for engine-driven sprite animation (opt-in).
+//!
+//! When `drive_sprite_animations` is on, the engine advances every
+//! `SpriteAnimation` component itself inside `tick()` (on the time-scaled
+//! dt) — the game no longer needs a `sprite_animation_tick` script.
+//! `setSpriteAnimationsPaused(true)` freezes that advance, which is how a
+//! pause menu stops sprite cycling without gating a per-frame script.
+//!
+//! Uses the in-tree `Game = GameWith(void)` (MockEcsBackend + StubRender,
+//! whose `Sprite` carries a writable `sprite_name`).
+
+const std = @import("std");
+const testing = std.testing;
+
+const engine = @import("engine");
+const Game = engine.Game;
+const SpriteAnimation = engine.SpriteAnimation;
+
+const FRAMES = [_][]const u8{ "f0", "f1", "f2" };
+
+fn makeAnimatedEntity(game: *Game) Game.EntityType {
+    const e = game.createEntity();
+    // fps=10 → 0.1 s/frame, so a 0.2 s tick advances exactly 2 frames.
+    game.addComponent(e, SpriteAnimation{ .frames = FRAMES[0..], .fps = 10 });
+    game.addComponent(e, Game.SpriteComp{ .sprite_name = "f0" });
+    return e;
+}
+
+// ── Flag surface ────────────────────────────────────────────────────
+
+test "drive/pause flags default off and round-trip" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    try testing.expect(!game.spriteAnimationsPaused());
+    game.setDriveSpriteAnimations(true);
+    game.setSpriteAnimationsPaused(true);
+    try testing.expect(game.spriteAnimationsPaused());
+    game.setSpriteAnimationsPaused(false);
+    try testing.expect(!game.spriteAnimationsPaused());
+}
+
+// ── Behaviour through tick() ────────────────────────────────────────
+
+test "tick does not advance sprite animation unless driving is enabled" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    const e = makeAnimatedEntity(&game);
+
+    // Driving off (default): the engine must not touch the animation.
+    game.tick(0.2);
+    const anim = game.getComponent(e, SpriteAnimation).?;
+    try testing.expectEqual(@as(u8, 0), anim.frame);
+}
+
+test "tick advances sprite animation when driving is enabled" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    const e = makeAnimatedEntity(&game);
+    game.setDriveSpriteAnimations(true);
+
+    game.tick(0.2); // 2 frames at fps=10
+    const anim = game.getComponent(e, SpriteAnimation).?;
+    try testing.expectEqual(@as(u8, 2), anim.frame);
+
+    const sprite = game.getComponent(e, Game.SpriteComp).?;
+    try testing.expectEqualStrings("f2", sprite.sprite_name);
+}
+
+test "paused freezes the advance and resume continues it" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    const e = makeAnimatedEntity(&game);
+    game.setDriveSpriteAnimations(true);
+
+    game.tick(0.1); // → frame 1
+    try testing.expectEqual(@as(u8, 1), game.getComponent(e, SpriteAnimation).?.frame);
+
+    game.setSpriteAnimationsPaused(true);
+    game.tick(0.2); // frozen — no advance
+    try testing.expectEqual(@as(u8, 1), game.getComponent(e, SpriteAnimation).?.frame);
+
+    game.setSpriteAnimationsPaused(false);
+    game.tick(0.1); // → frame 2
+    try testing.expectEqual(@as(u8, 2), game.getComponent(e, SpriteAnimation).?.frame);
+}


### PR DESCRIPTION
Lets the engine advance `SpriteAnimation` components itself, so games don't need a per-frame `sprite_animation_tick` script — and so a pause menu can freeze sprite cycling centrally.

## API
- `game.setDriveSpriteAnimations(bool)` — opt-in (default **off**, so existing projects that still run their own `sprite_animation_tick` script don't double-advance).
- `game.setSpriteAnimationsPaused(bool)` / `spriteAnimationsPaused()` — freeze/resume the engine-driven advance (the hook a pause menu toggles).

## How
The advance runs in `tick()`'s always-run block, **before** `resolveAtlasSprites`, on `scaled_dt` (so `time_scale` governs it) and only when driving is on and not paused.

## Why opt-in / why a pause flag
FP (and games like it) use a *soft* pause: a `GamePaused` ECS flag that keeps the script loop (menu, camera) running while gameplay freezes. The engine's hard pause (`setPaused`/`time_scale==0`) skips **all** scripts, so it can't drive a menu-style pause. This flag freezes just the engine-owned animation, in lock-step with the game's own pause, without touching script dispatch.

## Consumer
flying-platform-labelle deletes its `sprite_animation_tick.zig`, enables driving once at setup, and toggles `setSpriteAnimationsPaused` from its pause menu. Custom animation systems (the worker `AnimationState` FSM, sleep tween, cloud drift) remain game-gated — the engine only owns the generic `SpriteAnimation` component.

## Tests
`test/engine_sprite_anim_test.zig`: opt-in default-off, tick advances when driving, freeze-then-resume. `zig build test` green. Verified end-to-end in FP (sokol desktop): animations play during gameplay and freeze behind the pause menu.