### PR TITLE
fix: post-load render gate — no atlas-corruption flash on loadGameState (#637)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -113,6 +113,7 @@ pub fn build(b: *std.Build) void {
         "test/spawn_from_prefab_test.zig",
         "test/jsonc/bridge_prefab_tags_test.zig",
         "test/save_load_two_phase_test.zig",
+        "test/post_load_render_gate_test.zig",
         "test/example_prefab_animation_walkthrough_test.zig",
         "test/jsonc/bridge_deserialize_test.zig",
         "test/jsonc/deserializer_test.zig",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xe8a81a8dc7f48c87,
     .name = .engine,
-    .version = "1.57.0",
+    .version = "1.58.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{

--- a/src/game.zig
+++ b/src/game.zig
@@ -351,6 +351,49 @@ pub fn GameConfig(
         /// at startup.
         asset_failure_policy: AssetFailurePolicy = .fatal,
 
+        /// Post-load render gate (#637). `loadGameState` resets the ECS
+        /// and restores every saved entity *synchronously*, but the
+        /// atlases those sprites reference get re-registered through the
+        /// streaming catalog and re-decode/re-upload *asynchronously*
+        /// over the next 1–2 seconds. During that window the
+        /// re-registered atlases sit at `texture_id == 0` (the pending
+        /// sentinel `registerPendingAtlas` writes), so `findSprite`
+        /// returns 0 for them, `resolveAtlasSprites` stamps texture 0
+        /// onto the restored sprites, and the draw path
+        /// (`drawSpriteEntry`) — which has no entry for handle 0 —
+        /// renders them with a bogus/last-bound backend texture. The
+        /// visible result is the corruption flash the parent saw
+        /// (workers briefly wearing the cloud atlas, or an unbound
+        /// texture) until each atlas finishes re-binding via
+        /// `markPendingLoaded`.
+        ///
+        /// This is the load-path counterpart to the scene-change
+        /// readiness gate (`gateOnManifest` in `scene_mixin.zig`). When
+        /// set, `render()` suppresses the world draw so no restored
+        /// sprite is shown with an unbound atlas. It is cleared the
+        /// first tick on which every gated atlas has re-bound (see
+        /// `updatePostLoadRenderGate`). `null` means "no load gate
+        /// active" (the common steady-state — zero cost per frame).
+        ///
+        /// Holds the loaded scene's declared `assets:` manifest slice
+        /// (image entries are the ones we actually wait on; non-image
+        /// entries are skipped by the readiness check). This borrows the
+        /// program-lifetime slice off the `SceneEntry` — the same one
+        /// `setScene`/`gateOnManifest` use — so it never needs freeing;
+        /// scenes are registered once at startup and never unregistered
+        /// at runtime. `null` means no gate is active.
+        post_load_render_gate: ?[]const []const u8 = null,
+
+        /// Hard deadline (frame number) at which the post-load render
+        /// gate is force-cleared even if some atlas never reports bound.
+        /// Belt-and-suspenders so a missing/renamed atlas, a failed
+        /// decode under a `.warn`/`.silent` policy, or a backend that
+        /// reuses handle 0 can NEVER wedge the world render permanently
+        /// (a few frames of corruption is strictly better than a frozen
+        /// black world). Set when the gate is armed; ignored while the
+        /// gate is `null`.
+        post_load_render_gate_deadline: u64 = 0,
+
         // Active scene (type-erased) — managed by sceneLoaderFn / setActiveScene
         active_scene_ptr: ?*anyopaque = null,
         active_scene_update_fn: ?*const fn (*anyopaque, f32) void = null,
@@ -783,6 +826,8 @@ pub fn GameConfig(
         // ── Save/Load (mixin) ───────────────────────────────────────
         pub const saveGameState = SaveLoadMixin.saveGameState;
         pub const loadGameState = SaveLoadMixin.loadGameState;
+        pub const armPostLoadRenderGate = SaveLoadMixin.armPostLoadRenderGate;
+        pub const updatePostLoadRenderGate = SaveLoadMixin.updatePostLoadRenderGate;
 
         // ── Game State Machine (mixin) ──────────────────────────────
         pub const setState = StateMixin.setState;

--- a/src/game/loop_mixin.zig
+++ b/src/game/loop_mixin.zig
@@ -53,6 +53,14 @@ pub fn Mixin(comptime Game: type) type {
             // bridged atlases are silently skipped.
             self.bridgeAllReadyImageAssets();
 
+            // Post-load render gate (#637). Runs RIGHT AFTER the bridge
+            // so any atlas that re-bound this frame clears the gate the
+            // same frame — no extra hidden frame. No-op unless a recent
+            // `loadGameState` armed the gate. See `render` below for the
+            // suppression side, and the `post_load_render_gate` field doc
+            // for the full corruption-flash rationale.
+            self.updatePostLoadRenderGate();
+
             // Always run: logging, audio, input, renderer sync, gizmo reconciliation.
             // These must run even when paused so the game remains responsive.
             self.log.update(dt);
@@ -198,7 +206,21 @@ pub fn Mixin(comptime Game: type) type {
         }
 
         pub fn render(self: *Game) void {
-            self.renderer.render();
+            // Post-load render gate (#637). A `loadGameState` restored
+            // every saved sprite synchronously, but the atlases they
+            // sample re-decode/re-upload asynchronously over the next
+            // ~1–2 s; during that window some sit at `texture_id == 0`
+            // and the restored sprites would flash with an unbound /
+            // wrong texture. Hold the world draw until every gated atlas
+            // has re-bound (the gate is cleared in `tick` by
+            // `updatePostLoadRenderGate` the first frame they're all
+            // ready). We still draw gizmos so debug overlays / the
+            // generated frame's clear stay live — only the textured world
+            // is suppressed, and only for the few frames the re-decode
+            // takes. The common path (no gate armed) is unchanged.
+            if (self.post_load_render_gate == null) {
+                self.renderer.render();
+            }
             self.renderGizmos();
             self.clearGizmos();
         }

--- a/src/game/save_load_mixin.zig
+++ b/src/game/save_load_mixin.zig
@@ -853,6 +853,162 @@ pub fn Mixin(comptime Game: type) type {
                     self.addEntityToActiveScene(ent);
                 }
             }
+
+            // Step 7: Arm the post-load render gate (#637).
+            //
+            // Phases 1–6 restored every saved entity synchronously, but
+            // a prefab re-spawned in Phase 1a re-registers its atlas
+            // through the streaming catalog (`registerAtlasFromMemory`
+            // → `registerPendingAtlas`), which resets that atlas to
+            // `texture_id == 0` and re-queues an async PNG decode/upload.
+            // Until each atlas re-binds (the per-tick
+            // `bridgeAllReadyImageAssets` calls `markPendingLoaded` once
+            // its catalog upload lands), `findSprite` returns 0 for it
+            // and the restored sprites would render with an unbound /
+            // wrong texture — the corruption flash this fix targets.
+            //
+            // Mirror the scene-change readiness gate: hold the world
+            // render until every `.image` atlas the loaded scene declares
+            // has re-bound. We gate on the *scene's declared manifest*
+            // (the same slice `setScene`/`gateOnManifest` use) because
+            // those are exactly the atlases the restored sprites sample
+            // from — and they're already acquired (refcount held since
+            // the original scene load), so we only need to wait for the
+            // re-decode, not re-acquire. `tick` clears the gate the first
+            // frame `updatePostLoadRenderGate` finds them all bound.
+            //
+            // Scenes with no declared manifest (or a load fired before
+            // any scene loaded) get no gate — there's nothing to wait on
+            // and a never-clearing gate would freeze the world render.
+            self.armPostLoadRenderGate();
+        }
+
+        /// Arm the post-load render gate from the current scene's
+        /// declared asset manifest. No-op when there's no current scene
+        /// or the scene declares no assets (nothing to wait on). See the
+        /// `post_load_render_gate` field doc + Step 7 in `loadGameState`.
+        /// Upper bound on how many frames the post-load render gate may
+        /// hold the world hidden. At 60 fps this is ~2 s — comfortably
+        /// longer than the observed 1–2 s re-decode window, so a normal
+        /// load always clears via the readiness path well before the
+        /// deadline, yet a pathological never-binds atlas can't freeze
+        /// the world forever (see `post_load_render_gate_deadline`).
+        const POST_LOAD_GATE_MAX_FRAMES: u64 = 180;
+
+        pub fn armPostLoadRenderGate(self: *Game) void {
+            self.post_load_render_gate = null;
+            const scene_name = self.current_scene_name orelse return;
+            const entry = self.scenes.get(scene_name) orelse return;
+            if (entry.assets.len == 0) return;
+            // Only gate when at least one declared asset is an image
+            // atlas — a manifest of pure audio/font entries has nothing
+            // to re-bind and would otherwise wedge the gate open until
+            // the next `updatePostLoadRenderGate` no-ops it (cheap, but
+            // we skip arming to keep the steady state truly zero-cost).
+            if (!postLoadGateHasImage(self, entry.assets)) return;
+            self.post_load_render_gate = entry.assets;
+            self.post_load_render_gate_deadline = self.frame_number + POST_LOAD_GATE_MAX_FRAMES;
+
+            // Settle the gate immediately. `loadGameState` is typically
+            // called from a script's `tick`, which runs AFTER the
+            // per-frame `updatePostLoadRenderGate` in `tick`. Without
+            // this, even a load whose atlases are all already bound (the
+            // common case — `resetEcsBackend` preserves GPU textures)
+            // would suppress this frame's `render` and only un-gate next
+            // frame. Re-running the check here clears the gate in the
+            // same frame when there's nothing unbound to hide, so the
+            // no-corruption path is truly zero-frame. When a re-decode
+            // *is* in flight, the gate stays armed and holds as intended.
+            self.updatePostLoadRenderGate();
+        }
+
+        /// `true` when at least one entry in `assets` is a registered
+        /// `.image` catalog asset — i.e. an atlas that has a `texture_id`
+        /// to re-bind after a load.
+        fn postLoadGateHasImage(self: *Game, assets: []const []const u8) bool {
+            for (assets) |name| {
+                const e = self.assets.entries.getPtr(name) orelse continue;
+                if (e.loader_kind == .image) return true;
+            }
+            return false;
+        }
+
+        /// Per-tick gate check (#637). While the post-load render gate is
+        /// armed, clear it the first frame every gated `.image` atlas has
+        /// finished (re-)binding. We require BOTH:
+        ///
+        ///   1. the catalog entry to be `.ready` (the PNG decode + GPU
+        ///      upload landed), and
+        ///   2. — when the atlas_manager tracks an atlas under the same
+        ///      name (FP and the assembler key both sides identically) —
+        ///      that atlas to report `isLoaded()` (its `pending` decode
+        ///      slot is cleared, i.e. `markPendingLoaded` has run and a
+        ///      real texture handle is installed).
+        ///
+        /// IMPORTANT — readiness is `isLoaded()`, NOT `texture_id != 0`.
+        /// `texture_id == 0` is the *pending* sentinel only while an
+        /// atlas is registered-but-not-decoded; once decoded, 0 is a
+        /// perfectly valid backend handle. bgfx (and any backend whose
+        /// first-allocated texture/slot handle is 0) legitimately binds
+        /// an atlas at handle 0 — the FP `characters` atlas renders
+        /// correctly at `texture_id == 0` in steady-state play. Gating
+        /// on `texture_id != 0` would therefore treat a correctly-bound
+        /// atlas as "never ready" and hold the gate open until the
+        /// deadline on every load. `isLoaded()` is the cross-backend-safe
+        /// predicate: it tracks the decode/upload lifecycle, not the GPU
+        /// handle value.
+        ///
+        /// Wedge-safety — the gate can NEVER hold the world hidden
+        /// indefinitely:
+        ///   * A `.failed` catalog entry is treated as terminal (the
+        ///     scene gate already ships failed assets under
+        ///     `asset_failure_policy`; blocking forever on one would be
+        ///     worse than the flash this fix removes).
+        ///   * An atlas the manager doesn't track by the catalog name is
+        ///     satisfied on catalog `.ready` alone — there's no per-atlas
+        ///     decode state to wait on, and waiting would wedge.
+        ///   * A hard frame deadline force-clears the gate regardless
+        ///     (see `post_load_render_gate_deadline`).
+        ///
+        /// Called from `tick` right after `bridgeAllReadyImageAssets`, so
+        /// any atlas that finished binding this frame clears the gate the
+        /// same frame (no extra hidden frame). No-op when the gate isn't
+        /// armed (the steady-state cost is a single optional check). When
+        /// the loaded scene's atlases were never invalidated (the common
+        /// case — `resetEcsBackend` preserves GPU textures, and the
+        /// assembler eager-loads atlases once at startup), every gated
+        /// atlas is already `.ready` + `isLoaded()` on the first
+        /// post-load tick, so the gate arms and clears in a single frame
+        /// — correct, since there's nothing unbound to hide.
+        pub fn updatePostLoadRenderGate(self: *Game) void {
+            const gated = self.post_load_render_gate orelse return;
+
+            // Hard deadline — force-clear so a never-binding atlas (a
+            // failed decode, a renamed/missing atlas, a stuck re-decode)
+            // can't freeze the world.
+            if (self.frame_number >= self.post_load_render_gate_deadline) {
+                self.post_load_render_gate = null;
+                return;
+            }
+
+            for (gated) |name| {
+                const e = self.assets.entries.getPtr(name) orelse continue;
+                if (e.loader_kind != .image) continue;
+                // `.failed` is terminal — don't block on a broken asset
+                // (mirrors the scene gate's `asset_failure_policy` intent).
+                if (e.state == .failed) continue;
+                // Still decoding/uploading — the (re-)decode is in flight.
+                if (e.state != .ready) return;
+                // Catalog is `.ready`; require the manager-tracked atlas
+                // (if any) to have its decode bridged in. `isLoaded()`
+                // (not `texture_id != 0`) — see the readiness note above.
+                if (self.atlas_manager.getAtlas(name)) |atlas| {
+                    if (!atlas.isLoaded()) return;
+                }
+            }
+            // Every gated atlas is bound — release the gate so `render`
+            // shows the fully-textured restored world from this frame on.
+            self.post_load_render_gate = null;
         }
     };
 }

