### PR TITLE
feat: engine-owned vsync request API

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -76,6 +76,7 @@ pub fn build(b: *std.Build) void {
         "test/script_runner_test.zig",
         "test/game_log_test.zig",
         "test/fullscreen_api_test.zig",
+        "test/vsync_api_test.zig",
         "test/engine_sprite_anim_test.zig",
         "test/save_policy_test.zig",
         "test/save_load_mixin_test.zig",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xe8a81a8dc7f48c87,
     .name = .engine,
-    .version = "1.55.0",
+    .version = "1.56.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{

--- a/src/game.zig
+++ b/src/game.zig
@@ -382,6 +382,16 @@ pub fn GameConfig(
         /// `takeFullscreenRequest()` drain so the backend toggle fires
         /// exactly once per change instead of every frame.
         fullscreen_dirty: bool = false,
+        /// Desired vsync state, owned by the engine (same cooperative split
+        /// as `fullscreen`). Scripts flip it via `setVsync`/`toggleVsync`;
+        /// the generated frame loop drains `takeVsyncRequest()` and applies
+        /// the value to the window backend (`window.setVsync`). Defaults ON
+        /// to match every backend's prior hardcoded behaviour.
+        vsync: bool = true,
+        /// Set whenever `vsync` changes; cleared by the one-shot
+        /// `takeVsyncRequest()` drain so the backend swap-interval change
+        /// fires exactly once per change instead of every frame.
+        vsync_dirty: bool = false,
         /// Opt-in: when true the engine advances every `SpriteAnimation`
         /// component itself each tick (on the time-scaled dt), so a game
         /// no longer needs a `sprite_animation_tick` script of its own.
@@ -837,6 +847,10 @@ pub fn GameConfig(
         pub const toggleFullscreen = LifecycleMixin.toggleFullscreen;
         pub const isFullscreen = LifecycleMixin.isFullscreen;
         pub const takeFullscreenRequest = LifecycleMixin.takeFullscreenRequest;
+        pub const setVsync = LifecycleMixin.setVsync;
+        pub const toggleVsync = LifecycleMixin.toggleVsync;
+        pub const isVsync = LifecycleMixin.isVsync;
+        pub const takeVsyncRequest = LifecycleMixin.takeVsyncRequest;
         pub const setDriveSpriteAnimations = LifecycleMixin.setDriveSpriteAnimations;
         pub const setSpriteAnimationsPaused = LifecycleMixin.setSpriteAnimationsPaused;
         pub const spriteAnimationsPaused = LifecycleMixin.spriteAnimationsPaused;

--- a/src/game/lifecycle_mixin.zig
+++ b/src/game/lifecycle_mixin.zig
@@ -184,6 +184,45 @@ pub fn Mixin(comptime Game: type) type {
             return self.fullscreen;
         }
 
+        // ── Vsync ──
+        //
+        // Mirrors the Fullscreen split: the engine owns the *desired* vsync
+        // flag; the actual swap-interval change (bgfx `reset` with/without
+        // `BGFX_RESET_VSYNC`, sokol's per-platform swap-interval call, …)
+        // lives in the generated `main.zig` frame loop, which polls
+        // `takeVsyncRequest()` and forwards the value to `window.setVsync`.
+        // Defaults ON — every backend previously hardcoded vsync on.
+
+        /// Request a vsync on/off switch. No-op if already in the requested
+        /// mode. Takes effect on the next frame, when the generated main
+        /// drains `takeVsyncRequest()`.
+        pub fn setVsync(self: *Game, on: bool) void {
+            if (self.vsync == on) return;
+            self.vsync = on;
+            self.vsync_dirty = true;
+        }
+
+        /// Flip vsync on/off.
+        pub fn toggleVsync(self: *Game) void {
+            setVsync(self, !self.vsync);
+        }
+
+        /// The engine's desired vsync state. This is the value a settings UI
+        /// should bind a checkbox to — it reflects the latest
+        /// `setVsync`/`toggleVsync` call, not a backend query.
+        pub fn isVsync(self: *const Game) bool {
+            return self.vsync;
+        }
+
+        /// Frame-loop drain (generated main only): returns the new vsync
+        /// value exactly once after it changes, else `null`. The caller
+        /// forwards a non-null result to the window backend.
+        pub fn takeVsyncRequest(self: *Game) ?bool {
+            if (!self.vsync_dirty) return null;
+            self.vsync_dirty = false;
+            return self.vsync;
+        }
+
         // ── Engine-driven sprite animation ──
         //
         // Opt-in: instead of the game shipping a `sprite_animation_tick`

--- a/test/vsync_api_test.zig
+++ b/test/vsync_api_test.zig
@@ -1,0 +1,61 @@
+//! Tests for the engine-owned vsync request API on `Game`:
+//! `setVsync` / `toggleVsync` / `isVsync` / `takeVsyncRequest`.
+//!
+//! The engine holds only the *desired* vsync flag; the generated
+//! `main.zig` frame loop drains `takeVsyncRequest()` and forwards a
+//! non-null result to the window backend (`window.setVsync` in
+//! backends/{sokol,bgfx}/src/window.zig). That keeps the library
+//! backend-agnostic — same split as fullscreen.
+//!
+//! Note vsync defaults ON (every backend previously hardcoded vsync on),
+//! so the no-op / default expectations are the inverse of fullscreen's.
+
+const std = @import("std");
+const testing = std.testing;
+
+const engine = @import("engine");
+const Game = engine.Game;
+
+test "vsync: defaults to ON with no pending request" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    try testing.expect(game.isVsync());
+    try testing.expectEqual(@as(?bool, null), game.takeVsyncRequest());
+}
+
+test "vsync: setVsync flips state and queues a one-shot request" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    game.setVsync(false);
+    try testing.expect(!game.isVsync());
+
+    // The request drains exactly once — the backend swap-interval change
+    // must fire on the change, not every frame.
+    try testing.expectEqual(@as(?bool, false), game.takeVsyncRequest());
+    try testing.expectEqual(@as(?bool, null), game.takeVsyncRequest());
+}
+
+test "vsync: setting the current mode is a no-op (no request queued)" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    // Already on (default) → nothing to apply.
+    game.setVsync(true);
+    try testing.expectEqual(@as(?bool, null), game.takeVsyncRequest());
+}
+
+test "vsync: toggle alternates and each change drains once" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    game.toggleVsync(); // on -> off
+    try testing.expect(!game.isVsync());
+    try testing.expectEqual(@as(?bool, false), game.takeVsyncRequest());
+
+    game.toggleVsync(); // off -> on
+    try testing.expect(game.isVsync());
+    try testing.expectEqual(@as(?bool, true), game.takeVsyncRequest());
+    try testing.expectEqual(@as(?bool, null), game.takeVsyncRequest());
+}


### PR DESCRIPTION
Adds `setVsync`/`toggleVsync`/`isVsync`/`takeVsyncRequest` to `Game`, mirroring the fullscreen flag/drain split. The engine owns the desired vsync flag; the generated frame loop drains `takeVsyncRequest()` and forwards it to `window.setVsync`. Defaults ON (backends previously hardcoded vsync on).

Part of the vsync-toggle feature (paired: labelle-assembler#vsync, labelle-imgui#vsync, flying-platform Options UI).

- `src/game.zig`: `vsync`/`vsync_dirty` fields + mixin re-exports
- `src/game/lifecycle_mixin.zig`: the 4 methods
- `test/vsync_api_test.zig`: flag + one-shot-drain semantics (defaults ON)
- version → 1.56.0

564 engine tests pass incl. the new vsync test.