### PR TITLE
feat(coords): screenToLogical + yAxis() accessor; thread .y_axis convention

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -154,6 +154,10 @@ pub fn build(b: *std.Build) void {
         // #630 — scene-teardown: O(N) `unloadCurrentScene` drain (guarded
         // untrack) + `resetEcsBackend` clears `scene_entities`.
         "test/scene_teardown_test.zig",
+        // #639 — project Y-axis convention: `Game.y_axis` constant +
+        // `yAxis()` accessor + additive `screenToLogical` picking path
+        // (RFC §3, Q1→(b), Q3). Raw `screenToDesign` stays unchanged.
+        "test/y_axis_test.zig",
     };
 
     for (test_files) |test_file| {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,9 +1,14 @@
 .{
     .fingerprint = 0xe8a81a8dc7f48c87,
     .name = .engine,
-    .version = "1.59.0",
+    .version = "1.60.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
+        // Requires labelle-core >= v1.18.0 — the YAxis enum + canonical
+        // `toScreenY`/`screenToLogicalY` transforms the engine's
+        // `screenToLogical` picking path routes through (labelle-engine#639).
+        // A path dependency, so CI clones core `main` (>= v1.18.0) as the
+        // sibling `../labelle-core`.
         .labelle_core = .{
             .path = "../labelle-core",
         },

--- a/src/game.zig
+++ b/src/game.zig
@@ -54,6 +54,16 @@ const misc_mixin = @import("game/misc_mixin.zig");
 /// Full game configuration — the assembler fills ALL comptime slots.
 /// RenderImpl is a renderer plugin (e.g. gfx.GfxRenderer) satisfying RenderInterface.
 /// The engine does NOT depend on labelle-gfx — it accesses component types through RenderImpl.
+///
+/// **Y-axis convention.** This entry point keeps the historical positional
+/// signature (the assembler's `engine.GameConfig(...)` call ends at
+/// `GameEvents,`) and defaults the project's logical Y-axis to `.down` — the
+/// RFC's framework-native default (labelle-engine#639, RFC §3, Q1→(b)). A
+/// project that wants the math-/platformer-natural `.up` convention (today's
+/// behavior) goes through `GameConfigWithYAxis`, which the assembler (#370)
+/// will switch to once it parses `.y_axis` from `project.labelle`. Threading a
+/// new convention this way is purely additive: existing generated games (and
+/// every bundled assembler example) keep calling `GameConfig` unchanged.
 pub fn GameConfig(
     comptime RenderImpl: type,
     comptime EcsImpl: type,
@@ -65,6 +75,45 @@ pub fn GameConfig(
     comptime ComponentsType: type,
     comptime GizmoCategoriesSlice: anytype,
     comptime GameEventsParam: type,
+) type {
+    return GameConfigWithYAxis(
+        RenderImpl,
+        EcsImpl,
+        InputImpl,
+        AudioImpl,
+        GuiImpl,
+        Hooks,
+        LogSinkImpl,
+        ComponentsType,
+        GizmoCategoriesSlice,
+        GameEventsParam,
+        // RFC default — `y = 0` at the TOP, +Y down (screen-native).
+        .down,
+    );
+}
+
+/// Y-axis-aware game configuration — identical to `GameConfig` but with an
+/// explicit project Y-axis convention as the trailing comptime slot. The
+/// assembler emits this entry point once it parses `.y_axis` from
+/// `project.labelle` (labelle-engine#639 / assembler #370); until then
+/// `GameConfig` delegates here with the `.down` default so the threading is
+/// already in place and only the assembler's emitted call needs to change.
+///
+/// `y_axis_param` is surfaced as the comptime constant `Game.y_axis` (and the
+/// `game.yAxis()` accessor), and is consumed by `screenToLogical` — the
+/// axis-aware picking path — via core's canonical `screenToLogicalY` transform.
+pub fn GameConfigWithYAxis(
+    comptime RenderImpl: type,
+    comptime EcsImpl: type,
+    comptime InputImpl: type,
+    comptime AudioImpl: type,
+    comptime GuiImpl: type,
+    comptime Hooks: type,
+    comptime LogSinkImpl: type,
+    comptime ComponentsType: type,
+    comptime GizmoCategoriesSlice: anytype,
+    comptime GameEventsParam: type,
+    comptime y_axis_param: core.YAxis,
 ) type {
     // Validate renderer satisfies the contract
     _ = core.RenderInterface(RenderImpl);
@@ -170,6 +219,14 @@ pub fn GameConfig(
         pub const ComponentRegistry = ComponentsType;
         /// Gizmo categories discovered from plugins at comptime.
         pub const gizmo_categories = GizmoCategoriesSlice;
+
+        /// The project's logical Y-axis convention (labelle-engine#639,
+        /// RFC §3). `.down` (default) means `y = 0` is the TOP and +Y grows
+        /// downward — screen-native, the renderer flip is identity. `.up`
+        /// means `y = 0` is the BOTTOM and +Y grows upward — today's behavior,
+        /// the renderer flips on the way out. Consumed by `screenToLogical`
+        /// (axis-aware picking) and exposed at runtime via `yAxis()`.
+        pub const y_axis: core.YAxis = y_axis_param;
 
         // ── Mixin types ──────────────────────────────────────────
         const Visuals = visuals_mixin.Mixin(Self);
@@ -775,6 +832,30 @@ pub fn GameConfig(
         /// Backends without a design/physical distinction (raylib) get
         /// a passthrough — the input is returned unchanged.
         pub const screenToDesign = MiscMixin.screenToDesign;
+
+        /// Convert a physical-pixel screen coordinate into the project's
+        /// **logical** coordinate space — the same space as `Position` and
+        /// `setPosition`. This first maps through `screenToDesign` (raw,
+        /// y-down design pixels, unchanged) and then applies the project's
+        /// `.y_axis` convention to the Y component via core's canonical
+        /// `screenToLogicalY` transform.
+        ///
+        /// Under `.up` (today's default behavior) this flips Y
+        /// (`logical_y = height - design_y`) so a click at the top of the
+        /// window yields a *large* logical `y` — matching where an entity
+        /// placed there needs to sit. Under `.down` it's the identity, so
+        /// `screenToLogical` == `screenToDesign`.
+        ///
+        /// Use this for axis-aware picking / drag-to-place / gizmo
+        /// hit-testing (RFC Q1→(b), Q3). Code that wants raw window-space
+        /// coordinates (e.g. forwarding to imgui, or `cam.screenToWorld`,
+        /// which applies its own flip) keeps using `screenToDesign`.
+        pub const screenToLogical = MiscMixin.screenToLogical;
+
+        /// The project's logical Y-axis convention as a runtime value. Mirrors
+        /// the comptime `Game.y_axis` constant for callers that prefer an
+        /// accessor (RFC §3).
+        pub const yAxis = MiscMixin.yAxis;
 
         // ── Audio (mixin) ────────────────────────────────────────
         pub const playSound = AudioMixin.playSound;

--- a/src/game/misc_mixin.zig
+++ b/src/game/misc_mixin.zig
@@ -32,7 +32,7 @@ pub fn Mixin(comptime Game: type) type {
 
         /// The project's logical Y-axis convention as a runtime value
         /// (mirrors the comptime `Game.y_axis`). See RFC §3.
-        pub fn yAxis(_: *Game) core.YAxis {
+        pub fn yAxis(_: *const Game) core.YAxis {
             return Game.y_axis;
         }
 
@@ -50,13 +50,22 @@ pub fn Mixin(comptime Game: type) type {
 
         /// The screen height the renderer flips against. The renderer owns
         /// the authoritative value (set via `setScreenHeight`); we read its
-        /// `screen_height` field when present. Renderers without that field
-        /// (e.g. the engine-test `StubRender`) only ever run under `.down`
-        /// in practice, where the height is unused (identity flip), so a
-        /// `0` fallback is harmless.
+        /// `screen_height` field when present.
+        ///
+        /// Under `.up`, the flip (`height - y`) genuinely needs the height,
+        /// so a renderer without a `screen_height` field is a build error
+        /// rather than a silent `0` that would yield negative logical Y.
+        /// Under `.down` the height is unused (identity), so a `0` fallback
+        /// is harmless — this is the path the engine-test `StubRender`
+        /// (no `screen_height` field) takes.
         fn renderScreenHeight(self: *Game) f32 {
             if (comptime @hasField(RenderImpl, "screen_height")) {
                 return self.renderer.screen_height;
+            }
+            if (comptime Game.y_axis == .up) {
+                @compileError("Renderer " ++ @typeName(RenderImpl) ++
+                    " must expose a 'screen_height' field to be used with Game.y_axis == .up" ++
+                    " (the y-up flip `height - y` needs it).");
             }
             return 0;
         }

--- a/src/game/misc_mixin.zig
+++ b/src/game/misc_mixin.zig
@@ -8,6 +8,8 @@
 /// shells stay on `Game` — they fold to `void` on cameraless renderers —
 /// and forward here for the impl bodies.
 
+const core = @import("labelle-core");
+
 /// Returns the misc-accessors mixin for a given Game type.
 pub fn Mixin(comptime Game: type) type {
     const RenderImpl = @typeInfo(@FieldType(Game, "renderer")).pointer.child;
@@ -26,6 +28,37 @@ pub fn Mixin(comptime Game: type) type {
         /// a passthrough — the input is returned unchanged.
         pub fn screenToDesign(self: *Game, px: f32, py: f32) RenderImpl.ScreenPoint {
             return self.renderer.screenToDesign(px, py);
+        }
+
+        /// The project's logical Y-axis convention as a runtime value
+        /// (mirrors the comptime `Game.y_axis`). See RFC §3.
+        pub fn yAxis(_: *Game) core.YAxis {
+            return Game.y_axis;
+        }
+
+        /// Convert a physical-pixel screen coordinate into the project's
+        /// **logical** space (the `Position` space). Maps through the raw
+        /// `screenToDesign` first, then applies `Game.y_axis` to the Y
+        /// component via core's canonical `screenToLogicalY`. For `.down`
+        /// this is the identity (== `screenToDesign`); for `.up` it flips Y
+        /// (`height - design_y`). See RFC §3 (Q1→(b), Q3).
+        pub fn screenToLogical(self: *Game, px: f32, py: f32) RenderImpl.ScreenPoint {
+            var p = self.renderer.screenToDesign(px, py);
+            p.y = core.screenToLogicalY(Game.y_axis, p.y, renderScreenHeight(self));
+            return p;
+        }
+
+        /// The screen height the renderer flips against. The renderer owns
+        /// the authoritative value (set via `setScreenHeight`); we read its
+        /// `screen_height` field when present. Renderers without that field
+        /// (e.g. the engine-test `StubRender`) only ever run under `.down`
+        /// in practice, where the height is unused (identity flip), so a
+        /// `0` fallback is harmless.
+        fn renderScreenHeight(self: *Game) f32 {
+            if (comptime @hasField(RenderImpl, "screen_height")) {
+                return self.renderer.screen_height;
+            }
+            return 0;
         }
 
         /// Register an embedded JSONC scene source so `"include"`

--- a/src/root.zig
+++ b/src/root.zig
@@ -47,6 +47,10 @@ pub const requestedScene = runtime_env.requestedScene;
 
 // ── Game ──
 pub const GameConfig = game_mod.GameConfig;
+/// Y-axis-aware game configuration — `GameConfig` plus an explicit trailing
+/// `core.YAxis` slot. The assembler adopts this once it parses `.y_axis`
+/// from `project.labelle` (labelle-engine#639 / #370). See `game.zig`.
+pub const GameConfigWithYAxis = game_mod.GameConfigWithYAxis;
 pub const GameLog = game_log_mod.GameLog;
 pub const StubLogSink = core.StubLogSink;
 pub const StderrLogSink = core.StderrLogSink;

--- a/test/y_axis_test.zig
+++ b/test/y_axis_test.zig
@@ -1,0 +1,185 @@
+//! Tests for the project Y-axis convention (labelle-engine#639, RFC §3):
+//! the `Game.y_axis` comptime constant, the `game.yAxis()` accessor, the
+//! `.y_axis` default (`.down`), and the additive `screenToLogical` picking
+//! path (Q1→(b), Q3) — including the invariant that raw `screenToDesign`
+//! is *unchanged* by the convention.
+//!
+//! Uses a local `HeightRenderer` (mirroring `set_sprite_flip_test`'s
+//! `FlipRenderer`) so `screenToLogical` has a real `screen_height` to flip
+//! against without dragging in a graphics backend. The default `Game`
+//! (StubRender) covers the default-convention assertion.
+
+const std = @import("std");
+const testing = std.testing;
+const core = @import("labelle-core");
+const engine = @import("engine");
+
+const MockEcs = core.MockEcsBackend(u32);
+
+/// Minimal renderer that carries a `screen_height` field (settable via
+/// `setScreenHeight`) and a passthrough `screenToDesign`/`ScreenPoint` — the
+/// two surfaces `screenToLogical` composes. Everything else is a stub.
+fn HeightRenderer(comptime Entity: type) type {
+    return struct {
+        const Self = @This();
+
+        pub const ScreenPoint = struct { x: f32, y: f32 };
+
+        pub const Sprite = struct {
+            sprite_name: []const u8 = "",
+            visible: bool = true,
+            z_index: i16 = 0,
+            layer: enum { default } = .default,
+        };
+        pub const Shape = struct {
+            visible: bool = true,
+            z_index: i16 = 0,
+            layer: enum { default } = .default,
+        };
+
+        screen_height: f32 = 600,
+
+        pub fn init(_: std.mem.Allocator) Self {
+            return .{};
+        }
+        pub fn deinit(_: *Self) void {}
+        pub fn trackEntity(_: *Self, _: Entity, _: core.VisualType) void {}
+        pub fn untrackEntity(_: *Self, _: Entity) void {}
+        pub fn markPositionDirty(_: *Self, _: Entity) void {}
+        pub fn markPositionDirtyWithChildren(_: *Self, comptime _: type, _: anytype, _: Entity) void {}
+        pub fn updateHierarchyFlag(_: *Self, _: Entity, _: bool) void {}
+        pub fn markVisualDirty(_: *Self, _: Entity) void {}
+        pub fn sync(_: *Self, comptime _: type, _: anytype) void {}
+        pub fn render(_: *Self) void {}
+        pub fn setScreenHeight(self: *Self, h: f32) void {
+            self.screen_height = h;
+        }
+        pub fn clear(_: *Self) void {}
+        pub fn renderGizmoDraws(_: *Self, _: []const core.GizmoDraw) void {}
+        pub fn hasEntity(_: *const Self, _: Entity) bool {
+            return false;
+        }
+        /// Raw passthrough — backends without a design/physical distinction
+        /// return the input unchanged. `screenToLogical` then layers the
+        /// `.y_axis` transform on top of this.
+        pub fn screenToDesign(_: *const Self, px: f32, py: f32) ScreenPoint {
+            return .{ .x = px, .y = py };
+        }
+    };
+}
+
+const EmptyComponents = struct {
+    pub fn has(comptime _: []const u8) bool {
+        return false;
+    }
+    pub fn names() []const []const u8 {
+        return &.{};
+    }
+};
+
+fn GameOn(comptime y_axis: core.YAxis) type {
+    return engine.GameConfigWithYAxis(
+        HeightRenderer(MockEcs.Entity),
+        MockEcs,
+        engine.StubInput,
+        engine.StubAudio,
+        engine.StubGui,
+        void,
+        engine.StubLogSink,
+        EmptyComponents,
+        &.{},
+        void,
+        y_axis,
+    );
+}
+
+const DownGame = GameOn(.down);
+const UpGame = GameOn(.up);
+
+test "y_axis: GameConfig (positional) defaults to .down" {
+    // The historical positional entry point the assembler still emits must
+    // default to the RFC's screen-native convention.
+    try testing.expectEqual(core.YAxis.down, engine.Game.y_axis);
+
+    var game = engine.Game.init(testing.allocator);
+    defer game.deinit();
+    try testing.expectEqual(core.YAxis.down, game.yAxis());
+}
+
+test "y_axis: comptime constant and yAxis() accessor agree" {
+    try testing.expectEqual(core.YAxis.down, DownGame.y_axis);
+    try testing.expectEqual(core.YAxis.up, UpGame.y_axis);
+
+    var down = DownGame.init(testing.allocator);
+    defer down.deinit();
+    var up = UpGame.init(testing.allocator);
+    defer up.deinit();
+
+    try testing.expectEqual(core.YAxis.down, down.yAxis());
+    try testing.expectEqual(core.YAxis.up, up.yAxis());
+}
+
+test "screenToDesign stays RAW under both conventions (unchanged)" {
+    // The whole point of Q1→(b): existing games keep using raw screenToDesign,
+    // and it must be identical regardless of .y_axis.
+    var down = DownGame.init(testing.allocator);
+    defer down.deinit();
+    var up = UpGame.init(testing.allocator);
+    defer up.deinit();
+    down.setScreenHeight(600);
+    up.setScreenHeight(600);
+
+    const d = down.screenToDesign(120, 50);
+    const u = up.screenToDesign(120, 50);
+    try testing.expectEqual(@as(f32, 120), d.x);
+    try testing.expectEqual(@as(f32, 50), d.y);
+    try testing.expectEqual(@as(f32, 120), u.x);
+    try testing.expectEqual(@as(f32, 50), u.y); // raw, NOT flipped
+}
+
+test "screenToLogical under .down is the identity (== screenToDesign)" {
+    var game = DownGame.init(testing.allocator);
+    defer game.deinit();
+    game.setScreenHeight(600);
+
+    const p = game.screenToLogical(120, 50);
+    try testing.expectEqual(@as(f32, 120), p.x);
+    try testing.expectEqual(@as(f32, 50), p.y); // y-down: no flip
+}
+
+test "screenToLogical under .up flips Y (height - y), x untouched" {
+    var game = UpGame.init(testing.allocator);
+    defer game.deinit();
+    game.setScreenHeight(600);
+
+    // A click near the TOP of the window (small screen y) must yield a LARGE
+    // logical y — the space where a y-up entity placed there actually sits.
+    const top = game.screenToLogical(120, 50);
+    try testing.expectEqual(@as(f32, 120), top.x);
+    try testing.expectEqual(@as(f32, 550), top.y); // 600 - 50
+
+    // A click near the BOTTOM yields a small logical y.
+    const bottom = game.screenToLogical(120, 550);
+    try testing.expectEqual(@as(f32, 50), bottom.y); // 600 - 550
+}
+
+test "screenToLogical matches core.screenToLogicalY exactly (no duplicated transform)" {
+    var game = UpGame.init(testing.allocator);
+    defer game.deinit();
+    game.setScreenHeight(480);
+
+    const py: f32 = 137;
+    const p = game.screenToLogical(0, py);
+    const expected = core.screenToLogicalY(.up, py, 480);
+    try testing.expectEqual(expected, p.y);
+}
+
+test "screenToLogical round-trips through the renderer's set height" {
+    // Honours setScreenHeight rather than a baked-in default.
+    var game = UpGame.init(testing.allocator);
+    defer game.deinit();
+    game.setScreenHeight(1000);
+
+    const p = game.screenToLogical(0, 300);
+    try testing.expectEqual(@as(f32, 700), p.y); // 1000 - 300
+}


### PR DESCRIPTION
## What

Stage 2 of the **Y-axis convention epic** (#640, RFC §3 / Q1→(b) / Q3). Adds the engine-side picking accessor + threads the project's Y-axis convention from config. Built on **labelle-core v1.18.0** (`YAxis` + `toScreenY`/`screenToLogicalY`).

Closes #639, part of epic #640.

## Changes

- **`screenToLogical(px, py)`** — new, additive. Maps through raw `screenToDesign` first, then applies the project's `.y_axis` to the **Y** component via core's canonical `screenToLogicalY` (no duplicated transform). `.down` ⇒ identity (`== screenToDesign`); `.up` ⇒ `height - y`. This is the axis-aware picking / drag-to-place / gizmo hit-test path.
- **`screenToDesign` stays RAW** (window space, y-down) — untouched, so existing games aren't disturbed (the reason Q1→(b) makes adopting `.up` a no-op).
- **`Game.y_axis` comptime constant + `game.yAxis()` accessor** expose the active convention.
- **Thread `.y_axis` from config**: new `GameConfigWithYAxis(...)` entry point with a trailing `comptime core.YAxis` slot, **default `.down`** (RFC default). The historical positional `GameConfig` the assembler still emits delegates here with `.down`, so **no generated game or bundled assembler example needs to change** — the assembler (#370) switches to `GameConfigWithYAxis` once it parses `.y_axis` from `project.labelle`.
- The engine has no internal gizmo hit-test comparing raw mouse vs logical position (gizmos are debug draws), so Q3 is satisfied by providing `screenToLogical` for tool callers.
- `build.zig.zon`: documents the **core ≥ v1.18.0** requirement (path dep; CI clones core `main`), engine bumped **1.59.0 → 1.60.0**.

## Tests

New `test/y_axis_test.zig` (7 tests, wired into the `test` step): default `.down`, constant/accessor agreement, raw `screenToDesign` invariance under both axes, `.down` identity, `.up` flip, exact match against `core.screenToLogicalY`, and height round-trip via `setScreenHeight`. Discovery verified (force-failed one test → `zig build test` failed → reverted).

`zig build` ✅ · `zig build test --summary all` ✅ **587/587 tests, 118/118 steps**.

## Compatibility

Fully additive. `.up` reproduces today's behavior exactly; `screenToDesign` and `setPosition` are unchanged.