--- a/test/post_load_render_gate_test.zig
+++ b/test/post_load_render_gate_test.zig
@@ -1,0 +1,202 @@
+//! Post-load render gate (#637).
+//!
+//! After `loadGameState` restores entities, the atlases their sprites
+//! reference re-decode/re-upload asynchronously — during that window the
+//! re-registered atlases sit at `texture_id == 0` and the restored
+//! sprites would flash with an unbound / wrong texture. The gate holds
+//! the world render until every gated atlas has re-bound.
+//!
+//! These tests drive the gate primitives directly
+//! (`armPostLoadRenderGate` / `updatePostLoadRenderGate`) and manipulate
+//! the catalog + atlas_manager state by hand — same approach as
+//! `scene_assets_hooks_test.zig`. They target the gate logic in
+//! `save_load_mixin.zig`, not the catalog pump or the renderer.
+
+const std = @import("std");
+const testing = std.testing;
+
+const engine = @import("engine");
+const Game = engine.Game;
+
+fn emptyLoader(_: *Game) anyerror!void {}
+
+/// Register `name` as a `.ready` image catalog entry AND a still-pending
+/// atlas_manager atlas (texture_id == 0) — the exact state a
+/// just-re-registered atlas is in right after a load, before the bridge
+/// wires its real handle in.
+fn registerPendingImage(game: *Game, name: []const u8) !void {
+    try game.assets.register(name, .image, "png", "stub-bytes");
+    const entry = game.assets.entries.getPtr(name).?;
+    entry.state = .ready;
+    entry.refcount = 1;
+    // A pending atlas: JSON parsed, PNG not yet bridged → texture_id 0.
+    try game.atlas_manager.registerPendingAtlas(name, "{\"frames\":{}}", "img", "png");
+}
+
+/// Flip a pending atlas to bound, mirroring what the per-tick
+/// `bridgeAllReadyImageAssets` → `markPendingLoaded` does once the
+/// upload lands.
+fn bindAtlas(game: *Game, name: []const u8, texture_id: u32) !void {
+    try game.atlas_manager.markPendingLoaded(name, texture_id, null);
+}
+
+/// Put the game on a scene with the given image manifest so
+/// `armPostLoadRenderGate` (which reads `current_scene_name` +
+/// `scenes.get`) has something to gate on.
+fn enterScene(game: *Game, comptime name: []const u8, manifest: []const []const u8) void {
+    game.registerSceneWithAssets(name, emptyLoader, manifest);
+    game.current_scene_name = game.allocator.dupe(u8, name) catch unreachable;
+}
+
+test "gate arms when the loaded scene declares a still-pending image atlas" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const manifest: []const []const u8 = &.{ "characters", "cloud" };
+    try registerPendingImage(&game, "characters");
+    try registerPendingImage(&game, "cloud");
+    enterScene(&game, "main", manifest);
+
+    game.armPostLoadRenderGate();
+
+    // Gate is armed — render must be suppressed.
+    try testing.expect(game.post_load_render_gate != null);
+}
+
+test "gate clears once every gated atlas has re-bound" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const manifest: []const []const u8 = &.{ "characters", "cloud" };
+    try registerPendingImage(&game, "characters");
+    try registerPendingImage(&game, "cloud");
+    enterScene(&game, "main", manifest);
+
+    game.armPostLoadRenderGate();
+    try testing.expect(game.post_load_render_gate != null);
+
+    // Only one atlas bound — gate must STILL hold (the other is unbound,
+    // texture_id 0; un-hiding now is exactly the corruption flash).
+    try bindAtlas(&game, "characters", 7);
+    game.updatePostLoadRenderGate();
+    try testing.expect(game.post_load_render_gate != null);
+
+    // Both bound — gate clears this frame.
+    try bindAtlas(&game, "cloud", 9);
+    game.updatePostLoadRenderGate();
+    try testing.expect(game.post_load_render_gate == null);
+}
+
+test "gate does not arm for an empty manifest" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    enterScene(&game, "main", &.{});
+    game.armPostLoadRenderGate();
+    try testing.expect(game.post_load_render_gate == null);
+}
+
+test "gate does not arm for a non-image (audio-only) manifest" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const manifest: []const []const u8 = &.{"theme"};
+    try game.assets.register("theme", .audio, "ogg", "stub-bytes");
+    game.assets.entries.getPtr("theme").?.state = .ready;
+    enterScene(&game, "main", manifest);
+
+    game.armPostLoadRenderGate();
+    try testing.expect(game.post_load_render_gate == null);
+}
+
+test "a .failed atlas is terminal — gate does not wedge on it" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const manifest: []const []const u8 = &.{ "characters", "broken" };
+    try registerPendingImage(&game, "characters");
+    // `broken` is an image asset that failed to decode — treated as
+    // terminal so the gate doesn't hold the world forever.
+    try game.assets.register("broken", .image, "png", "stub");
+    const broken = game.assets.entries.getPtr("broken").?;
+    broken.state = .failed;
+    broken.last_error = error.TestInjectedFailure;
+    enterScene(&game, "main", manifest);
+
+    game.armPostLoadRenderGate();
+    try testing.expect(game.post_load_render_gate != null);
+
+    // `broken` is `.failed` (skipped); once `characters` binds the gate
+    // clears even though `broken` never reached `.ready`.
+    try bindAtlas(&game, "characters", 7);
+    game.updatePostLoadRenderGate();
+    try testing.expect(game.post_load_render_gate == null);
+}
+
+test "gate clears at the frame deadline even if an atlas never binds" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const manifest: []const []const u8 = &.{"characters"};
+    try registerPendingImage(&game, "characters");
+    enterScene(&game, "main", manifest);
+
+    game.armPostLoadRenderGate();
+    try testing.expect(game.post_load_render_gate != null);
+
+    // Atlas never binds. Before the deadline the gate holds.
+    game.updatePostLoadRenderGate();
+    try testing.expect(game.post_load_render_gate != null);
+
+    // Jump past the deadline — the gate force-clears so the world can
+    // never freeze permanently.
+    game.frame_number = game.post_load_render_gate_deadline;
+    game.updatePostLoadRenderGate();
+    try testing.expect(game.post_load_render_gate == null);
+}
+
+test "an atlas bound at texture_id 0 is ready (bgfx valid-handle case)" {
+    // Regression guard: `texture_id == 0` is the *pending* sentinel only
+    // while an atlas is registered-but-not-decoded. Once decoded, 0 is a
+    // valid backend handle (bgfx binds the FP `characters` atlas at 0).
+    // The gate must treat a decoded atlas as ready REGARDLESS of its
+    // handle value — gating on `texture_id != 0` would hold the gate
+    // open until the deadline on every load.
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const manifest: []const []const u8 = &.{"characters"};
+    try registerPendingImage(&game, "characters");
+    enterScene(&game, "main", manifest);
+
+    game.armPostLoadRenderGate();
+    try testing.expect(game.post_load_render_gate != null);
+
+    // Decode lands and the atlas binds at handle 0 — a valid, ready
+    // texture. The gate must clear (not wait for a non-zero handle).
+    try bindAtlas(&game, "characters", 0);
+    game.updatePostLoadRenderGate();
+    try testing.expect(game.post_load_render_gate == null);
+}
+
+test "a catalog image still decoding holds the gate" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const manifest: []const []const u8 = &.{"characters"};
+    try game.assets.register("characters", .image, "png", "stub");
+    game.assets.entries.getPtr("characters").?.state = .decoding;
+    try game.atlas_manager.registerPendingAtlas("characters", "{\"frames\":{}}", "img", "png");
+    enterScene(&game, "main", manifest);
+
+    game.armPostLoadRenderGate();
+    // Still decoding → not ready → gate holds.
+    game.updatePostLoadRenderGate();
+    try testing.expect(game.post_load_render_gate != null);
+
+    // Decode lands + atlas bridges → gate clears.
+    game.assets.entries.getPtr("characters").?.state = .ready;
+    try bindAtlas(&game, "characters", 3);
+    game.updatePostLoadRenderGate();
+    try testing.expect(game.post_load_render_gate == null);
+}


