### PR TITLE
fix: queued scene change dropped when its assets aren't ready yet

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xe8a81a8dc7f48c87,
     .name = .engine,
-    .version = "1.56.0",
+    .version = "1.57.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{

--- a/src/game/loop_mixin.zig
+++ b/src/game/loop_mixin.zig
@@ -6,7 +6,6 @@
 /// sprite resolve and input-event scans are reached through their own
 /// mixins (`AtlasMixin` / `InputEventsMixin`) instantiated against the same
 /// `Game`, matching how `game.zig` invoked them.
-const std = @import("std");
 const atlas_mixin = @import("atlas_mixin.zig");
 const input_events_mixin = @import("input_events_mixin.zig");
 
@@ -113,19 +112,27 @@ pub fn Mixin(comptime Game: type) type {
                 // Consume the request only once the swap actually COMMITTED
                 // (or hard-errored). `setScene`/`setSceneAtomic` DEFER —
                 // returning without swapping — while the target scene's asset
-                // manifest is still loading; the asset gate runs BEFORE any
-                // teardown, so on a deferral `current_scene_name` is unchanged.
-                // Previously the request was cleared unconditionally, dropping
-                // the scene change forever (there is no separate retry path) —
-                // which left a menu→colony transition stuck on the menu
-                // rendering only the background (the target's atlases hadn't
-                // been acquired yet). Keep it pending across deferrals so a
-                // later frame — by which point the gate's acquire has driven
-                // the atlases to `.ready` — commits the swap.
-                const committed = if (self.current_scene_name) |cur|
-                    std.mem.eql(u8, cur, next_scene)
+                // manifest is still loading. Previously the request was cleared
+                // unconditionally, dropping the scene change forever (there is
+                // no separate retry path) — which left a menu→colony transition
+                // stuck on the menu rendering only the background (the target's
+                // atlases hadn't been acquired yet). Keep it pending across
+                // deferrals so a later frame — by which point the gate's
+                // acquire has driven the atlases to `.ready` — commits.
+                //
+                // Commit signal: `pending_scene_assets` is set when the gate
+                // defers (acquireBatch) and cleared only when the swap
+                // commits, so `== null` means committed. (Using
+                // `current_scene_name == target` would falsely read as
+                // committed when RELOADING the current scene and the reload
+                // defers — the name already matches. See review on #635.)
+                // A scene with no declared assets never gates, so it always
+                // commits in one shot.
+                const has_assets = if (self.scenes.get(next_scene)) |entry|
+                    entry.assets.len > 0
                 else
                     false;
+                const committed = !has_assets or self.pending_scene_assets == null;
                 if (failed or committed) {
                     self.allocator.free(next_scene);
                     self.pending_scene_change = null;

--- a/src/game/loop_mixin.zig
+++ b/src/game/loop_mixin.zig
@@ -6,6 +6,7 @@
 /// sprite resolve and input-event scans are reached through their own
 /// mixins (`AtlasMixin` / `InputEventsMixin`) instantiated against the same
 /// `Game`, matching how `game.zig` invoked them.
+const std = @import("std");
 const atlas_mixin = @import("atlas_mixin.zig");
 const input_events_mixin = @import("input_events_mixin.zig");
 
@@ -99,15 +100,36 @@ pub fn Mixin(comptime Game: type) type {
             // Scene changes must process even when paused (e.g. pause menu → new scene)
             if (self.pending_scene_change) |next_scene| {
                 const atomic = self.pending_scene_atomic;
-                defer {
+                var failed = false;
+                if (atomic) {
+                    self.setSceneAtomic(next_scene) catch {
+                        failed = true;
+                    };
+                } else {
+                    self.setScene(next_scene) catch {
+                        failed = true;
+                    };
+                }
+                // Consume the request only once the swap actually COMMITTED
+                // (or hard-errored). `setScene`/`setSceneAtomic` DEFER —
+                // returning without swapping — while the target scene's asset
+                // manifest is still loading; the asset gate runs BEFORE any
+                // teardown, so on a deferral `current_scene_name` is unchanged.
+                // Previously the request was cleared unconditionally, dropping
+                // the scene change forever (there is no separate retry path) —
+                // which left a menu→colony transition stuck on the menu
+                // rendering only the background (the target's atlases hadn't
+                // been acquired yet). Keep it pending across deferrals so a
+                // later frame — by which point the gate's acquire has driven
+                // the atlases to `.ready` — commits the swap.
+                const committed = if (self.current_scene_name) |cur|
+                    std.mem.eql(u8, cur, next_scene)
+                else
+                    false;
+                if (failed or committed) {
                     self.allocator.free(next_scene);
                     self.pending_scene_change = null;
                     self.pending_scene_atomic = false;
-                }
-                if (atomic) {
-                    self.setSceneAtomic(next_scene) catch {};
-                } else {
-                    self.setScene(next_scene) catch {};
                 }
             }
 


### PR DESCRIPTION
## Bug
The per-frame loop processed `pending_scene_change` once and cleared it **unconditionally** (a `defer`), even when `setScene`/`setSceneAtomic` **deferred** — returned without swapping because the target scene's asset manifest was still loading. With no separate retry path, the scene change was **dropped forever**.

This only manifests when transitioning to a scene whose atlases aren't already acquired — most visibly a **menu → colony New Game** in flying-platform: the menu only loads the `background` atlas, so `queueSceneChange("main")` hit the asset gate, deferred, and was dropped. The player stayed on the menu scene — no entities, only the background rendered — while the colony atlases quietly finished loading (`ready`, but `current_scene=menu`).

## Fix
`loop_mixin.zig`: consume the request only once the swap actually **committed** (`current_scene_name == target`) or hard-errored. The asset gate runs before any teardown, so a deferral leaves `current_scene_name` unchanged — keep the request pending so a later frame (atlases now `.ready`) commits it.

## Validation
End-to-end on flying-platform (bgfx): menu New Game went from `scene=menu` / **1 sprite** (background only) to `scene=main` / **129 sprites** fully rendered. Engine `zig build test` green (28/28).

version → 1.57.0.