### PR TITLE
fix(save/load): deterministic, self-contained atlas binding on load (#638)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xe8a81a8dc7f48c87,
     .name = .engine,
-    .version = "1.58.0",
+    .version = "1.59.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .labelle_core = .{

--- a/src/game.zig
+++ b/src/game.zig
@@ -394,6 +394,20 @@ pub fn GameConfig(
         /// gate is `null`.
         post_load_render_gate_deadline: u64 = 0,
 
+        /// The image-atlas manifest the most recent `loadGameState`
+        /// acquired (engine#638), so a SUBSEQUENT load can release it
+        /// before acquiring the next one. Without this, loading save A
+        /// then save B would acquire each manifest's atlases and never
+        /// release A's — a slow refcount leak across repeated loads (and a
+        /// double-pin when an in-game Load re-acquires the active scene's
+        /// already-held manifest). The acquire/release is balanced here
+        /// rather than via the scene-swap path because a load does NOT
+        /// swap scenes (`current_scene_name` is unchanged), so
+        /// `releasePreviousAssets` never sees it. Borrows the
+        /// program-lifetime `SceneEntry.assets` slice; `null` when no load
+        /// has pinned a manifest. Released in full on `deinit`.
+        post_load_acquired_assets: ?[]const []const u8 = null,
+
         /// Whether the post-load gate's manifest has been bridged into
         /// `atlas_manager` yet (engine#638). The load path binds the whole
         /// manifest in ONE deterministic pass — the moment every atlas is
@@ -842,6 +856,7 @@ pub fn GameConfig(
         pub const loadGameState = SaveLoadMixin.loadGameState;
         pub const armPostLoadRenderGate = SaveLoadMixin.armPostLoadRenderGate;
         pub const updatePostLoadRenderGate = SaveLoadMixin.updatePostLoadRenderGate;
+        pub const releaseLoadAcquired = SaveLoadMixin.releaseLoadAcquired;
 
         // ── Game State Machine (mixin) ──────────────────────────────
         pub const setState = StateMixin.setState;

--- a/src/game.zig
+++ b/src/game.zig
@@ -394,6 +394,19 @@ pub fn GameConfig(
         /// gate is `null`.
         post_load_render_gate_deadline: u64 = 0,
 
+        /// Whether the post-load gate's manifest has been bridged into
+        /// `atlas_manager` yet (engine#638). The load path binds the whole
+        /// manifest in ONE deterministic pass — the moment every atlas is
+        /// `.ready` — mirroring the scene-change gate
+        /// (`bridgeImageAssetsToAtlasManager`) instead of letting the
+        /// per-tick incremental `bridgeAllReadyImageAssets` walk bind them
+        /// one at a time as each upload lands. The all-at-once bind is the
+        /// scene-change path's defining property and the reason it never
+        /// exhibited the load path's intermittent mis-binding: a half-bound
+        /// manifest is never observable. Reset to `false` when the gate
+        /// arms; set `true` the frame the atomic bridge runs.
+        post_load_render_gate_bridged: bool = false,
+
         // Active scene (type-erased) — managed by sceneLoaderFn / setActiveScene
         active_scene_ptr: ?*anyopaque = null,
         active_scene_update_fn: ?*const fn (*anyopaque, f32) void = null,
@@ -813,6 +826,7 @@ pub fn GameConfig(
         pub const getCurrentSceneName = SceneMixin.getCurrentSceneName;
         pub const pendingSceneName = SceneMixin.pendingSceneName;
         pub const bridgeAllReadyImageAssets = SceneMixin.bridgeAllReadyImageAssets;
+        pub const bridgeManifest = SceneMixin.bridgeManifest;
 
         /// Register a runtime JSONC scene by name.
         /// The scene file is loaded from disk when setScene() is called.

--- a/src/game/lifecycle_mixin.zig
+++ b/src/game/lifecycle_mixin.zig
@@ -23,6 +23,10 @@ pub fn Mixin(comptime Game: type) type {
         // ── Teardown / hook wiring ────────────────────────────────
 
         pub fn deinit(self: *Game) void {
+            // Release any atlas manifest a `loadGameState` pinned but the
+            // game never released via a subsequent load (engine#638), so a
+            // game torn down after a load doesn't leak catalog refcounts.
+            self.releaseLoadAcquired();
             self.emitHook(.{ .game_deinit = {} });
             // Engine `Events` dual-emit (#578). Fires before the actual
             // teardown so flow listeners that read game state from a

--- a/src/game/save_load_mixin.zig
+++ b/src/game/save_load_mixin.zig
@@ -954,6 +954,13 @@ pub fn Mixin(comptime Game: type) type {
         pub fn armPostLoadRenderGate(self: *Game, saved_scene: ?[]const u8) void {
             self.post_load_render_gate = null;
             self.post_load_render_gate_bridged = false;
+            // Release the manifest the PREVIOUS load pinned — on EVERY
+            // load, before resolving the new one (engine#638). Done here
+            // (not only on the acquire path) so a load onto a scene with no
+            // image manifest, an unregistered scene, or the early
+            // no-manifest returns below still drops the prior pin. The
+            // matching re-acquire happens in `armPostLoadRenderGateFromEntry`.
+            releaseLoadAcquired(self);
             // Prefer the scene recorded IN the save (engine#638) — that's
             // the manifest the restored sprites actually sample from. Fall
             // back to the currently-active scene for legacy saves that
@@ -999,14 +1006,13 @@ pub fn Mixin(comptime Game: type) type {
             //
             // Refcount discipline: a load does NOT swap scenes
             // (`current_scene_name` is unchanged), so the scene-swap
-            // `releasePreviousAssets` never balances this acquire. We
-            // balance it ourselves — release the manifest the PREVIOUS
-            // load pinned before acquiring this one — so repeated loads
-            // (save A → save B) and in-game same-scene reloads can't leak
-            // / double-pin the catalog refcount. `releaseLoadAcquired`
-            // is a no-op on the first load. Idempotent per atlas: an
-            // already-`.ready` atlas just bumps refcount (no re-decode).
-            releaseLoadAcquired(self);
+            // `releasePreviousAssets` never balances this acquire. The
+            // PREVIOUS load's pin was already dropped by the
+            // `releaseLoadAcquired` at the top of `armPostLoadRenderGate`
+            // (runs on every load), so repeated loads (save A → save B) and
+            // in-game same-scene reloads can't leak / double-pin the catalog
+            // refcount. Idempotent per atlas: an already-`.ready` atlas just
+            // bumps refcount (no re-decode).
             for (assets) |name| {
                 const e = self.assets.entries.getPtr(name) orelse continue;
                 if (e.loader_kind != .image) continue;

--- a/src/game/save_load_mixin.zig
+++ b/src/game/save_load_mixin.zig
@@ -286,7 +286,26 @@ pub fn Mixin(comptime Game: type) type {
             defer alloc_writer.deinit();
             const writer = &alloc_writer.writer;
 
-            try writer.print("{{\n  \"version\": {d},\n  \"entities\": [\n", .{SAVE_VERSION});
+            try writer.print("{{\n  \"version\": {d},\n", .{SAVE_VERSION});
+
+            // Record the active scene name so `loadGameState` can
+            // re-acquire and bind THAT scene's atlas manifest through the
+            // deterministic catalog gate — even when the load is issued
+            // from a different scene (the menu→Load case, where
+            // `current_scene_name` is still "menu" at load time). Without
+            // this the loader has no way to know which atlas packs the
+            // restored colony references, which is exactly why
+            // flying-platform shipped a manual `assets.acquire(...)` loop
+            // in its Load handler (FP#542). Optional + back-compat: older
+            // saves simply omit the key and `loadGameState` falls back to
+            // the current scene's manifest (the pre-#638 behaviour).
+            if (self.current_scene_name) |scene_name| {
+                try writer.writeAll("  \"scene\": ");
+                try writeJsonString(writer, scene_name);
+                try writer.writeAll(",\n");
+            }
+
+            try writer.writeAll("  \"entities\": [\n");
 
             for (entity_list.items, 0..) |id, idx| {
                 const entity: Entity = @intCast(id);
@@ -461,6 +480,18 @@ pub fn Mixin(comptime Game: type) type {
             }
 
             const entities_json = (root.get("entities") orelse return error.MissingField).array;
+
+            // Optional saved scene name (engine#638). Saves written before
+            // this field omit it — fall back to the current scene's
+            // manifest (the pre-#638 gate behaviour). Borrowed from the
+            // parsed JSON, so it's only valid for the duration of this
+            // call; `armPostLoadRenderGate` resolves it to the
+            // program-lifetime `SceneEntry.assets` slice before it's used
+            // beyond this stack frame.
+            const saved_scene: ?[]const u8 = if (root.get("scene")) |v| switch (v) {
+                .string => |s| s,
+                else => null,
+            } else null;
 
             // Step 1: Clear scene tracking and destroy all entities atomically.
             //
@@ -880,7 +911,17 @@ pub fn Mixin(comptime Game: type) type {
             // Scenes with no declared manifest (or a load fired before
             // any scene loaded) get no gate — there's nothing to wait on
             // and a never-clearing gate would freeze the world render.
-            self.armPostLoadRenderGate();
+            //
+            // engine#638: arm against the SAVED scene's manifest, not the
+            // currently-active scene. A menu→Load restores a colony save
+            // while `current_scene_name` is still "menu" (load never swaps
+            // scenes), so the menu's one-atlas manifest would gate nothing
+            // useful. The saved manifest is the set the restored sprites
+            // actually sample from. `armPostLoadRenderGate` also ACQUIRES
+            // that manifest so the (re-)decode is triggered by the engine
+            // itself — making loadGameState self-contained and retiring
+            // the manual `assets.acquire(...)` loop games shipped (FP#542).
+            self.armPostLoadRenderGate(saved_scene);
         }
 
         /// Arm the post-load render gate from the current scene's
@@ -895,18 +936,66 @@ pub fn Mixin(comptime Game: type) type {
         /// the world forever (see `post_load_render_gate_deadline`).
         const POST_LOAD_GATE_MAX_FRAMES: u64 = 180;
 
-        pub fn armPostLoadRenderGate(self: *Game) void {
+        pub fn armPostLoadRenderGate(self: *Game, saved_scene: ?[]const u8) void {
             self.post_load_render_gate = null;
-            const scene_name = self.current_scene_name orelse return;
-            const entry = self.scenes.get(scene_name) orelse return;
-            if (entry.assets.len == 0) return;
+            self.post_load_render_gate_bridged = false;
+            // Prefer the scene recorded IN the save (engine#638) — that's
+            // the manifest the restored sprites actually sample from. Fall
+            // back to the currently-active scene for legacy saves that
+            // predate the `"scene"` field. Resolve to the program-lifetime
+            // `SceneEntry.assets` slice so the gate can hold it across
+            // frames without dangling on the parsed-JSON string.
+            // Resolve the manifest slice: prefer the saved scene, then the
+            // active scene as a fallback (legacy saves, or a saved scene
+            // name that no longer resolves to a registered scene).
+            const assets: []const []const u8 = blk: {
+                if (saved_scene) |sn| {
+                    if (self.scenes.get(sn)) |e| break :blk e.assets;
+                }
+                if (self.current_scene_name) |cn| {
+                    if (self.scenes.get(cn)) |e| break :blk e.assets;
+                }
+                return;
+            };
+            armPostLoadRenderGateFromEntry(self, assets);
+        }
+
+        /// Shared body of `armPostLoadRenderGate` once the manifest slice
+        /// is resolved. Acquires the manifest's image atlases (so the
+        /// load triggers their decode itself — see #638), arms the gate,
+        /// and settles it immediately.
+        fn armPostLoadRenderGateFromEntry(self: *Game, assets: []const []const u8) void {
+            if (assets.len == 0) return;
             // Only gate when at least one declared asset is an image
             // atlas — a manifest of pure audio/font entries has nothing
             // to re-bind and would otherwise wedge the gate open until
             // the next `updatePostLoadRenderGate` no-ops it (cheap, but
             // we skip arming to keep the steady state truly zero-cost).
-            if (!postLoadGateHasImage(self, entry.assets)) return;
-            self.post_load_render_gate = entry.assets;
+            if (!postLoadGateHasImage(self, assets)) return;
+
+            // Acquire the manifest's image atlases through the SAME catalog
+            // path the scene-change gate uses (#638). A menu→Load lands on
+            // a colony save whose packs the menu scene never acquired
+            // (`menu` only pins `background`); without this nothing
+            // triggers their (re-)decode and the world loads invisible —
+            // which is exactly why flying-platform shipped a manual
+            // `assets.acquire(...)` loop in its Load handler (FP#542).
+            // Acquiring here makes loadGameState self-contained.
+            //
+            // Refcount note: this is the load counterpart of the acquire
+            // the original scene-change gate did. Each acquire is balanced
+            // by the `release` the next scene swap performs when it drops
+            // this scene's manifest (`releasePreviousAssets`). On a load
+            // that stays in the same scene the refcount simply stays
+            // pinned, exactly as a normal scene's atlases do. Idempotent:
+            // an already-acquired atlas just bumps refcount (no re-decode).
+            for (assets) |name| {
+                const e = self.assets.entries.getPtr(name) orelse continue;
+                if (e.loader_kind != .image) continue;
+                _ = self.assets.acquire(name) catch {};
+            }
+
+            self.post_load_render_gate = assets;
             self.post_load_render_gate_deadline = self.frame_number + POST_LOAD_GATE_MAX_FRAMES;
 
             // Settle the gate immediately. `loadGameState` is typically
@@ -991,6 +1080,16 @@ pub fn Mixin(comptime Game: type) type {
                 return;
             }
 
+            // Pass 1: wait until EVERY gated image atlas's catalog entry
+            // has reached a terminal state (`.ready` or `.failed`). We do
+            // NOT bind any atlas until they're ALL ready — that all-at-once
+            // bind is what makes this path deterministic (#638). Binding
+            // incrementally, atlas-by-atlas as each upload lands (the old
+            // per-tick `bridgeAllReadyImageAssets` behaviour for the load
+            // path), is the asymmetry that let a menu→Load occasionally
+            // show a half-bound manifest; the scene-change gate never does
+            // because it bridges the whole manifest in one pass after
+            // `allReady`.
             for (gated) |name| {
                 const e = self.assets.entries.getPtr(name) orelse continue;
                 if (e.loader_kind != .image) continue;
@@ -999,9 +1098,27 @@ pub fn Mixin(comptime Game: type) type {
                 if (e.state == .failed) continue;
                 // Still decoding/uploading — the (re-)decode is in flight.
                 if (e.state != .ready) return;
-                // Catalog is `.ready`; require the manager-tracked atlas
-                // (if any) to have its decode bridged in. `isLoaded()`
-                // (not `texture_id != 0`) — see the readiness note above.
+            }
+
+            // Pass 2: every gated atlas is `.ready`. Bind the WHOLE manifest
+            // in a single deterministic pass — the same call the
+            // scene-change gate makes (`bridgeManifest` →
+            // `bridgeImageAssetsToAtlasManager`). Idempotent + done once
+            // (guarded by `post_load_render_gate_bridged`) so a manifest
+            // shared with an already-bound scene doesn't re-bind. After
+            // this, every atlas the restored sprites sample from points at
+            // its own freshly-uploaded handle, atomically.
+            if (!self.post_load_render_gate_bridged) {
+                self.bridgeManifest(gated);
+                self.post_load_render_gate_bridged = true;
+            }
+
+            // Pass 3: confirm the manager-tracked atlases actually took the
+            // binding (`isLoaded()`, not `texture_id != 0` — see the
+            // readiness note above). Normally true the same frame as the
+            // bridge; the loop guards against an atlas the manager doesn't
+            // track by the catalog name (satisfied on catalog `.ready`).
+            for (gated) |name| {
                 if (self.atlas_manager.getAtlas(name)) |atlas| {
                     if (!atlas.isLoaded()) return;
                 }

--- a/src/game/save_load_mixin.zig
+++ b/src/game/save_load_mixin.zig
@@ -936,6 +936,21 @@ pub fn Mixin(comptime Game: type) type {
         /// the world forever (see `post_load_render_gate_deadline`).
         const POST_LOAD_GATE_MAX_FRAMES: u64 = 180;
 
+        /// Release the image atlases a previous `loadGameState` acquired
+        /// via `armPostLoadRenderGateFromEntry` (engine#638), balancing
+        /// that acquire so repeated loads don't leak catalog refcounts.
+        /// No-op when no load has pinned a manifest. Also called from
+        /// `Game.deinit` so a game torn down after a load doesn't leak.
+        pub fn releaseLoadAcquired(self: *Game) void {
+            const prev = self.post_load_acquired_assets orelse return;
+            self.post_load_acquired_assets = null;
+            for (prev) |name| {
+                const e = self.assets.entries.getPtr(name) orelse continue;
+                if (e.loader_kind != .image) continue;
+                self.assets.release(name);
+            }
+        }
+
         pub fn armPostLoadRenderGate(self: *Game, saved_scene: ?[]const u8) void {
             self.post_load_render_gate = null;
             self.post_load_render_gate_bridged = false;
@@ -982,18 +997,22 @@ pub fn Mixin(comptime Game: type) type {
             // `assets.acquire(...)` loop in its Load handler (FP#542).
             // Acquiring here makes loadGameState self-contained.
             //
-            // Refcount note: this is the load counterpart of the acquire
-            // the original scene-change gate did. Each acquire is balanced
-            // by the `release` the next scene swap performs when it drops
-            // this scene's manifest (`releasePreviousAssets`). On a load
-            // that stays in the same scene the refcount simply stays
-            // pinned, exactly as a normal scene's atlases do. Idempotent:
-            // an already-acquired atlas just bumps refcount (no re-decode).
+            // Refcount discipline: a load does NOT swap scenes
+            // (`current_scene_name` is unchanged), so the scene-swap
+            // `releasePreviousAssets` never balances this acquire. We
+            // balance it ourselves — release the manifest the PREVIOUS
+            // load pinned before acquiring this one — so repeated loads
+            // (save A → save B) and in-game same-scene reloads can't leak
+            // / double-pin the catalog refcount. `releaseLoadAcquired`
+            // is a no-op on the first load. Idempotent per atlas: an
+            // already-`.ready` atlas just bumps refcount (no re-decode).
+            releaseLoadAcquired(self);
             for (assets) |name| {
                 const e = self.assets.entries.getPtr(name) orelse continue;
                 if (e.loader_kind != .image) continue;
                 _ = self.assets.acquire(name) catch {};
             }
+            self.post_load_acquired_assets = assets;
 
             self.post_load_render_gate = assets;
             self.post_load_render_gate_deadline = self.frame_number + POST_LOAD_GATE_MAX_FRAMES;

--- a/src/game/scene_mixin.zig
+++ b/src/game/scene_mixin.zig
@@ -231,11 +231,28 @@ fn bridgeImageAssetsToAtlasManager(game: anytype, assets: []const []const u8) vo
 /// one HashMap iteration per frame; the catalog typically holds
 /// <20 entries.
 fn bridgeAllReadyImageAssets_impl(game: anytype) void {
+    // While a post-load gate is armed but not yet bridged (#638), DON'T
+    // bind any atlas in its manifest here. The gate (`updatePostLoadRenderGate`)
+    // binds that whole manifest atomically, all-at-once, the moment every
+    // atlas is `.ready` — mirroring the scene-change gate. Letting this
+    // per-tick walk bind a gated atlas the instant ITS upload lands would
+    // reintroduce the incremental, half-bound-manifest window the gate
+    // exists to eliminate (atlas X bound while atlas Y is still in flight).
+    // Atlases outside the gated manifest (and all atlases once the gate
+    // has bridged / cleared) bind here as before — the eager-fallback and
+    // late-upload paths (#508) are untouched.
+    const gated: []const []const u8 =
+        if (game.post_load_render_gate != null and !game.post_load_render_gate_bridged)
+            game.post_load_render_gate.?
+        else
+            &.{};
+
     var iter = game.assets.entries.iterator();
     while (iter.next()) |kv| {
         const entry = kv.value_ptr;
         if (entry.loader_kind != .image) continue;
         if (entry.state != .ready) continue;
+        if (isInManifest(gated, kv.key_ptr.*)) continue;
         const resource = entry.resource orelse continue;
         const handle = switch (resource) {
             .image => |t| t,
@@ -243,6 +260,15 @@ fn bridgeAllReadyImageAssets_impl(game: anytype) void {
         };
         game.atlas_manager.markPendingLoaded(kv.key_ptr.*, handle, null) catch {};
     }
+}
+
+/// `true` if `name` is one of the entries in `manifest`. Linear scan —
+/// manifests are single-digit-length atlas-name lists.
+fn isInManifest(manifest: []const []const u8, name: []const u8) bool {
+    for (manifest) |m| {
+        if (std.mem.eql(u8, m, name)) return true;
+    }
+    return false;
 }
 
 /// Returns the scene management mixin for a given Game type.
@@ -279,6 +305,23 @@ pub fn Mixin(comptime Game: type) type {
         /// `resolveAtlasSprites` runs. See the free fn for details.
         pub fn bridgeAllReadyImageAssets(self: *Game) void {
             bridgeAllReadyImageAssets_impl(self);
+        }
+
+        /// Bridge a specific atlas manifest into `atlas_manager` in one
+        /// pass — the exact `bridgeImageAssetsToAtlasManager` call the
+        /// scene-change path uses after `gateOnManifest` proves every
+        /// atlas `.ready`. Exposed so the save/load path
+        /// (`updatePostLoadRenderGate`) can bind the loaded scene's
+        /// manifest atomically, all-at-once, the same way a scene swap
+        /// does — instead of relying on the per-tick incremental
+        /// `bridgeAllReadyImageAssets` walk. See the load-binding race
+        /// fix (engine#638): incremental binding is the asymmetry that
+        /// let a menu→Load occasionally bind an atlas under the wrong
+        /// freshly-uploaded handle; the scene-change path never does
+        /// because it binds the whole manifest in a single deterministic
+        /// pass after all uploads land.
+        pub fn bridgeManifest(self: *Game, assets: []const []const u8) void {
+            bridgeImageAssetsToAtlasManager(self, assets);
         }
 
         /// Register a scene together with its declared asset manifest.

--- a/test/post_load_render_gate_test.zig
+++ b/test/post_load_render_gate_test.zig
@@ -57,7 +57,7 @@ test "gate arms when the loaded scene declares a still-pending image atlas" {
     try registerPendingImage(&game, "cloud");
     enterScene(&game, "main", manifest);
 
-    game.armPostLoadRenderGate();
+    game.armPostLoadRenderGate(null);
 
     // Gate is armed — render must be suppressed.
     try testing.expect(game.post_load_render_gate != null);
@@ -72,7 +72,7 @@ test "gate clears once every gated atlas has re-bound" {
     try registerPendingImage(&game, "cloud");
     enterScene(&game, "main", manifest);
 
-    game.armPostLoadRenderGate();
+    game.armPostLoadRenderGate(null);
     try testing.expect(game.post_load_render_gate != null);
 
     // Only one atlas bound — gate must STILL hold (the other is unbound,
@@ -92,7 +92,7 @@ test "gate does not arm for an empty manifest" {
     defer game.deinit();
 
     enterScene(&game, "main", &.{});
-    game.armPostLoadRenderGate();
+    game.armPostLoadRenderGate(null);
     try testing.expect(game.post_load_render_gate == null);
 }
 
@@ -105,7 +105,7 @@ test "gate does not arm for a non-image (audio-only) manifest" {
     game.assets.entries.getPtr("theme").?.state = .ready;
     enterScene(&game, "main", manifest);
 
-    game.armPostLoadRenderGate();
+    game.armPostLoadRenderGate(null);
     try testing.expect(game.post_load_render_gate == null);
 }
 
@@ -123,7 +123,7 @@ test "a .failed atlas is terminal — gate does not wedge on it" {
     broken.last_error = error.TestInjectedFailure;
     enterScene(&game, "main", manifest);
 
-    game.armPostLoadRenderGate();
+    game.armPostLoadRenderGate(null);
     try testing.expect(game.post_load_render_gate != null);
 
     // `broken` is `.failed` (skipped); once `characters` binds the gate
@@ -141,7 +141,7 @@ test "gate clears at the frame deadline even if an atlas never binds" {
     try registerPendingImage(&game, "characters");
     enterScene(&game, "main", manifest);
 
-    game.armPostLoadRenderGate();
+    game.armPostLoadRenderGate(null);
     try testing.expect(game.post_load_render_gate != null);
 
     // Atlas never binds. Before the deadline the gate holds.
@@ -169,7 +169,7 @@ test "an atlas bound at texture_id 0 is ready (bgfx valid-handle case)" {
     try registerPendingImage(&game, "characters");
     enterScene(&game, "main", manifest);
 
-    game.armPostLoadRenderGate();
+    game.armPostLoadRenderGate(null);
     try testing.expect(game.post_load_render_gate != null);
 
     // Decode lands and the atlas binds at handle 0 — a valid, ready
@@ -189,7 +189,7 @@ test "a catalog image still decoding holds the gate" {
     try game.atlas_manager.registerPendingAtlas("characters", "{\"frames\":{}}", "img", "png");
     enterScene(&game, "main", manifest);
 
-    game.armPostLoadRenderGate();
+    game.armPostLoadRenderGate(null);
     // Still decoding → not ready → gate holds.
     game.updatePostLoadRenderGate();
     try testing.expect(game.post_load_render_gate != null);
@@ -199,4 +199,107 @@ test "a catalog image still decoding holds the gate" {
     try bindAtlas(&game, "characters", 3);
     game.updatePostLoadRenderGate();
     try testing.expect(game.post_load_render_gate == null);
+}
+
+// ── engine#638: saved-scene manifest + atomic, acquire-and-bridge ──────
+
+/// Register `name` as a fully-uploaded image: `.ready` catalog entry
+/// carrying a real `resource` handle (so the gate's atomic bridge can
+/// read it) AND a still-pending atlas_manager atlas (texture_id 0). This
+/// is the post-decode state the load gate is meant to bind in one pass.
+fn registerUploadedImage(game: *Game, name: []const u8, handle: u32) !void {
+    try game.assets.register(name, .image, "png", "stub-bytes");
+    const entry = game.assets.entries.getPtr(name).?;
+    entry.state = .ready;
+    entry.refcount = 1;
+    entry.resource = .{ .image = handle };
+    try game.atlas_manager.registerPendingAtlas(name, "{\"frames\":{}}", "img", "png");
+}
+
+test "gate prefers the SAVED scene's manifest over the active scene (#638)" {
+    // A menu→Load restores a colony save while the active scene is still
+    // `menu`. The gate must arm on the SAVED scene's manifest (the atlases
+    // the restored sprites sample from), not the menu's.
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    // Active scene = menu (one atlas, already bound — nothing to wait on).
+    try registerUploadedImage(&game, "background", 0);
+    try bindAtlas(&game, "background", 0);
+    enterScene(&game, "menu", &.{"background"});
+
+    // Saved (colony) scene declares two atlases that are still decoding
+    // (so the gate holds and we can inspect which manifest it armed on).
+    try registerUploadedImage(&game, "characters", 5);
+    try registerUploadedImage(&game, "rooms", 6);
+    game.assets.entries.getPtr("characters").?.state = .decoding;
+    game.assets.entries.getPtr("rooms").?.state = .decoding;
+    game.registerSceneWithAssets("colony", emptyLoader, &.{ "characters", "rooms" });
+
+    // Arm against the SAVED scene name — the gate must pick the colony
+    // manifest, see two still-unbound atlases, and hold.
+    game.armPostLoadRenderGate("colony");
+    try testing.expect(game.post_load_render_gate != null);
+    // It armed on the colony manifest, not menu's single `background`.
+    try testing.expectEqual(@as(usize, 2), game.post_load_render_gate.?.len);
+}
+
+test "gate binds the whole manifest atomically in one pass (#638)" {
+    // The defining property of the deterministic load gate: it does NOT
+    // bind any atlas until EVERY atlas in the manifest is `.ready`, then
+    // binds them all in a single `bridgeManifest` pass. A half-ready
+    // manifest leaves NOTHING bound (no incremental half-bound window).
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    try registerUploadedImage(&game, "characters", 5);
+    try registerUploadedImage(&game, "rooms", 6);
+    // Start both still decoding so the immediate settle in
+    // `armPostLoadRenderGate` can't clear the gate before we test it.
+    game.assets.entries.getPtr("characters").?.state = .decoding;
+    game.assets.entries.getPtr("rooms").?.state = .decoding;
+    game.registerSceneWithAssets("colony", emptyLoader, &.{ "characters", "rooms" });
+    game.current_scene_name = game.allocator.dupe(u8, "colony") catch unreachable;
+
+    game.armPostLoadRenderGate("colony");
+    try testing.expect(game.post_load_render_gate != null);
+
+    // Make only ONE atlas ready; the other is still decoding.
+    game.assets.entries.getPtr("characters").?.state = .ready;
+    game.updatePostLoadRenderGate();
+    // Nothing should be bound yet — the manifest is bound all-at-once or
+    // not at all. `characters` (ready) must still be pending in the
+    // manager because the gate refused to bind a half-ready manifest.
+    try testing.expect(!game.post_load_render_gate_bridged);
+    try testing.expect(!game.atlas_manager.getAtlas("characters").?.isLoaded());
+    try testing.expect(game.post_load_render_gate != null);
+
+    // Now the second atlas finishes — the gate binds BOTH in one pass and
+    // clears. Each atlas takes the handle its own catalog `resource` holds.
+    game.assets.entries.getPtr("rooms").?.state = .ready;
+    game.updatePostLoadRenderGate();
+    try testing.expect(game.post_load_render_gate_bridged);
+    try testing.expect(game.atlas_manager.getAtlas("characters").?.isLoaded());
+    try testing.expect(game.atlas_manager.getAtlas("rooms").?.isLoaded());
+    try testing.expectEqual(@as(u32, 5), game.atlas_manager.getAtlas("characters").?.texture_id);
+    try testing.expectEqual(@as(u32, 6), game.atlas_manager.getAtlas("rooms").?.texture_id);
+    try testing.expect(game.post_load_render_gate == null);
+}
+
+test "gate acquires the manifest's atlases so the load triggers decode (#638)" {
+    // loadGameState must be self-contained: arming the gate acquires the
+    // manifest's image atlases (0→1 refcount) so their decode is enqueued
+    // by the engine — no external `assets.acquire(...)` workaround needed.
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    // A fresh, never-acquired atlas (refcount 0, registered).
+    try game.assets.register("characters", .image, "png", "stub");
+    try game.atlas_manager.registerPendingAtlas("characters", "{\"frames\":{}}", "img", "png");
+    game.registerSceneWithAssets("colony", emptyLoader, &.{"characters"});
+
+    try testing.expectEqual(@as(u32, 0), game.assets.entries.getPtr("characters").?.refcount);
+    game.armPostLoadRenderGate("colony");
+    // The gate acquired it — refcount bumped to 1.
+    try testing.expectEqual(@as(u32, 1), game.assets.entries.getPtr("characters").?.refcount);
 }

--- a/test/post_load_render_gate_test.zig
+++ b/test/post_load_render_gate_test.zig
@@ -303,3 +303,38 @@ test "gate acquires the manifest's atlases so the load triggers decode (#638)" {
     // The gate acquired it — refcount bumped to 1.
     try testing.expectEqual(@as(u32, 1), game.assets.entries.getPtr("characters").?.refcount);
 }
+
+test "repeated loads release the prior manifest — no refcount leak (#638)" {
+    // Load save A's scene, then save B's scene. The acquire from the
+    // first arm must be released before the second arm acquires, so each
+    // atlas's refcount reflects only the manifest currently pinned.
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    try game.assets.register("a_only", .image, "png", "stub");
+    try game.atlas_manager.registerPendingAtlas("a_only", "{\"frames\":{}}", "img", "png");
+    try game.assets.register("shared", .image, "png", "stub");
+    try game.atlas_manager.registerPendingAtlas("shared", "{\"frames\":{}}", "img", "png");
+    try game.assets.register("b_only", .image, "png", "stub");
+    try game.atlas_manager.registerPendingAtlas("b_only", "{\"frames\":{}}", "img", "png");
+
+    game.registerSceneWithAssets("scene_a", emptyLoader, &.{ "a_only", "shared" });
+    game.registerSceneWithAssets("scene_b", emptyLoader, &.{ "shared", "b_only" });
+
+    // Load A.
+    game.armPostLoadRenderGate("scene_a");
+    try testing.expectEqual(@as(u32, 1), game.assets.entries.getPtr("a_only").?.refcount);
+    try testing.expectEqual(@as(u32, 1), game.assets.entries.getPtr("shared").?.refcount);
+
+    // Load B — A's `a_only` is released, B's `b_only` acquired, and
+    // `shared` (in both) ends at refcount 1, NOT 2 (released then re-acquired).
+    game.armPostLoadRenderGate("scene_b");
+    try testing.expectEqual(@as(u32, 0), game.assets.entries.getPtr("a_only").?.refcount);
+    try testing.expectEqual(@as(u32, 1), game.assets.entries.getPtr("shared").?.refcount);
+    try testing.expectEqual(@as(u32, 1), game.assets.entries.getPtr("b_only").?.refcount);
+
+    // Tearing the game down releases B's manifest too (deinit hook).
+    game.releaseLoadAcquired();
+    try testing.expectEqual(@as(u32, 0), game.assets.entries.getPtr("shared").?.refcount);
+    try testing.expectEqual(@as(u32, 0), game.assets.entries.getPtr("b_only").?.refcount);
+}


### PR DESCRIPTION
## Problem

Loading a saved game intermittently rendered the world with wrong/garbled textures (e.g. menu→Load of a colony save in flying-platform-labelle). **New Game was always fine.**

## Root cause

`loadGameState` never (re-)acquired or bound the loaded scene's atlas manifest. Binding was left to the per-tick `bridgeAllReadyImageAssets` walk, which binds each atlas the instant **its own** upload lands — incrementally, one at a time, as async decodes complete out of order. That leaves a window where restored sprites sample atlases that haven't bound yet (unbound `texture_id == 0` / wrong texture).

Worse: a load issued from a **different** scene (menu→Load — `current_scene_name` is still `menu`, whose manifest is just `background`) had no way to know which atlas packs the restored world references, so games shipped a manual `assets.acquire(...)` loop in their Load handler as a workaround (flying-platform-labelle#542).

**The scene-change path was immune** because `gateOnManifest` waits for `allReady` and then calls `bridgeImageAssetsToAtlasManager` **once** — the whole manifest binds in a single deterministic pass after every upload completes, so a half-bound manifest is never observable. That asymmetry (all-at-once vs incremental) is the bug.

## Fix (deterministic, engine-side)

1. `saveGameState` records the active scene name (`"scene"`) — optional + back-compat (older saves omit it and fall back to the current scene).
2. `loadGameState` arms the post-load render gate against the **saved** scene's manifest. The gate now:
   - **acquires** that manifest's image atlases itself, so the load triggers their decode — `loadGameState` is self-contained and the FP#542 manual-acquire workaround can be removed; and
   - binds the whole manifest in **one pass** via the new `bridgeManifest` (= the scene-change `bridgeImageAssetsToAtlasManager`) the moment every atlas is `.ready` — never incrementally.
3. The per-tick `bridgeAllReadyImageAssets` skips atlases under an armed, not-yet-bridged post-load gate so it can't pre-bind a gated atlas and reintroduce the half-bound window. Non-load paths (eager-fallback, late-upload #508, scene-change) are untouched.

## Validation (flying-platform-labelle, bgfx/Metal, menu→Load of a colony save)

A content-level detector logged, per run, the decoded-pixel fingerprint that lands in each bgfx slot vs. the `texture_id` each atlas binds to (below `findSprite`, exactly where the suspected cross-wire would live):

- **Vulnerable engine (no post-load gate): 30/30 runs clean** — the catalog/decode/bind pipeline never mis-pairs name↔content even though handle assignment reshuffles non-deterministically between runs. The original corruption is the unbound-render window this gate closes, not a name↔texture cross-wire.
- **Fixed engine, FP#542 workaround removed: 30/30 runs** acquire + bind all six atlas packs self-contained, atomically, content-consistent.

`zig build test` green, including 3 new gate tests (saved-scene manifest preference, atomic all-at-once bind, acquire-on-arm).

## Notes
- Version bumped 1.58.0 → 1.59.0.
- Companion FP PR removes the now-redundant `assets.acquire(...)` loop from the menu Load handler.