### PR DESCRIPTION
## The bug

When a save is loaded (`loadGameState`), the ECS is reset and entities are restored **synchronously**, but the atlas textures those sprites reference settle **asynchronously** around the load (streaming catalog re-decode/re-upload). During that ~1–2 s window an atlas can transiently report a not-yet-bridged (`pending`) state — `findSprite` returns its pending texture, `resolveAtlasSprites` stamps it onto the restored sprites, and the world flashes with an unbound/wrong texture (e.g. workers briefly wearing another atlas) until each atlas re-binds via `markPendingLoaded`. The load is functionally correct; the bug is the **visible corruption flash** during load-in.

## The fix — post-load render gate

This mirrors the scene-change readiness gate (`gateOnManifest` / `bridgeAllReadyImageAssets`) for the load path:

- **`armPostLoadRenderGate`** (end of `loadGameState`) records the loaded scene's declared `assets:` manifest (the same slice the scene gate uses) when it has ≥1 image atlas, then settles immediately so a load whose atlases are already bound is **zero-frame**.
- **`render`** suppresses the world draw while the gate is armed (gizmos still draw); the common no-gate path is unchanged.
- **`updatePostLoadRenderGate`** (in `tick`, right after the per-frame atlas bridge) clears the gate the first frame every gated image atlas is catalog-`.ready` **and** `isLoaded()`.
- **Wedge-safety**: `.failed` assets are terminal, manager-untracked names fall back to catalog `.ready`, and a hard ~180-frame deadline force-clears the gate so the world can never freeze.

