### PR TITLE
feat(android): surfaceLost/surfaceRestored — GPU-context re-upload (RFC Accept gate, #386 Phase 4)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xe8a81a8dc7f48c87,
     .name = .engine,
-    .version = "1.64.0",
+    .version = "1.65.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         // Requires labelle-core >= v1.20.0 — font_types aliases core's

--- a/src/assets/catalog.zig
+++ b/src/assets/catalog.zig
@@ -14,6 +14,7 @@
 //!   * `catalog/tests_lifecycle.zig`— register/acquire/release/query tests
 //!   * `catalog/tests_pump.zig`     — pump() state-machine tests (#442)
 //!   * `catalog/tests_release.zig`  — release() backend-free tests (#446)
+//!   * `catalog/tests_surface_loss.zig` — GPU context-loss tests (#386)
 
 const engine = @import("catalog/engine.zig");
 
@@ -40,4 +41,5 @@ test {
     _ = @import("catalog/tests_lifecycle.zig");
     _ = @import("catalog/tests_pump.zig");
     _ = @import("catalog/tests_release.zig");
+    _ = @import("catalog/tests_surface_loss.zig");
 }

--- a/src/assets/catalog/engine.zig
+++ b/src/assets/catalog/engine.zig
@@ -83,6 +83,14 @@ pub const AssetCatalog = struct {
     /// frames pass without new work, the next `pump` still starts
     /// where the last one left off.
     pump_cursor: u8,
+    /// `true` while the GPU surface is alive. Cleared by
+    /// `invalidateGpuResources` (Android TERM_WINDOW) and restored by
+    /// `reenqueueGpuResident` (INIT_WINDOW). While `false`, `pump`'s
+    /// happy-path upload branch must not run — uploading into a dead
+    /// context would `destroyTexture` a stale handle / crash the
+    /// backend. See the GPU-context-loss design notes on
+    /// `invalidateGpuResources` below (epic #386 Phase 4).
+    gpu_alive: bool,
 
     /// Builds the catalog. The worker thread is spawned lazily on
     /// the first `acquire` — this keeps `init`'s signature infallible
@@ -108,6 +116,7 @@ pub const AssetCatalog = struct {
             .workers_started = false,
             .dispatch_counter = 0,
             .pump_cursor = 0,
+            .gpu_alive = true,
         };
     }
 
@@ -269,45 +278,61 @@ pub const AssetCatalog = struct {
         const needs_enqueue = entry.refcount == 0 and entry.state == .registered;
 
         if (needs_enqueue) {
-            // Spawn the worker pool BEFORE touching the refcount. If
-            // thread spawn fails, `try` bubbles the error with the
-            // catalog state unchanged — no leaked refcount that would
-            // trap the entry at `.registered` with `refcount > 0` forever.
-            try self.ensureWorker();
-            const request: WorkRequest = .{
-                .entry_name = kv.key_ptr.*,
-                .vtable = entry.loader,
-                .file_type = entry.file_type,
-                .bytes = entry.raw_bytes,
-                .params = entry.params,
-            };
-            // Round-robin across the worker pool so decode load is
-            // spread. If the picked ring is full (shouldn't happen in
-            // practice — 64-slot capacity vs. typical 6–30 atlases —
-            // but the contract tolerates it), fall through to
-            // `.registered` and let pump() retry via a future acquire.
-            const idx = self.dispatch_counter % NUM_WORKERS;
-            self.dispatch_counter +%= 1;
-            if (self.requests[idx].tryEnqueue(request)) |_| {
-                entry.state = .queued;
-
-                // `single_threaded` (WASM) has no worker thread
-                // running — `start()` is a no-op there (issue #461).
-                // Drain the request we just enqueued on the main
-                // thread so the result lands in the result ring
-                // before the next `pump()`.
-                if (builtin.single_threaded) {
-                    self.workers[idx].runOnce();
-                }
-            } else |err| switch (err) {
-                error.QueueFull => std.log.debug(
-                    "assets: request ring {d} full, deferring acquire of '{s}'",
-                    .{ idx, kv.key_ptr.* },
-                ),
-            }
+            try self.enqueueDecode(kv.key_ptr.*, entry);
         }
         entry.refcount += 1;
         return entry;
+    }
+
+    /// Enqueues a decode `WorkRequest` for `entry` and flips its state
+    /// to `.queued`. Factored out of `acquire` so the GPU-context-loss
+    /// re-enqueue path (`reenqueueGpuResident`) can re-fire a decode
+    /// without going through `acquire`'s refcount/needs-enqueue logic.
+    ///
+    /// `key` is the stable hashmap-owned key slice (program-lifetime per
+    /// the `@embedFile` invariant) — never a caller-supplied temporary,
+    /// since the worker borrows it on the request ring.
+    ///
+    /// Spawns the worker pool first; on `ensureWorker` failure the error
+    /// bubbles with the entry's state unchanged. If the picked request
+    /// ring is full, logs and leaves the state at `.registered` — a
+    /// later acquire / re-enqueue retries.
+    fn enqueueDecode(self: *AssetCatalog, key: []const u8, entry: *AssetEntry) !void {
+        // Spawn the worker pool BEFORE touching state. If thread spawn
+        // fails, `try` bubbles the error with the catalog state
+        // unchanged — no entry left trapped mid-transition.
+        try self.ensureWorker();
+        const request: WorkRequest = .{
+            .entry_name = key,
+            .vtable = entry.loader,
+            .file_type = entry.file_type,
+            .bytes = entry.raw_bytes,
+            .params = entry.params,
+        };
+        // Round-robin across the worker pool so decode load is
+        // spread. If the picked ring is full (shouldn't happen in
+        // practice — 64-slot capacity vs. typical 6–30 atlases —
+        // but the contract tolerates it), fall through to
+        // `.registered` and let a future enqueue retry.
+        const idx = self.dispatch_counter % NUM_WORKERS;
+        self.dispatch_counter +%= 1;
+        if (self.requests[idx].tryEnqueue(request)) |_| {
+            entry.state = .queued;
+
+            // `single_threaded` (WASM) has no worker thread
+            // running — `start()` is a no-op there (issue #461).
+            // Drain the request we just enqueued on the main
+            // thread so the result lands in the result ring
+            // before the next `pump()`.
+            if (builtin.single_threaded) {
+                self.workers[idx].runOnce();
+            }
+        } else |err| switch (err) {
+            error.QueueFull => std.log.debug(
+                "assets: request ring {d} full, deferring decode of '{s}'",
+                .{ idx, key },
+            ),
+        }
     }
 
     /// Drops the refcount. When it hits zero on a `.ready` entry, the
@@ -469,12 +494,25 @@ pub const AssetCatalog = struct {
                 var tried: u8 = 0;
                 while (tried < NUM_WORKERS) : (tried += 1) {
                     const idx: u8 = @intCast((@as(usize, self.pump_cursor) + tried) % NUM_WORKERS);
+                    // GPU context loss (Android TERM_WINDOW): leave any
+                    // happy-path upload result PARKED on the ring so an
+                    // in-flight decode landing mid-TERM doesn't upload
+                    // into a dead context. Peek first; only consume the
+                    // result if it's a cheap drain path (removed entry,
+                    // zombie, or decode error — none of which touch the
+                    // GPU). `reenqueueGpuResident` flips `gpu_alive` back
+                    // on and the parked results upload then. The peek
+                    // never advances `tail`, so the parked slot survives.
+                    if (!self.gpu_alive) {
+                        const peeked = self.results[idx].peek() orelse continue;
+                        if (self.isGpuUploadResult(peeked)) continue;
+                    }
                     if (self.results[idx].tryDequeue()) |r| {
                         self.pump_cursor = @intCast((@as(usize, idx) + 1) % NUM_WORKERS);
                         break :blk r;
                     }
                 }
-                return; // all rings empty
+                return; // all rings empty (or all remaining are GPU-parked)
             };
 
             // (1) Entry was removed between enqueue and dequeue. No
@@ -532,6 +570,92 @@ pub const AssetCatalog = struct {
             // resource handle is parked on `entry.resource`.
             entry.decoded = null;
             entry.state = .ready;
+        }
+    }
+
+    /// `true` if draining `result` from the ring would run the
+    /// GPU-touching happy-path upload (branch 4 of `pump`) for a
+    /// GPU-resident asset. Used by `pump` while `gpu_alive == false` to
+    /// leave such results parked on the ring rather than uploading into
+    /// a dead context.
+    ///
+    /// A result is GPU-bound only when it would reach branch (4) *and*
+    /// its payload is an image:
+    ///   * the entry still exists (else branch 1 — removed, GPU-free),
+    ///   * refcount > 0 (else branch 2 — zombie, GPU-free),
+    ///   * `err == null` (else branch 3 — decode error, GPU-free),
+    ///   * `decoded` is an `.image` (audio/font uploads don't touch the
+    ///     GPU surface that TERM_WINDOW destroyed, so they may drain).
+    fn isGpuUploadResult(self: *AssetCatalog, result: WorkResult) bool {
+        const entry = self.entries.getPtr(result.entry_name) orelse return false;
+        if (entry.refcount == 0) return false;
+        if (result.err != null) return false;
+        const payload = result.decoded orelse return false;
+        return payload == .image;
+    }
+
+    /// GPU surface lost (Android TERM_WINDOW / `surfaceLost`).
+    ///
+    /// TERM_WINDOW destroys every GPU texture but leaves game state and
+    /// the CPU-side allocator intact. For each GPU-resident, `.ready`
+    /// asset we drop the *stale* backend handle WITHOUT calling the
+    /// loader's `free` vtable: `free` would `destroyTexture` a handle
+    /// the driver has already invalidated, which is undefined behaviour
+    /// on a dead context. Instead we null `entry.resource` directly and
+    /// rewind state to `.registered`, leaving `refcount` untouched so
+    /// the asset's holders stay valid. `reenqueueGpuResident` re-fires
+    /// the decode → upload pipeline once the surface returns.
+    ///
+    /// Only `.image` assets are invalidated — `.audio` resources are
+    /// not GPU-resident and survive context loss. Entries that are
+    /// mid-flight (`.queued` / `.decoding`) or not yet uploaded
+    /// (`.registered` / `.failed`) are left alone; the `gpu_alive` gate
+    /// in `pump` handles an in-flight decode that lands during TERM.
+    pub fn invalidateGpuResources(self: *AssetCatalog) void {
+        self.gpu_alive = false;
+        var it = self.entries.valueIterator();
+        while (it.next()) |entry| {
+            if (entry.loader_kind != .image) continue;
+            if (entry.state != .ready) continue;
+            // Stale handle — the GPU context is gone. Do NOT call
+            // `entry.loader.free`: that destroys a now-invalid texture
+            // handle. Drop the slot directly.
+            entry.resource = null;
+            // `decoded` is already null on a `.ready` entry (pump nulls
+            // it after a successful upload); kept explicit for clarity.
+            entry.decoded = null;
+            entry.state = .registered;
+        }
+    }
+
+    /// GPU surface restored (Android INIT_WINDOW / `surfaceRestored`).
+    ///
+    /// Re-fires the decode → upload pipeline for every GPU-resident
+    /// asset that `invalidateGpuResources` rewound to `.registered`
+    /// while still referenced (`refcount > 0`). Goes through the shared
+    /// `enqueueDecode` so the worker re-decodes the CPU bitmap (which
+    /// `pump` freed after the original upload) and `pump` re-uploads
+    /// into the fresh context — `acquire` would not re-enqueue here
+    /// because refcount is already non-zero. Refcounts are never
+    /// touched. Clears the `gpu_alive` gate first so the resulting
+    /// uploads are no longer parked.
+    pub fn reenqueueGpuResident(self: *AssetCatalog) void {
+        self.gpu_alive = true;
+        var it = self.entries.iterator();
+        while (it.next()) |kv| {
+            const entry = kv.value_ptr;
+            if (entry.loader_kind != .image) continue;
+            if (entry.refcount == 0) continue;
+            if (entry.state != .registered) continue;
+            // Best-effort: a transient ring-full / worker-spawn failure
+            // leaves the entry at `.registered` for a later retry; a
+            // restored surface must not be able to fail the frame loop.
+            self.enqueueDecode(kv.key_ptr.*, entry) catch |err| {
+                std.log.warn(
+                    "assets: re-enqueue after surface restore failed for '{s}': {s}",
+                    .{ kv.key_ptr.*, @errorName(err) },
+                );
+            };
         }
     }
 };

