### PR TITLE
fix(scene): O(N) unload + clear scene_entities on resetEcsBackend (v1.53.1)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -149,6 +149,9 @@ pub fn build(b: *std.Build) void {
         // Runtime Scheduler for flow `Delay` nodes (#48 / #25 Stage 2).
         // Pause-aware timer wheel reusing the gameplay clock.
         "test/scheduler_test.zig",
+        // #630 — scene-teardown: O(N) `unloadCurrentScene` drain (guarded
+        // untrack) + `resetEcsBackend` clears `scene_entities`.
+        "test/scene_teardown_test.zig",
     };
 
     for (test_files) |test_file| {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xe8a81a8dc7f48c87,
     .name = .engine,
-    .version = "1.53.0",
+    .version = "1.53.1",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{

--- a/src/game.zig
+++ b/src/game.zig
@@ -312,13 +312,16 @@ pub fn GameConfig(
         /// for every entity they create.
         scene_entities: std.ArrayList(Entity) = .empty,
         /// Set for the duration of a full scene-entity drain
-        /// (`unloadCurrentScene`). While true, `untrackSceneEntity`
-        /// skips its O(N) swap-remove scan: the drain already owns the
-        /// list and removes each entry as it goes, so the per-entity
-        /// `destroyEntityOnly → untrackSceneEntity` self-scan would be
-        /// pure O(N²) waste (the entity is no longer in the list). See
-        /// `unloadCurrentScene` (#630).
-        tearing_down_scene: bool = false,
+        /// The entity currently being drained by `unloadCurrentScene`.
+        /// `untrackSceneEntity` skips its O(N) swap-remove scan ONLY for
+        /// this exact entity: the drain already `pop()`-ed it off the
+        /// list, so the per-entity `destroyEntityOnly → untrackSceneEntity`
+        /// self-scan would be pure O(N²) waste. A destroy-hook that
+        /// destroys a *different* tracked entity (a sibling) still untracks
+        /// it normally — so the drain won't pop an already-destroyed
+        /// sibling a second time (double-destroy). See `unloadCurrentScene`
+        /// (#630).
+        current_teardown_entity: ?Entity = null,
         current_scene_name: ?[]const u8 = null,
         pending_scene_change: ?[]const u8 = null,
         pending_scene_atomic: bool = false,

--- a/src/game.zig
+++ b/src/game.zig
@@ -311,6 +311,14 @@ pub fn GameConfig(
         /// into the incoming one. Loaders MUST call `trackSceneEntity`
         /// for every entity they create.
         scene_entities: std.ArrayList(Entity) = .empty,
+        /// Set for the duration of a full scene-entity drain
+        /// (`unloadCurrentScene`). While true, `untrackSceneEntity`
+        /// skips its O(N) swap-remove scan: the drain already owns the
+        /// list and removes each entry as it goes, so the per-entity
+        /// `destroyEntityOnly → untrackSceneEntity` self-scan would be
+        /// pure O(N²) waste (the entity is no longer in the list). See
+        /// `unloadCurrentScene` (#630).
+        tearing_down_scene: bool = false,
         current_scene_name: ?[]const u8 = null,
         pending_scene_change: ?[]const u8 = null,
         pending_scene_atomic: bool = false,

--- a/src/game/entity_mixin.zig
+++ b/src/game/entity_mixin.zig
@@ -420,7 +420,14 @@ pub fn Mixin(comptime Game: type) type {
         /// nothing — N destroys × O(N) = O(N²). Skipping it keeps the
         /// drain O(N) without changing which entities get destroyed (#630).
         pub fn untrackSceneEntity(self: *Game, entity: Entity) void {
-            if (self.tearing_down_scene) return;
+            // Skip the scan ONLY for the entity the drain is currently
+            // popping (already off the list — scanning is the O(N²) waste
+            // #630 fixes). Any OTHER tracked entity (e.g. a sibling
+            // destroyed by this one's `entity_destroyed` hook) must still
+            // untrack, or the drain would pop it again and double-destroy it.
+            if (self.current_teardown_entity) |cur| {
+                if (cur == entity) return;
+            }
             var i: usize = 0;
             while (i < self.scene_entities.items.len) : (i += 1) {
                 if (self.scene_entities.items[i] == entity) {

--- a/src/game/entity_mixin.zig
+++ b/src/game/entity_mixin.zig
@@ -411,7 +411,16 @@ pub fn Mixin(comptime Game: type) type {
         /// scene that churns through short-lived entities. O(N) scan +
         /// swap-remove — fine for scenes with hundreds of entities;
         /// revisit if a project pushes tens of thousands.
+        ///
+        /// During a full scene-entity drain (`unloadCurrentScene`) the
+        /// `tearing_down_scene` guard short-circuits the scan: that path
+        /// pops each entity off `scene_entities` itself before calling
+        /// `destroyEntityOnly`, so the entity is already gone from the
+        /// list and the scan would walk the whole remaining list finding
+        /// nothing — N destroys × O(N) = O(N²). Skipping it keeps the
+        /// drain O(N) without changing which entities get destroyed (#630).
         pub fn untrackSceneEntity(self: *Game, entity: Entity) void {
+            if (self.tearing_down_scene) return;
             var i: usize = 0;
             while (i < self.scene_entities.items.len) : (i += 1) {
                 if (self.scene_entities.items[i] == entity) {

--- a/src/game/scene_runtime_mixin.zig
+++ b/src/game/scene_runtime_mixin.zig
@@ -61,9 +61,19 @@ pub fn Mixin(comptime Game: type) type {
             // Destroy every entity the outgoing scene's loader created.
             // `destroyEntityOnly` skips the children-recursion so a parent
             // destroy doesn't double-free an already-listed child, and it
-            // calls `untrackSceneEntity` which swap-removes from this same
-            // list — so we pop from the end instead of iterating by index
-            // (which would skip entries).
+            // calls `untrackSceneEntity` which would swap-remove from this
+            // same list. We `pop()` each entry off the end ourselves, so
+            // the per-entity untrack has nothing left to find — its scan
+            // would walk the whole remaining list every call, making the
+            // drain O(N²). The `tearing_down_scene` guard makes that scan
+            // a no-op for the duration of the loop, so the drain is O(N).
+            // Behaviour is unchanged: every tracked entity is still popped
+            // and passed to `destroyEntityOnly` exactly once, so the
+            // `entity_destroyed` hooks fire identically — we only skip a
+            // redundant search that was guaranteed to find nothing. The
+            // `defer` restores the flag even if a hook panics. (#630)
+            self.tearing_down_scene = true;
+            defer self.tearing_down_scene = false;
             while (self.scene_entities.pop()) |entity| {
                 self.destroyEntityOnly(entity);
             }

--- a/src/game/scene_runtime_mixin.zig
+++ b/src/game/scene_runtime_mixin.zig
@@ -65,16 +65,19 @@ pub fn Mixin(comptime Game: type) type {
             // same list. We `pop()` each entry off the end ourselves, so
             // the per-entity untrack has nothing left to find — its scan
             // would walk the whole remaining list every call, making the
-            // drain O(N²). The `tearing_down_scene` guard makes that scan
-            // a no-op for the duration of the loop, so the drain is O(N).
-            // Behaviour is unchanged: every tracked entity is still popped
-            // and passed to `destroyEntityOnly` exactly once, so the
-            // `entity_destroyed` hooks fire identically — we only skip a
-            // redundant search that was guaranteed to find nothing. The
-            // `defer` restores the flag even if a hook panics. (#630)
-            self.tearing_down_scene = true;
-            defer self.tearing_down_scene = false;
+            // drain O(N²). Marking the entity currently being popped makes
+            // that scan a no-op for it (it's already off the list), so the
+            // drain is O(N). Behaviour is unchanged: every tracked entity is
+            // still popped and passed to `destroyEntityOnly` exactly once,
+            // so the `entity_destroyed` hooks fire identically — we only
+            // skip a redundant search guaranteed to find nothing. Crucially,
+            // a hook that destroys a DIFFERENT tracked entity still untracks
+            // it (only `current_teardown_entity` is skipped), so it isn't
+            // popped+destroyed twice. The `defer` clears the marker even if
+            // a hook panics. (#630)
+            defer self.current_teardown_entity = null;
             while (self.scene_entities.pop()) |entity| {
+                self.current_teardown_entity = entity;
                 self.destroyEntityOnly(entity);
             }
 

--- a/src/game/world_mixin.zig
+++ b/src/game/world_mixin.zig
@@ -127,6 +127,21 @@ pub fn Mixin(comptime Game: type) type {
                 self.tombstones = [_]?TombstoneEntry{null} ** tombstone_size;
                 self.tombstone_cursor = 0;
             }
+
+            // Drop the scene-entity tracking lists. The ECS was just
+            // wiped, so every ID those lists held is now a dangling
+            // handle. Today's callers (`setSceneAtomic`, `loadGameState`)
+            // already `clearRetainingCapacity()` these before calling us,
+            // so this is normally a no-op — but a *direct* `resetEcsBackend`
+            // would otherwise leave stale IDs that a later
+            // `unloadCurrentScene` would feed to `destroyEntityOnly` as
+            // invalid handles. Clearing here makes the reset
+            // self-consistent and idempotent w.r.t. the callers that
+            // already clear (clearing an empty list is fine). Mirrors the
+            // atomic path, which clears both the Game-level list and the
+            // active scene's own list. (#630)
+            self.scene_entities.clearRetainingCapacity();
+            self.clearActiveSceneEntities();
         }
 
         pub fn teardownActiveScene(self: *Game) void {

--- a/test/scene_teardown_test.zig
+++ b/test/scene_teardown_test.zig
@@ -1,11 +1,13 @@
 //! Tests for the scene-teardown fixes (labelle-engine#630):
 //!
 //!   1. `unloadCurrentScene` drains `scene_entities` in O(N), not
-//!      O(N²): the `tearing_down_scene` guard makes the per-entity
-//!      `untrackSceneEntity` swap-remove scan a no-op while the drain
-//!      pops each entity off the list itself. Behaviour is unchanged —
-//!      every tracked entity is still destroyed exactly once and the
-//!      `entity_destroyed` hook fires once per entity.
+//!      O(N²): `untrackSceneEntity` skips its swap-remove scan only for
+//!      the one entity currently being popped (`current_teardown_entity`),
+//!      while the drain pops each off the list itself. Behaviour is
+//!      unchanged — every tracked entity is still destroyed exactly once
+//!      and the hook fires once per entity — AND a hook that destroys a
+//!      *sibling* tracked entity still untracks it, so it is never
+//!      popped+destroyed twice.
 //!
 //!   2. `resetEcsBackend` clears `scene_entities` (and the active
 //!      scene's own list) so a *direct* call leaves no dangling IDs for
@@ -75,7 +77,7 @@ test "unloadCurrentScene destroys all tracked entities and empties scene_entitie
     // The tracking list is fully drained.
     try testing.expectEqual(@as(usize, 0), game.scene_entities.items.len);
     // The teardown guard is restored (not left stuck on).
-    try testing.expect(!game.tearing_down_scene);
+    try testing.expect(game.current_teardown_entity == null);
 
     // Every tracked entity fired its `entity_destroyed` hook EXACTLY once
     // — the O(N) fix must not drop or double-fire any destroy.
@@ -97,13 +99,13 @@ test "unloadCurrentScene on an empty scene is a no-op" {
 
     try testing.expectEqual(@as(usize, 0), game.scene_entities.items.len);
     try testing.expectEqual(@as(usize, 0), recorder.destroyed.items.len);
-    try testing.expect(!game.tearing_down_scene);
+    try testing.expect(game.current_teardown_entity == null);
 }
 
-// The `tearing_down_scene` guard must not leak into normal (non-drain)
+// The teardown marker must not leak into normal (non-drain)
 // `destroyEntityOnly` calls: a manual destroy still removes the entity
 // from `scene_entities` via the O(N) swap-remove path. This pins down
-// that the guard is scoped to the drain loop only.
+// that the skip is scoped to the drain loop only.
 test "manual destroyEntityOnly still untracks the entity (guard is drain-scoped)" {
     var recorder = DestroyRecorder{ .allocator = testing.allocator };
     defer recorder.deinit();
@@ -120,7 +122,7 @@ test "manual destroyEntityOnly still untracks the entity (guard is drain-scoped)
 
     // Outside a drain, the guard is false, so untrackSceneEntity runs its
     // scan and removes `a` from the list.
-    try testing.expect(!game.tearing_down_scene);
+    try testing.expect(game.current_teardown_entity == null);
     game.destroyEntityOnly(a);
     try testing.expectEqual(@as(usize, 1), game.scene_entities.items.len);
     try testing.expectEqual(@as(u32, b), game.scene_entities.items[0]);
@@ -131,6 +133,43 @@ test "manual destroyEntityOnly still untracks the entity (guard is drain-scoped)
     try testing.expectEqual(@as(usize, 0), game.scene_entities.items.len);
     try testing.expectEqual(@as(usize, 1), recorder.count(a));
     try testing.expectEqual(@as(usize, 1), recorder.count(b));
+}
+
+// The crux of the per-entity (not global) skip: during a drain, only the
+// entity currently being popped skips its untrack scan. A DIFFERENT tracked
+// entity — e.g. a sibling destroyed re-entrantly by the current entity's
+// `entity_destroyed` hook — must STILL untrack, or the drain would pop it a
+// second time and `destroyEntityOnly` it as an invalid handle (the bug a
+// global flag would reintroduce).
+test "untrackSceneEntity skips only the drained entity, not siblings" {
+    var recorder = DestroyRecorder{ .allocator = testing.allocator };
+    defer recorder.deinit();
+
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&recorder);
+
+    const a = game.createEntity();
+    const b = game.createEntity();
+    const c = game.createEntity();
+    game.trackSceneEntity(a);
+    game.trackSceneEntity(b);
+    game.trackSceneEntity(c);
+
+    // Simulate being mid-drain of `a` (what the drain loop sets).
+    game.current_teardown_entity = a;
+
+    // Untracking `a` is the wasteful self-scan the fix skips — `a` stays.
+    game.untrackSceneEntity(a);
+    try testing.expectEqual(@as(usize, 3), game.scene_entities.items.len);
+
+    // Untracking a sibling (`b`) MUST still remove it, so the drain won't
+    // pop+destroy it again.
+    game.untrackSceneEntity(b);
+    try testing.expectEqual(@as(usize, 2), game.scene_entities.items.len);
+    for (game.scene_entities.items) |e| try testing.expect(e != b);
+
+    game.current_teardown_entity = null;
 }
 
 // ── Issue 2: resetEcsBackend clears scene_entities ──────────────────────

--- a/test/scene_teardown_test.zig
+++ b/test/scene_teardown_test.zig
@@ -1,0 +1,169 @@
+//! Tests for the scene-teardown fixes (labelle-engine#630):
+//!
+//!   1. `unloadCurrentScene` drains `scene_entities` in O(N), not
+//!      O(N²): the `tearing_down_scene` guard makes the per-entity
+//!      `untrackSceneEntity` swap-remove scan a no-op while the drain
+//!      pops each entity off the list itself. Behaviour is unchanged —
+//!      every tracked entity is still destroyed exactly once and the
+//!      `entity_destroyed` hook fires once per entity.
+//!
+//!   2. `resetEcsBackend` clears `scene_entities` (and the active
+//!      scene's own list) so a *direct* call leaves no dangling IDs for
+//!      a later `unloadCurrentScene` to feed `destroyEntityOnly` as
+//!      invalid handles. Idempotent w.r.t. callers that already clear.
+//!
+//! Uses the in-tree `GameWith(Hooks)` (MockEcsBackend + StubRender), the
+//! same shape `pause_hook_test.zig` and `flows_game_api_test.zig` use.
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+
+const game_mod = engine.game_mod;
+
+// ── Hook recorder ───────────────────────────────────────────────────────
+//
+// Records each `entity_destroyed` payload so tests can assert the hook
+// fired exactly once per tracked entity (issue 1's behaviour-preservation
+// guarantee). The method name must match the hook variant tag —
+// mirrors `PauseRecorder` in `pause_hook_test.zig`.
+
+const DestroyRecorder = struct {
+    destroyed: std.ArrayListUnmanaged(u32) = .empty,
+    allocator: std.mem.Allocator,
+
+    pub fn entity_destroyed(self: *DestroyRecorder, info: anytype) void {
+        self.destroyed.append(self.allocator, @intCast(info.entity_id)) catch unreachable;
+    }
+
+    pub fn deinit(self: *DestroyRecorder) void {
+        self.destroyed.deinit(self.allocator);
+    }
+
+    fn count(self: *const DestroyRecorder, id: u32) usize {
+        var n: usize = 0;
+        for (self.destroyed.items) |d| {
+            if (d == id) n += 1;
+        }
+        return n;
+    }
+};
+
+const TestGame = game_mod.GameWith(*DestroyRecorder);
+
+// ── Issue 1: O(N) unload destroys every tracked entity exactly once ──────
+
+test "unloadCurrentScene destroys all tracked entities and empties scene_entities" {
+    var recorder = DestroyRecorder{ .allocator = testing.allocator };
+    defer recorder.deinit();
+
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&recorder);
+
+    // Track a batch of entities, exactly as a scene loader would.
+    var ids: [8]u32 = undefined;
+    for (&ids) |*slot| {
+        const e = game.createEntity();
+        game.trackSceneEntity(e);
+        slot.* = e;
+    }
+    try testing.expectEqual(@as(usize, 8), game.scene_entities.items.len);
+
+    game.unloadCurrentScene();
+
+    // The tracking list is fully drained.
+    try testing.expectEqual(@as(usize, 0), game.scene_entities.items.len);
+    // The teardown guard is restored (not left stuck on).
+    try testing.expect(!game.tearing_down_scene);
+
+    // Every tracked entity fired its `entity_destroyed` hook EXACTLY once
+    // — the O(N) fix must not drop or double-fire any destroy.
+    try testing.expectEqual(@as(usize, 8), recorder.destroyed.items.len);
+    for (ids) |id| {
+        try testing.expectEqual(@as(usize, 1), recorder.count(id));
+    }
+}
+
+test "unloadCurrentScene on an empty scene is a no-op" {
+    var recorder = DestroyRecorder{ .allocator = testing.allocator };
+    defer recorder.deinit();
+
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&recorder);
+
+    game.unloadCurrentScene();
+
+    try testing.expectEqual(@as(usize, 0), game.scene_entities.items.len);
+    try testing.expectEqual(@as(usize, 0), recorder.destroyed.items.len);
+    try testing.expect(!game.tearing_down_scene);
+}
+
+// The `tearing_down_scene` guard must not leak into normal (non-drain)
+// `destroyEntityOnly` calls: a manual destroy still removes the entity
+// from `scene_entities` via the O(N) swap-remove path. This pins down
+// that the guard is scoped to the drain loop only.
+test "manual destroyEntityOnly still untracks the entity (guard is drain-scoped)" {
+    var recorder = DestroyRecorder{ .allocator = testing.allocator };
+    defer recorder.deinit();
+
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&recorder);
+
+    const a = game.createEntity();
+    const b = game.createEntity();
+    game.trackSceneEntity(a);
+    game.trackSceneEntity(b);
+    try testing.expectEqual(@as(usize, 2), game.scene_entities.items.len);
+
+    // Outside a drain, the guard is false, so untrackSceneEntity runs its
+    // scan and removes `a` from the list.
+    try testing.expect(!game.tearing_down_scene);
+    game.destroyEntityOnly(a);
+    try testing.expectEqual(@as(usize, 1), game.scene_entities.items.len);
+    try testing.expectEqual(@as(u32, b), game.scene_entities.items[0]);
+
+    // A subsequent unload cleans up the remaining tracked entity without
+    // re-destroying `a` (it's already gone from the list).
+    game.unloadCurrentScene();
+    try testing.expectEqual(@as(usize, 0), game.scene_entities.items.len);
+    try testing.expectEqual(@as(usize, 1), recorder.count(a));
+    try testing.expectEqual(@as(usize, 1), recorder.count(b));
+}
+
+// ── Issue 2: resetEcsBackend clears scene_entities ──────────────────────
+
+test "resetEcsBackend clears scene_entities" {
+    var game = game_mod.Game.init(testing.allocator);
+    defer game.deinit();
+
+    // Track some entities, then wipe the ECS directly (no setSceneAtomic /
+    // loadGameState pre-clear). Before the fix, these stale IDs would
+    // survive and a later unload would destroy them as invalid handles.
+    for (0..5) |_| {
+        const e = game.createEntity();
+        game.trackSceneEntity(e);
+    }
+    try testing.expectEqual(@as(usize, 5), game.scene_entities.items.len);
+
+    game.resetEcsBackend();
+
+    try testing.expectEqual(@as(usize, 0), game.scene_entities.items.len);
+}
+
+test "resetEcsBackend is idempotent on an already-empty scene_entities" {
+    var game = game_mod.Game.init(testing.allocator);
+    defer game.deinit();
+
+    // Clearing an empty list (the existing setSceneAtomic / loadGameState
+    // ordering, which clears up front) must be harmless.
+    try testing.expectEqual(@as(usize, 0), game.scene_entities.items.len);
+    game.resetEcsBackend();
+    try testing.expectEqual(@as(usize, 0), game.scene_entities.items.len);
+
+    // And a second back-to-back reset is fine too.
+    game.resetEcsBackend();
+    try testing.expectEqual(@as(usize, 0), game.scene_entities.items.len);
+}


### PR DESCRIPTION
Fixes the two scene-teardown issues in #630.

## Issue 1 — O(N²) scene unload (faster, behaviour preserved)

`unloadCurrentScene` drains tracked entities with
`while (self.scene_entities.pop()) |e| self.destroyEntityOnly(e);`.
`destroyEntityOnly` calls `untrackSceneEntity`, which does an O(N)
swap-remove **scan** of `scene_entities` to find the entity — but the
entity was already removed by `pop()`, so that scan walked the whole
remaining list every call and found nothing. N destroys × O(N) scan =
**O(N²)** on every scene unload.

**Fix:** add a `tearing_down_scene` guard on `Game`, modelled on the
atomic path (`setSceneAtomic`), which already avoids this by clearing the
tracking lists up front so the per-entity untrack is a no-op. The drain
loop sets the flag (restored via `defer`, panic-safe), and
`untrackSceneEntity` early-returns while it's set.

**Behaviour is unchanged — just faster.** Every tracked entity is still
`pop()`-ed and passed to `destroyEntityOnly` exactly once, so the
`entity_destroyed` hooks (and the `engine__entity_destroyed` dual-emit)
fire identically and no entity is left un-destroyed. The only thing
skipped is a redundant scan that was guaranteed to find nothing. The
guard is scoped strictly to the drain loop, so manual `destroyEntityOnly`
calls outside an unload still untrack via the normal swap-remove path
(covered by a test).

## Issue 2 — `scene_entities` not cleared in `resetEcsBackend` (self-consistent)

`resetEcsBackend` wiped the ECS but did **not** clear `self.scene_entities`
(nor the active-scene entity list). Existing callers (`setSceneAtomic`,
`loadGameState`) clear these up front, so the bug was latent — but a
**direct** `resetEcsBackend` would leave stale, now-dangling IDs that a
later `unloadCurrentScene` would feed to `destroyEntityOnly` as invalid
handles.

**Fix:** `resetEcsBackend` now ends with
`self.scene_entities.clearRetainingCapacity()` and
`self.clearActiveSceneEntities()`, mirroring exactly what the atomic path
clears. Idempotent w.r.t. the callers that already clear up front
(clearing an empty list is a no-op).

## Tests

New `test/scene_teardown_test.zig` (wired into `build.zig`'s `test_files`,
using the in-tree `GameWith(Hooks)` like `pause_hook_test.zig`):

- `unloadCurrentScene` destroys all tracked entities, fires
  `entity_destroyed` **exactly once per entity**, empties `scene_entities`,
  and restores the `tearing_down_scene` guard.
- `unloadCurrentScene` on an empty scene is a no-op.
- The guard is drain-scoped: a manual `destroyEntityOnly` still untracks
  via the swap-remove path.
- `resetEcsBackend` clears `scene_entities` (the new behaviour).
- `resetEcsBackend` is idempotent on an already-empty list.

## Verify

- Baseline `zig build test`: 557/557 passed.
- After: 562/562 passed (+5 new tests), `zig build` clean.
- No public API changed; version bumped 1.53.0 → 1.53.1.

Refs #630