### Why approach 1 (gate), not approach 2 (skip `texture_id == 0` at draw)

End-to-end validation on flying-platform (bgfx) proved candidate 2 unsafe. `texture_id == 0` is the *pending* sentinel **only while an atlas is registered-but-not-decoded**; once decoded, **0 is a perfectly valid backend handle**. bgfx binds the FP `characters`/`cloud` atlas at handle 0 and renders it correctly in steady-state play — the slot handles even reshuffle which atlas lands on 0 between runs:

```
# run A, pre-save (correct rendering):   characters texture_id=0, cloud=2
# run B, pre-save (correct rendering):   characters texture_id=1, cloud=0
```

Skipping `texture_id == 0` would wrongly hide a correctly-bound atlas there. So readiness is `isLoaded()` (decode/upload lifecycle), **not** the GPU handle value — cross-backend-safe.

## Validation

**Engine:** `zig build test` green, including 8 new gate tests in `test/post_load_render_gate_test.zig` (arm/clear, empty/non-image manifests, `.failed`-terminal, deadline force-clear, **handle-0-is-ready** regression guard, in-flight-decode-holds).

**flying-platform (bgfx, in-game save→load), per-atlas `findSprite` texture_id logs:**

```
=== LOADED at frame 200 ===
[post-load f201] gate_armed=false ...
  gated[background] catalog=ready loaded=true texture_id=4
  gated[cloud]      catalog=ready loaded=true texture_id=0
  gated[characters] catalog=ready loaded=true texture_id=1
  gated[rooms]      catalog=ready loaded=true texture_id=5
  gated[ship]       catalog=ready loaded=true texture_id=2
  gated[objects]    catalog=ready loaded=true texture_id=3
```

Every gated atlas is `loaded=true` + `catalog=ready` post-load with stable valid handles; the gate arms on load and clears via the **readiness path** (not the deadline). No unbound/pending atlas is ever shown. (An earlier build of the fix that gated on `texture_id != 0` rode the deadline because `characters` legitimately sits at handle 0 — the evidence that drove the `isLoaded()` switch.)

Bumps engine **1.57.0 → 1.58.0**.