--- a/src/assets/catalog/tests_surface_loss.zig
+++ b/src/assets/catalog/tests_surface_loss.zig
@@ -1,0 +1,215 @@
+//! GPU surface-loss regression tests (epic #386 Phase 4).
+//!
+//! Host-side (no device) coverage of the catalog's GPU-context-loss
+//! mechanism: `invalidateGpuResources` (Android TERM_WINDOW) drops the
+//! stale GPU handle WITHOUT firing the loader's `free`/`unload` vtable —
+//! the dead context can't safely destroy a stale texture — and rewinds
+//! the entry to `.registered` while preserving its refcount.
+//! `reenqueueGpuResident` (INIT_WINDOW) re-fires the decode → upload
+//! pipeline so the asset re-uploads into the fresh context.
+//!
+//! Shares the image `PumpMock` from `test_support.zig`; the audio test
+//! installs a tiny local audio backend mock so an `.audio` entry can
+//! reach `.ready` and prove it is NOT invalidated by the image-only
+//! GPU-loss path.
+
+const std = @import("std");
+const testing = std.testing;
+
+const support = @import("test_support.zig");
+const AssetCatalog = support.AssetCatalog;
+const AssetState = support.AssetState;
+const UploadedResource = support.UploadedResource;
+const image_loader = support.image_loader;
+const PumpMock = support.PumpMock;
+const spinForResults = support.spinForResults;
+
+const dummy_bytes = support.dummy_bytes;
+const dummy_file_type = support.dummy_file_type;
+
+const audio_loader = @import("../loaders/audio.zig");
+
+/// Spin `pump()` until `name` reaches `.ready` or a bounded cap elapses
+/// (a failed/wedged decode must not hang the test). Mirrors the
+/// busy-pump in `loadAtlasIfNeededImpl`.
+fn pumpUntilReady(catalog: *AssetCatalog, name: []const u8) !void {
+    var spins: usize = 0;
+    while (spins < 4096) : (spins += 1) {
+        if (catalog.isReady(name)) return;
+        if (catalog.lastError(name)) |err| return err;
+        catalog.pump();
+        std.Thread.yield() catch {};
+    }
+    return error.PumpDidNotReachReady;
+}
+
+test "surface loss: invalidate drops GPU handle without free, preserving refcount; restore re-decodes" {
+    PumpMock.reset();
+    image_loader.setBackend(PumpMock.backend_value);
+    defer image_loader.clearBackend();
+
+    var catalog = AssetCatalog.init(testing.allocator);
+    defer catalog.deinit();
+
+    // Acquire → pump → .ready (refcount 1, one decode + one upload).
+    try catalog.register("ship", .image, dummy_file_type, dummy_bytes);
+    _ = try catalog.acquire("ship");
+    try spinForResults(&catalog, 1);
+    try pumpUntilReady(&catalog, "ship");
+
+    const entry = catalog.entries.getPtr("ship").?;
+    try testing.expectEqual(AssetState.ready, entry.state);
+    try testing.expect(entry.resource != null);
+    try testing.expectEqual(@as(u32, 1), entry.refcount);
+    try testing.expectEqual(@as(u32, 1), PumpMock.decode_calls);
+    try testing.expectEqual(@as(u32, 0), PumpMock.unload_calls);
+
+    // ── TERM_WINDOW ──
+    catalog.invalidateGpuResources();
+
+    // Stale handle dropped DIRECTLY: resource null, state rewound to
+    // .registered, refcount UNTOUCHED, and crucially the loader's
+    // free/unload vtable did NOT fire (unload_calls stays 0) — firing
+    // it would `destroyTexture` a handle the dead context already
+    // invalidated.
+    try testing.expectEqual(@as(?UploadedResource, null), entry.resource);
+    try testing.expectEqual(AssetState.registered, entry.state);
+    try testing.expectEqual(@as(u32, 1), entry.refcount);
+    try testing.expectEqual(@as(u32, 0), PumpMock.unload_calls);
+    try testing.expect(!catalog.gpu_alive);
+
+    // ── INIT_WINDOW ──
+    catalog.reenqueueGpuResident();
+    try testing.expect(catalog.gpu_alive);
+
+    // Re-fired decode lands and re-uploads into the fresh context.
+    try spinForResults(&catalog, 1);
+    try pumpUntilReady(&catalog, "ship");
+
+    try testing.expectEqual(AssetState.ready, entry.state);
+    try testing.expect(entry.resource != null);
+    try testing.expectEqual(@as(u32, 1), entry.refcount);
+    // The CPU bitmap was freed after the first upload, so restore had
+    // to RE-DECODE: a second decode (and a second upload) fired.
+    try testing.expectEqual(@as(u32, 2), PumpMock.decode_calls);
+    try testing.expectEqual(@as(u32, 2), PumpMock.upload_calls);
+    // Still no free/unload across the whole loss→restore cycle.
+    try testing.expectEqual(@as(u32, 0), PumpMock.unload_calls);
+
+    // Balance the refcount so deinit doesn't fire `free` on the live
+    // entry mid-teardown counting against unrelated assertions.
+    catalog.release("ship");
+}
+
+test "surface loss: gpu_alive gate parks an in-flight image upload during TERM" {
+    PumpMock.reset();
+    image_loader.setBackend(PumpMock.backend_value);
+    defer image_loader.clearBackend();
+
+    var catalog = AssetCatalog.init(testing.allocator);
+    defer catalog.deinit();
+
+    try catalog.register("late", .image, dummy_file_type, dummy_bytes);
+    _ = try catalog.acquire("late");
+    // Decode has landed on the result ring but we have NOT pumped the
+    // upload yet — this is the in-flight decode that arrives mid-TERM.
+    try spinForResults(&catalog, 1);
+
+    // TERM_WINDOW fires before pump uploads it.
+    catalog.invalidateGpuResources();
+
+    // pump must NOT upload into the dead context — the result stays
+    // PARKED on the ring (peeked, not dequeued). The entry is still
+    // `.queued` (acquire set it there; the parked upload never ran to
+    // flip it `.ready`, and invalidate only rewinds `.ready` entries),
+    // refcount preserved, and no upload fired.
+    catalog.pump();
+    const entry = catalog.entries.getPtr("late").?;
+    try testing.expectEqual(AssetState.queued, entry.state);
+    try testing.expectEqual(@as(u32, 1), entry.refcount);
+    try testing.expectEqual(@as(u32, 0), PumpMock.upload_calls);
+
+    // INIT_WINDOW: re-enqueue flips gpu_alive back on. The parked
+    // result now drains (and the re-enqueue may add a second decode);
+    // either way the entry reaches `.ready` with at least one upload.
+    catalog.reenqueueGpuResident();
+    try spinForResults(&catalog, 1);
+    try pumpUntilReady(&catalog, "late");
+    try testing.expectEqual(AssetState.ready, entry.state);
+    try testing.expect(PumpMock.upload_calls >= 1);
+
+    catalog.release("late");
+}
+
+// ── Audio backend mock (proves audio is NOT GPU-invalidated) ──
+
+const AudioMock = struct {
+    var decode_calls: u32 = 0;
+    var unload_calls: u32 = 0;
+
+    fn reset() void {
+        decode_calls = 0;
+        unload_calls = 0;
+    }
+
+    fn decodeFn(
+        file_type: [:0]const u8,
+        data: []const u8,
+        allocator: std.mem.Allocator,
+    ) anyerror!audio_loader.DecodedAudio {
+        _ = file_type;
+        _ = data;
+        decode_calls += 1;
+        const samples = try allocator.alloc(i16, 2);
+        @memset(samples, 0);
+        return .{ .samples = samples, .sample_rate = 44100, .channels = 1 };
+    }
+
+    fn uploadFn(decoded: audio_loader.DecodedAudio) anyerror!@import("audio_types").SoundId {
+        _ = decoded;
+        return .{ .index = 7, .generation = 1 };
+    }
+
+    fn unloadFn(sound: @import("audio_types").SoundId) void {
+        _ = sound;
+        unload_calls += 1;
+    }
+
+    const backend_value: audio_loader.AudioBackend = .{
+        .decode = decodeFn,
+        .upload = uploadFn,
+        .unload = unloadFn,
+    };
+};
+
+test "surface loss: an .audio entry is NOT invalidated by GPU context loss" {
+    AudioMock.reset();
+    audio_loader.setBackend(AudioMock.backend_value);
+    defer audio_loader.clearBackend();
+
+    var catalog = AssetCatalog.init(testing.allocator);
+    defer catalog.deinit();
+
+    try catalog.register("music", .audio, dummy_file_type, dummy_bytes);
+    _ = try catalog.acquire("music");
+    try spinForResults(&catalog, 1);
+    try pumpUntilReady(&catalog, "music");
+
+    const entry = catalog.entries.getPtr("music").?;
+    try testing.expectEqual(AssetState.ready, entry.state);
+    try testing.expect(entry.resource != null);
+
+    // TERM_WINDOW: audio is not GPU-resident, so the loss path must
+    // leave it fully intact — resource kept, state still `.ready`,
+    // refcount untouched, and certainly no `unload` fired.
+    catalog.invalidateGpuResources();
+    try testing.expectEqual(AssetState.ready, entry.state);
+    try testing.expect(entry.resource != null);
+    try testing.expectEqual(@as(u32, 1), entry.refcount);
+    try testing.expectEqual(@as(u32, 0), AudioMock.unload_calls);
+    // It was decoded exactly once — restore must not re-decode audio.
+    catalog.reenqueueGpuResident();
+    try testing.expectEqual(@as(u32, 1), AudioMock.decode_calls);
+
+    catalog.release("music");
+}

