### PR TITLE
refactor(font): adopt labelle-core value types; retire extern Glyph reinterpret (Phase 1, #647)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -27,6 +27,10 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+    // font_types now aliases the canonical Glyph/CodepointEntry/KernPair from
+    // labelle-core (labelle-assembler#647) instead of redefining them, so it
+    // needs core in its own module graph (it used to be a dependency-free leaf).
+    font_types_module.addImport("labelle-core", core_module);
 
     const engine_module = b.addModule("engine", .{
         .root_source_file = b.path("src/root.zig"),

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,10 +4,12 @@
     .version = "1.63.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
-        // Requires labelle-core >= v1.18.0 — the YAxis enum + canonical
-        // `toScreenY`/`screenToLogicalY` transforms the engine's
-        // `screenToLogical` picking path routes through (labelle-engine#639).
-        // A path dependency, so CI clones core `main` (>= v1.18.0) as the
+        // Requires labelle-core >= v1.20.0 — font_types aliases core's
+        // canonical Glyph/CodepointEntry/KernPair value types
+        // (labelle-engine#647), which supersede the earlier >= v1.18.0 YAxis
+        // floor (the YAxis enum + `toScreenY`/`screenToLogicalY` transforms the
+        // `screenToLogical` picking path routes through, labelle-engine#639).
+        // A path dependency, so CI clones core `main` (>= v1.20.0) as the
         // sibling `../labelle-core`.
         .labelle_core = .{
             .path = "../labelle-core",

--- a/src/font_types.zig
+++ b/src/font_types.zig
@@ -5,6 +5,8 @@
 //! rasterising is delegated to a `FontBackend` hook injected by the
 //! assembler at `Game.init`, mirroring `AudioBackend` and `ImageBackend`.
 
+const core = @import("labelle-core");
+
 /// Opaque handle for a loaded font (baked glyph atlas + metrics).
 /// Same shape as `audio_types.SoundId` — generation-tagged so the
 /// runtime can detect use-after-free against a stale handle.
@@ -19,46 +21,22 @@ pub const FontId = struct {
     }
 };
 
-/// One baked glyph. UV rect is in *pixels* of the atlas (not
-/// normalised) so the renderer can divide by atlas size once at
-/// upload time. `xoff` / `yoff` are pen-relative blit offsets that
-/// already incorporate the glyph's bearing — the renderer just adds
-/// them to the pen position. `advance` moves the pen for the next
-/// glyph. See `RFC-FONT-LOADER.md` §3.
-///
-/// `extern struct` so the assembler-generated `FontBackendAdapter` can
-/// `@ptrCast` slices between `[]BackendGfx.Glyph` and `[]engine.Glyph`
-/// (and the equivalent sokol-side types) — the three repos define
-/// structurally-identical-but-nominally-distinct `Glyph` types and
-/// rely on a zero-cost reinterpret at the codegen marshal boundary.
-/// Without `extern` the layout is unspecified and the reinterpret is
-/// UB. Layout-compatible across all three definitions: u16×4 then f32×3.
-pub const Glyph = extern struct {
-    u0: u16,
-    v0: u16,
-    u1: u16,
-    v1: u16,
+// `Glyph` / `CodepointEntry` / `KernPair` are now owned by **labelle-core**
+// (labelle-assembler#647, RFC §Q#2) and aliased here. They were `extern struct`s
+// duplicated across core/gfx/engine purely so the assembler-generated
+// `FontBackendAdapter` could `@ptrCast` slices between the nominally-distinct
+// copies. With one canonical type shared by all three repos the reinterpret
+// collapses to identity; the `extern` layout guarantee lives at the core
+// definition (`labelle-core/src/backend_contract.zig`). The field shape is
+// unchanged: u16×4 then f32×3 for `Glyph`. See `RFC-FONT-LOADER.md` §3.
 
-    xoff: f32,
-    yoff: f32,
-    advance: f32,
-};
+/// One baked glyph. UV rect in atlas *pixels*; `xoff`/`yoff` are
+/// pen-relative blit offsets; `advance` moves the pen for the next glyph.
+pub const Glyph = core.Glyph;
 
-/// Sorted (by `codepoint`) lookup from Unicode codepoint to dense
-/// index in the `glyphs` array. Renderers binary-search this per
-/// glyph. Built from `FontBakeParams.ranges` at bake time. `extern`
-/// for the same reason as `Glyph`.
-pub const CodepointEntry = extern struct {
-    codepoint: u32,
-    glyph_index: u32,
-};
+/// Sorted (by `codepoint`) lookup from Unicode codepoint to dense glyph
+/// index; renderers binary-search this per glyph.
+pub const CodepointEntry = core.CodepointEntry;
 
-/// One GPOS kern pair. `advance` is added to the pen advance when
-/// `first` is followed by `second`. Empty slice when kerning is
-/// disabled or the font has no GPOS kern table. `extern` for the
-/// same reason as `Glyph`.
-pub const KernPair = extern struct {
-    first: u32,
-    second: u32,
-    advance: f32,
-};
+/// One GPOS kern pair — `advance` added when `first` is followed by `second`.
+pub const KernPair = core.KernPair;

--- a/test/font_types_test.zig
+++ b/test/font_types_test.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const engine = @import("engine");
+const core = @import("labelle-core");
 
 test "FontId.invalid fails isValid" {
     const id = engine.FontId.invalid;
@@ -18,4 +19,14 @@ test "Glyph / CodepointEntry / KernPair sizes are stable PODs" {
     try std.testing.expectEqual(@as(usize, 20), @sizeOf(engine.Glyph));
     try std.testing.expectEqual(@as(usize, 8), @sizeOf(engine.CodepointEntry));
     try std.testing.expectEqual(@as(usize, 12), @sizeOf(engine.KernPair));
+}
+
+test "font value types are the canonical labelle-core types" {
+    // The point of #647 is *nominal* identity, not just matching layout: the
+    // size test above would still pass if engine reintroduced a structurally-
+    // identical-but-distinct `extern struct`. Lock the alias so the assembler's
+    // codegen-marshal `@ptrCast` stays a genuine identity cast.
+    try std.testing.expect(engine.Glyph == core.Glyph);
+    try std.testing.expect(engine.CodepointEntry == core.CodepointEntry);
+    try std.testing.expect(engine.KernPair == core.KernPair);
 }


### PR DESCRIPTION
Phase 1 of the **Pluggable backends** RFC. With the render backend contract + its value types now owned by **labelle-core** (v1.20.0), engine aliases the three font value types instead of redefining them.

Tracking: #647 (labelle-toolkit/labelle-assembler#387 / epic labelle-toolkit/labelle-assembler#386). Pairs with labelle-toolkit/labelle-core#45 (merged, v1.20.0) and labelle-toolkit/labelle-gfx#288.

## Changes
- `src/font_types.zig`: `Glyph` / `CodepointEntry` / `KernPair` are now aliases of `core.Glyph` / `core.CodepointEntry` / `core.KernPair` (`FontId` stays engine-local). This collapses the cross-repo nominal distinction that forced the `extern` `@ptrCast` reinterpret at the codegen marshal boundary to identity.
- `build.zig`: wire `labelle-core` into the `font_types` leaf module — it was deliberately dependency-free *because* it duplicated the `extern` types.

## Notes
No behaviour change; the `extern` field layout is unchanged (it now lives at the core definition). Engine `zig build test` green against core main / v1.20.0. The committed `labelle-core` dep stays a sibling `../labelle-core` path (engine's existing convention; the assembler unifies core across the diamond at assemble time).