### PR TITLE
refactor(game): split game.zig into mixins (<1000 lines/file)

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -40,6 +40,16 @@ const gizmo_mixin = @import("game/gizmo_mixin.zig");
 const scene_mixin = @import("game/scene_mixin.zig");
 const save_load_mixin = @import("game/save_load_mixin.zig");
 const state_mixin = @import("game/state_mixin.zig");
+const atlas_mixin = @import("game/atlas_mixin.zig");
+const world_mixin = @import("game/world_mixin.zig");
+const lifecycle_mixin = @import("game/lifecycle_mixin.zig");
+const components_mixin = @import("game/components_mixin.zig");
+const entity_mixin = @import("game/entity_mixin.zig");
+const scene_runtime_mixin = @import("game/scene_runtime_mixin.zig");
+const input_events_mixin = @import("game/input_events_mixin.zig");
+const events_mixin = @import("game/events_mixin.zig");
+const loop_mixin = @import("game/loop_mixin.zig");
+const misc_mixin = @import("game/misc_mixin.zig");
 
 /// Full game configuration — the assembler fills ALL comptime slots.
 /// RenderImpl is a renderer plugin (e.g. gfx.GfxRenderer) satisfying RenderInterface.
@@ -107,6 +117,21 @@ pub fn GameConfig(
         /// decl for `void`, but it's removed in Zig 0.16.) labelle-box2d
         /// already does the union check.
         pub const GameEvents = GameEventsParam;
+        // Internal event-dispatch types/flags surfaced for the events
+        // mixin (`game/events_mixin.zig`). These mirror the identically-
+        // named consts in `GameConfig`'s function body bit-for-bit (same
+        // expressions over the same in-scope params), so the mixin and the
+        // struct body share one comptime definition. Re-derived rather than
+        // aliased because a struct decl can't reference an outer const of
+        // the same name without a dependency loop.
+        pub const PayloadExport = Payload;
+        pub const EventBufferExport = EventBuffer;
+        pub const has_events_export = has_events;
+        pub const has_hooks_export = has_hooks;
+        // For the lifecycle mixin's `setHooks` (mirrors the function-body
+        // consts of the same role; see PayloadExport rationale).
+        pub const HooksParam = Hooks;
+        pub const HooksIsMergedExport = HooksIsMerged;
         pub const EcsBackend = EcsImpl;
         pub const SpriteComp = Sprite;
         pub const ShapeComp = Shape;
@@ -128,14 +153,14 @@ pub fn GameConfig(
         ///   - backend declares it  → drain `Self.Input.pollGamepadEvents`
         ///   - backend does NOT     → drain `core.gamepad_source.pollEvents`
         ///                            (and run its `init`/`deinit`)
-        const backend_polls_gamepads = @hasDecl(InputImpl, "pollGamepadEvents");
+        pub const backend_polls_gamepads = @hasDecl(InputImpl, "pollGamepadEvents");
 
         /// True only when we actually need the per-OS `gamepad_source`:
         /// the backend doesn't poll AND a flow listens for gamepad events.
         /// Gates the source's `init`/`deinit` lifecycle calls so an
         /// event-less game (or one on a backend that polls natively) never
         /// touches the OS source — keeping the feature zero-cost.
-        const uses_os_gamepad_source = !backend_polls_gamepads and gamepad_events_wanted;
+        pub const uses_os_gamepad_source = !backend_polls_gamepads and gamepad_events_wanted;
 
         pub const Audio = @import("audio.zig").AudioInterface(AudioImpl);
         pub const Gui = @import("gui.zig").GuiInterface(GuiImpl);
@@ -155,6 +180,16 @@ pub fn GameConfig(
         const SceneMixin = scene_mixin.Mixin(Self);
         const SaveLoadMixin = save_load_mixin.Mixin(Self);
         const StateMixin = state_mixin.Mixin(Self);
+        const AtlasMixin = atlas_mixin.Mixin(Self);
+        const WorldMixin = world_mixin.Mixin(Self);
+        const LifecycleMixin = lifecycle_mixin.Mixin(Self);
+        const ComponentsMixin = components_mixin.Mixin(Self);
+        const EntityMixin = entity_mixin.Mixin(Self);
+        const SceneRuntimeMixin = scene_runtime_mixin.Mixin(Self);
+        const InputEventsMixin = input_events_mixin.Mixin(Self);
+        const EventsMixin = events_mixin.Mixin(Self);
+        const LoopMixin = loop_mixin.Mixin(Self);
+        const MiscMixin = misc_mixin.Mixin(Self);
 
         /// Scene lifecycle hooks
         pub const SceneHooks = struct {
@@ -501,133 +536,14 @@ pub fn GameConfig(
             };
         }
 
-        pub fn deinit(self: *Self) void {
-            self.emitHook(.{ .game_deinit = {} });
-            // Engine `Events` dual-emit (#578). Fires before the actual
-            // teardown so flow listeners that read game state from a
-            // `game_deinit` handler still see the live world. Folds
-            // away when `GameEvents` doesn't carry the variant.
-            self.emitEngineEvent("engine__game_deinit", .{});
-            // Drain the buffered event so a `game_deinit` listener
-            // actually receives it before the event-buffer arena tears
-            // down below. The normal frame loop does this at
-            // `dispatchEvents`; on shutdown there is no next frame.
-            if (has_events) self.dispatchEvents();
-            // `Game` owns the preview channel by value when set, so we
-            // release it here. The generated `main.zig` is expected to
-            // call `game.preview.?.sendBye(...)` before `game.deinit()`
-            // for a graceful shutdown; the socket close + arena tear-down
-            // happens here regardless.
-            if (self.preview) |*p| p.deinit();
-            // Tear down the per-OS gamepad source iff we initialized it
-            // (core#18). Symmetric with the `init` call above and gated by
-            // the same comptime flag.
-            if (comptime uses_os_gamepad_source) core.gamepad_source.deinit();
-            // Drop any timers still in flight (#25 Stage 2). A game can
-            // exit mid-Delay; this frees each entry's owned `ctx` and the
-            // pending list without firing — no leaks under testing.allocator.
-            self.scheduler.deinit();
-            // Tear down the active scene FIRST. Scene teardown runs
-            // user-provided `deinit_fn`s that may call `game.assets.*`
-            // (release on unload is the natural pattern for the very
-            // API this PR is exposing), so the catalog MUST still be
-            // alive through it. Worker-thread safety is handled inside
-            // `AssetCatalog.deinit` — it stops the worker and drains
-            // the result ring before touching the hashmap, and its
-            // allocator is the Game's allocator which stays live
-            // through this whole call.
-            if (has_events) self.event_buffer.deinit(self.allocator);
-            self.teardownActiveScene();
-            self.scene_entities.deinit(self.allocator);
-            self.assets.deinit();
-            if (self.current_scene_name) |name| {
-                self.allocator.free(name);
-            }
-            if (self.pending_scene_change) |name| {
-                self.allocator.free(name);
-            }
-            if (self.pending_scene_assets) |name| {
-                self.allocator.free(name);
-            }
-            if (self.owned_initial_state) |name| {
-                self.allocator.free(name);
-            }
-            // Clean up inactive worlds
-            var world_iter = self.worlds.iterator();
-            while (world_iter.next()) |entry| {
-                self.allocator.free(entry.key_ptr.*);
-                entry.value_ptr.*.deinit();
-                self.allocator.destroy(entry.value_ptr.*);
-            }
-            self.worlds.deinit();
-            if (self.active_world_name) |name| {
-                self.allocator.free(name);
-            }
-            // Clean up active world
-            self.active_world.deinit();
-            self.allocator.destroy(self.active_world);
-            self.gizmo_state.deinit(self.allocator);
-            self.scenes.deinit();
-            self.jsonc_scenes.deinit();
-            // Free duplicated keys; values are program-lifetime @embedFile
-            // borrows so they aren't owned by this map.
-            var emb_iter = self.embedded_scene_sources.iterator();
-            while (emb_iter.next()) |entry| self.allocator.free(entry.key_ptr.*);
-            self.embedded_scene_sources.deinit();
-            self.atlas_manager.deinit();
-        }
+        pub const deinit = LifecycleMixin.deinit;
 
-        pub fn setHooks(self: *Self, receiver: Hooks) void {
-            // `self` is at its final, stable address by the time the game
-            // wires hooks (see generated main: `init` then `setHooks`), so
-            // pin the scheduler's type-erased game pointer here too — covers
-            // any `game.scheduler.after(...)` issued before the first tick.
-            self.bindScheduler();
-            if (has_hooks) {
-                if (HooksIsMerged) {
-                    self.hooks = receiver;
-                    // Inject game pointer into hook structs that declare game_ptr
-                    const merged = receiver.*;
-                    inline for (std.meta.fields(@TypeOf(merged.receivers))) |field| {
-                        const hook_ptr = @field(merged.receivers, field.name);
-                        const HookType = @typeInfo(@TypeOf(hook_ptr)).pointer.child;
-                        if (@hasField(HookType, "game_ptr")) {
-                            hook_ptr.game_ptr = @ptrCast(self);
-                        }
-                    }
-                } else {
-                    self.hooks = .{ .receiver = receiver };
-                    // Inject game pointer for single hook
-                    const HookType = @typeInfo(Hooks).pointer.child;
-                    if (@hasField(HookType, "game_ptr")) {
-                        receiver.game_ptr = @ptrCast(self);
-                    }
-                }
-                self.emitHook(.{ .game_init = .{ .allocator = self.allocator } });
-                // Engine `Events` dual-emit (#578). `engine.game_init`
-                // is empty by design — the on-disk Event-node form
-                // doesn't carry `Allocator`. Listeners that need an
-                // allocator should reach `game.allocator` directly.
-                self.emitEngineEvent("engine__game_init", .{});
-            }
-        }
+        pub const setHooks = LifecycleMixin.setHooks;
 
-        pub fn emitHook(self: *Self, payload: Payload) void {
-            if (has_hooks) {
-                if (self.hooks) |h| {
-                    h.emit(payload);
-                }
-            }
-        }
+        pub const emitHook = EventsMixin.emitHook;
 
         /// Emit a game event. Buffered and delivered to scripts at end of frame.
-        pub fn emit(self: *Self, event: GameEvents) void {
-            if (has_events) {
-                self.event_buffer.append(self.allocator, event) catch |err| {
-                    self.log.err("Failed to emit game event: {s}", .{@errorName(err)});
-                };
-            }
-        }
+        pub const emit = EventsMixin.emit;
 
         /// Engine-side tolerant emit for the `engine__<event>` variants
         /// declared on `engine.Events` (RFC-FLOW-VOCABULARY phase 6,
@@ -650,55 +566,7 @@ pub fn GameConfig(
         /// payload type is inferred against
         /// `@FieldType(GameEvents, tag)`, mirroring how
         /// `dispatchEvents` reconstructs the union variant.
-        pub inline fn emitEngineEvent(
-            self: *Self,
-            comptime tag: []const u8,
-            payload: anytype,
-        ) void {
-            // Comptime gate: when the project's `GameEvents` doesn't
-            // carry the requested variant — e.g. unit-test games using
-            // `GameWith(Hooks)` with `GameEvents = void`, or any
-            // project the assembler hasn't yet been re-run against —
-            // the entire body folds to a no-op. Returning the early
-            // empty body via comptime branching avoids semantic
-            // analysis on a `@unionInit` against `void`/missing field.
-            const should_emit = comptime blk: {
-                if (!has_events) break :blk false;
-                const ev_info = @typeInfo(GameEvents);
-                if (ev_info != .@"union") break :blk false;
-                break :blk @hasField(GameEvents, tag);
-            };
-            if (comptime !should_emit) return;
-            // From here on `GameEvents` is known to be a union with
-            // the variant. Build the payload by copying fields from
-            // the caller's anonymous struct literal into a value of
-            // the merged union's declared payload type — Zig 0.16
-            // does not auto-coerce anonymous struct literals to a
-            // *different* named struct even when fields match, so we
-            // do it field-by-field. This also lets the caller pass
-            // the engine's `Entity` type for entity-typed fields:
-            // the @intCast widens to `u32` here without forcing the
-            // call site to spell it out.
-            const Payload_t = @FieldType(GameEvents, tag);
-            var typed: Payload_t = undefined;
-            const fields = comptime std.meta.fields(Payload_t);
-            inline for (fields) |f| {
-                if (comptime @hasField(@TypeOf(payload), f.name)) {
-                    const src_val = @field(payload, f.name);
-                    const SrcT = @TypeOf(src_val);
-                    if (comptime @typeInfo(f.type) == .int and @typeInfo(SrcT) == .int) {
-                        @field(typed, f.name) = @intCast(src_val);
-                    } else {
-                        @field(typed, f.name) = src_val;
-                    }
-                } else if (comptime f.default_value_ptr != null) {
-                    @field(typed, f.name) = @as(*const f.type, @ptrCast(@alignCast(f.default_value_ptr.?))).*;
-                } else {
-                    @compileError("emitEngineEvent: missing field '" ++ f.name ++ "' for variant '" ++ tag ++ "'");
-                }
-            }
-            self.emit(@unionInit(GameEvents, tag, typed));
-        }
+        pub const emitEngineEvent = EventsMixin.emitEngineEvent;
 
         /// Emit a game event synchronously — dispatch to registered hooks
         /// immediately, bypassing the end-of-frame buffer. Use when the
@@ -725,268 +593,31 @@ pub fn GameConfig(
         ///   earlier in the same frame, even though those were queued
         ///   first. Mixing the two on a single event kind produces
         ///   out-of-order handler calls — usually not what you want.
-        pub fn emitSync(self: *Self, event: GameEvents) void {
-            // Skip the switch + @unionInit payload construction when
-            // the game has no hooks to dispatch to — same comptime
-            // shortcut `emitHook` relies on. Folds the entire call
-            // away in zero-hook builds.
-            if (!has_events or !has_hooks) return;
-            switch (event) {
-                inline else => |data, tag| {
-                    self.emitHook(@unionInit(Payload, @tagName(tag), data));
-                },
-            }
-        }
+        pub const emitSync = EventsMixin.emitSync;
 
         /// Deliver buffered game events to hooks. Called at end of frame.
-        pub fn dispatchEvents(self: *Self) void {
-            if (!has_events) return;
-            var dispatch_buf: EventBuffer = .empty;
-            std.mem.swap(EventBuffer, &self.event_buffer, &dispatch_buf);
-
-            for (dispatch_buf.items) |event| {
-                switch (event) {
-                    inline else => |data, tag| {
-                        self.emitHook(@unionInit(Payload, @tagName(tag), data));
-                    },
-                }
-            }
-            dispatch_buf.clearRetainingCapacity();
-
-            if (self.event_buffer.items.len == 0) {
-                std.mem.swap(EventBuffer, &self.event_buffer, &dispatch_buf);
-            }
-            dispatch_buf.deinit(self.allocator);
-        }
+        pub const dispatchEvents = EventsMixin.dispatchEvents;
 
         // ── Debug entity guards (#419, #420) ─────────────────────
 
-        fn recordTombstone(self: *Self, entity: Entity) void {
-            if (comptime is_debug) {
-                self.tombstones[self.tombstone_cursor] = TombstoneEntry{ .entity = entity, .frame = self.frame_number };
-                self.tombstone_cursor = (self.tombstone_cursor + 1) % tombstone_size;
-            }
-        }
+        pub const recordTombstone = EntityMixin.recordTombstone;
 
-        pub fn findTombstone(self: *const Self, entity: Entity) ?TombstoneEntry {
-            if (comptime !is_debug) return null;
-            // Iterate backwards from cursor to return the most recent match
-            // (entity IDs can be reused after resetEcsBackend or ECS recycling)
-            var j: usize = 0;
-            while (j < tombstone_size) : (j += 1) {
-                const i = (self.tombstone_cursor + tombstone_size - 1 - j) % tombstone_size;
-                if (self.tombstones[i]) |entry| {
-                    if (entry.entity == entity) return entry;
-                }
-            }
-            return null;
-        }
-
-        pub fn assertEntityAlive(self: *const Self, entity: Entity, comptime operation: []const u8) void {
-            if (comptime is_debug) {
-                if (!self.ecs_backend.entityExists(entity)) {
-                    if (self.findTombstone(entity)) |tomb| {
-                        std.debug.print("{s} on destroyed entity {d} (destroyed in frame {d}, current frame {d})\n", .{
-                            operation, entity, tomb.frame, self.frame_number,
-                        });
-                        @panic(operation ++ " on destroyed entity");
-                    } else {
-                        std.debug.print("{s} on invalid entity {d} (not in tombstone ring — destroyed long ago or never existed)\n", .{
-                            operation, entity,
-                        });
-                        @panic(operation ++ " on invalid entity");
-                    }
-                }
-            }
-        }
+        pub const findTombstone = EntityMixin.findTombstone;
+        pub const assertEntityAlive = EntityMixin.assertEntityAlive;
 
         // ── Entity Management ─────────────────────────────────────
+        pub const createEntity = EntityMixin.createEntity;
+        pub const spawnPrefab = EntityMixin.spawnPrefab;
+        pub const spawnFromPrefab = EntityMixin.spawnFromPrefab;
+        pub const tagAsPrefabInstance = EntityMixin.tagAsPrefabInstance;
+        pub const destroyEntity = EntityMixin.destroyEntity;
+        pub const destroyEntityOnly = EntityMixin.destroyEntityOnly;
 
-        pub fn createEntity(self: *Self) Entity {
-            const entity = self.ecs_backend.createEntity();
-            self.emitHook(.{ .entity_created = .{ .entity_id = entity } });
-            // Engine `Events` dual-emit (#578). `entity` is widened to
-            // u32 — same convention as box2d's `Events.collision_begin`.
-            self.emitEngineEvent("engine__entity_created", .{ .entity = @as(u32, @intCast(entity)) });
-            // Preview telemetry: the prefab path tags `PrefabInstance`
-            // *after* createEntity returns (see `tagAsPrefabInstance`),
-            // so we can't carry the prefab name here. Emit null; a
-            // future enhancement can re-emit on tag.
-            if (self.preview) |*p| p.emitEntityCreated(@intCast(entity), null) catch {};
-            return entity;
-        }
-
-        /// Spawn an entity from a named prefab at the given position.
-        /// Returns the entity, or null if the prefab was not found.
-        /// Requires a JSONC scene to have been loaded (which sets up the prefab directory).
-        pub fn spawnPrefab(self: *Self, name: []const u8, pos: Position) ?Entity {
-            if (self.spawn_prefab_fn) |func| {
-                return func(self, name, pos);
-            }
-            self.log.err("[Game] spawnPrefab: no prefab loader configured (load a JSONC scene first)", .{});
-            return null;
-        }
-
-        /// Spawn a prefab *and* tag it for save/load Phase 1 reinstantiation.
-        ///
-        /// Wraps `spawnPrefab` with two additions from
-        /// `RFC-SAVE-LOAD-PREFABS.md`:
-        ///
-        /// 1. The **root** entity gets `PrefabInstance { path, overrides = "" }`
-        ///    so the save mixin's built-in handler (added in #474)
-        ///    records its prefab origin.
-        /// 2. Each **child** entity (recursively) gets
-        ///    `PrefabChild { root, local_path = "children[i]..." }` so
-        ///    Phase 1 on load can map saved child IDs back to newly-
-        ///    spawned children via `(root, local_path)`.
-        ///
-        /// `PrefabInstance.path` and every `PrefabChild.local_path` are
-        /// duped into `active_world.nested_entity_arena` — lifetime
-        /// matches the prefab children (world-scoped), freed on scene
-        /// change. Same ownership contract as the save mixin's load-
-        /// side allocation. `PrefabInstance.overrides` is the string
-        /// literal `""` in this first-cut slice (program lifetime, no
-        /// arena allocation needed for a zero-length literal); the
-        /// structured-overrides pipeline lands in a follow-up and will
-        /// dupe `overrides` into the same arena then.
-        ///
-        /// **Interaction with the save mixin:** tagged entities
-        /// always survive `saveGameState` → `loadGameState` round-
-        /// trip. Since the sweep in `saveGameState` auto-collects
-        /// entities with `PrefabInstance` / `PrefabChild` (in
-        /// addition to the registry-driven saveable / marker pass),
-        /// a purely-visual prefab — even one whose root has only
-        /// `Sprite` + the engine's auto-attached `PrefabInstance` —
-        /// still round-trips cleanly and Phase 1 respawns it from
-        /// the `path`. Game authors don't need to sprinkle marker
-        /// components solely to placate save/load.
-        ///
-        /// Caveat: this covers *collection only*. If a prefab root's
-        /// components are all non-saveable, Phase 2 has no overrides
-        /// to apply, so the respawned entity reflects the prefab's
-        /// literal declaration. Game-owned `.saveable` components
-        /// override that (per-instance state lives through
-        /// round-trips). `.transient` components reset to the
-        /// prefab's values.
-        pub fn spawnFromPrefab(self: *Self, path: []const u8, pos: Position) ?Entity {
-            const entity = self.spawnPrefab(path, pos) orelse return null;
-            // Any tagging failure (arena OOM on path dupe, or inside
-            // the recursive child walk) leaves the world with an
-            // orphan entity tree that has no `PrefabInstance` tag —
-            // scene-tracked, component-populated, but invisible to
-            // the save mixin's Phase 1. Destroy the whole tree on
-            // failure so `spawnFromPrefab`'s null return really
-            // means "the world is unchanged."
-            //
-            // Log the error name before tearing down: `null` return
-            // collides with the "unknown prefab" signal from
-            // `spawnPrefab`, so without the log an OOM during tagging
-            // is indistinguishable from a typo in the prefab path.
-            self.tagAsPrefabInstance(entity, path) catch |err| {
-                self.log.err("[Game] spawnFromPrefab: tagging failed for '{s}': {s}", .{ path, @errorName(err) });
-                self.destroyEntity(entity);
-                return null;
-            };
-            return entity;
-        }
-
-        /// Tag `entity` as a prefab root (attach `PrefabInstance`) and
-        /// walk its descendants attaching `PrefabChild` markers with
-        /// `local_path` relative to the root.
-        ///
-        /// Used by both `spawnFromPrefab` (runtime spawn path) and
-        /// `JsoncSceneBridge::loadEntityInternal` (scene-load path) so
-        /// the `(root, local_path)` key the save mixin uses to match
-        /// saved children to respawned ones is generated consistently.
-        pub fn tagAsPrefabInstance(self: *Self, entity: Entity, path: []const u8) !void {
-            const arena = self.active_world.nested_entity_arena.allocator();
-            const path_dup = try arena.dupe(u8, path);
-
-            self.ecs_backend.addComponent(entity, PrefabInstance{
-                .path = path_dup,
-                .overrides = "",
-            });
-
-            try tagPrefabChildren(self, entity, entity, "children", arena);
-        }
-
-        /// Recursively tag every descendant of `root` with `PrefabChild`.
-        /// `base_path` is the dotted path accumulated so far (e.g.
-        /// `"children"` at the top level; `"children[0].children"` one
-        /// level in). Each child appends `[i]` to form its unique path
-        /// within the prefab tree.
-        ///
-        /// Propagates allocation errors up instead of silently
-        /// `continue`-ing — a partially-tagged tree would have
-        /// `PrefabChild` on some descendants and not others, breaking
-        /// the `(root, local_path)` lookup the two-phase load relies
-        /// on. Atomic: if anything fails, `spawnFromPrefab` destroys
-        /// the tree and returns null.
-        fn tagPrefabChildren(
-            self: *Self,
-            root: Entity,
-            parent: Entity,
-            base_path: []const u8,
-            arena: std.mem.Allocator,
-        ) !void {
-            const children = self.getChildren(parent);
-            for (children, 0..) |child, i| {
-                const child_path = try std.fmt.allocPrint(
-                    arena,
-                    "{s}[{d}]",
-                    .{ base_path, i },
-                );
-                self.ecs_backend.addComponent(child, PrefabChildT{
-                    .root = root,
-                    .local_path = child_path,
-                });
-                // Skip the `.children` suffix allocation when `child` is
-                // a leaf. Two-level prefab trees (hydroponics: root +
-                // room + plant overlay) are common; without this gate
-                // the leaf gets an unused `"children[i].children"`
-                // string arena-allocated every spawn.
-                if (self.hasChildren(child)) {
-                    const next_base = try std.fmt.allocPrint(
-                        arena,
-                        "{s}.children",
-                        .{child_path},
-                    );
-                    try tagPrefabChildren(self, root, child, next_base, arena);
-                }
-            }
-        }
-
-        pub fn destroyEntity(self: *Self, entity: Entity) void {
-            if (self.ecs_backend.getComponent(entity, Children)) |children_comp| {
-                for (children_comp.getChildren()) |child| {
-                    self.destroyEntity(child);
-                }
-            }
-            // Preview telemetry emits BEFORE the actual destroy so any
-            // editor-side consumer can still introspect the entity from
-            // a `getComponent` style API while reacting to the frame.
-            if (self.preview) |*p| p.emitEntityDestroyed(@intCast(entity)) catch {};
-            self.untrackSceneEntity(entity);
-            self.active_world.sprite_cache.invalidate(@intCast(entity));
-            self.renderer.untrackEntity(entity);
-            self.ecs_backend.destroyEntity(entity);
-            self.recordTombstone(entity);
-            self.emitHook(.{ .entity_destroyed = .{ .entity_id = entity } });
-            // Engine `Events` dual-emit (#578).
-            self.emitEngineEvent("engine__entity_destroyed", .{ .entity = @as(u32, @intCast(entity)) });
-        }
-
-        pub fn destroyEntityOnly(self: *Self, entity: Entity) void {
-            if (self.preview) |*p| p.emitEntityDestroyed(@intCast(entity)) catch {};
-            self.untrackSceneEntity(entity);
-            self.active_world.sprite_cache.invalidate(@intCast(entity));
-            self.renderer.untrackEntity(entity);
-            self.ecs_backend.destroyEntity(entity);
-            self.recordTombstone(entity);
-            self.emitHook(.{ .entity_destroyed = .{ .entity_id = entity } });
-            // Engine `Events` dual-emit (#578).
-            self.emitEngineEvent("engine__entity_destroyed", .{ .entity = @as(u32, @intCast(entity)) });
-        }
+        // ── View collection helpers (#510) ────────────────────────
+        pub const collectEntities = EntityMixin.collectEntities;
+        pub const collectEntitiesBuf = EntityMixin.collectEntitiesBuf;
+        pub const collectEntitiesIf = EntityMixin.collectEntitiesIf;
+        pub const collectEntitiesBufIf = EntityMixin.collectEntitiesBufIf;
 
         // ── Visuals (mixin) ──────────────────────────────────────
         pub const addSprite = Visuals.addSprite;
@@ -1000,372 +631,29 @@ pub fn GameConfig(
         pub const setZIndex = Visuals.setZIndex;
         pub const setSpriteFlip = Visuals.setSpriteFlip;
 
-        // ── View collection helpers (#510) ────────────────────────
-        //
-        // Iterating an ECS view while mutating the world (adding /
-        // removing components, destroying entities) risks
-        // invalidating the iterator on backends that don't tolerate
-        // concurrent mutation. The two helpers below absorb the
-        // "collect first, then mutate" boilerplate every dispatcher
-        // / hook / tick was hand-rolling.
-        //
-        // Both forward `include` and `exclude` straight to
-        // `self.active_world.ecs_backend.view(include, exclude)` and
-        // close the view via `defer view.deinit()`. The include /
-        // exclude tuple shape mirrors what the caller would have
-        // passed to `view` directly, so the migration from
-        // hand-rolled to helper is just lifting the iteration
-        // boilerplate out.
-
-        /// Heap-allocated collection. Returns an `ArrayList(Entity)`
-        /// the caller `deinit`s. Picks the heap path when the
-        /// expected size is unknown or large (save / load,
-        /// debug-snapshot scans, one-shot batch ops).
-        pub fn collectEntities(
-            self: *Self,
-            comptime include: anytype,
-            comptime exclude: anytype,
-            allocator: std.mem.Allocator,
-        ) !std.ArrayList(Entity) {
-            var buf: std.ArrayList(Entity) = .empty;
-            errdefer buf.deinit(allocator);
-            var view = self.ecs_backend.view(include, exclude);
-            defer view.deinit();
-            while (view.next()) |ent| {
-                try buf.append(allocator, ent);
-            }
-            return buf;
-        }
-
-        /// Stack-allocated collection. Fills `buf` and returns the
-        /// number of entities written. Sets `overflowed.*` to true
-        /// if the view contained more entities than `buf.len`. Use
-        /// for per-tick scans where allocating in the hot loop
-        /// would be wasteful and the worst-case set is bounded.
-        ///
-        /// On overflow the caller decides what to do — typically
-        /// `log.warn(...)` + retry next frame (matches the existing
-        /// `sleep_hooks.frame_end` convention).
-        pub fn collectEntitiesBuf(
-            self: *Self,
-            comptime include: anytype,
-            comptime exclude: anytype,
-            buf: []Entity,
-            overflowed: *bool,
-        ) usize {
-            overflowed.* = false;
-            var count: usize = 0;
-            var view = self.ecs_backend.view(include, exclude);
-            defer view.deinit();
-            while (view.next()) |ent| {
-                if (count < buf.len) {
-                    buf[count] = ent;
-                    count += 1;
-                } else {
-                    overflowed.* = true;
-                }
-            }
-            return count;
-        }
-
-        /// Same shape as `collectEntities`, with an extra runtime
-        /// `predicate(self, entity) bool` filter. Use when the
-        /// caller needs to check a component **field value** (or any
-        /// derived condition) — the comptime include / exclude
-        /// tuple only filters on component existence. The predicate
-        /// receives the live `Game` pointer so it can
-        /// `getComponent(...)` for whatever runtime state the
-        /// filter inspects.
-        ///
-        /// **Predicate contract: read-only.** The whole point of the
-        /// `collect*` helpers is to *avoid* mutating the world
-        /// inside the view's iteration. The predicate runs while
-        /// the iterator is live; adding / removing components or
-        /// destroying entities from inside it risks the same
-        /// concurrent-mutation hazard the helpers exist to dodge.
-        /// Use the predicate to *inspect* state (via
-        /// `getComponent`, etc.); commit mutations in the loop the
-        /// caller writes over the returned list.
-        pub fn collectEntitiesIf(
-            self: *Self,
-            comptime include: anytype,
-            comptime exclude: anytype,
-            allocator: std.mem.Allocator,
-            predicate: *const fn (*Self, Entity) bool,
-        ) !std.ArrayList(Entity) {
-            var buf: std.ArrayList(Entity) = .empty;
-            errdefer buf.deinit(allocator);
-            var view = self.ecs_backend.view(include, exclude);
-            defer view.deinit();
-            while (view.next()) |ent| {
-                if (predicate(self, ent)) {
-                    try buf.append(allocator, ent);
-                }
-            }
-            return buf;
-        }
-
-        /// Same shape as `collectEntitiesBuf`, with the runtime
-        /// `predicate` filter. Useful for the per-tick scan path
-        /// where the worst case is bounded and a heap allocation
-        /// per frame would be wasteful — same `overflowed`
-        /// out-pointer contract.
-        ///
-        /// **Predicate contract: read-only** — same rule as
-        /// `collectEntitiesIf`. The hot-path stack variant is the
-        /// one most likely to be tempted with a per-tick mutation
-        /// inside the predicate; resist. Inspect only.
-        ///
-        /// On overflow the iteration breaks early: once the buffer
-        /// is full and we've seen one more predicate-accepted
-        /// entity, there's nothing the caller can do with the rest
-        /// (they go in next tick's pass), so spending more
-        /// predicate calls is wasted work. Predicate-rejected
-        /// entities don't count toward the cap — a view full of
-        /// rejects never trips the overflow flag.
-        pub fn collectEntitiesBufIf(
-            self: *Self,
-            comptime include: anytype,
-            comptime exclude: anytype,
-            buf: []Entity,
-            overflowed: *bool,
-            predicate: *const fn (*Self, Entity) bool,
-        ) usize {
-            overflowed.* = false;
-            var count: usize = 0;
-            var view = self.ecs_backend.view(include, exclude);
-            defer view.deinit();
-            while (view.next()) |ent| {
-                if (!predicate(self, ent)) continue;
-                if (count < buf.len) {
-                    buf[count] = ent;
-                    count += 1;
-                } else {
-                    overflowed.* = true;
-                    break;
-                }
-            }
-            return count;
-        }
-
         // ── Position & Hierarchy ──────────────────────────────────
 
-        pub fn setPosition(self: *Self, entity: Entity, pos: Position) void {
-            self.ecs_backend.addComponent(entity, pos);
-            self.renderer.markPositionDirtyWithChildren(EcsImpl, self.ecs_backend, entity);
-            self.notifyComponentChanged(entity, pos);
-        }
-
-        /// Preview-mode helper. No-op unless `self.preview` is set AND
-        /// the editor has subscribed to this component's name. Folded
-        /// out by the compiler in non-preview builds because the
-        /// `preview` field defaults to `null`.
-        ///
-        /// Generic over the component type so it can be called from
-        /// any setter site without forcing the caller to spell out
-        /// `@typeName` + `std.mem.asBytes` boilerplate. The
-        /// subscription check runs first so `comp` is never read in
-        /// the common "nobody's watching" path.
-        inline fn notifyComponentChanged(self: *Self, entity: Entity, comp: anytype) void {
-            if (self.preview) |*p| {
-                // Callers may pass either a value or a `*T` (the
-                // generic `addComponent` / `setComponent` accept
-                // `anytype`). Strip the pointer so the subscription
-                // name and serialized bytes describe the component,
-                // not its address.
-                const T = @TypeOf(comp);
-                if (comptime @typeInfo(T) == .pointer) {
-                    const name = @typeName(@typeInfo(T).pointer.child);
-                    if (p.isComponentSubscribed(name)) {
-                        p.emitComponentChanged(@intCast(entity), name, std.mem.asBytes(comp)) catch {};
-                    }
-                } else {
-                    const name = @typeName(T);
-                    if (p.isComponentSubscribed(name)) {
-                        p.emitComponentChanged(@intCast(entity), name, std.mem.asBytes(&comp)) catch {};
-                    }
-                }
-            }
-        }
-
-        pub fn getPosition(self: *Self, entity: Entity) Position {
-            if (self.ecs_backend.getComponent(entity, Position)) |p| return p.*;
-            return Position{};
-        }
-
-        pub fn getWorldPosition(self: *Self, entity: Entity) Position {
-            return hierarchy.computeWorldPos(EcsImpl, Parent, self.ecs_backend, entity, 0);
-        }
-
-        pub fn setWorldPosition(self: *Self, entity: Entity, world_pos: Position) void {
-            if (self.ecs_backend.getComponent(entity, Parent)) |parent_comp| {
-                const parent_world = hierarchy.computeWorldPos(EcsImpl, Parent, self.ecs_backend, parent_comp.entity, 0);
-                self.setPosition(entity, .{ .x = world_pos.x - parent_world.x, .y = world_pos.y - parent_world.y });
-            } else {
-                self.setPosition(entity, world_pos);
-            }
-        }
-
-        pub fn setParent(self: *Self, child: Entity, parent_entity: Entity, opts: struct {
-            inherit_rotation: bool = false,
-            inherit_scale: bool = false,
-        }) void {
-            self.assertEntityAlive(child, "setParent (child)");
-            self.assertEntityAlive(parent_entity, "setParent (parent)");
-            if (hierarchy.wouldCreateCycle(EcsImpl, Parent, self.ecs_backend, child, parent_entity)) return;
-
-            if (self.ecs_backend.getComponent(child, Parent)) |old_parent_comp| {
-                if (self.ecs_backend.getComponent(old_parent_comp.entity, Children)) |old_children| {
-                    old_children.removeChild(child);
-                }
-            }
-
-            self.ecs_backend.addComponent(child, Parent{
-                .entity = parent_entity,
-                .inherit_rotation = opts.inherit_rotation,
-                .inherit_scale = opts.inherit_scale,
-            });
-
-            if (self.ecs_backend.getComponent(parent_entity, Children)) |children_comp| {
-                children_comp.addChild(child);
-            } else {
-                var new_children = Children{};
-                new_children.addChild(child);
-                self.ecs_backend.addComponent(parent_entity, new_children);
-            }
-
-            self.renderer.updateHierarchyFlag(child, true);
-            self.renderer.markPositionDirty(child);
-        }
-
-        pub fn setParentKeepTransform(self: *Self, child: Entity, parent_entity: Entity, opts: struct {
-            inherit_rotation: bool = false,
-            inherit_scale: bool = false,
-        }) void {
-            const world_pos = self.getWorldPosition(child);
-            self.setParent(child, parent_entity, opts);
-            self.setWorldPosition(child, world_pos);
-        }
-
-        pub fn removeParent(self: *Self, child: Entity) void {
-            self.assertEntityAlive(child, "removeParent");
-            if (self.ecs_backend.getComponent(child, Parent)) |parent_comp| {
-                if (self.ecs_backend.getComponent(parent_comp.entity, Children)) |children_comp| {
-                    children_comp.removeChild(child);
-                }
-            }
-            self.ecs_backend.removeComponent(child, Parent);
-            self.renderer.updateHierarchyFlag(child, false);
-            self.renderer.markPositionDirty(child);
-        }
-
-        pub fn removeParentKeepTransform(self: *Self, child: Entity) void {
-            const world_pos = self.getWorldPosition(child);
-            self.removeParent(child);
-            self.setPosition(child, world_pos);
-        }
-
-        pub fn getParent(self: *Self, entity: Entity) ?Entity {
-            if (self.ecs_backend.getComponent(entity, Parent)) |p| return p.entity;
-            return null;
-        }
-
-        pub fn getChildren(self: *Self, entity: Entity) []const Entity {
-            if (self.ecs_backend.getComponent(entity, Children)) |c| return c.getChildren();
-            return &.{};
-        }
-
-        pub fn hasChildren(self: *Self, entity: Entity) bool {
-            if (self.ecs_backend.getComponent(entity, Children)) |c| return c.count() > 0;
-            return false;
-        }
-
-        pub fn isRoot(self: *Self, entity: Entity) bool {
-            return !self.ecs_backend.hasComponent(entity, Parent);
-        }
+        pub const setPosition = ComponentsMixin.setPosition;
+        pub const getPosition = ComponentsMixin.getPosition;
+        pub const getWorldPosition = ComponentsMixin.getWorldPosition;
+        pub const setWorldPosition = ComponentsMixin.setWorldPosition;
+        pub const setParent = ComponentsMixin.setParent;
+        pub const setParentKeepTransform = ComponentsMixin.setParentKeepTransform;
+        pub const removeParent = ComponentsMixin.removeParent;
+        pub const removeParentKeepTransform = ComponentsMixin.removeParentKeepTransform;
+        pub const getParent = ComponentsMixin.getParent;
+        pub const getChildren = ComponentsMixin.getChildren;
+        pub const hasChildren = ComponentsMixin.hasChildren;
+        pub const isRoot = ComponentsMixin.isRoot;
 
         // ── Generic Component Access ──────────────────────────────
-
-        pub fn addComponent(self: *Self, entity: Entity, component: anytype) void {
-            self.ecs_backend.addComponent(entity, component);
-            const T = @TypeOf(component);
-            if (@typeInfo(T) == .@"struct" and @hasDecl(T, "onAdd")) {
-                T.onAdd(ComponentPayload{ .entity_id = @intCast(entity), .game_ptr = @ptrCast(self) });
-            }
-            self.notifyComponentChanged(entity, component);
-        }
-
-        pub fn setComponent(self: *Self, entity: Entity, component: anytype) void {
-            const T = @TypeOf(component);
-            const is_update = self.ecs_backend.hasComponent(entity, T);
-            self.ecs_backend.addComponent(entity, component);
-            if (@typeInfo(T) == .@"struct") {
-                if (is_update and @hasDecl(T, "onSet")) {
-                    T.onSet(ComponentPayload{ .entity_id = @intCast(entity), .game_ptr = @ptrCast(self) });
-                } else if (!is_update and @hasDecl(T, "onAdd")) {
-                    T.onAdd(ComponentPayload{ .entity_id = @intCast(entity), .game_ptr = @ptrCast(self) });
-                }
-            }
-            self.notifyComponentChanged(entity, component);
-        }
-
-        pub fn getComponent(self: *Self, entity: Entity, comptime T: type) ?*T {
-            return self.ecs_backend.getComponent(entity, T);
-        }
-
-        /// Writes a single field of component `T` on `entity` in place.
-        ///
-        /// Silently no-ops when the entity does not have a component
-        /// of type `T` — same semantics as `getComponent` returning
-        /// `null`. This matches the flow-codegen runtime contract:
-        /// generated `OnUpdate` flows that touch a missing component
-        /// should not crash the game loop.
-        ///
-        /// The `comptime field: std.meta.FieldEnum(T)` selector keeps
-        /// the call site type-checked end-to-end. The flow-codegen
-        /// emits `game.setField(Position, .x, entity, value)`.
-        ///
-        /// Preview telemetry is fired after the mutation through the
-        /// same `notifyComponentChanged` path used by `setComponent`,
-        /// so the editor sees an updated component frame when it has
-        /// subscribed to `T`. For `Position` specifically the renderer's
-        /// dirty-tracking is also poked (mirroring `setPosition`) so
-        /// a flow that nudges `Position.x` doesn't drift the on-screen
-        /// sprite out of sync with the ECS state.
-        pub fn setField(
-            self: *Self,
-            comptime T: type,
-            comptime field: std.meta.FieldEnum(T),
-            entity: Entity,
-            value: @FieldType(T, @tagName(field)),
-        ) void {
-            const comp_ptr = self.ecs_backend.getComponent(entity, T) orelse return;
-            @field(comp_ptr.*, @tagName(field)) = value;
-            if (T == Position) {
-                self.renderer.markPositionDirtyWithChildren(EcsImpl, self.ecs_backend, entity);
-            }
-            self.notifyComponentChanged(entity, comp_ptr);
-        }
-
-        pub fn hasComponent(self: *Self, entity: Entity, comptime T: type) bool {
-            return self.ecs_backend.hasComponent(entity, T);
-        }
-
-        pub fn removeComponent(self: *Self, entity: Entity, comptime T: type) void {
-            if (@typeInfo(T) == .@"struct" and @hasDecl(T, "onRemove")) {
-                T.onRemove(ComponentPayload{ .entity_id = @intCast(entity), .game_ptr = @ptrCast(self) });
-            }
-            self.ecs_backend.removeComponent(entity, T);
-        }
-
-        /// Fire onReady for a component type on a given entity.
-        /// Called by the scene loader after ALL components have been added,
-        /// so onReady callbacks can safely access sibling components.
-        pub fn fireOnReady(self: *Self, entity: Entity, comptime T: type) void {
-            if (@typeInfo(T) == .@"struct" and @hasDecl(T, "onReady")) {
-                T.onReady(ComponentPayload{ .entity_id = @intCast(entity), .game_ptr = @ptrCast(self) });
-            }
-        }
+        pub const addComponent = ComponentsMixin.addComponent;
+        pub const setComponent = ComponentsMixin.setComponent;
+        pub const getComponent = ComponentsMixin.getComponent;
+        pub const setField = ComponentsMixin.setField;
+        pub const hasComponent = ComponentsMixin.hasComponent;
+        pub const removeComponent = ComponentsMixin.removeComponent;
+        pub const fireOnReady = ComponentsMixin.fireOnReady;
 
         // ── Input (mixin) ────────────────────────────────────────
         pub const isKeyDown = InputMixin.isKeyDown;
@@ -1395,9 +683,7 @@ pub fn GameConfig(
         ///
         /// Backends without a design/physical distinction (raylib) get
         /// a passthrough — the input is returned unchanged.
-        pub fn screenToDesign(self: *Self, px: f32, py: f32) RenderImpl.ScreenPoint {
-            return self.renderer.screenToDesign(px, py);
-        }
+        pub const screenToDesign = MiscMixin.screenToDesign;
 
         // ── Audio (mixin) ────────────────────────────────────────
         pub const playSound = AudioMixin.playSound;
@@ -1453,13 +739,7 @@ pub fn GameConfig(
         /// is typically a comptime `@embedFile(...)` slice. Caller
         /// retains no ownership — the map dupes the key and borrows
         /// the source's program-lifetime slice.
-        pub fn addEmbeddedSceneSource(self: *Self, path: []const u8, source: []const u8) !void {
-            const gop = try self.embedded_scene_sources.getOrPut(path);
-            if (!gop.found_existing) {
-                gop.key_ptr.* = try self.allocator.dupe(u8, path);
-            }
-            gop.value_ptr.* = source;
-        }
+        pub const addEmbeddedSceneSource = MiscMixin.addEmbeddedSceneSource;
         pub const setSceneAssets = SceneMixin.setSceneAssets;
         pub const setSceneInitialState = SceneMixin.setSceneInitialState;
         pub const setScene = SceneMixin.setScene;
@@ -1472,19 +752,12 @@ pub fn GameConfig(
 
         /// Register a runtime JSONC scene by name.
         /// The scene file is loaded from disk when setScene() is called.
-        pub fn registerJsoncScene(self: *Self, name: []const u8, scene_path: []const u8, prefab_dir: []const u8) void {
-            self.jsonc_scenes.put(name, .{
-                .scene_path = scene_path,
-                .prefab_dir = prefab_dir,
-            }) catch {};
-        }
+        pub const registerJsoncScene = MiscMixin.registerJsoncScene;
 
         // ── Hot Reload ──────────────────────────────────────────────
 
         /// Signal that the current scene should be reloaded on the next tick.
-        pub fn requestReload(self: *Self) void {
-            self.hot_reload_dirty = true;
-        }
+        pub const requestReload = MiscMixin.requestReload;
 
         // ── Save/Load (mixin) ───────────────────────────────────────
         pub const saveGameState = SaveLoadMixin.saveGameState;
@@ -1496,193 +769,32 @@ pub fn GameConfig(
         pub const getState = StateMixin.getState;
 
         // ── Pause flag (#465) ───────────────────────────────────────
-
-        /// Set the engine-level pause flag. Emits `pause_changed` when
-        /// the value transitions; idempotent if already at `paused`.
-        ///
-        /// Intended to be called from a game-side sync script that
-        /// mirrors a game-owned `GamePaused` component (or equivalent)
-        /// into the engine, so plugin-shipped scripts can gate via
-        /// `game.isPaused()` without importing game components.
-        pub fn setPaused(self: *Self, paused: bool) void {
-            if (self.paused == paused) return;
-            self.paused = paused;
-            self.emitHook(.{ .pause_changed = .{ .paused = paused } });
-            // Engine `Events` dual-emit (#578).
-            self.emitEngineEvent("engine__pause_changed", .{ .paused = paused });
-        }
-
-        /// Read the engine-level pause predicate. Returns true if
-        /// *either* the explicit `paused` flag is set OR `time_scale`
-        /// is zero — both are valid pause mechanisms and tick gating
-        /// should honour both uniformly.
-        ///
-        /// Plugin scripts should use this instead of reaching for a
-        /// game-side `GamePaused` component — the latter would couple
-        /// plugin code to the game's component types across module
-        /// boundaries.
-        pub fn isPaused(self: *const Self) bool {
-            return self.paused or self.time_scale == 0;
-        }
+        // Full docs in `game/scene_runtime_mixin.zig`.
+        pub const setPaused = SceneRuntimeMixin.setPaused;
+        pub const isPaused = SceneRuntimeMixin.isPaused;
 
         // ── ControllerManager game-facing API (#611) ─────────────────
-        //
-        // Thin forwarders over the embedded `controller_manager` so game
-        // scripts and plugins reach the assignment/query API without poking
-        // the field directly. Available only when the project's
-        // `GameEvents` carries a player-level controller variant — calling
-        // any of these in a game that doesn't is a compile error (the
-        // manager field is `void`), which is the intended guard rail.
+        // Thin forwarders over the embedded `controller_manager`; available
+        // only when `GameEvents` carries a player-level controller variant
+        // (else the field is `void` and these `@compileError`). Full docs
+        // in `game/input_events_mixin.zig`.
+        pub const controllerManager = InputEventsMixin.controllerManager;
+        pub const assignController = InputEventsMixin.assignController;
+        pub const unassignPlayer = InputEventsMixin.unassignPlayer;
+        pub const playerForController = InputEventsMixin.playerForController;
+        pub const controllerForPlayer = InputEventsMixin.controllerForPlayer;
+        pub const setAutoPauseOnControllerLost = InputEventsMixin.setAutoPauseOnControllerLost;
 
-        /// Mutable handle to the embedded `ControllerManager`. Use for the
-        /// full API (iteration, `availableControllers`, opt-in helpers like
-        /// `autoBindFreeSlots` / `joinOnButton`). Requires a controller
-        /// event in `GameEvents`.
-        pub fn controllerManager(self: *Self) *ControllerManagerType {
-            comptime if (!controller_events_wanted)
-                @compileError("controllerManager() requires a player-level controller event " ++
-                    "(engine.player_joined / controller_available / ...) in GameEvents");
-            return &self.controller_manager;
-        }
-
-        /// Assign an unassigned `controller` to `player`. Emits
-        /// `player_joined` on the next `dispatchEvents`. Errors if the
-        /// player id is out of range or the controller isn't in the pool.
-        pub fn assignController(self: *Self, controller: u32, player: u32) !void {
-            comptime if (!controller_events_wanted)
-                @compileError("assignController() requires a player-level controller event in GameEvents");
-            try self.controller_manager.assign(controller, player);
-            self.drainControllerManagerEvents();
-        }
-
-        /// Release a player's controller binding, returning the controller
-        /// (if still present) to the unassigned pool.
-        pub fn unassignPlayer(self: *Self, player: u32) void {
-            comptime if (!controller_events_wanted)
-                @compileError("unassignPlayer() requires a player-level controller event in GameEvents");
-            self.controller_manager.unassign(player);
-            self.drainControllerManagerEvents();
-        }
-
-        /// The player a controller is bound to, or `NO_PLAYER`.
-        pub fn playerForController(self: *Self, controller: u32) u32 {
-            comptime if (!controller_events_wanted)
-                @compileError("playerForController() requires a player-level controller event in GameEvents");
-            return self.controller_manager.playerFor(controller);
-        }
-
-        /// The controller currently backing a player, or `NO_CONTROLLER`.
-        pub fn controllerForPlayer(self: *Self, player: u32) u32 {
-            comptime if (!controller_events_wanted)
-                @compileError("controllerForPlayer() requires a player-level controller event in GameEvents");
-            return self.controller_manager.controllerFor(player);
-        }
-
-        /// Toggle the opt-in auto-pause policy (#465 precedent): when on, a
-        /// real `player_controller_lost` drives `setPaused(true)`, and the
-        /// game resumes once every player is whole again. OFF by default —
-        /// the engine never forces a pause.
-        pub fn setAutoPauseOnControllerLost(self: *Self, enabled: bool) void {
-            self.auto_pause_on_controller_lost = enabled;
-        }
-
-        pub fn unloadCurrentScene(self: *Self) void {
-            if (has_events) self.event_buffer.clearRetainingCapacity();
-            if (self.current_scene_name) |name| {
-                self.emitHook(.{ .scene_unload = .{ .name = name } });
-                // Engine `Events` dual-emit (#578).
-                self.emitEngineEvent("engine__scene_unloaded", .{ .name = name });
-                if (self.scenes.get(name)) |entry| {
-                    if (entry.hooks.onUnload) |onUnload| {
-                        onUnload(self);
-                    }
-                }
-            }
-            // Destroy every entity the outgoing scene's loader created.
-            // `destroyEntityOnly` skips the children-recursion so a parent
-            // destroy doesn't double-free an already-listed child, and it
-            // calls `untrackSceneEntity` which swap-removes from this same
-            // list — so we pop from the end instead of iterating by index
-            // (which would skip entries).
-            while (self.scene_entities.pop()) |entity| {
-                self.destroyEntityOnly(entity);
-            }
-
-            // Scene deinit destroys non-persistent entities (which untracks them
-            // from the renderer). Persistent entities remain in ECS + renderer.
-            self.teardownActiveScene();
-        }
-
-        /// Register an entity as owned by the current scene. Called by
-        /// scene loaders (JSONC bridge, comptime registerScene callbacks)
-        /// so `unloadCurrentScene` can destroy the entity when the scene
-        /// swaps out. Silently no-ops on OOM — the scene still works, we
-        /// just lose the auto-cleanup for the un-tracked entity.
-        pub fn trackSceneEntity(self: *Self, entity: Entity) void {
-            self.scene_entities.append(self.allocator, entity) catch {};
-        }
-
-        /// Remove an entity from the scene-tracking list. Called by
-        /// `destroyEntity`/`destroyEntityOnly` so (1) a scene's cleanup
-        /// loop never double-destroys a tracked-then-manually-destroyed
-        /// entity and (2) the list doesn't grow unboundedly across a
-        /// scene that churns through short-lived entities. O(N) scan +
-        /// swap-remove — fine for scenes with hundreds of entities;
-        /// revisit if a project pushes tens of thousands.
-        fn untrackSceneEntity(self: *Self, entity: Entity) void {
-            var i: usize = 0;
-            while (i < self.scene_entities.items.len) : (i += 1) {
-                if (self.scene_entities.items[i] == entity) {
-                    _ = self.scene_entities.swapRemove(i);
-                    return;
-                }
-            }
-        }
-
-        /// Store a type-erased active scene. Called by sceneLoaderFn to hand
-        /// the heap-allocated Scene to the engine for lifecycle management.
-        pub fn setActiveScene(
-            self: *Self,
-            ptr: *anyopaque,
-            update_fn: *const fn (*anyopaque, f32) void,
-            deinit_fn: *const fn (*anyopaque, std.mem.Allocator) void,
-            get_entity_fn: ?*const fn (*anyopaque, []const u8) ?Entity,
-            add_entity_fn: ?*const fn (*anyopaque, Entity) void,
-            clear_entities_fn: ?*const fn (*anyopaque) void,
-        ) void {
-            self.teardownActiveScene();
-            self.active_scene_ptr = ptr;
-            self.active_scene_update_fn = update_fn;
-            self.active_scene_deinit_fn = deinit_fn;
-            self.active_scene_get_entity_fn = get_entity_fn;
-            self.active_scene_add_entity_fn = add_entity_fn;
-            self.active_scene_clear_entities_fn = clear_entities_fn;
-        }
-
-        /// Look up a named entity from the active scene.
-        pub fn getEntityByName(self: *const Self, name: []const u8) ?Entity {
-            if (self.active_scene_ptr) |ptr| {
-                if (self.active_scene_get_entity_fn) |get_fn| {
-                    return get_fn(ptr, name);
-                }
-            }
-            return null;
-        }
-
-        /// Register a runtime-created entity with the active scene.
-        pub fn addEntityToActiveScene(self: *Self, entity: Entity) void {
-            if (self.active_scene_ptr) |ptr| if (self.active_scene_add_entity_fn) |add_fn| {
-                add_fn(ptr, entity);
-            };
-        }
-
-        /// Remove all entities from the active scene's entity list.
-        /// Does NOT destroy ECS entities — caller handles that.
-        pub fn clearActiveSceneEntities(self: *Self) void {
-            if (self.active_scene_ptr) |ptr| if (self.active_scene_clear_entities_fn) |clear_fn| {
-                clear_fn(ptr);
-            };
-        }
+        // ── Active scene runtime (mixin) ──────────────────────────
+        // Full docs in `game/scene_runtime_mixin.zig` /
+        // `game/entity_mixin.zig` (scene-entity tracking).
+        pub const unloadCurrentScene = SceneRuntimeMixin.unloadCurrentScene;
+        pub const trackSceneEntity = EntityMixin.trackSceneEntity;
+        pub const untrackSceneEntity = EntityMixin.untrackSceneEntity;
+        pub const setActiveScene = SceneRuntimeMixin.setActiveScene;
+        pub const getEntityByName = SceneRuntimeMixin.getEntityByName;
+        pub const addEntityToActiveScene = SceneRuntimeMixin.addEntityToActiveScene;
+        pub const clearActiveSceneEntities = SceneRuntimeMixin.clearActiveSceneEntities;
 
         /// Destroy all entities and visuals atomically, then reinitialize
         /// the ECS backend and renderer to a clean state. The nested entity
@@ -1692,238 +804,36 @@ pub fn GameConfig(
         /// should also be cleared.
         // ── World Management ─────────────────────────────────────
 
-        /// Create a new named world. The world is inactive (stored in the map).
-        /// Returns error.WorldAlreadyExists if the name is taken.
-        pub fn createWorld(self: *Self, name: []const u8) !void {
-            if (self.worlds.contains(name)) return error.WorldAlreadyExists;
-            const duped = try self.allocator.dupe(u8, name);
-            errdefer self.allocator.free(duped);
-            const world = try self.allocator.create(World);
-            errdefer {
-                world.deinit();
-                self.allocator.destroy(world);
-            }
-            world.* = World.init(self.allocator);
-            try self.worlds.put(duped, world);
-        }
+        pub const createWorld = WorldMixin.createWorld;
+        pub const destroyWorld = WorldMixin.destroyWorld;
+        pub const setActiveWorld = WorldMixin.setActiveWorld;
+        pub const renameWorld = WorldMixin.renameWorld;
+        pub const getWorld = WorldMixin.getWorld;
+        pub const getActiveWorldName = WorldMixin.getActiveWorldName;
+        pub const worldExists = WorldMixin.worldExists;
+        pub const resetEcsBackend = WorldMixin.resetEcsBackend;
+        pub const teardownActiveScene = WorldMixin.teardownActiveScene;
 
-        /// Destroy a named inactive world. Frees all its entities and visuals.
-        pub fn destroyWorld(self: *Self, name: []const u8) void {
-            if (self.worlds.fetchRemove(name)) |kv| {
-                kv.value.deinit();
-                self.allocator.destroy(kv.value);
-                self.allocator.free(kv.key);
-            }
-        }
-
-        /// Swap the active world. The named world becomes active; the current
-        /// active world is shelved into the map (if named) or destroyed (if unnamed).
-        /// Verifies the target exists BEFORE modifying any state.
-        pub fn setActiveWorld(self: *Self, name: []const u8) !void {
-            // Remove target first — guarantees a free slot for shelving the current world
-            const kv = self.worlds.fetchRemove(name) orelse return error.WorldNotFound;
-
-            // Shelve or destroy current active world
-            if (self.active_world_name) |current_name| {
-                // Named world — shelve into map (can't fail: we just freed a slot)
-                self.worlds.put(current_name, self.active_world) catch @panic("OOM shelving world");
-            } else {
-                // Unnamed default world — destroy it
-                self.active_world.deinit();
-                self.allocator.destroy(self.active_world);
-            }
-
-            // Activate the named world
-            self.active_world = kv.value;
-            self.ecs_backend = &kv.value.ecs_backend;
-            self.renderer = &kv.value.renderer;
-            self.active_world_name = kv.key;
-        }
-
-        /// Rename an inactive world in the map.
-        pub fn renameWorld(self: *Self, old_name: []const u8, new_name: []const u8) !void {
-            if (self.worlds.contains(new_name)) return error.WorldAlreadyExists;
-
-            // Dupe new name first (before removing) so failure is safe
-            const duped = try self.allocator.dupe(u8, new_name);
-            errdefer self.allocator.free(duped);
-
-            if (self.worlds.fetchRemove(old_name)) |kv| {
-                self.allocator.free(kv.key);
-                self.worlds.put(duped, kv.value) catch {
-                    // Restore old entry on failure
-                    const restored_key = self.allocator.dupe(u8, old_name) catch @panic("OOM restoring world");
-                    self.worlds.put(restored_key, kv.value) catch @panic("OOM restoring world");
-                    self.allocator.free(duped);
-                    return error.OutOfMemory;
-                };
-            } else {
-                self.allocator.free(duped);
-                return error.WorldNotFound;
-            }
-        }
-
-        /// Get a pointer to an inactive world.
-        pub fn getWorld(self: *Self, name: []const u8) ?*World {
-            return self.worlds.get(name);
-        }
-
-        /// Get the name of the active world (null if unnamed/default).
-        pub fn getActiveWorldName(self: *const Self) ?[]const u8 {
-            return self.active_world_name;
-        }
-
-        /// Check if a world exists in the inactive map.
-        pub fn worldExists(self: *const Self, name: []const u8) bool {
-            return self.worlds.contains(name);
-        }
-
-        pub fn resetEcsBackend(self: *Self) void {
-            // Tear down active world's fields (reverse of init order)
-            self.gizmo_state.deinit(self.allocator);
-            self.active_world.sprite_cache.deinit();
-            // Clear renderer entity tracking but keep GPU textures loaded.
-            // Textures are expensive to reload (embedded atlas data parsed at startup).
-            self.active_world.renderer.clear();
-            self.active_world.ecs_backend.deinit();
-            _ = self.active_world.nested_entity_arena.reset(.retain_capacity);
-
-            // Reinitialize ECS + sprite cache (but NOT renderer — textures preserved)
-            self.active_world.ecs_backend = EcsImpl.init(self.allocator);
-            self.active_world.sprite_cache = atlas_mod.SpriteCache.init(self.allocator);
-            self.gizmo_state = gizmo_draws_mod.GizmoState(Entity).init(self.allocator);
-            // Re-sync backward-compatible pointers
-            self.ecs_backend = &self.active_world.ecs_backend;
-            // Clear tombstones — old entity IDs are meaningless after ECS reset
-            if (comptime is_debug) {
-                self.tombstones = [_]?TombstoneEntry{null} ** tombstone_size;
-                self.tombstone_cursor = 0;
-            }
-        }
-
-        pub fn teardownActiveScene(self: *Self) void {
-            if (self.active_scene_ptr) |ptr| {
-                if (self.active_scene_deinit_fn) |deinit_fn| {
-                    deinit_fn(ptr, self.allocator);
-                }
-                self.active_scene_ptr = null;
-                self.active_scene_update_fn = null;
-                self.active_scene_deinit_fn = null;
-                self.active_scene_get_entity_fn = null;
-                self.active_scene_add_entity_fn = null;
-                self.active_scene_clear_entities_fn = null;
-
-
-                self.active_world.sprite_cache.clear();
-                // Free nested entity array allocations from the outgoing scene
-                _ = self.active_world.nested_entity_arena.reset(.retain_capacity);
-            }
-        }
-
-        // ── Game Loop ─────────────────────────────────────────────
-
-        pub fn quit(self: *Self) void {
-            self.running = false;
-        }
-
-        pub fn isRunning(self: *const Self) bool {
-            return self.running;
-        }
-
-        // ── Fullscreen ──
-        //
-        // The engine owns the *desired* fullscreen flag; the actual
-        // platform window call (sokol `sapp.toggleFullscreen`, raylib
-        // `ToggleFullscreen`, …) lives in the generated `main.zig` frame
-        // loop, which polls `takeFullscreenRequest()` and forwards the
-        // value to `window.setFullscreen`. Keeping the call out of the
-        // library is what lets the engine stay backend-agnostic — the
-        // same reason `quit()` only flips `running` and lets the frame
-        // loop call `window.requestQuit()`.
-
-        /// Request a fullscreen / windowed switch. No-op if already in the
-        /// requested mode. Takes effect on the next frame, when the
-        /// generated main drains `takeFullscreenRequest()`.
-        pub fn setFullscreen(self: *Self, on: bool) void {
-            if (self.fullscreen == on) return;
-            self.fullscreen = on;
-            self.fullscreen_dirty = true;
-        }
-
-        /// Flip between fullscreen and windowed.
-        pub fn toggleFullscreen(self: *Self) void {
-            self.setFullscreen(!self.fullscreen);
-        }
-
-        /// The engine's desired fullscreen state. This is the value a
-        /// settings UI should bind a checkbox to — it reflects the latest
-        /// `setFullscreen`/`toggleFullscreen` call, not a backend query.
-        pub fn isFullscreen(self: *const Self) bool {
-            return self.fullscreen;
-        }
-
-        /// Frame-loop drain (generated main only): returns the new
-        /// fullscreen value exactly once after it changes, else `null`.
-        /// The caller forwards a non-null result to the window backend.
-        pub fn takeFullscreenRequest(self: *Self) ?bool {
-            if (!self.fullscreen_dirty) return null;
-            self.fullscreen_dirty = false;
-            return self.fullscreen;
-        }
-
-        // ── Engine-driven sprite animation ──
-        //
-        // Opt-in: instead of the game shipping a `sprite_animation_tick`
-        // script that calls `spriteAnimationTick(game, dt)`, the engine
-        // can advance every `SpriteAnimation` itself in `tick()` on the
-        // time-scaled clock (see the always-run block). A game enables it
-        // once at startup and deletes its script; a pause menu freezes
-        // sprite cycling via `setSpriteAnimationsPaused` without having to
-        // gate a per-frame script.
-
-        /// Turn engine-driven sprite-animation advancement on/off. When on,
-        /// the game must NOT also run a `sprite_animation_tick` script, or
-        /// animations advance twice per frame.
-        pub fn setDriveSpriteAnimations(self: *Self, on: bool) void {
-            self.drive_sprite_animations = on;
-        }
-
-        /// Freeze (`true`) or resume (`false`) the engine-driven sprite
-        /// animation advance. No-op unless `drive_sprite_animations` is on.
-        pub fn setSpriteAnimationsPaused(self: *Self, paused: bool) void {
-            self.sprite_animations_paused = paused;
-        }
-
-        /// Whether engine-driven sprite animation is currently frozen.
-        pub fn spriteAnimationsPaused(self: *const Self) bool {
-            return self.sprite_animations_paused;
-        }
-
-        // ── Time scale ──
-
-        pub fn setTimeScale(self: *Self, scale: f32) void {
-            self.time_scale = @max(0, scale);
-        }
-
-        pub fn getTimeScale(self: *const Self) f32 {
-            return self.time_scale;
-        }
-
-        pub fn pause(self: *Self) void {
-            self.time_scale = 0;
-            self.setPaused(true);
-        }
-
-        pub fn resume_(self: *Self) void {
-            self.time_scale = 1.0;
-            self.setPaused(false);
-        }
-
-        /// Seconds of gameplay time elapsed (time-scaled, pause-aware) —
-        /// the clock flow `Cooldown`/`Delay` nodes (#25) measure against.
-        pub fn elapsedSeconds(self: *const Self) f64 {
-            return self.clock_s;
-        }
+        // ── Game Loop / Fullscreen / sprite-anim / time scale ─────
+        // Runtime-control accessors; full docs in
+        // `game/lifecycle_mixin.zig`. The engine owns the *desired*
+        // fullscreen flag — the generated `main.zig` drains
+        // `takeFullscreenRequest()` and forwards it to the window backend,
+        // keeping the library backend-agnostic.
+        pub const quit = LifecycleMixin.quit;
+        pub const isRunning = LifecycleMixin.isRunning;
+        pub const setFullscreen = LifecycleMixin.setFullscreen;
+        pub const toggleFullscreen = LifecycleMixin.toggleFullscreen;
+        pub const isFullscreen = LifecycleMixin.isFullscreen;
+        pub const takeFullscreenRequest = LifecycleMixin.takeFullscreenRequest;
+        pub const setDriveSpriteAnimations = LifecycleMixin.setDriveSpriteAnimations;
+        pub const setSpriteAnimationsPaused = LifecycleMixin.setSpriteAnimationsPaused;
+        pub const spriteAnimationsPaused = LifecycleMixin.spriteAnimationsPaused;
+        pub const setTimeScale = LifecycleMixin.setTimeScale;
+        pub const getTimeScale = LifecycleMixin.getTimeScale;
+        pub const pause = LifecycleMixin.pause;
+        pub const resume_ = LifecycleMixin.resume_;
+        pub const elapsedSeconds = LifecycleMixin.elapsedSeconds;
 
         // ── Input events (labelle-gui#208) ───────────────────────
         //
@@ -1935,17 +845,17 @@ pub fn GameConfig(
 
         /// True when `GameEvents` declares `field` (the qualified
         /// `engine__<name>` tag). Same gate `emitEngineEvent` uses.
-        inline fn engineEventWanted(comptime field: []const u8) bool {
+        pub inline fn engineEventWanted(comptime field: []const u8) bool {
             if (!has_events) return false;
             if (@typeInfo(GameEvents) != .@"union") return false;
             return @hasField(GameEvents, field);
         }
 
-        const keyboard_events_wanted = engineEventWanted("engine__key_pressed") or
+        pub const keyboard_events_wanted = engineEventWanted("engine__key_pressed") or
             engineEventWanted("engine__key_released");
-        const mouse_events_wanted = engineEventWanted("engine__mouse_button_pressed") or
+        pub const mouse_events_wanted = engineEventWanted("engine__mouse_button_pressed") or
             engineEventWanted("engine__mouse_button_released");
-        const gamepad_events_wanted = engineEventWanted("engine__gamepad_connected") or
+        pub const gamepad_events_wanted = engineEventWanted("engine__gamepad_connected") or
             engineEventWanted("engine__gamepad_disconnected") or
             // The ControllerManager consumes the SAME drained gamepad
             // events, so any project that listens to a player-level event
@@ -1958,7 +868,7 @@ pub fn GameConfig(
         /// state machine + output drain so an unused game pays nothing
         /// (the whole `controller_manager` field + per-tick work folds
         /// away). Mirrors the `gamepad_events_wanted` gate.
-        const controller_events_wanted = engineEventWanted("engine__controller_available") or
+        pub const controller_events_wanted = engineEventWanted("engine__controller_available") or
             engineEventWanted("engine__controller_removed") or
             engineEventWanted("engine__player_joined") or
             engineEventWanted("engine__player_controller_lost") or
@@ -1972,345 +882,12 @@ pub fn GameConfig(
         else
             void;
 
-        /// Scan the unified `InputInterface` for input edges and emit
-        /// the matching engine events into the buffer. Every query goes
-        /// through `Self.Input` (the backend-agnostic wrapper) — never a
-        /// backend's native API — which is what keeps this portable
-        /// across raylib / sokol / SDL. Called from `tick` while input
-        /// state is still current; buffered events drain via
-        /// `dispatchEvents` the same frame.
-        fn scanInputEvents(self: *Self) void {
-            // Each category's emit calls are gated at comptime (so an
-            // unused one folds away), but the per-element scans are plain
-            // RUNTIME `for`s over the comptime enum-value slices — NOT
-            // `inline for`. Unrolling ~114 keys would inline
-            // `emitEngineEvent` (itself an `inline for` over payload
-            // fields) once per key, bloating the binary and needing a big
-            // `@setEvalBranchQuota`; a runtime loop has one call site per
-            // category (gemini #606).
+        // Input-event scanning + ControllerManager drain live in
+        // `InputEventsMixin`; `tick` calls them as `InputEventsMixin.scan*`.
 
-            // ── Keyboard ──
-            if (comptime keyboard_events_wanted) {
-                const pressed_wanted = comptime engineEventWanted("engine__key_pressed");
-                const released_wanted = comptime engineEventWanted("engine__key_released");
-                for (std.enums.values(input_types.KeyboardKey)) |k| {
-                    if (k == .key_null) continue; // sentinel, not a real key
-                    const code: u32 = @intCast(@intFromEnum(k));
-                    if (pressed_wanted and Self.Input.isKeyPressed(code))
-                        self.emitEngineEvent("engine__key_pressed", .{ .key = code });
-                    if (released_wanted and Self.Input.isKeyReleased(code))
-                        self.emitEngineEvent("engine__key_released", .{ .key = code });
-                }
-            }
+        pub const tick = LoopMixin.tick;
 
-            // ── Mouse buttons ──
-            if (comptime mouse_events_wanted) {
-                const pressed_wanted = comptime engineEventWanted("engine__mouse_button_pressed");
-                const released_wanted = comptime engineEventWanted("engine__mouse_button_released");
-                for (std.enums.values(input_types.MouseButton)) |b| {
-                    const code: u32 = @intCast(@intFromEnum(b));
-                    if (pressed_wanted and Self.Input.isMouseButtonPressed(code))
-                        self.emitEngineEvent("engine__mouse_button_pressed", .{
-                            .button = code,
-                            .x = Self.Input.getMouseX(),
-                            .y = Self.Input.getMouseY(),
-                        });
-                    if (released_wanted and Self.Input.isMouseButtonReleased(code))
-                        self.emitEngineEvent("engine__mouse_button_released", .{
-                            .button = code,
-                            .x = Self.Input.getMouseX(),
-                            .y = Self.Input.getMouseY(),
-                        });
-                }
-            }
-
-        }
-
-        /// Drain gamepad hotplug events (core#18) and the
-        /// `ControllerManager` (#611). Split OUT of `scanInputEvents`
-        /// because it MUST run every frame, INCLUDING while paused: when
-        /// the opt-in auto-pause gates the game on a lost controller, the
-        /// reconnect that lifts the pause arrives as a gamepad event — if we
-        /// only scanned in the active-frame body (past the pause gate) the
-        /// game would deadlock paused forever. Keyboard/mouse scanning stays
-        /// gameplay-only in `scanInputEvents`.
-        fn scanGamepadEvents(self: *Self) void {
-            // ── Gamepad connect / disconnect (drained queue, core#18) ──
-            //
-            // Drain hotplug events from a single source — picked at
-            // comptime by `backend_polls_gamepads` so the backend and the
-            // per-OS `gamepad_source` never both run — and emit one engine
-            // event per drained `GamepadEvent`. No fixed 4-slot cap and no
-            // engine-side prev-state diff: edge detection now belongs to
-            // the source. The whole block folds away when no flow listens
-            // (the `comptime gamepad_events_wanted` gate), so it stays
-            // zero-cost — and on the fallback path that also means
-            // `gamepad_source.pollEvents` is never called.
-            if (comptime gamepad_events_wanted) {
-                const conn_wanted = comptime engineEventWanted("engine__gamepad_connected");
-                const disc_wanted = comptime engineEventWanted("engine__gamepad_disconnected");
-
-                var buf: [gamepad_drain_capacity]core.gamepad.GamepadEvent = undefined;
-                const n = if (comptime backend_polls_gamepads)
-                    Self.Input.pollGamepadEvents(&buf)
-                else
-                    core.gamepad_source.pollEvents(&buf);
-
-                for (buf[0..n]) |ev| {
-                    switch (ev.kind) {
-                        .connected => if (conn_wanted) self.emitEngineEvent(
-                            "engine__gamepad_connected",
-                            .{
-                                .id = ev.slot,
-                                .name = ev.name,
-                                .name_len = ev.name_len,
-                                .guid = ev.guid,
-                                .source_class = ev.source_class,
-                                .type_hint = ev.type_hint,
-                            },
-                        ),
-                        .disconnected => if (disc_wanted) self.emitEngineEvent(
-                            "engine__gamepad_disconnected",
-                            .{ .id = ev.slot },
-                        ),
-                    }
-                    // The ControllerManager consumes the SAME drained
-                    // events (#611). Feed it here so a project listening to
-                    // a player-level event but NOT the raw `gamepad_*` pair
-                    // still drives the mapping layer.
-                    if (comptime controller_events_wanted) {
-                        switch (ev.kind) {
-                            .connected => self.controller_manager.onConnected(ev),
-                            .disconnected => self.controller_manager.onDisconnected(ev.slot),
-                        }
-                    }
-                }
-            }
-
-            // Advance the manager's debounce clock and drain its
-            // player-level output into engine events (#611). The clock is
-            // the pause-aware gameplay clock, so a debounce window measured
-            // in seconds holds correctly behind a pause menu. Runs after the
-            // feed above so a connect+expire within one tick is consistent.
-            if (comptime controller_events_wanted) {
-                self.controller_manager.advance(self.elapsedSeconds());
-                self.drainControllerManagerEvents();
-            }
-        }
-
-        /// Pull the `ControllerManager`'s pending player-level events and
-        /// re-emit each as the matching engine event, applying the opt-in
-        /// auto-pause policy (#611). Folds away unless a controller event is
-        /// wanted.
-        fn drainControllerManagerEvents(self: *Self) void {
-            if (comptime !controller_events_wanted) return;
-            var evbuf: [ControllerManagerType.event_capacity]controller_manager_mod.ManagerEvent = undefined;
-            const m = self.controller_manager.drainEvents(&evbuf);
-            for (evbuf[0..m]) |mev| {
-                switch (mev) {
-                    .controller_available => |c| self.emitEngineEvent("engine__controller_available", .{
-                        .controller_id = c.controller_id,
-                        .name = c.name,
-                        .name_len = c.name_len,
-                        .guid = c.guid,
-                        .source_class = c.source_class,
-                        .type_hint = c.type_hint,
-                    }),
-                    .controller_removed => |c| self.emitEngineEvent("engine__controller_removed", .{
-                        .controller_id = c.controller_id,
-                    }),
-                    .player_joined => |p| self.emitEngineEvent("engine__player_joined", .{
-                        .player = p.player,
-                        .controller_id = p.controller_id,
-                    }),
-                    .player_controller_lost => |p| {
-                        self.emitEngineEvent("engine__player_controller_lost", .{ .player = p.player });
-                        // Opt-in auto-pause (#465 precedent): a real loss
-                        // gates the game until the controller is back.
-                        if (self.auto_pause_on_controller_lost) self.setPaused(true);
-                    },
-                    .player_controller_restored => |p| {
-                        self.emitEngineEvent("engine__player_controller_restored", .{
-                            .player = p.player,
-                            .controller_id = p.controller_id,
-                        });
-                        // Resume only once NO player is still waiting — with
-                        // multiple lost pads we stay paused until the last
-                        // one reconnects.
-                        if (self.auto_pause_on_controller_lost and !self.anyPlayerWaiting()) {
-                            self.setPaused(false);
-                        }
-                    },
-                }
-            }
-        }
-
-        /// `true` when any active player's controller is currently absent
-        /// (debouncing or lost). Drives the auto-pause resume gate.
-        fn anyPlayerWaiting(self: *const Self) bool {
-            if (comptime !controller_events_wanted) return false;
-            var p: u32 = 0;
-            while (p < ControllerManagerType.capacity_players) : (p += 1) {
-                if (self.controller_manager.isPlayerWaiting(p)) return true;
-            }
-            return false;
-        }
-
-        pub fn tick(self: *Self, dt: f32) void {
-            const scaled_dt = dt * self.time_scale;
-            // Freeze the gameplay clock under EITHER pause path — the
-            // `paused` flag (#465) doesn't zero `time_scale`, so guarding
-            // on `isPaused()` (paused OR time_scale==0) is what makes a
-            // Cooldown/Delay hold behind a pause menu (bugbot/gemini #603).
-            if (!self.isPaused()) self.clock_s += @as(f64, scaled_dt);
-
-            // Fire any flow `Delay` timers that have come due (#25 Stage 2).
-            // Run this every tick AFTER the clock update. `bindScheduler`
-            // keeps the type-erased `game_ctx` pointed at our stable address
-            // (idempotent). When paused, `elapsedSeconds()` is frozen, so no
-            // timer is ever due — pause-freeze falls out of the clock reuse
-            // for free, with no separate accumulator. A firing callback may
-            // re-entrantly `after()`; the scheduler iterates defensively.
-            self.bindScheduler();
-            self.scheduler.tick();
-
-            // Drain any worker-decoded asset uploads onto the GPU.
-            // Without this no acquired asset ever reaches `.ready`,
-            // and the Phase 2 setScene gate (#458) spins forever in
-            // its `not_ready` branch. Pump runs every frame even
-            // when paused so loading screens keep filling the bar
-            // through pause states.
-            self.assets.pump();
-
-            // Wire late-uploaded atlases into atlas_manager (#508). The
-            // setScene-time bridge is a no-op for any asset that wasn't
-            // .ready yet (eager-fallback path completes setScene before
-            // assets reach .ready). Without this per-tick walk those
-            // atlases keep texture_id=0, every sprite samples from
-            // texture 0, and rendering looks wrong. Idempotent — already-
-            // bridged atlases are silently skipped.
-            self.bridgeAllReadyImageAssets();
-
-            // Always run: logging, audio, input, renderer sync, gizmo reconciliation.
-            // These must run even when paused so the game remains responsive.
-            self.log.update(dt);
-            Audio.update();
-            Input.updateGestures(dt);
-            // Engine-driven sprite animation (opt-in via
-            // `drive_sprite_animations`). Advance every `SpriteAnimation`
-            // on the time-scaled dt BEFORE `resolveAtlasSprites` so the
-            // new frame's `sprite_name` is resolved to a `source_rect` the
-            // same frame. Frozen when `sprite_animations_paused` — that's
-            // how a pause menu stops sprite cycling without gating a
-            // per-frame game script. Lives in the always-run block (not the
-            // gameplay-skip section) so it advances on `scaled_dt`, which a
-            // `time_scale==0` hard pause already zeroes.
-            // `scaled_dt != 0` skips the ECS walk entirely when time is
-            // frozen (a `time_scale==0` hard pause, which still runs this
-            // always-run block) — no frame can advance on a zero dt anyway.
-            // Slow-mo keeps a tiny non-zero dt, so it still animates.
-            if (self.drive_sprite_animations and !self.sprite_animations_paused and scaled_dt != 0) {
-                @import("sprite_animation_tick.zig").tick(self, scaled_dt);
-            }
-            self.resolveAtlasSprites();
-            self.renderer.sync(EcsImpl, self.ecs_backend);
-
-            // Gamepad hotplug + ControllerManager drain (core#18 / #611).
-            // Runs in the ALWAYS-RUN section, BEFORE the pause gate below,
-            // so a controller reconnect that should lift an opt-in
-            // auto-pause is still seen while the game is paused. Folds away
-            // entirely when no gamepad/controller event is wanted.
-            self.scanGamepadEvents();
-
-            // Reconcile gizmos for runtime-created entities
-            if (self.gizmo_reconcile_fn) |reconcile_fn| {
-                reconcile_fn(self);
-            }
-
-            // State changes must process even when paused (e.g. pause → menu).
-            // Clear pending BEFORE setState so hooks can re-queue without being overwritten.
-            if (self.pending_state_change) |new_state| {
-                self.pending_state_change = null;
-                self.setState(new_state);
-            }
-
-            // Scene changes must process even when paused (e.g. pause menu → new scene)
-            if (self.pending_scene_change) |next_scene| {
-                const atomic = self.pending_scene_atomic;
-                defer {
-                    self.allocator.free(next_scene);
-                    self.pending_scene_change = null;
-                    self.pending_scene_atomic = false;
-                }
-                if (atomic) {
-                    self.setSceneAtomic(next_scene) catch {};
-                } else {
-                    self.setScene(next_scene) catch {};
-                }
-            }
-
-            // Hot reload: re-trigger the current scene's loader
-            if (self.hot_reload_dirty) {
-                self.hot_reload_dirty = false;
-                if (self.current_scene_name) |name| {
-                    if (self.scenes.get(name)) |entry| {
-                        self.unloadCurrentScene();
-                        self.emitHook(.{ .scene_before_load = .{ .name = name, .allocator = self.allocator } });
-                        // Engine `Events` dual-emit (#578).
-                        self.emitEngineEvent("engine__scene_loading", .{ .name = name });
-                        entry.loader_fn(self) catch {};
-                        self.emitHook(.{ .scene_load = .{ .name = name } });
-                        // Engine `Events` dual-emit (#578).
-                        self.emitEngineEvent("engine__scene_loaded", .{ .name = name });
-                    }
-                }
-            }
-
-            // Paused: skip game logic but keep frame counter advancing.
-            // Gates on the unified `isPaused()` so an explicit
-            // `setPaused(true)` halts the tick even when time_scale is
-            // still 1.0 — not just the `scaled_dt == 0` variant below.
-            if (self.isPaused()) {
-                self.frame_number += 1;
-                return;
-            }
-
-            self.emitHook(.{ .frame_start = .{ .frame_number = self.frame_number, .dt = scaled_dt } });
-            // Engine `Events` dual-emit (#578) — fires every active
-            // frame at the top of the tick. Folds away in unit-test
-            // games (`GameEvents = void`).
-            self.emitEngineEvent("engine__tick", .{ .frame_number = self.frame_number, .dt = scaled_dt });
-
-            if (self.active_scene_ptr) |scene_ptr| {
-                if (self.active_scene_update_fn) |update_fn| {
-                    update_fn(scene_ptr, scaled_dt);
-                }
-            }
-
-            self.emitHook(.{ .frame_end = .{ .frame_number = self.frame_number, .dt = scaled_dt } });
-            // Engine `Events` dual-emit (#578).
-            self.emitEngineEvent("engine__post_tick", .{ .frame_number = self.frame_number, .dt = scaled_dt });
-
-            // Input events (labelle-gui#208). Scan the unified
-            // `InputInterface` and buffer matching engine events. Placed
-            // here, at the tail of the active-frame body, so the events
-            // land in `event_buffer` alongside this frame's lifecycle
-            // events and drain together on the next `dispatchEvents`
-            // (called by the generated main loop right after `tick`) —
-            // i.e. they dispatch the SAME frame. Input state is current
-            // during `tick` (scripts already read it here). Each scan
-            // loop is comptime-gated, so an event-less game runs none of
-            // this.
-            self.scanInputEvents();
-
-            self.frame_number += 1;
-        }
-
-        pub fn render(self: *Self) void {
-            self.renderer.render();
-            self.renderGizmos();
-            self.clearGizmos();
-        }
+        pub const render = LoopMixin.render;
 
         // ── Camera ────────────────────────────────────────────────
 
@@ -2319,502 +896,51 @@ pub fn GameConfig(
         pub const CameraManagerType = if (has_camera) RenderImpl.CameraManagerType else void;
 
         /// Set the screen height on the active world's renderer.
-        pub fn setScreenHeight(self: *Self, height: f32) void {
-            self.renderer.setScreenHeight(height);
-        }
+        pub const setScreenHeight = MiscMixin.setScreenHeight;
 
         /// Get the primary camera (for renderers that support cameras).
-        pub const getCamera = if (has_camera) getCameraImpl else void;
-        fn getCameraImpl(self: *Self) *CameraType {
-            return self.renderer.getCamera();
-        }
+        pub const getCamera = if (has_camera) MiscMixin.getCameraImpl else void;
 
         /// Get the camera manager (for multi-camera / split-screen).
-        pub const getCameraManager = if (has_camera) getCameraManagerImpl else void;
-        fn getCameraManagerImpl(self: *Self) *CameraManagerType {
-            return self.renderer.getCameraManager();
-        }
+        pub const getCameraManager = if (has_camera) MiscMixin.getCameraManagerImpl else void;
 
         // ── Atlas ─────────────────────────────────────────────────
 
         const has_load_texture = @hasDecl(RenderImpl, "loadTexture");
 
-        /// Load a TexturePacker JSON atlas. Parses the JSON into the engine's
-        /// TextureManager and loads the texture via the renderer.
-        /// Only available when the renderer supports loadTexture.
-        pub const loadAtlas = if (has_load_texture) loadAtlasImpl else @compileError("Renderer does not support loadTexture");
+        // The atlas + streaming-asset API lives in `game/atlas_mixin.zig`;
+        // see there for the full per-method docs. Capability-gated entries
+        // fold to a `@compileError` shell on renderers that lack the
+        // matching texture-loading hook (`loadTexture` / `loadTextureFromMemory`).
+        pub const loadAtlas = if (has_load_texture) AtlasMixin.loadAtlasImpl else @compileError("Renderer does not support loadTexture");
+        pub const loadAtlasComptime = if (has_load_texture) AtlasMixin.loadAtlasComptimeImpl else @compileError("Renderer does not support loadTexture");
 
-        fn loadAtlasImpl(self: *Self, name: []const u8, json_path: [:0]const u8, texture_path: [:0]const u8) !void {
-            const tex_id = try self.renderer.loadTexture(texture_path);
-            // Convert renderer's TextureId (enum/opaque) to u32 for engine storage
-            const id: u32 = if (@typeInfo(@TypeOf(tex_id)) == .@"enum")
-                @intFromEnum(tex_id)
-            else
-                tex_id;
-            const dims = self.queryTextureDims(tex_id);
-            try self.atlas_manager.loadAtlasFromJson(name, json_path, id, dims);
-        }
-
-        /// Load an atlas from comptime sprite data (zero runtime parsing).
-        /// Usage: game.loadAtlasComptime("chars", &MyAtlas.sprites, "chars.png");
-        /// Only available when the renderer supports loadTexture.
-        pub const loadAtlasComptime = if (has_load_texture) loadAtlasComptimeImpl else @compileError("Renderer does not support loadTexture");
-
-        fn loadAtlasComptimeImpl(self: *Self, name: []const u8, comptime sprites: []const atlas_mod.SpriteData, texture_path: [:0]const u8) !void {
-            const tex_id = try self.renderer.loadTexture(texture_path);
-            const id: u32 = if (@typeInfo(@TypeOf(tex_id)) == .@"enum")
-                @intFromEnum(tex_id)
-            else
-                tex_id;
-            try self.atlas_manager.loadAtlasComptime(name, sprites, id);
-        }
-
-        /// Load an atlas from embedded memory (PNG bytes + JSON content).
-        /// Usage: game.loadAtlasFromMemory("bg", json_bytes, png_bytes, ".png");
-        ///
-        /// Convenience: `registerAtlasFromMemory` + `loadAtlasIfNeeded`.
-        /// Still blocks the calling frame — the PNG decode now runs on
-        /// the asset worker thread (Asset Streaming RFC #437), but this
-        /// method pumps the catalog synchronously until the atlas is
-        /// `.ready` so the surface behaviour matches the legacy eager
-        /// path. Cold-start UX is unchanged by design — spreading the
-        /// decode cost across frames is Phase 2's job (scene-manifest
-        /// acquire, not this shim).
         const has_load_from_memory = @hasDecl(RenderImpl, "loadTextureFromMemory");
-        pub const loadAtlasFromMemory = if (has_load_from_memory) loadAtlasFromMemoryImpl else @compileError("Renderer does not support loadTextureFromMemory");
-
-        fn loadAtlasFromMemoryImpl(self: *Self, name: []const u8, json_content: []const u8, image_data: []const u8, file_type: [:0]const u8) !void {
-            try self.registerAtlasFromMemoryImpl(name, json_content, image_data, file_type);
-            _ = try self.loadAtlasIfNeededImpl(name);
-        }
-
-        /// Register an atlas in **deferred** mode: parse the JSON
-        /// eagerly (cheap) but skip the PNG decode (expensive). The
-        /// atlas is added to the manager with no `texture_id` and a
-        /// `pending` block carrying the PNG byte slice. The first call
-        /// to `loadAtlasIfNeeded(name)` decodes the PNG, uploads to
-        /// the GPU, and promotes the atlas to "loaded".
-        ///
-        /// `image_data` must outlive the atlas — typically a slice
-        /// from `@embedFile`, which lives forever. Pair this with
-        /// `loadAtlasIfNeeded` from a loading-scene script to spread
-        /// PNG decode cost across multiple frames instead of paying
-        /// for everything in `init()`.
-        ///
-        /// Side effect (RFC #437 #443): the same name is registered on
-        /// `self.assets` as a `.image` asset carrying the PNG bytes, so
-        /// the pump-driven shim below can run the decode off-thread.
-        /// Existing scene / script code that already registered the
-        /// asset directly on the catalog — e.g. assembler-generated
-        /// init code that walks the scene's `assets` manifest — is
-        /// tolerated: `register` reports `AssetAlreadyRegistered` and
-        /// we swallow that specific error.
-        pub const registerAtlasFromMemory = if (has_load_from_memory) registerAtlasFromMemoryImpl else @compileError("Renderer does not support loadTextureFromMemory");
-
-        fn registerAtlasFromMemoryImpl(self: *Self, name: []const u8, json_content: []const u8, image_data: []const u8, file_type: [:0]const u8) !void {
-            // Keep the legacy TextureManager side-effects: parse JSON
-            // eagerly so `findSprite` works after the catalog finishes
-            // uploading, stash the `PendingImage` so `markPendingLoaded`
-            // can derive the texture scale against the JSON's meta.size
-            // once the shim learns the actual dims.
-            try self.atlas_manager.registerPendingAtlas(name, json_content, image_data, file_type);
-
-            // Mirror onto the catalog. Double-registration (e.g. when
-            // the assembler's scene manifest code already registered
-            // the same name on the catalog) is not an error: the
-            // catalog is the source of truth for the PNG bytes, and
-            // re-registering identical bytes is a no-op from the
-            // loader's perspective.
-            self.assets.register(name, .image, file_type, image_data) catch |err| switch (err) {
-                error.AssetAlreadyRegistered => {},
-                else => return err,
-            };
-        }
-
-        /// Decode a previously-registered pending atlas if it hasn't
-        /// already been loaded. No-op (returns `false`) when the atlas
-        /// is already loaded — safe to call every frame from a loading
-        /// loop. Returns `true` on the call that actually performed
-        /// the decode, so a loading script can advance a progress
-        /// counter.
-        ///
-        /// Implementation (RFC #437 §2): bumps the catalog refcount so
-        /// the worker thread picks up the decode, then busy-pumps until
-        /// the entry is `.ready` (happy path) or `lastError` is set
-        /// (decode / upload failed). `std.Thread.yield()` between
-        /// iterations keeps the loop cooperative on single-core
-        /// targets. **The `pump()` call inside the loop is
-        /// load-bearing** — without it the worker finishes the decode
-        /// but the main thread never finalises the upload, and the
-        /// loop spins forever. See the "deadlock regression" test in
-        /// `test/asset_streaming_shim_test.zig`.
-        pub const loadAtlasIfNeeded = if (has_load_from_memory) loadAtlasIfNeededImpl else @compileError("Renderer does not support loadTextureFromMemory");
-
-        fn loadAtlasIfNeededImpl(self: *Self, name: []const u8) !bool {
-            const atlas = self.atlas_manager.getAtlasMut(name) orelse return error.AtlasNotFound;
-            if (atlas.isLoaded()) return false;
-
-            // Bump refcount on the catalog. First acquire on a fresh
-            // entry enqueues the decode; subsequent acquires just pin
-            // the refcount so the zombie-drop path in `pump()` can't
-            // rewind us while we are waiting for the upload to land.
-            //
-            // `errdefer release` guarantees the shim returns the
-            // refcount on every failure path (lastError, missing
-            // entry, wrong asset kind, markPendingLoaded error, …).
-            // Without it, a failed load leaks a phantom refcount that
-            // keeps the entry acquired forever — and since `acquire`
-            // only re-enqueues on the 0→1 transition, a retry after
-            // failure would just bump the leak without re-triggering
-            // a decode.
-            _ = try self.assets.acquire(name);
-            // Mirror of the acquire above. Runs on any error path so
-            // the catalog refcount stays consistent. On the happy path
-            // — when `markPendingLoaded` succeeds and we `return true`
-            // — the defer does NOT fire, intentionally leaving the
-            // refcount at 1 to keep the loaded entry pinned in the
-            // catalog (prevents the zombie-drop path from rewinding
-            // the state back to `.registered` if Phase 2 ever calls
-            // `release` for an unrelated scene transition).
-            errdefer self.assets.release(name);
-
-            // Busy-pump until the decode + upload complete OR the
-            // catalog surfaces an error via `lastError`. Same-thread
-            // async-under-the-hood, sync-at-the-surface: no visible
-            // UX change from the legacy path that called
-            // `renderer.loadTextureFromMemory` directly on the main
-            // thread.
-            //
-            // Known limitation (pre-existing from #450's acquire
-            // design): if the request ring was full when `acquire`
-            // fired, the work request is dropped, state stays
-            // `.registered`, refcount is bumped, and neither `pump()`
-            // nor any other layer re-enqueues it. This loop would
-            // then spin forever. Not reachable on current workloads
-            // (64-slot ring vs single-digit asset counts), but a
-            // follow-up should either make `acquire` fail on
-            // QueueFull or add retry logic to `pump()`.
-            while (!self.assets.isReady(name)) {
-                if (self.assets.lastError(name)) |err| {
-                    // Rewind .failed → .registered so the next
-                    // loadAtlasIfNeeded retries the decode instead of
-                    // returning the stale error forever. Without this,
-                    // any decode/upload failure becomes permanent: the
-                    // errdefer above drops refcount to 0, but state
-                    // stays .failed, and `acquire` only re-enqueues
-                    // from .registered. So the retry would hit the
-                    // already-set lastError and immediately return
-                    // the old error without re-triggering work — a
-                    // regression from the legacy direct-decode path
-                    // which simply re-attempted the call.
-                    self.assets.resetFailed(name);
-                    return err;
-                }
-                self.assets.pump();
-                // Don't bridge here — `loadAtlasIfNeeded` (the shim
-                // calling this loop) does its own `markPendingLoaded`
-                // after the asset reaches .ready, and double-bridging
-                // returns AtlasNotPending. The main tick loop catches
-                // late-uploaded atlases for the eager-fallback path.
-                std.Thread.yield() catch {};
-            }
-
-            // Upload done — the catalog has a valid `UploadedResource`
-            // for the entry. Pull the backend-assigned texture handle
-            // out and seed the TextureManager's `RuntimeAtlas` so the
-            // rest of the engine (sprite cache, `findSprite`, etc.)
-            // can look the texture up through the legacy path.
-            const entry = self.assets.entries.getPtr(name) orelse return error.AtlasNotFound;
-            const resource = entry.resource orelse return error.AssetNotReady;
-            const id: u32 = switch (resource) {
-                .image => |t| t,
-                else => return error.WrongAssetKind,
-            };
-
-            // The catalog-managed upload path does NOT populate the
-            // renderer's texture side-table — the assembler-generated
-            // adapter uploads directly to the GPU backend, bypassing
-            // `renderer.loadTextureFromMemory`. `getTextureInfo` would
-            // therefore return null for catalog-uploaded textures, so
-            // `markPendingLoaded` gets `null` dims and falls back to
-            // scale=1.0. Matches the legacy fallback behavior when the
-            // renderer doesn't expose `getTextureInfo` at all. Atlases
-            // that shipped a downscaled PNG and relied on automatic
-            // texture_scale derivation will need an explicit workflow
-            // once Phase 2 takes over the cold-start path — out of
-            // scope for #443.
-            try self.atlas_manager.markPendingLoaded(name, id, null);
-            return true;
-        }
+        pub const loadAtlasFromMemory = if (has_load_from_memory) AtlasMixin.loadAtlasFromMemoryImpl else @compileError("Renderer does not support loadTextureFromMemory");
+        pub const registerAtlasFromMemory = if (has_load_from_memory) AtlasMixin.registerAtlasFromMemoryImpl else @compileError("Renderer does not support loadTextureFromMemory");
+        pub const loadAtlasIfNeeded = if (has_load_from_memory) AtlasMixin.loadAtlasIfNeededImpl else @compileError("Renderer does not support loadTextureFromMemory");
 
         // ── Audio asset shims (Phase 4 of Asset Streaming RFC, #447) ──
-
-        /// Register a sound effect in deferred mode: the catalog keeps
-        /// a pointer to the encoded WAV/OGG bytes; decode + upload
-        /// happen the first time `loadSoundIfNeeded(name)` (or the
-        /// scene-manifest acquire path) bumps the refcount above zero.
-        ///
-        /// `audio_data` must outlive the catalog entry — typically a
-        /// slice from `@embedFile`. `file_type` is the lower-case
-        /// extension without the leading dot (e.g. `"wav"`, `"ogg"`).
-        ///
-        /// Idempotent against repeat-registration of the same name —
-        /// the assembler-generated scene manifest may register the
-        /// asset before this shim, and re-registering identical bytes
-        /// is a no-op.
-        pub fn registerSoundFromMemory(self: *Self, name: []const u8, file_type: [:0]const u8, audio_data: []const u8) !void {
-            self.assets.register(name, .audio, file_type, audio_data) catch |err| switch (err) {
-                error.AssetAlreadyRegistered => {},
-                else => return err,
-            };
-        }
-
-        /// Convenience: `registerSoundFromMemory` + `loadSoundIfNeeded`.
-        /// Blocks the calling frame until decode + upload finish, same
-        /// surface contract as `loadAtlasFromMemory` for images.
-        pub fn loadSoundFromMemory(self: *Self, name: []const u8, file_type: [:0]const u8, audio_data: []const u8) !void {
-            try self.registerSoundFromMemory(name, file_type, audio_data);
-            _ = try self.loadSoundIfNeeded(name);
-        }
-
-        /// Shared busy-pump used by `loadSoundIfNeeded` and
-        /// `loadFontIfNeeded`. The atlas counterpart
-        /// (`loadAtlasIfNeededImpl`) does NOT delegate here because
-        /// it threads a `markPendingLoaded` call into the
-        /// `TextureManager` after the upload — the audio + font paths
-        /// have no equivalent post-upload bridging.
-        ///
-        /// Lifecycle (see `loadAtlasIfNeededImpl` for the long-form
-        /// rationale this mirrors): bumps the catalog refcount so the
-        /// worker enqueues the decode, then busy-pumps until the entry
-        /// is `.ready` (happy path) or `lastError` is set (decode /
-        /// upload failed). `errdefer release` keeps the refcount
-        /// consistent on every failure path so a retry after a failed
-        /// load actually re-triggers the decode (without the
-        /// `resetFailed`, `acquire` would only re-enqueue on a fresh
-        /// `.registered` entry).
-        fn loadAssetIfNeededInternal(self: *Self, name: []const u8) !bool {
-            if (self.assets.isReady(name)) return false;
-            _ = try self.assets.acquire(name);
-            errdefer self.assets.release(name);
-            while (!self.assets.isReady(name)) {
-                if (self.assets.lastError(name)) |err| {
-                    self.assets.resetFailed(name);
-                    return err;
-                }
-                self.assets.pump();
-                std.Thread.yield() catch {};
-            }
-            return true;
-        }
-
-        /// Decode + upload a previously-registered sound if it hasn't
-        /// already been loaded. No-op (returns `false`) on already-ready
-        /// entries.
-        pub fn loadSoundIfNeeded(self: *Self, name: []const u8) !bool {
-            return self.loadAssetIfNeededInternal(name);
-        }
+        pub const registerSoundFromMemory = AtlasMixin.registerSoundFromMemory;
+        pub const loadSoundFromMemory = AtlasMixin.loadSoundFromMemory;
+        pub const loadSoundIfNeeded = AtlasMixin.loadSoundIfNeeded;
 
         // ── Font asset shims (Phase 4 of Asset Streaming RFC, #448) ──
+        pub const registerFontFromMemory = AtlasMixin.registerFontFromMemory;
+        pub const loadFontFromMemory = AtlasMixin.loadFontFromMemory;
+        pub const loadFontIfNeeded = AtlasMixin.loadFontIfNeeded;
 
-        /// Register a font in deferred mode: the catalog stores the
-        /// encoded TTF/OTF bytes alongside the bake params; rasterise +
-        /// atlas upload happen the first time `loadFontIfNeeded(name)`
-        /// (or the scene-manifest acquire path) bumps the refcount.
-        ///
-        /// `font_data` and `params` are borrowed — both must outlive
-        /// the catalog entry. `params` rides through `WorkRequest.params`
-        /// as a `?*const anyopaque` and is cast back to
-        /// `*const FontBakeParams` inside the font loader's `decode`
-        /// (RFC-FONT-LOADER §7). `file_type` is the lower-case
-        /// extension without the leading dot (`"ttf"`, `"otf"`).
-        pub fn registerFontFromMemory(
-            self: *Self,
-            name: []const u8,
-            file_type: [:0]const u8,
-            font_data: []const u8,
-            params: *const assets_mod.font_loader.FontBakeParams,
-        ) !void {
-            self.assets.registerFont(name, file_type, font_data, params) catch |err| switch (err) {
-                error.AssetAlreadyRegistered => {},
-                else => return err,
-            };
-        }
-
-        /// Convenience: `registerFontFromMemory` + `loadFontIfNeeded`.
-        pub fn loadFontFromMemory(
-            self: *Self,
-            name: []const u8,
-            file_type: [:0]const u8,
-            font_data: []const u8,
-            params: *const assets_mod.font_loader.FontBakeParams,
-        ) !void {
-            try self.registerFontFromMemory(name, file_type, font_data, params);
-            _ = try self.loadFontIfNeeded(name);
-        }
-
-        /// Decode + upload a previously-registered font if it hasn't
-        /// already been loaded. Delegates to the shared
-        /// `loadAssetIfNeededInternal` busy-pump.
-        pub fn loadFontIfNeeded(self: *Self, name: []const u8) !bool {
-            return self.loadAssetIfNeededInternal(name);
-        }
-
-        /// Whether an atlas's PNG has been decoded. Returns `false`
-        /// for unregistered atlases too — both states mean "you can't
-        /// use it yet". Used by loading scripts to decide which
-        /// atlases still need a `loadAtlasIfNeeded` call.
-        ///
-        /// Reads from the `TextureManager` side, not the catalog: the
-        /// atlas is only "loaded" from the engine's point of view once
-        /// `markPendingLoaded` has populated the `RuntimeAtlas` with a
-        /// real `texture_id`. A catalog entry that is `.ready` but has
-        /// not yet been drained by `loadAtlasIfNeeded` is still
-        /// considered "not loaded" for the legacy surface.
-        pub fn isAtlasLoaded(self: *Self, name: []const u8) bool {
-            const atlas = self.atlas_manager.getAtlas(name) orelse return false;
-            return atlas.isLoaded();
-        }
-
-        /// Look up the actual pixel dimensions of a freshly-loaded
-        /// texture, so the atlas loader can derive a scale against the
-        /// JSON's logical `meta.size`. Returns null when the renderer
-        /// doesn't expose a `getTextureInfo` accessor — the atlas
-        /// loader then falls back to scale=1.0 (legacy behavior).
-        ///
-        /// Texture dims are clamped to `[0, max u32]` before the float
-        /// → int cast so a malformed renderer that returns negative or
-        /// NaN values can't trigger an `@intFromFloat` panic. Real
-        /// renderers always return positive integers, so this is a
-        /// belt-and-braces guard for buggy backend mocks.
-        fn queryTextureDims(self: *Self, tex_id: anytype) ?atlas_mod.TextureManager.TextureDims {
-            if (!@hasDecl(RenderImpl, "getTextureInfo")) return null;
-            const info = self.renderer.getTextureInfo(tex_id) orelse return null;
-            return .{
-                .width = clampToU32(info.width),
-                .height = clampToU32(info.height),
-            };
-        }
-
-        fn clampToU32(v: f32) u32 {
-            if (!std.math.isFinite(v) or v <= 0) return 0;
-            // `@floatFromInt(maxInt(u32))` rounds *up* to 2^32 in f32
-            // because the f32 mantissa is only 24 bits, so comparing
-            // against it would let `@intFromFloat` see exactly 2^32 —
-            // one above the u32 range, triggering UB / safety panic.
-            // The largest f32 value strictly less than 2^32 is
-            // 4_294_967_040 (= 2^32 - 2^8). Clamp to that.
-            const max_safe: f32 = 4_294_967_040.0;
-            if (v >= max_safe) return std.math.maxInt(u32);
-            return @intFromFloat(v);
-        }
-
-        pub fn getTextureManager(self: *Self) *atlas_mod.TextureManager {
-            return &self.atlas_manager;
-        }
-
-        /// Look up a sprite by name across all loaded atlases (uncached).
-        pub fn findSprite(self: *const Self, sprite_name: []const u8) ?atlas_mod.FindSpriteResult {
-            return self.atlas_manager.findSprite(sprite_name);
-        }
-
-        /// Look up a sprite for an entity using the per-entity cache.
-        /// Returns cached result when atlas version and sprite name haven't changed.
-        pub fn findSpriteCached(self: *Self, entity_id: u32, sprite_name: []const u8) ?atlas_mod.FindSpriteResult {
-            return self.active_world.sprite_cache.lookup(entity_id, sprite_name, &self.atlas_manager);
-        }
-
-        /// Unload an atlas by name, freeing sprite data.
-        pub fn unloadAtlas(self: *Self, name: []const u8) void {
-            self.atlas_manager.unloadAtlas(name);
-        }
-
-        // ── Atlas Resolution ──────────────────────────────────────
-
-        const has_atlas_sprite_fields = @hasField(Sprite, "source_rect") and @hasField(Sprite, "texture") and @hasField(Sprite, "sprite_name");
-
-        /// Resolve sprite_name → source_rect + texture for all atlas sprites.
-        /// Called automatically before renderer sync each frame.
-        /// Only marks entities dirty on cache misses (sprite name or atlas version changed).
-        fn resolveAtlasSprites(self: *Self) void {
-            if (!has_atlas_sprite_fields) return;
-            if (self.atlas_manager.atlasCount() == 0) return;
-
-            var v = self.ecs_backend.view(.{Sprite}, .{});
-            defer v.deinit();
-            while (v.next()) |entity| {
-                const sprite = self.ecs_backend.getComponent(entity, Sprite).?;
-                if (sprite.sprite_name.len == 0) continue;
-
-                const misses_before = self.active_world.sprite_cache.misses;
-                if (self.active_world.sprite_cache.lookup(@intCast(entity), sprite.sprite_name, &self.atlas_manager)) |result| {
-                    // Only update and mark dirty on cache miss (new sprite or atlas changed)
-                    if (self.active_world.sprite_cache.misses != misses_before) {
-                        sprite.texture = @enumFromInt(result.texture_id);
-                        // The atlas data is in the JSON's logical pixel
-                        // grid. `texture_scale_*` maps that grid onto the
-                        // actual texture pixels — `1.0` for the common
-                        // case, `< 1` when the user shipped a downscaled
-                        // PNG without re-running TexturePacker.
-                        //
-                        // Two distinct mappings are needed:
-                        //
-                        //   * The PHYSICAL atlas footprint (`sprite.x/y`,
-                        //     `sprite.width/height`) is in texture-pixel
-                        //     coordinates regardless of rotation. Each
-                        //     axis scales independently, so x/width go
-                        //     through `texture_scale_x` and y/height go
-                        //     through `texture_scale_y`.
-                        //
-                        //   * The DISPLAY dimensions (`getWidth/Height`)
-                        //     swap when the sprite was rotated 90° in the
-                        //     atlas — that's the on-screen size. They
-                        //     stay un-scaled.
-                        //
-                        // Mixing the two (multiplying `getWidth()` by
-                        // `texture_scale_x`) is wrong for rotated sprites
-                        // because `getWidth()` returns the post-rotation
-                        // height — a vertical dimension scaled by a
-                        // horizontal factor.
-                        const phys_x: f32 = @floatFromInt(result.sprite.x);
-                        const phys_y: f32 = @floatFromInt(result.sprite.y);
-                        const phys_w: f32 = @floatFromInt(result.sprite.width);
-                        const phys_h: f32 = @floatFromInt(result.sprite.height);
-                        const display_w: f32 = @floatFromInt(result.sprite.getWidth());
-                        const display_h: f32 = @floatFromInt(result.sprite.getHeight());
-                        const scaled_w = phys_w * result.texture_scale_x;
-                        const scaled_h = phys_h * result.texture_scale_y;
-                        sprite.source_rect = .{
-                            .x = phys_x * result.texture_scale_x,
-                            .y = phys_y * result.texture_scale_y,
-                            // `source_rect.width/height` are in the same
-                            // post-rotation orientation that the renderer
-                            // expects (matching `getWidth/Height`),
-                            // so swap when the sprite was rotated.
-                            .width = if (result.sprite.rotated) scaled_h else scaled_w,
-                            .height = if (result.sprite.rotated) scaled_w else scaled_h,
-                            .display_width = display_w,
-                            .display_height = display_h,
-                        };
-                        self.renderer.markVisualDirty(entity);
-                    }
-                }
-            }
-        }
+        pub const isAtlasLoaded = AtlasMixin.isAtlasLoaded;
+        pub const getTextureManager = AtlasMixin.getTextureManager;
+        pub const findSprite = AtlasMixin.findSprite;
+        pub const findSpriteCached = AtlasMixin.findSpriteCached;
+        pub const unloadAtlas = AtlasMixin.unloadAtlas;
 
         // ── Accessors ─────────────────────────────────────────────
 
-        pub fn getRenderer(self: *Self) *RenderImpl {
-            return self.renderer;
-        }
-
-        pub fn getEcsBackend(self: *Self) *EcsImpl {
-            return self.ecs_backend;
-        }
-
-        pub fn entityCount(self: *Self) usize {
-            return @intCast(self.ecs_backend.entityCount());
-        }
+        pub const getRenderer = MiscMixin.getRenderer;
+        pub const getEcsBackend = MiscMixin.getEcsBackend;
+        pub const entityCount = MiscMixin.entityCount;
     };
 }
 

--- a/src/game/atlas_mixin.zig
+++ b/src/game/atlas_mixin.zig
@@ -1,0 +1,346 @@
+/// Atlas + streaming-asset mixin — texture/atlas loading, the Asset
+/// Streaming RFC (#437) deferred-load shims (images, audio, fonts), atlas
+/// sprite lookup, and per-frame `sprite_name → source_rect` resolution.
+///
+/// Extracted verbatim from `game.zig`; behaviour is identical. Methods
+/// gated on renderer capability (`loadTexture` / `loadTextureFromMemory`)
+/// are exposed as `pub const X = if (cap) Ximpl else @compileError(...)`
+/// in `game.zig`, exactly as before — this mixin supplies the `*Impl`
+/// bodies plus the always-available helpers.
+const std = @import("std");
+const atlas_mod = @import("../atlas.zig");
+const assets_mod = @import("../assets/mod.zig");
+
+/// Returns the atlas/asset management mixin for a given Game type.
+pub fn Mixin(comptime Game: type) type {
+    const Sprite = Game.SpriteComp;
+
+    const has_atlas_sprite_fields = @hasField(Sprite, "source_rect") and @hasField(Sprite, "texture") and @hasField(Sprite, "sprite_name");
+
+    return struct {
+        // ── Atlas ─────────────────────────────────────────────────
+
+        pub fn loadAtlasImpl(self: *Game, name: []const u8, json_path: [:0]const u8, texture_path: [:0]const u8) !void {
+            const tex_id = try self.renderer.loadTexture(texture_path);
+            // Convert renderer's TextureId (enum/opaque) to u32 for engine storage
+            const id: u32 = if (@typeInfo(@TypeOf(tex_id)) == .@"enum")
+                @intFromEnum(tex_id)
+            else
+                tex_id;
+            const dims = queryTextureDims(self, tex_id);
+            try self.atlas_manager.loadAtlasFromJson(name, json_path, id, dims);
+        }
+
+        pub fn loadAtlasComptimeImpl(self: *Game, name: []const u8, comptime sprites: []const atlas_mod.SpriteData, texture_path: [:0]const u8) !void {
+            const tex_id = try self.renderer.loadTexture(texture_path);
+            const id: u32 = if (@typeInfo(@TypeOf(tex_id)) == .@"enum")
+                @intFromEnum(tex_id)
+            else
+                tex_id;
+            try self.atlas_manager.loadAtlasComptime(name, sprites, id);
+        }
+
+        pub fn loadAtlasFromMemoryImpl(self: *Game, name: []const u8, json_content: []const u8, image_data: []const u8, file_type: [:0]const u8) !void {
+            try self.registerAtlasFromMemory(name, json_content, image_data, file_type);
+            _ = try self.loadAtlasIfNeeded(name);
+        }
+
+        pub fn registerAtlasFromMemoryImpl(self: *Game, name: []const u8, json_content: []const u8, image_data: []const u8, file_type: [:0]const u8) !void {
+            // Keep the legacy TextureManager side-effects: parse JSON
+            // eagerly so `findSprite` works after the catalog finishes
+            // uploading, stash the `PendingImage` so `markPendingLoaded`
+            // can derive the texture scale against the JSON's meta.size
+            // once the shim learns the actual dims.
+            try self.atlas_manager.registerPendingAtlas(name, json_content, image_data, file_type);
+
+            // Mirror onto the catalog. Double-registration (e.g. when
+            // the assembler's scene manifest code already registered
+            // the same name on the catalog) is not an error: the
+            // catalog is the source of truth for the PNG bytes, and
+            // re-registering identical bytes is a no-op from the
+            // loader's perspective.
+            self.assets.register(name, .image, file_type, image_data) catch |err| switch (err) {
+                error.AssetAlreadyRegistered => {},
+                else => return err,
+            };
+        }
+
+        pub fn loadAtlasIfNeededImpl(self: *Game, name: []const u8) !bool {
+            const atlas = self.atlas_manager.getAtlasMut(name) orelse return error.AtlasNotFound;
+            if (atlas.isLoaded()) return false;
+
+            // Bump refcount on the catalog. First acquire on a fresh
+            // entry enqueues the decode; subsequent acquires just pin
+            // the refcount so the zombie-drop path in `pump()` can't
+            // rewind us while we are waiting for the upload to land.
+            //
+            // `errdefer release` guarantees the shim returns the
+            // refcount on every failure path (lastError, missing
+            // entry, wrong asset kind, markPendingLoaded error, …).
+            // Without it, a failed load leaks a phantom refcount that
+            // keeps the entry acquired forever — and since `acquire`
+            // only re-enqueues on the 0→1 transition, a retry after
+            // failure would just bump the leak without re-triggering
+            // a decode.
+            _ = try self.assets.acquire(name);
+            // Mirror of the acquire above. Runs on any error path so
+            // the catalog refcount stays consistent. On the happy path
+            // — when `markPendingLoaded` succeeds and we `return true`
+            // — the defer does NOT fire, intentionally leaving the
+            // refcount at 1 to keep the loaded entry pinned in the
+            // catalog (prevents the zombie-drop path from rewinding
+            // the state back to `.registered` if Phase 2 ever calls
+            // `release` for an unrelated scene transition).
+            errdefer self.assets.release(name);
+
+            // Busy-pump until the decode + upload complete OR the
+            // catalog surfaces an error via `lastError`. Same-thread
+            // async-under-the-hood, sync-at-the-surface: no visible
+            // UX change from the legacy path that called
+            // `renderer.loadTextureFromMemory` directly on the main
+            // thread.
+            //
+            // Known limitation (pre-existing from #450's acquire
+            // design): if the request ring was full when `acquire`
+            // fired, the work request is dropped, state stays
+            // `.registered`, refcount is bumped, and neither `pump()`
+            // nor any other layer re-enqueues it. This loop would
+            // then spin forever. Not reachable on current workloads
+            // (64-slot ring vs single-digit asset counts), but a
+            // follow-up should either make `acquire` fail on
+            // QueueFull or add retry logic to `pump()`.
+            while (!self.assets.isReady(name)) {
+                if (self.assets.lastError(name)) |err| {
+                    // Rewind .failed → .registered so the next
+                    // loadAtlasIfNeeded retries the decode instead of
+                    // returning the stale error forever. Without this,
+                    // any decode/upload failure becomes permanent: the
+                    // errdefer above drops refcount to 0, but state
+                    // stays .failed, and `acquire` only re-enqueues
+                    // from .registered. So the retry would hit the
+                    // already-set lastError and immediately return
+                    // the old error without re-triggering work — a
+                    // regression from the legacy direct-decode path
+                    // which simply re-attempted the call.
+                    self.assets.resetFailed(name);
+                    return err;
+                }
+                self.assets.pump();
+                // Don't bridge here — `loadAtlasIfNeeded` (the shim
+                // calling this loop) does its own `markPendingLoaded`
+                // after the asset reaches .ready, and double-bridging
+                // returns AtlasNotPending. The main tick loop catches
+                // late-uploaded atlases for the eager-fallback path.
+                std.Thread.yield() catch {};
+            }
+
+            // Upload done — the catalog has a valid `UploadedResource`
+            // for the entry. Pull the backend-assigned texture handle
+            // out and seed the TextureManager's `RuntimeAtlas` so the
+            // rest of the engine (sprite cache, `findSprite`, etc.)
+            // can look the texture up through the legacy path.
+            const entry = self.assets.entries.getPtr(name) orelse return error.AtlasNotFound;
+            const resource = entry.resource orelse return error.AssetNotReady;
+            const id: u32 = switch (resource) {
+                .image => |t| t,
+                else => return error.WrongAssetKind,
+            };
+
+            // The catalog-managed upload path does NOT populate the
+            // renderer's texture side-table — the assembler-generated
+            // adapter uploads directly to the GPU backend, bypassing
+            // `renderer.loadTextureFromMemory`. `getTextureInfo` would
+            // therefore return null for catalog-uploaded textures, so
+            // `markPendingLoaded` gets `null` dims and falls back to
+            // scale=1.0. Matches the legacy fallback behavior when the
+            // renderer doesn't expose `getTextureInfo` at all. Atlases
+            // that shipped a downscaled PNG and relied on automatic
+            // texture_scale derivation will need an explicit workflow
+            // once Phase 2 takes over the cold-start path — out of
+            // scope for #443.
+            try self.atlas_manager.markPendingLoaded(name, id, null);
+            return true;
+        }
+
+        // ── Audio asset shims (Phase 4 of Asset Streaming RFC, #447) ──
+
+        pub fn registerSoundFromMemory(self: *Game, name: []const u8, file_type: [:0]const u8, audio_data: []const u8) !void {
+            self.assets.register(name, .audio, file_type, audio_data) catch |err| switch (err) {
+                error.AssetAlreadyRegistered => {},
+                else => return err,
+            };
+        }
+
+        pub fn loadSoundFromMemory(self: *Game, name: []const u8, file_type: [:0]const u8, audio_data: []const u8) !void {
+            try self.registerSoundFromMemory(name, file_type, audio_data);
+            _ = try self.loadSoundIfNeeded(name);
+        }
+
+        pub fn loadAssetIfNeededInternal(self: *Game, name: []const u8) !bool {
+            if (self.assets.isReady(name)) return false;
+            _ = try self.assets.acquire(name);
+            errdefer self.assets.release(name);
+            while (!self.assets.isReady(name)) {
+                if (self.assets.lastError(name)) |err| {
+                    self.assets.resetFailed(name);
+                    return err;
+                }
+                self.assets.pump();
+                std.Thread.yield() catch {};
+            }
+            return true;
+        }
+
+        pub fn loadSoundIfNeeded(self: *Game, name: []const u8) !bool {
+            return loadAssetIfNeededInternal(self, name);
+        }
+
+        // ── Font asset shims (Phase 4 of Asset Streaming RFC, #448) ──
+
+        pub fn registerFontFromMemory(
+            self: *Game,
+            name: []const u8,
+            file_type: [:0]const u8,
+            font_data: []const u8,
+            params: *const assets_mod.font_loader.FontBakeParams,
+        ) !void {
+            self.assets.registerFont(name, file_type, font_data, params) catch |err| switch (err) {
+                error.AssetAlreadyRegistered => {},
+                else => return err,
+            };
+        }
+
+        pub fn loadFontFromMemory(
+            self: *Game,
+            name: []const u8,
+            file_type: [:0]const u8,
+            font_data: []const u8,
+            params: *const assets_mod.font_loader.FontBakeParams,
+        ) !void {
+            try self.registerFontFromMemory(name, file_type, font_data, params);
+            _ = try self.loadFontIfNeeded(name);
+        }
+
+        pub fn loadFontIfNeeded(self: *Game, name: []const u8) !bool {
+            return loadAssetIfNeededInternal(self, name);
+        }
+
+        pub fn isAtlasLoaded(self: *Game, name: []const u8) bool {
+            const atlas = self.atlas_manager.getAtlas(name) orelse return false;
+            return atlas.isLoaded();
+        }
+
+        pub fn queryTextureDims(self: *Game, tex_id: anytype) ?atlas_mod.TextureManager.TextureDims {
+            if (!@hasDecl(@TypeOf(self.renderer.*), "getTextureInfo")) return null;
+            const info = self.renderer.getTextureInfo(tex_id) orelse return null;
+            return .{
+                .width = clampToU32(info.width),
+                .height = clampToU32(info.height),
+            };
+        }
+
+        pub fn clampToU32(v: f32) u32 {
+            if (!std.math.isFinite(v) or v <= 0) return 0;
+            // `@floatFromInt(maxInt(u32))` rounds *up* to 2^32 in f32
+            // because the f32 mantissa is only 24 bits, so comparing
+            // against it would let `@intFromFloat` see exactly 2^32 —
+            // one above the u32 range, triggering UB / safety panic.
+            // The largest f32 value strictly less than 2^32 is
+            // 4_294_967_040 (= 2^32 - 2^8). Clamp to that.
+            const max_safe: f32 = 4_294_967_040.0;
+            if (v >= max_safe) return std.math.maxInt(u32);
+            return @intFromFloat(v);
+        }
+
+        pub fn getTextureManager(self: *Game) *atlas_mod.TextureManager {
+            return &self.atlas_manager;
+        }
+
+        /// Look up a sprite by name across all loaded atlases (uncached).
+        pub fn findSprite(self: *const Game, sprite_name: []const u8) ?atlas_mod.FindSpriteResult {
+            return self.atlas_manager.findSprite(sprite_name);
+        }
+
+        /// Look up a sprite for an entity using the per-entity cache.
+        /// Returns cached result when atlas version and sprite name haven't changed.
+        pub fn findSpriteCached(self: *Game, entity_id: u32, sprite_name: []const u8) ?atlas_mod.FindSpriteResult {
+            return self.active_world.sprite_cache.lookup(entity_id, sprite_name, &self.atlas_manager);
+        }
+
+        /// Unload an atlas by name, freeing sprite data.
+        pub fn unloadAtlas(self: *Game, name: []const u8) void {
+            self.atlas_manager.unloadAtlas(name);
+        }
+
+        // ── Atlas Resolution ──────────────────────────────────────
+
+        /// Resolve sprite_name → source_rect + texture for all atlas sprites.
+        /// Called automatically before renderer sync each frame.
+        /// Only marks entities dirty on cache misses (sprite name or atlas version changed).
+        pub fn resolveAtlasSprites(self: *Game) void {
+            if (!has_atlas_sprite_fields) return;
+            if (self.atlas_manager.atlasCount() == 0) return;
+
+            var v = self.ecs_backend.view(.{Sprite}, .{});
+            defer v.deinit();
+            while (v.next()) |entity| {
+                const sprite = self.ecs_backend.getComponent(entity, Sprite).?;
+                if (sprite.sprite_name.len == 0) continue;
+
+                const misses_before = self.active_world.sprite_cache.misses;
+                if (self.active_world.sprite_cache.lookup(@intCast(entity), sprite.sprite_name, &self.atlas_manager)) |result| {
+                    // Only update and mark dirty on cache miss (new sprite or atlas changed)
+                    if (self.active_world.sprite_cache.misses != misses_before) {
+                        sprite.texture = @enumFromInt(result.texture_id);
+                        // The atlas data is in the JSON's logical pixel
+                        // grid. `texture_scale_*` maps that grid onto the
+                        // actual texture pixels — `1.0` for the common
+                        // case, `< 1` when the user shipped a downscaled
+                        // PNG without re-running TexturePacker.
+                        //
+                        // Two distinct mappings are needed:
+                        //
+                        //   * The PHYSICAL atlas footprint (`sprite.x/y`,
+                        //     `sprite.width/height`) is in texture-pixel
+                        //     coordinates regardless of rotation. Each
+                        //     axis scales independently, so x/width go
+                        //     through `texture_scale_x` and y/height go
+                        //     through `texture_scale_y`.
+                        //
+                        //   * The DISPLAY dimensions (`getWidth/Height`)
+                        //     swap when the sprite was rotated 90° in the
+                        //     atlas — that's the on-screen size. They
+                        //     stay un-scaled.
+                        //
+                        // Mixing the two (multiplying `getWidth()` by
+                        // `texture_scale_x`) is wrong for rotated sprites
+                        // because `getWidth()` returns the post-rotation
+                        // height — a vertical dimension scaled by a
+                        // horizontal factor.
+                        const phys_x: f32 = @floatFromInt(result.sprite.x);
+                        const phys_y: f32 = @floatFromInt(result.sprite.y);
+                        const phys_w: f32 = @floatFromInt(result.sprite.width);
+                        const phys_h: f32 = @floatFromInt(result.sprite.height);
+                        const display_w: f32 = @floatFromInt(result.sprite.getWidth());
+                        const display_h: f32 = @floatFromInt(result.sprite.getHeight());
+                        const scaled_w = phys_w * result.texture_scale_x;
+                        const scaled_h = phys_h * result.texture_scale_y;
+                        sprite.source_rect = .{
+                            .x = phys_x * result.texture_scale_x,
+                            .y = phys_y * result.texture_scale_y,
+                            // `source_rect.width/height` are in the same
+                            // post-rotation orientation that the renderer
+                            // expects (matching `getWidth/Height`),
+                            // so swap when the sprite was rotated.
+                            .width = if (result.sprite.rotated) scaled_h else scaled_w,
+                            .height = if (result.sprite.rotated) scaled_w else scaled_h,
+                            .display_width = display_w,
+                            .display_height = display_h,
+                        };
+                        self.renderer.markVisualDirty(entity);
+                    }
+                }
+            }
+        }
+    };
+}

--- a/src/game/components_mixin.zig
+++ b/src/game/components_mixin.zig
@@ -1,0 +1,242 @@
+/// Components mixin — position, parent/child hierarchy, and generic
+/// component access (add / set / get / setField / has / remove / fireOnReady),
+/// plus the preview-mode `notifyComponentChanged` telemetry helper.
+///
+/// Extracted verbatim from `game.zig`; behaviour is identical. Intra-cluster
+/// calls use lexical sibling-function syntax (`setPosition(self, ...)`) so
+/// they resolve inside this struct rather than round-tripping through the
+/// `Game` re-export — except `assertEntityAlive`, which stays on `Game`
+/// (tombstone-guard cluster) and is reached via `self.assertEntityAlive`.
+const std = @import("std");
+const core = @import("labelle-core");
+const Position = core.Position;
+const hooks_types = @import("../hooks_types.zig");
+const ComponentPayload = hooks_types.ComponentPayload;
+const hierarchy = @import("hierarchy.zig");
+
+/// Returns the components/hierarchy mixin for a given Game type.
+pub fn Mixin(comptime Game: type) type {
+    const Entity = Game.EntityType;
+    const EcsImpl = Game.EcsBackend;
+    const Parent = Game.ParentComp;
+    const Children = Game.ChildrenComp;
+
+    return struct {
+        pub fn setPosition(self: *Game, entity: Entity, pos: Position) void {
+            self.ecs_backend.addComponent(entity, pos);
+            self.renderer.markPositionDirtyWithChildren(EcsImpl, self.ecs_backend, entity);
+            notifyComponentChanged(self, entity, pos);
+        }
+
+        /// Preview-mode helper. No-op unless `self.preview` is set AND
+        /// the editor has subscribed to this component's name. Folded
+        /// out by the compiler in non-preview builds because the
+        /// `preview` field defaults to `null`.
+        ///
+        /// Generic over the component type so it can be called from
+        /// any setter site without forcing the caller to spell out
+        /// `@typeName` + `std.mem.asBytes` boilerplate. The
+        /// subscription check runs first so `comp` is never read in
+        /// the common "nobody's watching" path.
+        pub inline fn notifyComponentChanged(self: *Game, entity: Entity, comp: anytype) void {
+            if (self.preview) |*p| {
+                // Callers may pass either a value or a `*T` (the
+                // generic `addComponent` / `setComponent` accept
+                // `anytype`). Strip the pointer so the subscription
+                // name and serialized bytes describe the component,
+                // not its address.
+                const T = @TypeOf(comp);
+                if (comptime @typeInfo(T) == .pointer) {
+                    const name = @typeName(@typeInfo(T).pointer.child);
+                    if (p.isComponentSubscribed(name)) {
+                        p.emitComponentChanged(@intCast(entity), name, std.mem.asBytes(comp)) catch {};
+                    }
+                } else {
+                    const name = @typeName(T);
+                    if (p.isComponentSubscribed(name)) {
+                        p.emitComponentChanged(@intCast(entity), name, std.mem.asBytes(&comp)) catch {};
+                    }
+                }
+            }
+        }
+
+        pub fn getPosition(self: *Game, entity: Entity) Position {
+            if (self.ecs_backend.getComponent(entity, Position)) |p| return p.*;
+            return Position{};
+        }
+
+        pub fn getWorldPosition(self: *Game, entity: Entity) Position {
+            return hierarchy.computeWorldPos(EcsImpl, Parent, self.ecs_backend, entity, 0);
+        }
+
+        pub fn setWorldPosition(self: *Game, entity: Entity, world_pos: Position) void {
+            if (self.ecs_backend.getComponent(entity, Parent)) |parent_comp| {
+                const parent_world = hierarchy.computeWorldPos(EcsImpl, Parent, self.ecs_backend, parent_comp.entity, 0);
+                setPosition(self, entity, .{ .x = world_pos.x - parent_world.x, .y = world_pos.y - parent_world.y });
+            } else {
+                setPosition(self, entity, world_pos);
+            }
+        }
+
+        pub fn setParent(self: *Game, child: Entity, parent_entity: Entity, opts: struct {
+            inherit_rotation: bool = false,
+            inherit_scale: bool = false,
+        }) void {
+            self.assertEntityAlive(child, "setParent (child)");
+            self.assertEntityAlive(parent_entity, "setParent (parent)");
+            if (hierarchy.wouldCreateCycle(EcsImpl, Parent, self.ecs_backend, child, parent_entity)) return;
+
+            if (self.ecs_backend.getComponent(child, Parent)) |old_parent_comp| {
+                if (self.ecs_backend.getComponent(old_parent_comp.entity, Children)) |old_children| {
+                    old_children.removeChild(child);
+                }
+            }
+
+            self.ecs_backend.addComponent(child, Parent{
+                .entity = parent_entity,
+                .inherit_rotation = opts.inherit_rotation,
+                .inherit_scale = opts.inherit_scale,
+            });
+
+            if (self.ecs_backend.getComponent(parent_entity, Children)) |children_comp| {
+                children_comp.addChild(child);
+            } else {
+                var new_children = Children{};
+                new_children.addChild(child);
+                self.ecs_backend.addComponent(parent_entity, new_children);
+            }
+
+            self.renderer.updateHierarchyFlag(child, true);
+            self.renderer.markPositionDirty(child);
+        }
+
+        pub fn setParentKeepTransform(self: *Game, child: Entity, parent_entity: Entity, opts: struct {
+            inherit_rotation: bool = false,
+            inherit_scale: bool = false,
+        }) void {
+            const world_pos = getWorldPosition(self, child);
+            setParent(self, child, parent_entity, opts);
+            setWorldPosition(self, child, world_pos);
+        }
+
+        pub fn removeParent(self: *Game, child: Entity) void {
+            self.assertEntityAlive(child, "removeParent");
+            if (self.ecs_backend.getComponent(child, Parent)) |parent_comp| {
+                if (self.ecs_backend.getComponent(parent_comp.entity, Children)) |children_comp| {
+                    children_comp.removeChild(child);
+                }
+            }
+            self.ecs_backend.removeComponent(child, Parent);
+            self.renderer.updateHierarchyFlag(child, false);
+            self.renderer.markPositionDirty(child);
+        }
+
+        pub fn removeParentKeepTransform(self: *Game, child: Entity) void {
+            const world_pos = getWorldPosition(self, child);
+            removeParent(self, child);
+            setPosition(self, child, world_pos);
+        }
+
+        pub fn getParent(self: *Game, entity: Entity) ?Entity {
+            if (self.ecs_backend.getComponent(entity, Parent)) |p| return p.entity;
+            return null;
+        }
+
+        pub fn getChildren(self: *Game, entity: Entity) []const Entity {
+            if (self.ecs_backend.getComponent(entity, Children)) |c| return c.getChildren();
+            return &.{};
+        }
+
+        pub fn hasChildren(self: *Game, entity: Entity) bool {
+            if (self.ecs_backend.getComponent(entity, Children)) |c| return c.count() > 0;
+            return false;
+        }
+
+        pub fn isRoot(self: *Game, entity: Entity) bool {
+            return !self.ecs_backend.hasComponent(entity, Parent);
+        }
+
+        // ── Generic Component Access ──────────────────────────────
+
+        pub fn addComponent(self: *Game, entity: Entity, component: anytype) void {
+            self.ecs_backend.addComponent(entity, component);
+            const T = @TypeOf(component);
+            if (@typeInfo(T) == .@"struct" and @hasDecl(T, "onAdd")) {
+                T.onAdd(ComponentPayload{ .entity_id = @intCast(entity), .game_ptr = @ptrCast(self) });
+            }
+            notifyComponentChanged(self, entity, component);
+        }
+
+        pub fn setComponent(self: *Game, entity: Entity, component: anytype) void {
+            const T = @TypeOf(component);
+            const is_update = self.ecs_backend.hasComponent(entity, T);
+            self.ecs_backend.addComponent(entity, component);
+            if (@typeInfo(T) == .@"struct") {
+                if (is_update and @hasDecl(T, "onSet")) {
+                    T.onSet(ComponentPayload{ .entity_id = @intCast(entity), .game_ptr = @ptrCast(self) });
+                } else if (!is_update and @hasDecl(T, "onAdd")) {
+                    T.onAdd(ComponentPayload{ .entity_id = @intCast(entity), .game_ptr = @ptrCast(self) });
+                }
+            }
+            notifyComponentChanged(self, entity, component);
+        }
+
+        pub fn getComponent(self: *Game, entity: Entity, comptime T: type) ?*T {
+            return self.ecs_backend.getComponent(entity, T);
+        }
+
+        /// Writes a single field of component `T` on `entity` in place.
+        ///
+        /// Silently no-ops when the entity does not have a component
+        /// of type `T` — same semantics as `getComponent` returning
+        /// `null`. This matches the flow-codegen runtime contract:
+        /// generated `OnUpdate` flows that touch a missing component
+        /// should not crash the game loop.
+        ///
+        /// The `comptime field: std.meta.FieldEnum(T)` selector keeps
+        /// the call site type-checked end-to-end. The flow-codegen
+        /// emits `game.setField(Position, .x, entity, value)`.
+        ///
+        /// Preview telemetry is fired after the mutation through the
+        /// same `notifyComponentChanged` path used by `setComponent`,
+        /// so the editor sees an updated component frame when it has
+        /// subscribed to `T`. For `Position` specifically the renderer's
+        /// dirty-tracking is also poked (mirroring `setPosition`) so
+        /// a flow that nudges `Position.x` doesn't drift the on-screen
+        /// sprite out of sync with the ECS state.
+        pub fn setField(
+            self: *Game,
+            comptime T: type,
+            comptime field: std.meta.FieldEnum(T),
+            entity: Entity,
+            value: @FieldType(T, @tagName(field)),
+        ) void {
+            const comp_ptr = self.ecs_backend.getComponent(entity, T) orelse return;
+            @field(comp_ptr.*, @tagName(field)) = value;
+            if (T == Position) {
+                self.renderer.markPositionDirtyWithChildren(EcsImpl, self.ecs_backend, entity);
+            }
+            notifyComponentChanged(self, entity, comp_ptr);
+        }
+
+        pub fn hasComponent(self: *Game, entity: Entity, comptime T: type) bool {
+            return self.ecs_backend.hasComponent(entity, T);
+        }
+
+        pub fn removeComponent(self: *Game, entity: Entity, comptime T: type) void {
+            if (@typeInfo(T) == .@"struct" and @hasDecl(T, "onRemove")) {
+                T.onRemove(ComponentPayload{ .entity_id = @intCast(entity), .game_ptr = @ptrCast(self) });
+            }
+            self.ecs_backend.removeComponent(entity, T);
+        }
+
+        /// Fire onReady for a component type on a given entity.
+        /// Called by the scene loader after ALL components have been added,
+        /// so onReady callbacks can safely access sibling components.
+        pub fn fireOnReady(self: *Game, entity: Entity, comptime T: type) void {
+            if (@typeInfo(T) == .@"struct" and @hasDecl(T, "onReady")) {
+                T.onReady(ComponentPayload{ .entity_id = @intCast(entity), .game_ptr = @ptrCast(self) });
+            }
+        }
+    };
+}

--- a/src/game/entity_mixin.zig
+++ b/src/game/entity_mixin.zig
@@ -1,0 +1,424 @@
+/// Entity mixin — entity lifecycle (create / destroy), prefab spawning
+/// and save/load Phase-1 tagging, the view-collection helpers (#510),
+/// the debug tombstone-record write, and scene-entity tracking.
+///
+/// Extracted verbatim from `game.zig`; behaviour is identical. Intra-cluster
+/// helpers (`tagPrefabChildren`, `untrackSceneEntity`, `recordTombstone`)
+/// are called via lexical sibling-function syntax so they resolve inside
+/// this struct. Cross-cluster calls (`emitHook`, `emitEngineEvent`,
+/// `getChildren`, `hasChildren`, `tagAsPrefabInstance`, `destroyEntity`)
+/// route through the `Game` re-exports.
+const std = @import("std");
+const builtin = @import("builtin");
+const core = @import("labelle-core");
+const Position = core.Position;
+const PrefabInstance = core.PrefabInstance;
+
+/// Returns the entity-lifecycle mixin for a given Game type.
+pub fn Mixin(comptime Game: type) type {
+    const Entity = Game.EntityType;
+    const Children = Game.ChildrenComp;
+    const PrefabChildT = Game.PrefabChildComp;
+    const TombstoneEntry = Game.TombstoneEntry;
+    const tombstone_size = Game.tombstone_size;
+    const is_debug = builtin.mode == .Debug;
+
+    return struct {
+        // ── Debug entity guards (#419, #420) ─────────────────────
+
+        pub fn recordTombstone(self: *Game, entity: Entity) void {
+            if (comptime is_debug) {
+                self.tombstones[self.tombstone_cursor] = TombstoneEntry{ .entity = entity, .frame = self.frame_number };
+                self.tombstone_cursor = (self.tombstone_cursor + 1) % tombstone_size;
+            }
+        }
+
+        pub fn findTombstone(self: *const Game, entity: Entity) ?TombstoneEntry {
+            if (comptime !is_debug) return null;
+            // Iterate backwards from cursor to return the most recent match
+            // (entity IDs can be reused after resetEcsBackend or ECS recycling)
+            var j: usize = 0;
+            while (j < tombstone_size) : (j += 1) {
+                const i = (self.tombstone_cursor + tombstone_size - 1 - j) % tombstone_size;
+                if (self.tombstones[i]) |entry| {
+                    if (entry.entity == entity) return entry;
+                }
+            }
+            return null;
+        }
+
+        pub fn assertEntityAlive(self: *const Game, entity: Entity, comptime operation: []const u8) void {
+            if (comptime is_debug) {
+                if (!self.ecs_backend.entityExists(entity)) {
+                    if (findTombstone(self, entity)) |tomb| {
+                        std.debug.print("{s} on destroyed entity {d} (destroyed in frame {d}, current frame {d})\n", .{
+                            operation, entity, tomb.frame, self.frame_number,
+                        });
+                        @panic(operation ++ " on destroyed entity");
+                    } else {
+                        std.debug.print("{s} on invalid entity {d} (not in tombstone ring — destroyed long ago or never existed)\n", .{
+                            operation, entity,
+                        });
+                        @panic(operation ++ " on invalid entity");
+                    }
+                }
+            }
+        }
+
+        // ── Entity Management ─────────────────────────────────────
+
+        pub fn createEntity(self: *Game) Entity {
+            const entity = self.ecs_backend.createEntity();
+            self.emitHook(.{ .entity_created = .{ .entity_id = entity } });
+            // Engine `Events` dual-emit (#578). `entity` is widened to
+            // u32 — same convention as box2d's `Events.collision_begin`.
+            self.emitEngineEvent("engine__entity_created", .{ .entity = @as(u32, @intCast(entity)) });
+            // Preview telemetry: the prefab path tags `PrefabInstance`
+            // *after* createEntity returns (see `tagAsPrefabInstance`),
+            // so we can't carry the prefab name here. Emit null; a
+            // future enhancement can re-emit on tag.
+            if (self.preview) |*p| p.emitEntityCreated(@intCast(entity), null) catch {};
+            return entity;
+        }
+
+        /// Spawn an entity from a named prefab at the given position.
+        /// Returns the entity, or null if the prefab was not found.
+        /// Requires a JSONC scene to have been loaded (which sets up the prefab directory).
+        pub fn spawnPrefab(self: *Game, name: []const u8, pos: Position) ?Entity {
+            if (self.spawn_prefab_fn) |func| {
+                return func(self, name, pos);
+            }
+            self.log.err("[Game] spawnPrefab: no prefab loader configured (load a JSONC scene first)", .{});
+            return null;
+        }
+
+        /// Spawn a prefab *and* tag it for save/load Phase 1 reinstantiation.
+        ///
+        /// Wraps `spawnPrefab` with two additions from
+        /// `RFC-SAVE-LOAD-PREFABS.md`:
+        ///
+        /// 1. The **root** entity gets `PrefabInstance { path, overrides = "" }`
+        ///    so the save mixin's built-in handler (added in #474)
+        ///    records its prefab origin.
+        /// 2. Each **child** entity (recursively) gets
+        ///    `PrefabChild { root, local_path = "children[i]..." }` so
+        ///    Phase 1 on load can map saved child IDs back to newly-
+        ///    spawned children via `(root, local_path)`.
+        ///
+        /// `PrefabInstance.path` and every `PrefabChild.local_path` are
+        /// duped into `active_world.nested_entity_arena` — lifetime
+        /// matches the prefab children (world-scoped), freed on scene
+        /// change. Same ownership contract as the save mixin's load-
+        /// side allocation. `PrefabInstance.overrides` is the string
+        /// literal `""` in this first-cut slice (program lifetime, no
+        /// arena allocation needed for a zero-length literal); the
+        /// structured-overrides pipeline lands in a follow-up and will
+        /// dupe `overrides` into the same arena then.
+        ///
+        /// **Interaction with the save mixin:** tagged entities
+        /// always survive `saveGameState` → `loadGameState` round-
+        /// trip. Since the sweep in `saveGameState` auto-collects
+        /// entities with `PrefabInstance` / `PrefabChild` (in
+        /// addition to the registry-driven saveable / marker pass),
+        /// a purely-visual prefab — even one whose root has only
+        /// `Sprite` + the engine's auto-attached `PrefabInstance` —
+        /// still round-trips cleanly and Phase 1 respawns it from
+        /// the `path`. Game authors don't need to sprinkle marker
+        /// components solely to placate save/load.
+        ///
+        /// Caveat: this covers *collection only*. If a prefab root's
+        /// components are all non-saveable, Phase 2 has no overrides
+        /// to apply, so the respawned entity reflects the prefab's
+        /// literal declaration. Game-owned `.saveable` components
+        /// override that (per-instance state lives through
+        /// round-trips). `.transient` components reset to the
+        /// prefab's values.
+        pub fn spawnFromPrefab(self: *Game, path: []const u8, pos: Position) ?Entity {
+            const entity = spawnPrefab(self, path, pos) orelse return null;
+            // Any tagging failure (arena OOM on path dupe, or inside
+            // the recursive child walk) leaves the world with an
+            // orphan entity tree that has no `PrefabInstance` tag —
+            // scene-tracked, component-populated, but invisible to
+            // the save mixin's Phase 1. Destroy the whole tree on
+            // failure so `spawnFromPrefab`'s null return really
+            // means "the world is unchanged."
+            //
+            // Log the error name before tearing down: `null` return
+            // collides with the "unknown prefab" signal from
+            // `spawnPrefab`, so without the log an OOM during tagging
+            // is indistinguishable from a typo in the prefab path.
+            self.tagAsPrefabInstance(entity, path) catch |err| {
+                self.log.err("[Game] spawnFromPrefab: tagging failed for '{s}': {s}", .{ path, @errorName(err) });
+                self.destroyEntity(entity);
+                return null;
+            };
+            return entity;
+        }
+
+        /// Tag `entity` as a prefab root (attach `PrefabInstance`) and
+        /// walk its descendants attaching `PrefabChild` markers with
+        /// `local_path` relative to the root.
+        ///
+        /// Used by both `spawnFromPrefab` (runtime spawn path) and
+        /// `JsoncSceneBridge::loadEntityInternal` (scene-load path) so
+        /// the `(root, local_path)` key the save mixin uses to match
+        /// saved children to respawned ones is generated consistently.
+        pub fn tagAsPrefabInstance(self: *Game, entity: Entity, path: []const u8) !void {
+            const arena = self.active_world.nested_entity_arena.allocator();
+            const path_dup = try arena.dupe(u8, path);
+
+            self.ecs_backend.addComponent(entity, PrefabInstance{
+                .path = path_dup,
+                .overrides = "",
+            });
+
+            try tagPrefabChildren(self, entity, entity, "children", arena);
+        }
+
+        /// Recursively tag every descendant of `root` with `PrefabChild`.
+        /// `base_path` is the dotted path accumulated so far (e.g.
+        /// `"children"` at the top level; `"children[0].children"` one
+        /// level in). Each child appends `[i]` to form its unique path
+        /// within the prefab tree.
+        ///
+        /// Propagates allocation errors up instead of silently
+        /// `continue`-ing — a partially-tagged tree would have
+        /// `PrefabChild` on some descendants and not others, breaking
+        /// the `(root, local_path)` lookup the two-phase load relies
+        /// on. Atomic: if anything fails, `spawnFromPrefab` destroys
+        /// the tree and returns null.
+        fn tagPrefabChildren(
+            self: *Game,
+            root: Entity,
+            parent: Entity,
+            base_path: []const u8,
+            arena: std.mem.Allocator,
+        ) !void {
+            const children = self.getChildren(parent);
+            for (children, 0..) |child, i| {
+                const child_path = try std.fmt.allocPrint(
+                    arena,
+                    "{s}[{d}]",
+                    .{ base_path, i },
+                );
+                self.ecs_backend.addComponent(child, PrefabChildT{
+                    .root = root,
+                    .local_path = child_path,
+                });
+                // Skip the `.children` suffix allocation when `child` is
+                // a leaf. Two-level prefab trees (hydroponics: root +
+                // room + plant overlay) are common; without this gate
+                // the leaf gets an unused `"children[i].children"`
+                // string arena-allocated every spawn.
+                if (self.hasChildren(child)) {
+                    const next_base = try std.fmt.allocPrint(
+                        arena,
+                        "{s}.children",
+                        .{child_path},
+                    );
+                    try tagPrefabChildren(self, root, child, next_base, arena);
+                }
+            }
+        }
+
+        pub fn destroyEntity(self: *Game, entity: Entity) void {
+            if (self.ecs_backend.getComponent(entity, Children)) |children_comp| {
+                for (children_comp.getChildren()) |child| {
+                    destroyEntity(self, child);
+                }
+            }
+            // Preview telemetry emits BEFORE the actual destroy so any
+            // editor-side consumer can still introspect the entity from
+            // a `getComponent` style API while reacting to the frame.
+            if (self.preview) |*p| p.emitEntityDestroyed(@intCast(entity)) catch {};
+            untrackSceneEntity(self, entity);
+            self.active_world.sprite_cache.invalidate(@intCast(entity));
+            self.renderer.untrackEntity(entity);
+            self.ecs_backend.destroyEntity(entity);
+            recordTombstone(self, entity);
+            self.emitHook(.{ .entity_destroyed = .{ .entity_id = entity } });
+            // Engine `Events` dual-emit (#578).
+            self.emitEngineEvent("engine__entity_destroyed", .{ .entity = @as(u32, @intCast(entity)) });
+        }
+
+        pub fn destroyEntityOnly(self: *Game, entity: Entity) void {
+            if (self.preview) |*p| p.emitEntityDestroyed(@intCast(entity)) catch {};
+            untrackSceneEntity(self, entity);
+            self.active_world.sprite_cache.invalidate(@intCast(entity));
+            self.renderer.untrackEntity(entity);
+            self.ecs_backend.destroyEntity(entity);
+            recordTombstone(self, entity);
+            self.emitHook(.{ .entity_destroyed = .{ .entity_id = entity } });
+            // Engine `Events` dual-emit (#578).
+            self.emitEngineEvent("engine__entity_destroyed", .{ .entity = @as(u32, @intCast(entity)) });
+        }
+
+        // ── View collection helpers (#510) ────────────────────────
+        //
+        // Iterating an ECS view while mutating the world (adding /
+        // removing components, destroying entities) risks
+        // invalidating the iterator on backends that don't tolerate
+        // concurrent mutation. The helpers below absorb the
+        // "collect first, then mutate" boilerplate every dispatcher
+        // / hook / tick was hand-rolling.
+
+        /// Heap-allocated collection. Returns an `ArrayList(Entity)`
+        /// the caller `deinit`s. Picks the heap path when the
+        /// expected size is unknown or large (save / load,
+        /// debug-snapshot scans, one-shot batch ops).
+        pub fn collectEntities(
+            self: *Game,
+            comptime include: anytype,
+            comptime exclude: anytype,
+            allocator: std.mem.Allocator,
+        ) !std.ArrayList(Entity) {
+            var buf: std.ArrayList(Entity) = .empty;
+            errdefer buf.deinit(allocator);
+            var view = self.ecs_backend.view(include, exclude);
+            defer view.deinit();
+            while (view.next()) |ent| {
+                try buf.append(allocator, ent);
+            }
+            return buf;
+        }
+
+        /// Stack-allocated collection. Fills `buf` and returns the
+        /// number of entities written. Sets `overflowed.*` to true
+        /// if the view contained more entities than `buf.len`. Use
+        /// for per-tick scans where allocating in the hot loop
+        /// would be wasteful and the worst-case set is bounded.
+        ///
+        /// On overflow the caller decides what to do — typically
+        /// `log.warn(...)` + retry next frame (matches the existing
+        /// `sleep_hooks.frame_end` convention).
+        pub fn collectEntitiesBuf(
+            self: *Game,
+            comptime include: anytype,
+            comptime exclude: anytype,
+            buf: []Entity,
+            overflowed: *bool,
+        ) usize {
+            overflowed.* = false;
+            var count: usize = 0;
+            var view = self.ecs_backend.view(include, exclude);
+            defer view.deinit();
+            while (view.next()) |ent| {
+                if (count < buf.len) {
+                    buf[count] = ent;
+                    count += 1;
+                } else {
+                    overflowed.* = true;
+                }
+            }
+            return count;
+        }
+
+        /// Same shape as `collectEntities`, with an extra runtime
+        /// `predicate(self, entity) bool` filter. Use when the
+        /// caller needs to check a component **field value** (or any
+        /// derived condition) — the comptime include / exclude
+        /// tuple only filters on component existence. The predicate
+        /// receives the live `Game` pointer so it can
+        /// `getComponent(...)` for whatever runtime state the
+        /// filter inspects.
+        ///
+        /// **Predicate contract: read-only.** The whole point of the
+        /// `collect*` helpers is to *avoid* mutating the world
+        /// inside the view's iteration. The predicate runs while
+        /// the iterator is live; adding / removing components or
+        /// destroying entities from inside it risks the same
+        /// concurrent-mutation hazard the helpers exist to dodge.
+        /// Use the predicate to *inspect* state (via
+        /// `getComponent`, etc.); commit mutations in the loop the
+        /// caller writes over the returned list.
+        pub fn collectEntitiesIf(
+            self: *Game,
+            comptime include: anytype,
+            comptime exclude: anytype,
+            allocator: std.mem.Allocator,
+            predicate: *const fn (*Game, Entity) bool,
+        ) !std.ArrayList(Entity) {
+            var buf: std.ArrayList(Entity) = .empty;
+            errdefer buf.deinit(allocator);
+            var view = self.ecs_backend.view(include, exclude);
+            defer view.deinit();
+            while (view.next()) |ent| {
+                if (predicate(self, ent)) {
+                    try buf.append(allocator, ent);
+                }
+            }
+            return buf;
+        }
+
+        /// Same shape as `collectEntitiesBuf`, with the runtime
+        /// `predicate` filter. Useful for the per-tick scan path
+        /// where the worst case is bounded and a heap allocation
+        /// per frame would be wasteful — same `overflowed`
+        /// out-pointer contract.
+        ///
+        /// **Predicate contract: read-only** — same rule as
+        /// `collectEntitiesIf`. The hot-path stack variant is the
+        /// one most likely to be tempted with a per-tick mutation
+        /// inside the predicate; resist. Inspect only.
+        ///
+        /// On overflow the iteration breaks early: once the buffer
+        /// is full and we've seen one more predicate-accepted
+        /// entity, there's nothing the caller can do with the rest
+        /// (they go in next tick's pass), so spending more
+        /// predicate calls is wasted work. Predicate-rejected
+        /// entities don't count toward the cap — a view full of
+        /// rejects never trips the overflow flag.
+        pub fn collectEntitiesBufIf(
+            self: *Game,
+            comptime include: anytype,
+            comptime exclude: anytype,
+            buf: []Entity,
+            overflowed: *bool,
+            predicate: *const fn (*Game, Entity) bool,
+        ) usize {
+            overflowed.* = false;
+            var count: usize = 0;
+            var view = self.ecs_backend.view(include, exclude);
+            defer view.deinit();
+            while (view.next()) |ent| {
+                if (!predicate(self, ent)) continue;
+                if (count < buf.len) {
+                    buf[count] = ent;
+                    count += 1;
+                } else {
+                    overflowed.* = true;
+                    break;
+                }
+            }
+            return count;
+        }
+
+        // ── Scene-entity tracking ─────────────────────────────────
+
+        /// Register an entity as owned by the current scene. Called by
+        /// scene loaders (JSONC bridge, comptime registerScene callbacks)
+        /// so `unloadCurrentScene` can destroy the entity when the scene
+        /// swaps out. Silently no-ops on OOM — the scene still works, we
+        /// just lose the auto-cleanup for the un-tracked entity.
+        pub fn trackSceneEntity(self: *Game, entity: Entity) void {
+            self.scene_entities.append(self.allocator, entity) catch {};
+        }
+
+        /// Remove an entity from the scene-tracking list. Called by
+        /// `destroyEntity`/`destroyEntityOnly` so (1) a scene's cleanup
+        /// loop never double-destroys a tracked-then-manually-destroyed
+        /// entity and (2) the list doesn't grow unboundedly across a
+        /// scene that churns through short-lived entities. O(N) scan +
+        /// swap-remove — fine for scenes with hundreds of entities;
+        /// revisit if a project pushes tens of thousands.
+        pub fn untrackSceneEntity(self: *Game, entity: Entity) void {
+            var i: usize = 0;
+            while (i < self.scene_entities.items.len) : (i += 1) {
+                if (self.scene_entities.items[i] == entity) {
+                    _ = self.scene_entities.swapRemove(i);
+                    return;
+                }
+            }
+        }
+    };
+}

--- a/src/game/events_mixin.zig
+++ b/src/game/events_mixin.zig
@@ -1,0 +1,170 @@
+/// Events mixin — hook + game-event dispatch: `emitHook` (typed hook
+/// payload), `emit` (buffered game event), `emitEngineEvent` (tolerant
+/// `engine__<event>` dual-emit, #578), `emitSync` (immediate), and
+/// `dispatchEvents` (end-of-frame buffer drain).
+///
+/// Extracted verbatim from `game.zig`; behaviour is identical. The
+/// comptime types/flags this needs (`Payload`, `has_hooks`, `has_events`,
+/// `EventBuffer`) are defined in `GameConfig`'s function body and surfaced
+/// onto `Game` as `pub const` re-exports so this mixin reads a single
+/// comptime source of truth via `Game.*`. Intra-cluster calls
+/// (`emit`, `emitHook`) use lexical sibling syntax.
+const std = @import("std");
+
+/// Returns the events-dispatch mixin for a given Game type.
+pub fn Mixin(comptime Game: type) type {
+    const GameEvents = Game.GameEvents;
+    const Payload = Game.PayloadExport;
+    const EventBuffer = Game.EventBufferExport;
+    const has_events = Game.has_events_export;
+    const has_hooks = Game.has_hooks_export;
+
+    return struct {
+        pub fn emitHook(self: *Game, payload: Payload) void {
+            if (has_hooks) {
+                if (self.hooks) |h| {
+                    h.emit(payload);
+                }
+            }
+        }
+
+        /// Emit a game event. Buffered and delivered to scripts at end of frame.
+        pub fn emit(self: *Game, event: GameEvents) void {
+            if (has_events) {
+                self.event_buffer.append(self.allocator, event) catch |err| {
+                    self.log.err("Failed to emit game event: {s}", .{@errorName(err)});
+                };
+            }
+        }
+
+        /// Engine-side tolerant emit for the `engine__<event>` variants
+        /// declared on `engine.Events` (RFC-FLOW-VOCABULARY phase 6,
+        /// #578). The assembler folds the engine's `Events` block into
+        /// `PluginEvents`, which is itself merged into `GameEvents`. So
+        /// in any project where the assembler ran, `GameEvents` has the
+        /// `engine__<event>` variants. But unit tests build `Game`
+        /// directly with `GameEvents = void` (the `GameWith(Hooks)`
+        /// path), so the engine's own lifecycle code can't blindly call
+        /// `self.emit(.{ .engine__game_init = .{} })` — there would be
+        /// no such field in the union.
+        ///
+        /// This helper does the comptime gate: when `GameEvents` is a
+        /// union *and* declares the variant tag, the dispatch goes
+        /// through `emit`; otherwise the call folds away to a no-op.
+        ///
+        /// The variant must be passed as `comptime`-known struct
+        /// literal — e.g. `self.emitEngineEvent("engine__game_init", .{})`
+        /// — so the field-presence check resolves at compile time. The
+        /// payload type is inferred against
+        /// `@FieldType(GameEvents, tag)`, mirroring how
+        /// `dispatchEvents` reconstructs the union variant.
+        pub inline fn emitEngineEvent(
+            self: *Game,
+            comptime tag: []const u8,
+            payload: anytype,
+        ) void {
+            // Comptime gate: when the project's `GameEvents` doesn't
+            // carry the requested variant — e.g. unit-test games using
+            // `GameWith(Hooks)` with `GameEvents = void`, or any
+            // project the assembler hasn't yet been re-run against —
+            // the entire body folds to a no-op. Returning the early
+            // empty body via comptime branching avoids semantic
+            // analysis on a `@unionInit` against `void`/missing field.
+            const should_emit = comptime blk: {
+                if (!has_events) break :blk false;
+                const ev_info = @typeInfo(GameEvents);
+                if (ev_info != .@"union") break :blk false;
+                break :blk @hasField(GameEvents, tag);
+            };
+            if (comptime !should_emit) return;
+            // From here on `GameEvents` is known to be a union with
+            // the variant. Build the payload by copying fields from
+            // the caller's anonymous struct literal into a value of
+            // the merged union's declared payload type — Zig 0.16
+            // does not auto-coerce anonymous struct literals to a
+            // *different* named struct even when fields match, so we
+            // do it field-by-field. This also lets the caller pass
+            // the engine's `Entity` type for entity-typed fields:
+            // the @intCast widens to `u32` here without forcing the
+            // call site to spell it out.
+            const Payload_t = @FieldType(GameEvents, tag);
+            var typed: Payload_t = undefined;
+            const fields = comptime std.meta.fields(Payload_t);
+            inline for (fields) |f| {
+                if (comptime @hasField(@TypeOf(payload), f.name)) {
+                    const src_val = @field(payload, f.name);
+                    const SrcT = @TypeOf(src_val);
+                    if (comptime @typeInfo(f.type) == .int and @typeInfo(SrcT) == .int) {
+                        @field(typed, f.name) = @intCast(src_val);
+                    } else {
+                        @field(typed, f.name) = src_val;
+                    }
+                } else if (comptime f.default_value_ptr != null) {
+                    @field(typed, f.name) = @as(*const f.type, @ptrCast(@alignCast(f.default_value_ptr.?))).*;
+                } else {
+                    @compileError("emitEngineEvent: missing field '" ++ f.name ++ "' for variant '" ++ tag ++ "'");
+                }
+            }
+            emit(self, @unionInit(GameEvents, tag, typed));
+        }
+
+        /// Emit a game event synchronously — dispatch to registered hooks
+        /// immediately, bypassing the end-of-frame buffer. Use when the
+        /// caller needs the handler to have run before the next
+        /// statement (cross-plugin state machines that can't tolerate
+        /// the buffered-dispatch window).
+        ///
+        /// ## Caveats
+        ///
+        /// The event-buffer design in the custom-game-events RFC exists
+        /// precisely to avoid these, so reach for `emitSync` only when
+        /// the buffered path is provably wrong for the call site:
+        ///
+        /// - **Re-entrancy.** Handlers run mid-tick, inside whatever
+        ///   script or plugin called `emitSync`. A handler that itself
+        ///   mutates entity state, emits more events, or calls back
+        ///   into the caller's own code can interleave with partially-
+        ///   completed work on the stack above. Favour buffered `emit`
+        ///   unless the caller is a leaf operation.
+        ///
+        /// - **Ordering vs buffered events.** `emitSync` does NOT drain
+        ///   the end-of-frame buffer first. A hook fired synchronously
+        ///   mid-tick runs *before* all the events `emit` queued
+        ///   earlier in the same frame, even though those were queued
+        ///   first. Mixing the two on a single event kind produces
+        ///   out-of-order handler calls — usually not what you want.
+        pub fn emitSync(self: *Game, event: GameEvents) void {
+            // Skip the switch + @unionInit payload construction when
+            // the game has no hooks to dispatch to — same comptime
+            // shortcut `emitHook` relies on. Folds the entire call
+            // away in zero-hook builds.
+            if (!has_events or !has_hooks) return;
+            switch (event) {
+                inline else => |data, tag| {
+                    emitHook(self, @unionInit(Payload, @tagName(tag), data));
+                },
+            }
+        }
+
+        /// Deliver buffered game events to hooks. Called at end of frame.
+        pub fn dispatchEvents(self: *Game) void {
+            if (!has_events) return;
+            var dispatch_buf: EventBuffer = .empty;
+            std.mem.swap(EventBuffer, &self.event_buffer, &dispatch_buf);
+
+            for (dispatch_buf.items) |event| {
+                switch (event) {
+                    inline else => |data, tag| {
+                        emitHook(self, @unionInit(Payload, @tagName(tag), data));
+                    },
+                }
+            }
+            dispatch_buf.clearRetainingCapacity();
+
+            if (self.event_buffer.items.len == 0) {
+                std.mem.swap(EventBuffer, &self.event_buffer, &dispatch_buf);
+            }
+            dispatch_buf.deinit(self.allocator);
+        }
+    };
+}

--- a/src/game/input_events_mixin.zig
+++ b/src/game/input_events_mixin.zig
@@ -1,0 +1,278 @@
+/// Input-events mixin — the per-tick input edge scanning that turns
+/// keyboard / mouse / gamepad state into buffered engine events
+/// (labelle-gui#208, core#18), the `ControllerManager` drain + auto-pause
+/// policy (#611), and the game-facing controller assignment/query API.
+///
+/// Extracted verbatim from `game.zig`; behaviour is identical. The comptime
+/// gate consts (`keyboard_events_wanted`, … `backend_polls_gamepads`) and
+/// `ControllerManagerType` stay defined on `Game` — they're shared with the
+/// struct's field declarations and `init`/`deinit` — and are read here via
+/// `Game.<gate>` so there is a single comptime source of truth (no risk of
+/// the mixin computing a divergent value).
+const std = @import("std");
+const core = @import("labelle-core");
+const input_types = @import("../input_types.zig");
+const controller_manager_mod = @import("../controller_manager.zig");
+
+/// Fixed scratch capacity for draining gamepad hotplug events per tick
+/// (core#18). Mirrors `game.zig`'s `gamepad_drain_capacity`.
+const gamepad_drain_capacity = 16;
+
+/// Returns the input-events mixin for a given Game type.
+pub fn Mixin(comptime Game: type) type {
+    const keyboard_events_wanted = Game.keyboard_events_wanted;
+    const mouse_events_wanted = Game.mouse_events_wanted;
+    const gamepad_events_wanted = Game.gamepad_events_wanted;
+    const controller_events_wanted = Game.controller_events_wanted;
+    const backend_polls_gamepads = Game.backend_polls_gamepads;
+    const engineEventWanted = Game.engineEventWanted;
+    const ControllerManagerType = Game.ControllerManagerType;
+
+    return struct {
+        // ── ControllerManager game-facing API (#611) ─────────────────
+        //
+        // Thin forwarders over the embedded `controller_manager` so game
+        // scripts and plugins reach the assignment/query API without poking
+        // the field directly. Available only when the project's
+        // `GameEvents` carries a player-level controller variant — calling
+        // any of these in a game that doesn't is a compile error (the
+        // manager field is `void`), which is the intended guard rail.
+
+        /// Mutable handle to the embedded `ControllerManager`. Use for the
+        /// full API (iteration, `availableControllers`, opt-in helpers like
+        /// `autoBindFreeSlots` / `joinOnButton`). Requires a controller
+        /// event in `GameEvents`.
+        pub fn controllerManager(self: *Game) *ControllerManagerType {
+            comptime if (!controller_events_wanted)
+                @compileError("controllerManager() requires a player-level controller event " ++
+                    "(engine.player_joined / controller_available / ...) in GameEvents");
+            return &self.controller_manager;
+        }
+
+        /// Assign an unassigned `controller` to `player`. Emits
+        /// `player_joined` on the next `dispatchEvents`. Errors if the
+        /// player id is out of range or the controller isn't in the pool.
+        pub fn assignController(self: *Game, controller: u32, player: u32) !void {
+            comptime if (!controller_events_wanted)
+                @compileError("assignController() requires a player-level controller event in GameEvents");
+            try self.controller_manager.assign(controller, player);
+            drainControllerManagerEvents(self);
+        }
+
+        /// Release a player's controller binding, returning the controller
+        /// (if still present) to the unassigned pool.
+        pub fn unassignPlayer(self: *Game, player: u32) void {
+            comptime if (!controller_events_wanted)
+                @compileError("unassignPlayer() requires a player-level controller event in GameEvents");
+            self.controller_manager.unassign(player);
+            drainControllerManagerEvents(self);
+        }
+
+        /// The player a controller is bound to, or `NO_PLAYER`.
+        pub fn playerForController(self: *Game, controller: u32) u32 {
+            comptime if (!controller_events_wanted)
+                @compileError("playerForController() requires a player-level controller event in GameEvents");
+            return self.controller_manager.playerFor(controller);
+        }
+
+        /// The controller currently backing a player, or `NO_CONTROLLER`.
+        pub fn controllerForPlayer(self: *Game, player: u32) u32 {
+            comptime if (!controller_events_wanted)
+                @compileError("controllerForPlayer() requires a player-level controller event in GameEvents");
+            return self.controller_manager.controllerFor(player);
+        }
+
+        /// Toggle the opt-in auto-pause policy (#465 precedent): when on, a
+        /// real `player_controller_lost` drives `setPaused(true)`, and the
+        /// game resumes once every player is whole again. OFF by default —
+        /// the engine never forces a pause.
+        pub fn setAutoPauseOnControllerLost(self: *Game, enabled: bool) void {
+            self.auto_pause_on_controller_lost = enabled;
+        }
+
+        // ── Input events (labelle-gui#208) ───────────────────────
+
+        /// Scan the unified `InputInterface` for input edges and emit
+        /// the matching engine events into the buffer. Every query goes
+        /// through `Game.Input` (the backend-agnostic wrapper) — never a
+        /// backend's native API — which is what keeps this portable
+        /// across raylib / sokol / SDL. Called from `tick` while input
+        /// state is still current; buffered events drain via
+        /// `dispatchEvents` the same frame.
+        pub fn scanInputEvents(self: *Game) void {
+            // Each category's emit calls are gated at comptime (so an
+            // unused one folds away), but the per-element scans are plain
+            // RUNTIME `for`s over the comptime enum-value slices — NOT
+            // `inline for`. Unrolling ~114 keys would inline
+            // `emitEngineEvent` (itself an `inline for` over payload
+            // fields) once per key, bloating the binary and needing a big
+            // `@setEvalBranchQuota`; a runtime loop has one call site per
+            // category (gemini #606).
+
+            // ── Keyboard ──
+            if (comptime keyboard_events_wanted) {
+                const pressed_wanted = comptime engineEventWanted("engine__key_pressed");
+                const released_wanted = comptime engineEventWanted("engine__key_released");
+                for (std.enums.values(input_types.KeyboardKey)) |k| {
+                    if (k == .key_null) continue; // sentinel, not a real key
+                    const code: u32 = @intCast(@intFromEnum(k));
+                    if (pressed_wanted and Game.Input.isKeyPressed(code))
+                        self.emitEngineEvent("engine__key_pressed", .{ .key = code });
+                    if (released_wanted and Game.Input.isKeyReleased(code))
+                        self.emitEngineEvent("engine__key_released", .{ .key = code });
+                }
+            }
+
+            // ── Mouse buttons ──
+            if (comptime mouse_events_wanted) {
+                const pressed_wanted = comptime engineEventWanted("engine__mouse_button_pressed");
+                const released_wanted = comptime engineEventWanted("engine__mouse_button_released");
+                for (std.enums.values(input_types.MouseButton)) |b| {
+                    const code: u32 = @intCast(@intFromEnum(b));
+                    if (pressed_wanted and Game.Input.isMouseButtonPressed(code))
+                        self.emitEngineEvent("engine__mouse_button_pressed", .{
+                            .button = code,
+                            .x = Game.Input.getMouseX(),
+                            .y = Game.Input.getMouseY(),
+                        });
+                    if (released_wanted and Game.Input.isMouseButtonReleased(code))
+                        self.emitEngineEvent("engine__mouse_button_released", .{
+                            .button = code,
+                            .x = Game.Input.getMouseX(),
+                            .y = Game.Input.getMouseY(),
+                        });
+                }
+            }
+        }
+
+        /// Drain gamepad hotplug events (core#18) and the
+        /// `ControllerManager` (#611). Split OUT of `scanInputEvents`
+        /// because it MUST run every frame, INCLUDING while paused: when
+        /// the opt-in auto-pause gates the game on a lost controller, the
+        /// reconnect that lifts the pause arrives as a gamepad event — if we
+        /// only scanned in the active-frame body (past the pause gate) the
+        /// game would deadlock paused forever. Keyboard/mouse scanning stays
+        /// gameplay-only in `scanInputEvents`.
+        pub fn scanGamepadEvents(self: *Game) void {
+            // ── Gamepad connect / disconnect (drained queue, core#18) ──
+            //
+            // Drain hotplug events from a single source — picked at
+            // comptime by `backend_polls_gamepads` so the backend and the
+            // per-OS `gamepad_source` never both run — and emit one engine
+            // event per drained `GamepadEvent`. No fixed 4-slot cap and no
+            // engine-side prev-state diff: edge detection now belongs to
+            // the source. The whole block folds away when no flow listens
+            // (the `comptime gamepad_events_wanted` gate), so it stays
+            // zero-cost — and on the fallback path that also means
+            // `gamepad_source.pollEvents` is never called.
+            if (comptime gamepad_events_wanted) {
+                const conn_wanted = comptime engineEventWanted("engine__gamepad_connected");
+                const disc_wanted = comptime engineEventWanted("engine__gamepad_disconnected");
+
+                var buf: [gamepad_drain_capacity]core.gamepad.GamepadEvent = undefined;
+                const n = if (comptime backend_polls_gamepads)
+                    Game.Input.pollGamepadEvents(&buf)
+                else
+                    core.gamepad_source.pollEvents(&buf);
+
+                for (buf[0..n]) |ev| {
+                    switch (ev.kind) {
+                        .connected => if (conn_wanted) self.emitEngineEvent(
+                            "engine__gamepad_connected",
+                            .{
+                                .id = ev.slot,
+                                .name = ev.name,
+                                .name_len = ev.name_len,
+                                .guid = ev.guid,
+                                .source_class = ev.source_class,
+                                .type_hint = ev.type_hint,
+                            },
+                        ),
+                        .disconnected => if (disc_wanted) self.emitEngineEvent(
+                            "engine__gamepad_disconnected",
+                            .{ .id = ev.slot },
+                        ),
+                    }
+                    // The ControllerManager consumes the SAME drained
+                    // events (#611). Feed it here so a project listening to
+                    // a player-level event but NOT the raw `gamepad_*` pair
+                    // still drives the mapping layer.
+                    if (comptime controller_events_wanted) {
+                        switch (ev.kind) {
+                            .connected => self.controller_manager.onConnected(ev),
+                            .disconnected => self.controller_manager.onDisconnected(ev.slot),
+                        }
+                    }
+                }
+            }
+
+            // Advance the manager's debounce clock and drain its
+            // player-level output into engine events (#611). The clock is
+            // the pause-aware gameplay clock, so a debounce window measured
+            // in seconds holds correctly behind a pause menu. Runs after the
+            // feed above so a connect+expire within one tick is consistent.
+            if (comptime controller_events_wanted) {
+                self.controller_manager.advance(self.elapsedSeconds());
+                drainControllerManagerEvents(self);
+            }
+        }
+
+        /// Pull the `ControllerManager`'s pending player-level events and
+        /// re-emit each as the matching engine event, applying the opt-in
+        /// auto-pause policy (#611). Folds away unless a controller event is
+        /// wanted.
+        pub fn drainControllerManagerEvents(self: *Game) void {
+            if (comptime !controller_events_wanted) return;
+            var evbuf: [ControllerManagerType.event_capacity]controller_manager_mod.ManagerEvent = undefined;
+            const m = self.controller_manager.drainEvents(&evbuf);
+            for (evbuf[0..m]) |mev| {
+                switch (mev) {
+                    .controller_available => |c| self.emitEngineEvent("engine__controller_available", .{
+                        .controller_id = c.controller_id,
+                        .name = c.name,
+                        .name_len = c.name_len,
+                        .guid = c.guid,
+                        .source_class = c.source_class,
+                        .type_hint = c.type_hint,
+                    }),
+                    .controller_removed => |c| self.emitEngineEvent("engine__controller_removed", .{
+                        .controller_id = c.controller_id,
+                    }),
+                    .player_joined => |p| self.emitEngineEvent("engine__player_joined", .{
+                        .player = p.player,
+                        .controller_id = p.controller_id,
+                    }),
+                    .player_controller_lost => |p| {
+                        self.emitEngineEvent("engine__player_controller_lost", .{ .player = p.player });
+                        // Opt-in auto-pause (#465 precedent): a real loss
+                        // gates the game until the controller is back.
+                        if (self.auto_pause_on_controller_lost) self.setPaused(true);
+                    },
+                    .player_controller_restored => |p| {
+                        self.emitEngineEvent("engine__player_controller_restored", .{
+                            .player = p.player,
+                            .controller_id = p.controller_id,
+                        });
+                        // Resume only once NO player is still waiting — with
+                        // multiple lost pads we stay paused until the last
+                        // one reconnects.
+                        if (self.auto_pause_on_controller_lost and !anyPlayerWaiting(self)) {
+                            self.setPaused(false);
+                        }
+                    },
+                }
+            }
+        }
+
+        /// `true` when any active player's controller is currently absent
+        /// (debouncing or lost). Drives the auto-pause resume gate.
+        pub fn anyPlayerWaiting(self: *const Game) bool {
+            if (comptime !controller_events_wanted) return false;
+            var p: u32 = 0;
+            while (p < ControllerManagerType.capacity_players) : (p += 1) {
+                if (self.controller_manager.isPlayerWaiting(p)) return true;
+            }
+            return false;
+        }
+    };
+}

--- a/src/game/lifecycle_mixin.zig
+++ b/src/game/lifecycle_mixin.zig
@@ -1,0 +1,241 @@
+/// Lifecycle / runtime-control mixin — the small field-accessor clusters
+/// that drive the game loop's runtime knobs: quit flag, fullscreen
+/// request, engine-driven sprite-animation toggles, time scale, and the
+/// gameplay clock readout.
+///
+/// Extracted verbatim from `game.zig`; behaviour is identical. Each method
+/// just reads or writes a `Game` field — the actual platform effects
+/// (window fullscreen, animation advance) happen elsewhere, driven off
+/// these flags.
+
+const std = @import("std");
+const core = @import("labelle-core");
+
+/// Returns the lifecycle/runtime-control mixin for a given Game type.
+pub fn Mixin(comptime Game: type) type {
+    const has_events = Game.has_events_export;
+    const has_hooks = Game.has_hooks_export;
+    const HooksIsMerged = Game.HooksIsMergedExport;
+    const Hooks = Game.HooksParam;
+    const uses_os_gamepad_source = Game.uses_os_gamepad_source;
+
+    return struct {
+        // ── Teardown / hook wiring ────────────────────────────────
+
+        pub fn deinit(self: *Game) void {
+            self.emitHook(.{ .game_deinit = {} });
+            // Engine `Events` dual-emit (#578). Fires before the actual
+            // teardown so flow listeners that read game state from a
+            // `game_deinit` handler still see the live world. Folds
+            // away when `GameEvents` doesn't carry the variant.
+            self.emitEngineEvent("engine__game_deinit", .{});
+            // Drain the buffered event so a `game_deinit` listener
+            // actually receives it before the event-buffer arena tears
+            // down below. The normal frame loop does this at
+            // `dispatchEvents`; on shutdown there is no next frame.
+            if (has_events) self.dispatchEvents();
+            // `Game` owns the preview channel by value when set, so we
+            // release it here. The generated `main.zig` is expected to
+            // call `game.preview.?.sendBye(...)` before `game.deinit()`
+            // for a graceful shutdown; the socket close + arena tear-down
+            // happens here regardless.
+            if (self.preview) |*p| p.deinit();
+            // Tear down the per-OS gamepad source iff we initialized it
+            // (core#18). Symmetric with the `init` call above and gated by
+            // the same comptime flag.
+            if (comptime uses_os_gamepad_source) core.gamepad_source.deinit();
+            // Drop any timers still in flight (#25 Stage 2). A game can
+            // exit mid-Delay; this frees each entry's owned `ctx` and the
+            // pending list without firing — no leaks under testing.allocator.
+            self.scheduler.deinit();
+            // Tear down the active scene FIRST. Scene teardown runs
+            // user-provided `deinit_fn`s that may call `game.assets.*`
+            // (release on unload is the natural pattern for the very
+            // API this PR is exposing), so the catalog MUST still be
+            // alive through it. Worker-thread safety is handled inside
+            // `AssetCatalog.deinit` — it stops the worker and drains
+            // the result ring before touching the hashmap, and its
+            // allocator is the Game's allocator which stays live
+            // through this whole call.
+            if (has_events) self.event_buffer.deinit(self.allocator);
+            self.teardownActiveScene();
+            self.scene_entities.deinit(self.allocator);
+            self.assets.deinit();
+            if (self.current_scene_name) |name| {
+                self.allocator.free(name);
+            }
+            if (self.pending_scene_change) |name| {
+                self.allocator.free(name);
+            }
+            if (self.pending_scene_assets) |name| {
+                self.allocator.free(name);
+            }
+            if (self.owned_initial_state) |name| {
+                self.allocator.free(name);
+            }
+            // Clean up inactive worlds
+            var world_iter = self.worlds.iterator();
+            while (world_iter.next()) |entry| {
+                self.allocator.free(entry.key_ptr.*);
+                entry.value_ptr.*.deinit();
+                self.allocator.destroy(entry.value_ptr.*);
+            }
+            self.worlds.deinit();
+            if (self.active_world_name) |name| {
+                self.allocator.free(name);
+            }
+            // Clean up active world
+            self.active_world.deinit();
+            self.allocator.destroy(self.active_world);
+            self.gizmo_state.deinit(self.allocator);
+            self.scenes.deinit();
+            self.jsonc_scenes.deinit();
+            // Free duplicated keys; values are program-lifetime @embedFile
+            // borrows so they aren't owned by this map.
+            var emb_iter = self.embedded_scene_sources.iterator();
+            while (emb_iter.next()) |entry| self.allocator.free(entry.key_ptr.*);
+            self.embedded_scene_sources.deinit();
+            self.atlas_manager.deinit();
+        }
+
+        pub fn setHooks(self: *Game, receiver: Hooks) void {
+            // `self` is at its final, stable address by the time the game
+            // wires hooks (see generated main: `init` then `setHooks`), so
+            // pin the scheduler's type-erased game pointer here too — covers
+            // any `game.scheduler.after(...)` issued before the first tick.
+            self.bindScheduler();
+            if (has_hooks) {
+                if (HooksIsMerged) {
+                    self.hooks = receiver;
+                    // Inject game pointer into hook structs that declare game_ptr
+                    const merged = receiver.*;
+                    inline for (std.meta.fields(@TypeOf(merged.receivers))) |field| {
+                        const hook_ptr = @field(merged.receivers, field.name);
+                        const HookType = @typeInfo(@TypeOf(hook_ptr)).pointer.child;
+                        if (@hasField(HookType, "game_ptr")) {
+                            hook_ptr.game_ptr = @ptrCast(self);
+                        }
+                    }
+                } else {
+                    self.hooks = .{ .receiver = receiver };
+                    // Inject game pointer for single hook
+                    const HookType = @typeInfo(Hooks).pointer.child;
+                    if (@hasField(HookType, "game_ptr")) {
+                        receiver.game_ptr = @ptrCast(self);
+                    }
+                }
+                self.emitHook(.{ .game_init = .{ .allocator = self.allocator } });
+                // Engine `Events` dual-emit (#578). `engine.game_init`
+                // is empty by design — the on-disk Event-node form
+                // doesn't carry `Allocator`. Listeners that need an
+                // allocator should reach `game.allocator` directly.
+                self.emitEngineEvent("engine__game_init", .{});
+            }
+        }
+
+        // ── Game Loop ─────────────────────────────────────────────
+
+        pub fn quit(self: *Game) void {
+            self.running = false;
+        }
+
+        pub fn isRunning(self: *const Game) bool {
+            return self.running;
+        }
+
+        // ── Fullscreen ──
+        //
+        // The engine owns the *desired* fullscreen flag; the actual
+        // platform window call (sokol `sapp.toggleFullscreen`, raylib
+        // `ToggleFullscreen`, …) lives in the generated `main.zig` frame
+        // loop, which polls `takeFullscreenRequest()` and forwards the
+        // value to `window.setFullscreen`. Keeping the call out of the
+        // library is what lets the engine stay backend-agnostic — the
+        // same reason `quit()` only flips `running` and lets the frame
+        // loop call `window.requestQuit()`.
+
+        /// Request a fullscreen / windowed switch. No-op if already in the
+        /// requested mode. Takes effect on the next frame, when the
+        /// generated main drains `takeFullscreenRequest()`.
+        pub fn setFullscreen(self: *Game, on: bool) void {
+            if (self.fullscreen == on) return;
+            self.fullscreen = on;
+            self.fullscreen_dirty = true;
+        }
+
+        /// Flip between fullscreen and windowed.
+        pub fn toggleFullscreen(self: *Game) void {
+            setFullscreen(self, !self.fullscreen);
+        }
+
+        /// The engine's desired fullscreen state. This is the value a
+        /// settings UI should bind a checkbox to — it reflects the latest
+        /// `setFullscreen`/`toggleFullscreen` call, not a backend query.
+        pub fn isFullscreen(self: *const Game) bool {
+            return self.fullscreen;
+        }
+
+        /// Frame-loop drain (generated main only): returns the new
+        /// fullscreen value exactly once after it changes, else `null`.
+        /// The caller forwards a non-null result to the window backend.
+        pub fn takeFullscreenRequest(self: *Game) ?bool {
+            if (!self.fullscreen_dirty) return null;
+            self.fullscreen_dirty = false;
+            return self.fullscreen;
+        }
+
+        // ── Engine-driven sprite animation ──
+        //
+        // Opt-in: instead of the game shipping a `sprite_animation_tick`
+        // script that calls `spriteAnimationTick(game, dt)`, the engine
+        // can advance every `SpriteAnimation` itself in `tick()` on the
+        // time-scaled clock (see the always-run block). A game enables it
+        // once at startup and deletes its script; a pause menu freezes
+        // sprite cycling via `setSpriteAnimationsPaused` without having to
+        // gate a per-frame script.
+
+        /// Turn engine-driven sprite-animation advancement on/off. When on,
+        /// the game must NOT also run a `sprite_animation_tick` script, or
+        /// animations advance twice per frame.
+        pub fn setDriveSpriteAnimations(self: *Game, on: bool) void {
+            self.drive_sprite_animations = on;
+        }
+
+        /// Freeze (`true`) or resume (`false`) the engine-driven sprite
+        /// animation advance. No-op unless `drive_sprite_animations` is on.
+        pub fn setSpriteAnimationsPaused(self: *Game, paused: bool) void {
+            self.sprite_animations_paused = paused;
+        }
+
+        /// Whether engine-driven sprite animation is currently frozen.
+        pub fn spriteAnimationsPaused(self: *const Game) bool {
+            return self.sprite_animations_paused;
+        }
+
+        // ── Time scale ──
+
+        pub fn setTimeScale(self: *Game, scale: f32) void {
+            self.time_scale = @max(0, scale);
+        }
+
+        pub fn getTimeScale(self: *const Game) f32 {
+            return self.time_scale;
+        }
+
+        pub fn pause(self: *Game) void {
+            self.time_scale = 0;
+            self.setPaused(true);
+        }
+
+        pub fn resume_(self: *Game) void {
+            self.time_scale = 1.0;
+            self.setPaused(false);
+        }
+
+        /// Seconds of gameplay time elapsed (time-scaled, pause-aware) —
+        /// the clock flow `Cooldown`/`Delay` nodes (#25) measure against.
+        pub fn elapsedSeconds(self: *const Game) f64 {
+            return self.clock_s;
+        }
+    };
+}

--- a/src/game/loop_mixin.zig
+++ b/src/game/loop_mixin.zig
@@ -1,0 +1,177 @@
+/// Loop mixin — the per-frame `tick` (clock, scheduler, asset pump,
+/// always-run sync block, pause gate, scene/state/hot-reload transitions,
+/// lifecycle hooks) and `render`.
+///
+/// Extracted verbatim from `game.zig`; behaviour is identical. The atlas
+/// sprite resolve and input-event scans are reached through their own
+/// mixins (`AtlasMixin` / `InputEventsMixin`) instantiated against the same
+/// `Game`, matching how `game.zig` invoked them.
+const atlas_mixin = @import("atlas_mixin.zig");
+const input_events_mixin = @import("input_events_mixin.zig");
+
+/// Returns the per-frame loop mixin for a given Game type.
+pub fn Mixin(comptime Game: type) type {
+    const Audio = Game.Audio;
+    const Input = Game.Input;
+    const EcsImpl = Game.EcsBackend;
+    const AtlasMixin = atlas_mixin.Mixin(Game);
+    const InputEventsMixin = input_events_mixin.Mixin(Game);
+
+    return struct {
+        pub fn tick(self: *Game, dt: f32) void {
+            const scaled_dt = dt * self.time_scale;
+            // Freeze the gameplay clock under EITHER pause path — the
+            // `paused` flag (#465) doesn't zero `time_scale`, so guarding
+            // on `isPaused()` (paused OR time_scale==0) is what makes a
+            // Cooldown/Delay hold behind a pause menu (bugbot/gemini #603).
+            if (!self.isPaused()) self.clock_s += @as(f64, scaled_dt);
+
+            // Fire any flow `Delay` timers that have come due (#25 Stage 2).
+            // Run this every tick AFTER the clock update. `bindScheduler`
+            // keeps the type-erased `game_ctx` pointed at our stable address
+            // (idempotent). When paused, `elapsedSeconds()` is frozen, so no
+            // timer is ever due — pause-freeze falls out of the clock reuse
+            // for free, with no separate accumulator. A firing callback may
+            // re-entrantly `after()`; the scheduler iterates defensively.
+            self.bindScheduler();
+            self.scheduler.tick();
+
+            // Drain any worker-decoded asset uploads onto the GPU.
+            // Without this no acquired asset ever reaches `.ready`,
+            // and the Phase 2 setScene gate (#458) spins forever in
+            // its `not_ready` branch. Pump runs every frame even
+            // when paused so loading screens keep filling the bar
+            // through pause states.
+            self.assets.pump();
+
+            // Wire late-uploaded atlases into atlas_manager (#508). The
+            // setScene-time bridge is a no-op for any asset that wasn't
+            // .ready yet (eager-fallback path completes setScene before
+            // assets reach .ready). Without this per-tick walk those
+            // atlases keep texture_id=0, every sprite samples from
+            // texture 0, and rendering looks wrong. Idempotent — already-
+            // bridged atlases are silently skipped.
+            self.bridgeAllReadyImageAssets();
+
+            // Always run: logging, audio, input, renderer sync, gizmo reconciliation.
+            // These must run even when paused so the game remains responsive.
+            self.log.update(dt);
+            Audio.update();
+            Input.updateGestures(dt);
+            // Engine-driven sprite animation (opt-in via
+            // `drive_sprite_animations`). Advance every `SpriteAnimation`
+            // on the time-scaled dt BEFORE `resolveAtlasSprites` so the
+            // new frame's `sprite_name` is resolved to a `source_rect` the
+            // same frame. Frozen when `sprite_animations_paused` — that's
+            // how a pause menu stops sprite cycling without gating a
+            // per-frame game script. Lives in the always-run block (not the
+            // gameplay-skip section) so it advances on `scaled_dt`, which a
+            // `time_scale==0` hard pause already zeroes.
+            // `scaled_dt != 0` skips the ECS walk entirely when time is
+            // frozen (a `time_scale==0` hard pause, which still runs this
+            // always-run block) — no frame can advance on a zero dt anyway.
+            // Slow-mo keeps a tiny non-zero dt, so it still animates.
+            if (self.drive_sprite_animations and !self.sprite_animations_paused and scaled_dt != 0) {
+                @import("../sprite_animation_tick.zig").tick(self, scaled_dt);
+            }
+            AtlasMixin.resolveAtlasSprites(self);
+            self.renderer.sync(EcsImpl, self.ecs_backend);
+
+            // Gamepad hotplug + ControllerManager drain (core#18 / #611).
+            // Runs in the ALWAYS-RUN section, BEFORE the pause gate below,
+            // so a controller reconnect that should lift an opt-in
+            // auto-pause is still seen while the game is paused. Folds away
+            // entirely when no gamepad/controller event is wanted.
+            InputEventsMixin.scanGamepadEvents(self);
+
+            // Reconcile gizmos for runtime-created entities
+            if (self.gizmo_reconcile_fn) |reconcile_fn| {
+                reconcile_fn(self);
+            }
+
+            // State changes must process even when paused (e.g. pause → menu).
+            // Clear pending BEFORE setState so hooks can re-queue without being overwritten.
+            if (self.pending_state_change) |new_state| {
+                self.pending_state_change = null;
+                self.setState(new_state);
+            }
+
+            // Scene changes must process even when paused (e.g. pause menu → new scene)
+            if (self.pending_scene_change) |next_scene| {
+                const atomic = self.pending_scene_atomic;
+                defer {
+                    self.allocator.free(next_scene);
+                    self.pending_scene_change = null;
+                    self.pending_scene_atomic = false;
+                }
+                if (atomic) {
+                    self.setSceneAtomic(next_scene) catch {};
+                } else {
+                    self.setScene(next_scene) catch {};
+                }
+            }
+
+            // Hot reload: re-trigger the current scene's loader
+            if (self.hot_reload_dirty) {
+                self.hot_reload_dirty = false;
+                if (self.current_scene_name) |name| {
+                    if (self.scenes.get(name)) |entry| {
+                        self.unloadCurrentScene();
+                        self.emitHook(.{ .scene_before_load = .{ .name = name, .allocator = self.allocator } });
+                        // Engine `Events` dual-emit (#578).
+                        self.emitEngineEvent("engine__scene_loading", .{ .name = name });
+                        entry.loader_fn(self) catch {};
+                        self.emitHook(.{ .scene_load = .{ .name = name } });
+                        // Engine `Events` dual-emit (#578).
+                        self.emitEngineEvent("engine__scene_loaded", .{ .name = name });
+                    }
+                }
+            }
+
+            // Paused: skip game logic but keep frame counter advancing.
+            // Gates on the unified `isPaused()` so an explicit
+            // `setPaused(true)` halts the tick even when time_scale is
+            // still 1.0 — not just the `scaled_dt == 0` variant below.
+            if (self.isPaused()) {
+                self.frame_number += 1;
+                return;
+            }
+
+            self.emitHook(.{ .frame_start = .{ .frame_number = self.frame_number, .dt = scaled_dt } });
+            // Engine `Events` dual-emit (#578) — fires every active
+            // frame at the top of the tick. Folds away in unit-test
+            // games (`GameEvents = void`).
+            self.emitEngineEvent("engine__tick", .{ .frame_number = self.frame_number, .dt = scaled_dt });
+
+            if (self.active_scene_ptr) |scene_ptr| {
+                if (self.active_scene_update_fn) |update_fn| {
+                    update_fn(scene_ptr, scaled_dt);
+                }
+            }
+
+            self.emitHook(.{ .frame_end = .{ .frame_number = self.frame_number, .dt = scaled_dt } });
+            // Engine `Events` dual-emit (#578).
+            self.emitEngineEvent("engine__post_tick", .{ .frame_number = self.frame_number, .dt = scaled_dt });
+
+            // Input events (labelle-gui#208). Scan the unified
+            // `InputInterface` and buffer matching engine events. Placed
+            // here, at the tail of the active-frame body, so the events
+            // land in `event_buffer` alongside this frame's lifecycle
+            // events and drain together on the next `dispatchEvents`
+            // (called by the generated main loop right after `tick`) —
+            // i.e. they dispatch the SAME frame. Input state is current
+            // during `tick` (scripts already read it here). Each scan
+            // loop is comptime-gated, so an event-less game runs none of
+            // this.
+            InputEventsMixin.scanInputEvents(self);
+
+            self.frame_number += 1;
+        }
+
+        pub fn render(self: *Game) void {
+            self.renderer.render();
+            self.renderGizmos();
+            self.clearGizmos();
+        }
+    };
+}

--- a/src/game/misc_mixin.zig
+++ b/src/game/misc_mixin.zig
@@ -1,0 +1,90 @@
+/// Misc mixin — small leaf accessors and forwarders that don't belong to
+/// a larger cohesive cluster: design-coord conversion, embedded-scene /
+/// JSONC scene registration, hot-reload request, screen height, camera
+/// accessors, and the renderer / ECS / entity-count getters.
+///
+/// Extracted verbatim from `game.zig`; behaviour is identical. The camera
+/// gate (`has_camera`) and the `getCamera`/`getCameraManager` `pub const`
+/// shells stay on `Game` — they fold to `void` on cameraless renderers —
+/// and forward here for the impl bodies.
+
+/// Returns the misc-accessors mixin for a given Game type.
+pub fn Mixin(comptime Game: type) type {
+    const RenderImpl = @typeInfo(@FieldType(Game, "renderer")).pointer.child;
+    const EcsImpl = Game.EcsBackend;
+    const CameraType = Game.CameraType;
+    const CameraManagerType = Game.CameraManagerType;
+
+    return struct {
+        /// Convert a physical-pixel screen coordinate (raw touch / mouse
+        /// event coords from the backend) to a design-pixel coordinate
+        /// inside the pillarboxed/letterboxed canvas. Use this before
+        /// feeding touch / mouse coords to `cam.screenToWorld` so the
+        /// math lines up with the game's design coordinate system.
+        ///
+        /// Backends without a design/physical distinction (raylib) get
+        /// a passthrough — the input is returned unchanged.
+        pub fn screenToDesign(self: *Game, px: f32, py: f32) RenderImpl.ScreenPoint {
+            return self.renderer.screenToDesign(px, py);
+        }
+
+        /// Register an embedded JSONC scene source so `"include"`
+        /// directives can resolve against memory instead of disk.
+        /// Mirrors `addEmbeddedPrefab` — the assembler emits one call
+        /// per scene fragment in `main()` / `init()` so WASM and
+        /// Android builds (no project directory in cwd) can still
+        /// resolve nested scene includes. `path` is the include-
+        /// relative path (e.g. `"scenes/obstacles.jsonc"`); `source`
+        /// is typically a comptime `@embedFile(...)` slice. Caller
+        /// retains no ownership — the map dupes the key and borrows
+        /// the source's program-lifetime slice.
+        pub fn addEmbeddedSceneSource(self: *Game, path: []const u8, source: []const u8) !void {
+            const gop = try self.embedded_scene_sources.getOrPut(path);
+            if (!gop.found_existing) {
+                gop.key_ptr.* = try self.allocator.dupe(u8, path);
+            }
+            gop.value_ptr.* = source;
+        }
+
+        /// Register a runtime JSONC scene by name.
+        /// The scene file is loaded from disk when setScene() is called.
+        pub fn registerJsoncScene(self: *Game, name: []const u8, scene_path: []const u8, prefab_dir: []const u8) void {
+            self.jsonc_scenes.put(name, .{
+                .scene_path = scene_path,
+                .prefab_dir = prefab_dir,
+            }) catch {};
+        }
+
+        /// Signal that the current scene should be reloaded on the next tick.
+        pub fn requestReload(self: *Game) void {
+            self.hot_reload_dirty = true;
+        }
+
+        /// Set the screen height on the active world's renderer.
+        pub fn setScreenHeight(self: *Game, height: f32) void {
+            self.renderer.setScreenHeight(height);
+        }
+
+        pub fn getCameraImpl(self: *Game) *CameraType {
+            return self.renderer.getCamera();
+        }
+
+        pub fn getCameraManagerImpl(self: *Game) *CameraManagerType {
+            return self.renderer.getCameraManager();
+        }
+
+        // ── Accessors ─────────────────────────────────────────────
+
+        pub fn getRenderer(self: *Game) *RenderImpl {
+            return self.renderer;
+        }
+
+        pub fn getEcsBackend(self: *Game) *EcsImpl {
+            return self.ecs_backend;
+        }
+
+        pub fn entityCount(self: *Game) usize {
+            return @intCast(self.ecs_backend.entityCount());
+        }
+    };
+}

--- a/src/game/scene_runtime_mixin.zig
+++ b/src/game/scene_runtime_mixin.zig
@@ -1,0 +1,121 @@
+/// Scene-runtime mixin — the engine-level pause flag (#465) and the
+/// active-scene runtime plumbing: unload-on-swap, the type-erased active
+/// scene registration, and the named-entity / add / clear forwarders.
+///
+/// Extracted verbatim from `game.zig`; behaviour is identical. `setPaused`
+/// and `unloadCurrentScene` reach `emitHook` / `emitEngineEvent` /
+/// `teardownActiveScene` / `destroyEntityOnly` through the `Game`
+/// re-exports.
+
+/// Returns the scene-runtime mixin for a given Game type.
+pub fn Mixin(comptime Game: type) type {
+    const Entity = Game.EntityType;
+    const has_events = Game.GameEvents != void;
+    const std = @import("std");
+
+    return struct {
+        // ── Pause flag (#465) ───────────────────────────────────────
+
+        /// Set the engine-level pause flag. Emits `pause_changed` when
+        /// the value transitions; idempotent if already at `paused`.
+        ///
+        /// Intended to be called from a game-side sync script that
+        /// mirrors a game-owned `GamePaused` component (or equivalent)
+        /// into the engine, so plugin-shipped scripts can gate via
+        /// `game.isPaused()` without importing game components.
+        pub fn setPaused(self: *Game, paused: bool) void {
+            if (self.paused == paused) return;
+            self.paused = paused;
+            self.emitHook(.{ .pause_changed = .{ .paused = paused } });
+            // Engine `Events` dual-emit (#578).
+            self.emitEngineEvent("engine__pause_changed", .{ .paused = paused });
+        }
+
+        /// Read the engine-level pause predicate. Returns true if
+        /// *either* the explicit `paused` flag is set OR `time_scale`
+        /// is zero — both are valid pause mechanisms and tick gating
+        /// should honour both uniformly.
+        ///
+        /// Plugin scripts should use this instead of reaching for a
+        /// game-side `GamePaused` component — the latter would couple
+        /// plugin code to the game's component types across module
+        /// boundaries.
+        pub fn isPaused(self: *const Game) bool {
+            return self.paused or self.time_scale == 0;
+        }
+
+        // ── Active scene runtime ──────────────────────────────────
+
+        pub fn unloadCurrentScene(self: *Game) void {
+            if (has_events) self.event_buffer.clearRetainingCapacity();
+            if (self.current_scene_name) |name| {
+                self.emitHook(.{ .scene_unload = .{ .name = name } });
+                // Engine `Events` dual-emit (#578).
+                self.emitEngineEvent("engine__scene_unloaded", .{ .name = name });
+                if (self.scenes.get(name)) |entry| {
+                    if (entry.hooks.onUnload) |onUnload| {
+                        onUnload(self);
+                    }
+                }
+            }
+            // Destroy every entity the outgoing scene's loader created.
+            // `destroyEntityOnly` skips the children-recursion so a parent
+            // destroy doesn't double-free an already-listed child, and it
+            // calls `untrackSceneEntity` which swap-removes from this same
+            // list — so we pop from the end instead of iterating by index
+            // (which would skip entries).
+            while (self.scene_entities.pop()) |entity| {
+                self.destroyEntityOnly(entity);
+            }
+
+            // Scene deinit destroys non-persistent entities (which untracks them
+            // from the renderer). Persistent entities remain in ECS + renderer.
+            self.teardownActiveScene();
+        }
+
+        /// Store a type-erased active scene. Called by sceneLoaderFn to hand
+        /// the heap-allocated Scene to the engine for lifecycle management.
+        pub fn setActiveScene(
+            self: *Game,
+            ptr: *anyopaque,
+            update_fn: *const fn (*anyopaque, f32) void,
+            deinit_fn: *const fn (*anyopaque, std.mem.Allocator) void,
+            get_entity_fn: ?*const fn (*anyopaque, []const u8) ?Entity,
+            add_entity_fn: ?*const fn (*anyopaque, Entity) void,
+            clear_entities_fn: ?*const fn (*anyopaque) void,
+        ) void {
+            self.teardownActiveScene();
+            self.active_scene_ptr = ptr;
+            self.active_scene_update_fn = update_fn;
+            self.active_scene_deinit_fn = deinit_fn;
+            self.active_scene_get_entity_fn = get_entity_fn;
+            self.active_scene_add_entity_fn = add_entity_fn;
+            self.active_scene_clear_entities_fn = clear_entities_fn;
+        }
+
+        /// Look up a named entity from the active scene.
+        pub fn getEntityByName(self: *const Game, name: []const u8) ?Entity {
+            if (self.active_scene_ptr) |ptr| {
+                if (self.active_scene_get_entity_fn) |get_fn| {
+                    return get_fn(ptr, name);
+                }
+            }
+            return null;
+        }
+
+        /// Register a runtime-created entity with the active scene.
+        pub fn addEntityToActiveScene(self: *Game, entity: Entity) void {
+            if (self.active_scene_ptr) |ptr| if (self.active_scene_add_entity_fn) |add_fn| {
+                add_fn(ptr, entity);
+            };
+        }
+
+        /// Remove all entities from the active scene's entity list.
+        /// Does NOT destroy ECS entities — caller handles that.
+        pub fn clearActiveSceneEntities(self: *Game) void {
+            if (self.active_scene_ptr) |ptr| if (self.active_scene_clear_entities_fn) |clear_fn| {
+                clear_fn(ptr);
+            };
+        }
+    };
+}

--- a/src/game/world_mixin.zig
+++ b/src/game/world_mixin.zig
@@ -1,0 +1,150 @@
+/// World mixin — multi-world management (create / destroy / swap /
+/// rename / query), the ECS-backend reset, and active-scene teardown.
+///
+/// Extracted verbatim from `game.zig`; behaviour is identical. A "world"
+/// bundles ECS, renderer, sprite cache, and arena (`Game.World`); the
+/// active world is the live one and inactive worlds are shelved in
+/// `game.worlds`.
+const std = @import("std");
+const builtin = @import("builtin");
+const atlas_mod = @import("../atlas.zig");
+const gizmo_draws_mod = @import("gizmo_draws.zig");
+
+/// Returns the world management mixin for a given Game type.
+pub fn Mixin(comptime Game: type) type {
+    const Entity = Game.EntityType;
+    const EcsImpl = Game.EcsBackend;
+    const World = Game.World;
+    const TombstoneEntry = Game.TombstoneEntry;
+    const tombstone_size = Game.tombstone_size;
+    const is_debug = builtin.mode == .Debug;
+
+    return struct {
+        /// Create a new named world. The world is inactive (stored in the map).
+        /// Returns error.WorldAlreadyExists if the name is taken.
+        pub fn createWorld(self: *Game, name: []const u8) !void {
+            if (self.worlds.contains(name)) return error.WorldAlreadyExists;
+            const duped = try self.allocator.dupe(u8, name);
+            errdefer self.allocator.free(duped);
+            const world = try self.allocator.create(World);
+            errdefer {
+                world.deinit();
+                self.allocator.destroy(world);
+            }
+            world.* = World.init(self.allocator);
+            try self.worlds.put(duped, world);
+        }
+
+        /// Destroy a named inactive world. Frees all its entities and visuals.
+        pub fn destroyWorld(self: *Game, name: []const u8) void {
+            if (self.worlds.fetchRemove(name)) |kv| {
+                kv.value.deinit();
+                self.allocator.destroy(kv.value);
+                self.allocator.free(kv.key);
+            }
+        }
+
+        /// Swap the active world. The named world becomes active; the current
+        /// active world is shelved into the map (if named) or destroyed (if unnamed).
+        /// Verifies the target exists BEFORE modifying any state.
+        pub fn setActiveWorld(self: *Game, name: []const u8) !void {
+            // Remove target first — guarantees a free slot for shelving the current world
+            const kv = self.worlds.fetchRemove(name) orelse return error.WorldNotFound;
+
+            // Shelve or destroy current active world
+            if (self.active_world_name) |current_name| {
+                // Named world — shelve into map (can't fail: we just freed a slot)
+                self.worlds.put(current_name, self.active_world) catch @panic("OOM shelving world");
+            } else {
+                // Unnamed default world — destroy it
+                self.active_world.deinit();
+                self.allocator.destroy(self.active_world);
+            }
+
+            // Activate the named world
+            self.active_world = kv.value;
+            self.ecs_backend = &kv.value.ecs_backend;
+            self.renderer = &kv.value.renderer;
+            self.active_world_name = kv.key;
+        }
+
+        /// Rename an inactive world in the map.
+        pub fn renameWorld(self: *Game, old_name: []const u8, new_name: []const u8) !void {
+            if (self.worlds.contains(new_name)) return error.WorldAlreadyExists;
+
+            // Dupe new name first (before removing) so failure is safe
+            const duped = try self.allocator.dupe(u8, new_name);
+            errdefer self.allocator.free(duped);
+
+            if (self.worlds.fetchRemove(old_name)) |kv| {
+                self.allocator.free(kv.key);
+                self.worlds.put(duped, kv.value) catch {
+                    // Restore old entry on failure
+                    const restored_key = self.allocator.dupe(u8, old_name) catch @panic("OOM restoring world");
+                    self.worlds.put(restored_key, kv.value) catch @panic("OOM restoring world");
+                    self.allocator.free(duped);
+                    return error.OutOfMemory;
+                };
+            } else {
+                self.allocator.free(duped);
+                return error.WorldNotFound;
+            }
+        }
+
+        /// Get a pointer to an inactive world.
+        pub fn getWorld(self: *Game, name: []const u8) ?*World {
+            return self.worlds.get(name);
+        }
+
+        /// Get the name of the active world (null if unnamed/default).
+        pub fn getActiveWorldName(self: *const Game) ?[]const u8 {
+            return self.active_world_name;
+        }
+
+        /// Check if a world exists in the inactive map.
+        pub fn worldExists(self: *const Game, name: []const u8) bool {
+            return self.worlds.contains(name);
+        }
+
+        pub fn resetEcsBackend(self: *Game) void {
+            // Tear down active world's fields (reverse of init order)
+            self.gizmo_state.deinit(self.allocator);
+            self.active_world.sprite_cache.deinit();
+            // Clear renderer entity tracking but keep GPU textures loaded.
+            // Textures are expensive to reload (embedded atlas data parsed at startup).
+            self.active_world.renderer.clear();
+            self.active_world.ecs_backend.deinit();
+            _ = self.active_world.nested_entity_arena.reset(.retain_capacity);
+
+            // Reinitialize ECS + sprite cache (but NOT renderer — textures preserved)
+            self.active_world.ecs_backend = EcsImpl.init(self.allocator);
+            self.active_world.sprite_cache = atlas_mod.SpriteCache.init(self.allocator);
+            self.gizmo_state = gizmo_draws_mod.GizmoState(Entity).init(self.allocator);
+            // Re-sync backward-compatible pointers
+            self.ecs_backend = &self.active_world.ecs_backend;
+            // Clear tombstones — old entity IDs are meaningless after ECS reset
+            if (comptime is_debug) {
+                self.tombstones = [_]?TombstoneEntry{null} ** tombstone_size;
+                self.tombstone_cursor = 0;
+            }
+        }
+
+        pub fn teardownActiveScene(self: *Game) void {
+            if (self.active_scene_ptr) |ptr| {
+                if (self.active_scene_deinit_fn) |deinit_fn| {
+                    deinit_fn(ptr, self.allocator);
+                }
+                self.active_scene_ptr = null;
+                self.active_scene_update_fn = null;
+                self.active_scene_deinit_fn = null;
+                self.active_scene_get_entity_fn = null;
+                self.active_scene_add_entity_fn = null;
+                self.active_scene_clear_entities_fn = null;
+
+                self.active_world.sprite_cache.clear();
+                // Free nested entity array allocations from the outgoing scene
+                _ = self.active_world.nested_entity_arena.reset(.retain_capacity);
+            }
+        }
+    };
+}


### PR DESCRIPTION
## What

Splits `src/game.zig` (was **2842 lines**) so no file exceeds 1000 lines, continuing the existing mixin pattern in `src/game/*.zig`. `game.zig` is now the struct skeleton (field declarations, nested types, `init`, comptime composition) at **968 lines**; cohesive method clusters moved into 10 new `src/game/*.zig` mixins, each following the established `pub fn Mixin(comptime Game: type) type` shape.

## New mixins

| File | Cluster | Lines |
|------|---------|-------|
| `atlas_mixin.zig` | texture/atlas loading + streaming-asset shims (image/audio/font), sprite lookup, `resolveAtlasSprites` | 346 |
| `entity_mixin.zig` | entity lifecycle, prefab spawn+tag, `collect*` helpers, tombstone guards, scene-entity tracking | 424 |
| `input_events_mixin.zig` | input edge scanning, `ControllerManager` drain + forwarders | 278 |
| `lifecycle_mixin.zig` | quit/fullscreen/sprite-anim/time-scale accessors + `deinit` + `setHooks` | 241 |
| `components_mixin.zig` | position/hierarchy + generic component access | 242 |
| `loop_mixin.zig` | per-frame `tick` + `render` | 177 |
| `events_mixin.zig` | `emitHook`/`emit`/`emitEngineEvent`/`emitSync`/`dispatchEvents` | 170 |
| `world_mixin.zig` | multi-world create/destroy/swap/rename, `resetEcsBackend`, `teardownActiveScene` | 150 |
| `scene_runtime_mixin.zig` | pause flag + active-scene runtime plumbing | 121 |
| `misc_mixin.zig` | leaf accessors (`screenToDesign`, camera, `getRenderer`, ...) | 90 |

`src/game.zig`: **968** lines. Every file (game.zig + all mixins) is < 1000.

## Behavior-preserving

- **No API or behavior change. No version bump. No test expectations touched.**
- Every originally-public decl remains reachable under the same name/signature — verified by diffing the `pub`-decl set before/after (0 removed).
- A small set of internal comptime flags/types was promoted from private `const` to `pub const` so mixins share a single comptime source of truth (`*_events_wanted`, `backend_polls_gamepads`, `uses_os_gamepad_source`, `engineEventWanted`, and the event-dispatch type/flag bridges `PayloadExport`/`EventBufferExport`/`has_events_export`/`has_hooks_export`/`HooksParam`/`HooksIsMergedExport`). These are purely additive — no existing decl changed.

## Verification

- Baseline `zig build test`: **28/28 passed** (confirmed before any change).
- Final `zig build` and `zig build test`: clean / **28/28 passed**, identical set.

Do not merge.