--- a/src/assets/worker.zig
+++ b/src/assets/worker.zig
@@ -153,6 +153,21 @@ pub fn SpscRing(comptime T: type, comptime capacity: u32) type {
             return item;
         }
 
+        /// Consumer-side peek. Returns a copy of the next item without
+        /// advancing `tail` (the slot stays on the ring). Safe from the
+        /// single consumer thread only — it reads the producer's `head`
+        /// with `acquire` exactly like `tryDequeue`, but never publishes
+        /// a `tail` advance, so the producer cannot reclaim the slot.
+        /// Used by `AssetCatalog.pump` to classify a result during GPU
+        /// context loss without consuming a GPU-bound upload that must
+        /// wait for the surface to come back (epic #386 Phase 4).
+        pub fn peek(self: *const Self) ?T {
+            const tail = self.tail.load(.monotonic);
+            const head = self.head.load(.acquire);
+            if (head == tail) return null;
+            return self.buffer[tail & mask];
+        }
+
         /// Non-atomic snapshot — only safe from the consumer side or
         /// while both threads are quiesced. Used by `deinit` drain.
         pub fn isEmpty(self: *const Self) bool {

--- a/src/atlas.zig
+++ b/src/atlas.zig
@@ -153,6 +153,18 @@ pub const RuntimeAtlas = struct {
     /// `pending`. After that point the atlas is indistinguishable from
     /// one loaded eagerly. `is_loaded()` is the predicate.
     pending: ?PendingImage = null,
+    /// Retained copy of the `PendingImage` that `markPendingLoaded`
+    /// promoted. Survives the `pending = null` clear so the
+    /// GPU-context-loss path (`invalidateUploadedTextures`, Android
+    /// TERM_WINDOW) can re-arm `pending` and let the idempotent per-tick
+    /// `bridgeAllReadyImageAssets` re-wire a fresh `texture_id` once the
+    /// surface returns. The borrowed `bytes` / `file_type` slices are
+    /// program-lifetime (`@embedFile`), so retaining them is free. `null`
+    /// for atlases never loaded via the pending path (eager
+    /// `loadAtlasFromJson` / `loadAtlasComptime`), which therefore don't
+    /// participate in GPU re-upload — they hold a renderer-owned texture
+    /// the catalog re-decode path doesn't manage. (epic #386 Phase 4)
+    loaded_image: ?PendingImage = null,
 
     pub fn init(allocator: std.mem.Allocator) RuntimeAtlas {
         return .{ .sprites = std.StringHashMap(SpriteData).init(allocator) };
@@ -373,7 +385,36 @@ pub const TextureManager = struct {
         const pending = atlas.pending orelse return error.AtlasNotPending;
         atlas.texture_id = texture_id;
         applyTextureScale(atlas, pending.meta, actual_dims);
+        // Retain the pending descriptor so a GPU context loss can re-arm
+        // it (`invalidateUploadedTextures`). The slices it holds are
+        // program-lifetime, so this is just a value copy.
+        atlas.loaded_image = pending;
         atlas.pending = null;
+        self.version += 1;
+    }
+
+    /// GPU surface lost (Android TERM_WINDOW / `Game.surfaceLost`).
+    ///
+    /// TERM_WINDOW destroys every GPU texture; the `texture_id` each
+    /// atlas holds is now stale. For every atlas that was loaded via the
+    /// pending path (`loaded_image != null`), reset `texture_id = 0` and
+    /// re-arm `pending` from the retained descriptor so the idempotent
+    /// per-tick `bridgeAllReadyImageAssets` → `markPendingLoaded` walk
+    /// re-wires a FRESH handle once the catalog re-uploads. Without the
+    /// re-arm, `markPendingLoaded` would early-return `AtlasNotPending`
+    /// and the atlas would keep its dead `texture_id`.
+    ///
+    /// Atlases loaded eagerly (`loaded_image == null`) are left alone —
+    /// they don't go through the catalog re-decode pipeline, so there is
+    /// nothing here to re-wire them to. Bumps `version` so the sprite
+    /// cache re-resolves against the reset `texture_id`.
+    pub fn invalidateUploadedTextures(self: *TextureManager) void {
+        var it = self.atlases.valueIterator();
+        while (it.next()) |atlas| {
+            const retained = atlas.loaded_image orelse continue;
+            atlas.texture_id = 0;
+            atlas.pending = retained;
+        }
         self.version += 1;
     }
 

--- a/src/game.zig
+++ b/src/game.zig
@@ -1059,6 +1059,11 @@ pub fn GameConfigWithYAxis(
         pub const getTimeScale = LifecycleMixin.getTimeScale;
         pub const pause = LifecycleMixin.pause;
         pub const resume_ = LifecycleMixin.resume_;
+        // GPU surface lifecycle (Android context loss, epic #386 Phase 4).
+        // The bgfx-Android backend calls these on TERM_WINDOW /
+        // INIT_WINDOW to invalidate + re-upload GPU-resident assets.
+        pub const surfaceLost = LifecycleMixin.surfaceLost;
+        pub const surfaceRestored = LifecycleMixin.surfaceRestored;
         pub const elapsedSeconds = LifecycleMixin.elapsedSeconds;
 
         // ── Input events (labelle-gui#208) ───────────────────────

--- a/src/game/lifecycle_mixin.zig
+++ b/src/game/lifecycle_mixin.zig
@@ -275,6 +275,80 @@ pub fn Mixin(comptime Game: type) type {
             self.setPaused(false);
         }
 
+        // ── GPU surface lifecycle (Android context loss, epic #386 Phase 4) ──
+
+        /// Backend entry point for GPU surface loss (Android TERM_WINDOW).
+        ///
+        /// TERM_WINDOW destroys every GPU texture but leaves game state
+        /// and the CPU allocator intact. We:
+        ///   1. Drop the catalog's stale GPU handles WITHOUT calling the
+        ///      loader `free` vtable (the context is dead — destroying a
+        ///      handle on it is UB). Refcounts are preserved so the
+        ///      asset's holders stay valid.
+        ///   2. Re-arm every atlas's `texture_id` so the idempotent
+        ///      per-tick bridge re-wires fresh handles after restore.
+        ///   3. Emit `engine__surface_lost` for flow/script listeners.
+        ///
+        /// `reenqueueGpuResident` + `surfaceRestored` do the inverse once
+        /// INIT_WINDOW recreates the surface.
+        pub fn surfaceLost(self: *Game) void {
+            self.assets.invalidateGpuResources();
+            self.atlas_manager.invalidateUploadedTextures();
+            std.log.info("surface_lost: invalidated gpu-resident assets, refcounts preserved", .{});
+            // Engine `Events` dual-emit (#578); folds away when the game
+            // doesn't subscribe.
+            self.emitEngineEvent("engine__surface_lost", .{});
+        }
+
+        /// Backend entry point for GPU surface restore (Android
+        /// INIT_WINDOW). Re-fires the decode → upload pipeline for every
+        /// GPU-resident asset (refcounts untouched) and then FORCE-PUMPS
+        /// synchronously so the first restored frame isn't black — the
+        /// catalog freed the decoded CPU bitmap after the original
+        /// upload, so the re-upload requires a re-decode round-trip the
+        /// async per-tick pump would otherwise spread across several
+        /// frames. Bounded so a wedged decode can't hang the restore.
+        pub fn surfaceRestored(self: *Game) void {
+            self.assets.reenqueueGpuResident();
+            forcePumpCurrentScene(self);
+            std.log.info("surface_restored: re-enqueued + pumped to ready", .{});
+            // Engine `Events` dual-emit (#578).
+            self.emitEngineEvent("engine__surface_restored", .{});
+        }
+
+        /// Synchronously pump the catalog until the current scene's
+        /// manifest assets are all `.ready`, or a bounded iteration cap
+        /// elapses (so a failed/wedged decode can't spin forever). Mirrors
+        /// the busy-pump pattern in `loadAtlasIfNeededImpl` /
+        /// `acquireImmediately`: `pump()` + `bridgeAllReadyImageAssets()`
+        /// + `Thread.yield()` per spin. When the current scene has no
+        /// declared manifest, falls through to the bounded cap after one
+        /// drain so any re-enqueued asset still gets a chance to upload.
+        fn forcePumpCurrentScene(self: *Game) void {
+            // Cap matches a generous worst case: a handful of atlases each
+            // taking a few pump cycles to decode + upload. Past this the
+            // restore returns and the normal per-tick pump finishes the
+            // tail — never a hang.
+            const max_spins: usize = 4096;
+            const manifest: []const []const u8 = blk: {
+                const name = self.current_scene_name orelse break :blk &.{};
+                const entry = self.scenes.get(name) orelse break :blk &.{};
+                break :blk entry.assets;
+            };
+
+            var spins: usize = 0;
+            while (spins < max_spins) : (spins += 1) {
+                self.assets.pump();
+                self.bridgeAllReadyImageAssets();
+                // Done once every manifest asset is ready. `allReady`
+                // over an empty manifest is trivially true, so a
+                // scene with no declared assets exits after the first
+                // drain+bridge — exactly the single-pass we want.
+                if (self.assets.allReady(manifest)) break;
+                std.Thread.yield() catch {};
+            }
+        }
+
         /// Seconds of gameplay time elapsed (time-scaled, pause-aware) —
         /// the clock flow `Cooldown`/`Delay` nodes (#25) measure against.
         pub fn elapsedSeconds(self: *const Game) f64 {

--- a/src/root.zig
+++ b/src/root.zig
@@ -413,6 +413,27 @@ pub const Events = struct {
         player: u32,
         controller_id: u32,
     };
+
+    // ── GPU surface lifecycle (Android context loss, epic #386 Phase 4) ──
+    //
+    // On Android, TERM_WINDOW destroys every GPU texture (game state and
+    // the CPU allocator survive); INIT_WINDOW recreates the surface. The
+    // backend calls `Game.surfaceLost` / `Game.surfaceRestored`, which
+    // invalidate + re-upload the GPU-resident asset catalog and emit
+    // these events so flows/scripts can pause/resume rendering-dependent
+    // work across the gap. Both carry no payload — the transition itself
+    // is the signal. Zero-cost when no listener subscribes (same gate
+    // `emitEngineEvent` uses for every other engine event).
+
+    /// Fired when the GPU surface is lost and the catalog has dropped its
+    /// stale texture handles (refcounts preserved). No new GPU work
+    /// should run until `surface_restored`.
+    pub const surface_lost = struct {};
+
+    /// Fired after the GPU surface is restored, the catalog has
+    /// re-enqueued its GPU-resident assets, and the first frame has been
+    /// pumped back to `.ready`.
+    pub const surface_restored = struct {};
 };
 
 // ── Hook Types ──


### PR DESCRIPTION
The engine half of bgfx-Android GPU-context-loss handling — the **Accept gate** of the pluggable-backends RFC. On Android, TERM_WINDOW destroys all GPU textures (game state survives); INIT_WINDOW recreates the surface. The backend (labelle-assembler) calls two new `Game` methods.

## Granularity (decided by the code)
`pump` frees the decoded CPU bitmap right after GPU upload (`entry.decoded = null`), so re-upload needs **re-decode (re-acquire)**, not re-upload-only — and it **reuses the acquire→pump pipeline** (rewind GPU-resident entries, let the normal decode→upload re-run). No dedicated pass.

## Changes
- **`catalog/engine.zig`:** `invalidateGpuResources()` (forget GPU-resident `.image` handles — `resource = null`, NEVER `free` (dead context), rewind to `.registered`, refcount preserved; excludes `.audio`); `reenqueueGpuResident()` (re-fire decode for live entries, bypassing acquire's `refcount==0` guard via the extracted `enqueueDecode`); a `gpu_alive` flag + a consumer-side `SpscRing.peek()` so an in-flight decode landing mid-TERM is parked (not uploaded into a dead context) while cheap drain paths still run.
- **`game.zig`/`lifecycle_mixin.zig`:** `surfaceLost()` (invalidate + atlas-manager reset + event) / `surfaceRestored()` (re-enqueue + **force-pump** the current scene so the first restored frame isn't black + event). Always-present `pub fn`s → backend gates with `@hasDecl`.
- **`atlas.zig`:** `invalidateUploadedTextures()` — resets each catalog atlas `texture_id=0` + re-arms its retained `PendingImage` so the idempotent per-tick bridge re-wires fresh handles.
- **`root.zig`:** `surface_lost`/`surface_restored` engine events (the seam for plugin/script-owned GPU state).

## Verified
3 regression tests (existing mock): invalidate→`resource==null`/`.registered`/refcount preserved/**0 frees** → re-enqueue→re-decoded (`decode_calls==2`); the gpu_alive park; audio survives untouched. `zig build test` green. Bump v1.64.0 → **v1.65.0** (additive/back-compat). Paired with assembler bgfx-android wiring.