### PR TITLE
feat(assets): carry GPU-compressed blobs through the catalog decode→upload

### DIFF
--- a/src/assets/loader.zig
+++ b/src/assets/loader.zig
@@ -53,9 +53,11 @@ pub const Texture = u32;
 /// stubbed until those PRs ship.
 pub const DecodedPayload = union(LoaderKind) {
     image: struct {
-        pixels: []u8, // RGBA8, allocator-owned
+        pixels: []u8, // RGBA8, allocator-owned — OR a raw GPU-compressed
+        // (ASTC) blob when `compressed` is set (uploaded verbatim, no decode).
         width: u32,
         height: u32,
+        compressed: bool = false,
     },
     audio: struct {
         samples: []i16, // interleaved PCM, allocator-owned

--- a/src/assets/loaders/image.zig
+++ b/src/assets/loaders/image.zig
@@ -68,9 +68,16 @@ const Texture = loader.Texture;
 /// whatever `DecodedImage` shape labelle-gfx uses on its side of the
 /// dependency boundary without a nominal-type conflict.
 pub const DecodedImage = struct {
-    pixels: []u8, // RGBA8, allocator-owned
+    pixels: []u8, // RGBA8, allocator-owned — OR, when `compressed`, the raw
+    // GPU-compressed blob (e.g. ASTC) to upload verbatim, no CPU decode.
     width: u32,
     height: u32,
+    /// True when `pixels` holds a GPU-compressed blob (ASTC) rather than RGBA8.
+    /// The adapter's `upload` routes these to the backend's `uploadCompressed`
+    /// instead of `uploadTexture` (the worker-thread `decode` did no CPU work —
+    /// it just duped the blob and read dims from the header). Backends without
+    /// compressed support never set this, so the RGBA path is unchanged.
+    compressed: bool = false,
 };
 
 /// Runtime backend hook. The assembler fills this in at `Game.init`
@@ -135,6 +142,7 @@ fn decode(
         .pixels = decoded.pixels,
         .width = decoded.width,
         .height = decoded.height,
+        .compressed = decoded.compressed,
     } };
 }
 
@@ -156,6 +164,7 @@ fn upload(
         .pixels = image.pixels,
         .width = image.width,
         .height = image.height,
+        .compressed = image.compressed,
     });
 
     // Upload succeeded: the GPU has its own copy, so we can release

--- a/src/assets/loaders/image.zig
+++ b/src/assets/loaders/image.zig
@@ -230,6 +230,7 @@ const MockBackend = struct {
     var upload_fails: bool = false;
     var decode_width: u32 = 2;
     var decode_height: u32 = 2;
+    var decode_compressed: bool = false;
 
     fn reset() void {
         decode_calls = 0;
@@ -242,6 +243,7 @@ const MockBackend = struct {
         upload_fails = false;
         decode_width = 2;
         decode_height = 2;
+        decode_compressed = false;
     }
 
     fn decodeFn(
@@ -258,7 +260,7 @@ const MockBackend = struct {
         // Fill with a recognisable byte so the upload mock can assert
         // it was called with the same bytes the decode produced.
         @memset(pixels, 0xAB);
-        return .{ .pixels = pixels, .width = decode_width, .height = decode_height };
+        return .{ .pixels = pixels, .width = decode_width, .height = decode_height, .compressed = decode_compressed };
     }
 
     fn uploadFn(decoded: DecodedImage) anyerror!Texture {
@@ -335,6 +337,46 @@ test "image loader: mock backend decode→upload→free round-trip" {
     // `testing.allocator` would flag a leak of the pixel buffer here
     // if upload had failed to free it. It is a GPA under the hood,
     // so a double-free would also trip.
+}
+
+test "image loader: compressed decode→upload round-trip" {
+    MockBackend.reset();
+    MockBackend.decode_compressed = true;
+    setBackend(MockBackend.backend_value);
+    defer clearBackend();
+
+    // 1. decode produces a GPU-compressed blob — the `compressed` flag
+    //    must survive the marshal into the loader's DecodedPayload.image.
+    const payload = try decode("astc", "fake-astc-blob", null, testing.allocator);
+    try testing.expectEqual(@as(u32, 1), MockBackend.decode_calls);
+    try testing.expect(payload.image.compressed);
+
+    // 2. upload still succeeds and the backend observes the same flag,
+    //    confirming the compressed bit is threaded all the way through.
+    var entry: AssetEntry = .{
+        .state = .decoding,
+        .refcount = 1,
+        .loader = &vtable,
+        .loader_kind = .image,
+        .raw_bytes = "fake-astc-blob",
+        .file_type = "astc",
+        .decoded = payload,
+        .resource = null,
+        .params = null,
+        .last_error = null,
+    };
+    try upload(&entry, payload, testing.allocator);
+    try testing.expectEqual(@as(u32, 1), MockBackend.upload_calls);
+    try testing.expect(entry.resource != null);
+    try testing.expectEqual(@as(Texture, 1), entry.resource.?.image);
+    try testing.expect(MockBackend.last_uploaded != null);
+    try testing.expect(MockBackend.last_uploaded.?.compressed);
+
+    // 3. free releases the texture, and `testing.allocator` confirms the
+    //    compressed CPU blob was freed by the successful upload path.
+    free(&entry);
+    try testing.expectEqual(@as(u32, 1), MockBackend.unload_calls);
+    try testing.expectEqual(@as(?UploadedResource, null), entry.resource);
 }
 
 test "image loader: drop path frees pixels without touching GPU" {


### PR DESCRIPTION
## What

The async streaming asset catalog (engine#450) loads atlases via an injected `ImageBackend` that strictly splits worker-thread `decode` (CPU/stb) → main-thread `upload` (RGBA `uploadTexture`). This path **bypasses gfx's synchronous `loadTextureFromMemory` compressed seam**, so GPU-compressed (ASTC) blobs always fall through to `stb_image` and fail with `error.LoadFailed`.

This PR is the **engine half**: let `DecodedImage` carry a raw compressed blob from `decode` → `upload` so the adapter can route it to the backend's compressed-upload path.

## Changes

- Add `compressed: bool = false` to `DecodedImage` in `src/assets/loaders/image.zig`. When `true`, `pixels` holds the raw ASTC blob (not RGBA8) — the worker `decode` does no CPU work, it just dupes the blob and reads dims from the header.
- Add the same flag to the internal `DecodedPayload.image` struct in `src/assets/loader.zig`.
- Thread the flag through the loader's `decode` (return) and `upload` (the `b.upload(...)` call).

Default is `false`, so the RGBA path is completely unchanged.

## Scope / testing

The `ImageBackend` adapter is supplied by the assembler at codegen time (not in this repo), so this PR alone does **not** exercise the compressed branch end-to-end — that's expected. Paired **gfx** and **assembler** PRs complete the path.

- `zig build` — clean.
- `zig build test` — all pass, including the image-loader mock-backend `decode→upload→free` round-trip.

## Context

Part of the ASTC cold-start epic labelle-gfx#269. Found while validating ASTC on the real flying-platform-labelle game, where the menu atlas returned `error.LoadFailed` until this seam was threaded through.