### PR TITLE
feat(engine): wire audio backend into video backend (in-engine video audio)

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -685,6 +685,23 @@ pub fn GameConfigWithYAxis(
             // or no flow listens (`uses_os_gamepad_source` folds it away),
             // and the source's own `init` is `@hasDecl`-guarded per platform.
             if (comptime uses_os_gamepad_source) core.gamepad_source.init();
+            // Wire the audio backend into a video backend that supports it (e.g.
+            // the bgfx VideoBackend), so opened videos play their audio track in
+            // A/V sync — the player's master clock is the audio position
+            // (#549/#306). Comptime-gated: stub video, or an audio backend
+            // without the mixer API, folds this away. The VideoBackend can't
+            // import the audio module (one mixer), so the engine — which holds
+            // both impls — injects the raw audio fns as function pointers.
+            if (comptime @hasDecl(VideoImpl, "setAudioBackend") and @hasDecl(AudioImpl, "loadMusicFromPcm")) {
+                VideoImpl.setAudioBackend(.{
+                    .loadPcm = &AudioImpl.loadMusicFromPcm,
+                    .play = &AudioImpl.playMusic,
+                    .update = &AudioImpl.updateMusic,
+                    .stop = &AudioImpl.stopMusic,
+                    .clock = &AudioImpl.musicPositionSeconds,
+                    .unload = &AudioImpl.unloadMusic,
+                });
+            }
             return .{
                 .allocator = allocator,
                 .active_world = world,


### PR DESCRIPTION
Pairs with labelle-assembler#382 to give in-engine video **sound** (#549/#306).

`Game.init` injects the audio backend's mixer fns into a video backend that supports it (the bgfx `VideoBackend`'s `setAudioBackend`), so opened videos play their audio track with the audio position as the player's master clock for A/V sync.

- Comptime-gated: `@hasDecl(VideoImpl, "setAudioBackend") and @hasDecl(AudioImpl, "loadMusicFromPcm")` — `StubVideo` / non-mixer audio backends fold it away (unchanged).
- The engine holds both `VideoImpl` + `AudioImpl`, so it's the natural wiring point (the gfx module must not import the audio module — one mixer).
- 597/597 tests pass.

Requires the assembler-side `VideoBackend.setAudioBackend` (labelle-assembler#382).

🤖 Generated with [Claude Code](https://claude.com/claude-code)