### PR TITLE
fix(roster): entitiesWith read-time eviction violates borrowed-slice lifetime contract (#657)

### DIFF
--- a/scene/src/component.zig
+++ b/scene/src/component.zig
@@ -100,6 +100,12 @@ pub fn ComponentRegistry(comptime component_map: anytype) type {
 ///       .{ .Health = Health, .Speed = Speed },
 ///       plugin_foo.Components,
 ///   });
+///
+/// NOTE: this registry does not expose a `names()` decl, so it cannot be
+/// used with `PackView` / `globalNames` (those need the flat name list a
+/// single-source registry provides). Producing a deduplicated name list
+/// across the multiple maps is a follow-up (#657 ride-along); until then
+/// route Packs queries through a single-source `ComponentRegistry*`.
 pub fn ComponentRegistryMulti(comptime component_maps: anytype) type {
     const maps_info = @typeInfo(@TypeOf(component_maps));
 

--- a/src/game.zig
+++ b/src/game.zig
@@ -164,7 +164,7 @@ pub fn GameConfigWithYAxis(
 
         pub const EntityType = Entity;
 
-        // ── Roster cache (#653, Packs Phase 2) ────────────────────
+        // ── Roster cache (#653, Packs Phase 2 / #657) ─────────────
         // `entitiesWith(Tag)` hands back a slice borrowed from one of
         // these slots — engine-owned, valid only until the next
         // structural mutation (component add/remove, entity
@@ -173,17 +173,21 @@ pub fn GameConfigWithYAxis(
         // whose stored `gen` no longer matches is stale and gets
         // re-queried lazily on the next read.
         //
-        // v1 keeps a small fixed map of slots keyed by a comptime hash
-        // of the tag-set's (alphabetically sorted) component type
-        // names. Up to `roster_cache_slots` distinct tag-sets cache
-        // concurrently; beyond that a round-robin cursor picks the
-        // eviction victim and refills it on demand. Single-cache or a
-        // small fixed map is explicitly acceptable for v1 — caching
-        // every distinct tag-set with zero eviction is a follow-up.
-        pub const roster_cache_slots = 8;
+        // Slots live in a hash map (`roster_cache`) keyed by a comptime
+        // hash of the tag-set's (alphabetically sorted) component type
+        // names (`rosterKey`). Because every key is a comptime constant
+        // — there is no runtime-constructed key — the key space is
+        // *statically bounded* by the distinct `entitiesWith` tag-sets
+        // in the compiled game. That bound is what lets the map cache
+        // every tag-set with **zero eviction**: a slot's buffer is only
+        // ever rewritten for the SAME tag-set after a generation bump,
+        // so a borrowed slice can never be silently clobbered by a read
+        // of a *different* tag-set (#657). The prior v1 design used a
+        // fixed 8-slot array with round-robin eviction, which mutated a
+        // still-borrowed buffer during an unrelated read once more than
+        // 8 tag-sets were live — a lifetime-contract violation this
+        // follow-up removes.
         const RosterSlot = struct {
-            /// Comptime hash of the tag-set this slot caches.
-            key: u64 = 0,
             /// `roster_generation` value at which `list` was filled.
             gen: u64 = 0,
             /// False until first filled (or after an OOM during refill).
@@ -676,12 +680,12 @@ pub fn GameConfigWithYAxis(
         /// staleness. Wraps with `+%=`; collisions across a full u64
         /// wrap are not a practical concern.
         roster_generation: u64 = 0,
-        /// Fixed map of cached `entitiesWith` rosters. See `RosterSlot`.
-        roster_cache: [roster_cache_slots]RosterSlot = [_]RosterSlot{.{}} ** roster_cache_slots,
-        /// Round-robin cursor for slot eviction once every slot is in
-        /// use — cycles the victim so two colliding hot tag-sets don't
-        /// evict each other every read (see `rosterSlotFor`).
-        roster_evict_cursor: usize = 0,
+        /// Cached `entitiesWith` rosters, keyed by the comptime tag-set
+        /// hash (`rosterKey`). Never evicts — the key space is
+        /// statically bounded by the compiled game's tag-sets — so a
+        /// borrowed slice is never clobbered by a read of another
+        /// tag-set (#657). See `RosterSlot`.
+        roster_cache: std.AutoHashMap(u64, RosterSlot) = undefined,
 
         // Gizmos
         gizmos_enabled: bool = true,
@@ -749,6 +753,7 @@ pub fn GameConfigWithYAxis(
                 .ecs_backend = &world.ecs_backend,
                 .renderer = &world.renderer,
                 .worlds = std.StringHashMap(*World).init(allocator),
+                .roster_cache = std.AutoHashMap(u64, RosterSlot).init(allocator),
                 .atlas_manager = atlas_mod.TextureManager.init(allocator),
                 .assets = assets_mod.AssetCatalog.init(allocator),
                 .scenes = std.StringHashMap(SceneEntry).init(allocator),
@@ -857,7 +862,7 @@ pub fn GameConfigWithYAxis(
         pub const setZIndex = Visuals.setZIndex;
         pub const setSpriteFlip = Visuals.setSpriteFlip;
 
-        // ── Roster cache (#653) ───────────────────────────────────
+        // ── Roster cache (#653, #657) ─────────────────────────────
         //
         // `entitiesWith(includes)` returns a slice **borrowed from an
         // engine-owned cache**. The slice is valid only until the next
@@ -869,6 +874,20 @@ pub fn GameConfigWithYAxis(
         // re-scanning the ECS; the first read after a mutation lazily
         // re-queries.
         //
+        // Slots live in a hash map keyed by the comptime tag-set hash
+        // (`rosterKey`). The key space is statically bounded (every key
+        // is a comptime constant), so the map **never evicts**: a
+        // slot's buffer is only ever rewritten for the SAME tag-set
+        // after a generation bump. That is precisely what makes the
+        // borrowed-slice contract sound — within a mutation-free window
+        // the slice is stable **no matter how many other tag-sets are
+        // queried** (the #657 fix; the old fixed-slot design could evict
+        // and clobber a still-borrowed buffer during an unrelated read).
+        //
+        // On OOM the read logs and returns a truncated roster, leaving
+        // the entry `valid = false` so the next read retries the full
+        // query rather than treating the partial result as fresh.
+        //
         // This backs the Packs query-surface caching (e.g.
         // `citizens.idleWorkers()` borrows from here) and the
         // "borrowed-slice" lifetime contract for list-returning
@@ -877,16 +896,28 @@ pub fn GameConfigWithYAxis(
         //
         // `includes` mirrors the include tuple of `collectEntities`
         // (e.g. `.{Health}` or `.{Health, Velocity}`); the exclude set
-        // is always empty for rosters. Distinct tag-sets are cached in
-        // separate slots up to `roster_cache_slots`; see `RosterSlot`.
+        // is always empty for rosters. See `RosterSlot`.
         pub fn entitiesWith(self: *Self, comptime includes: anytype) []const Entity {
             const key = comptime rosterKey(includes);
-            const slot = self.rosterSlotFor(key);
-            // Cache hit: same tag-set, filled at the current epoch.
-            if (slot.valid and slot.key == key and slot.gen == self.roster_generation) {
+            // A rehash while inserting a new key moves `RosterSlot`
+            // *values*, but borrowed slices point at each list's heap
+            // buffer, not the slot struct — so never hold `value_ptr`
+            // across another `roster_cache` operation (this fn doesn't).
+            const gop = self.roster_cache.getOrPut(key) catch |err| {
+                // OOM growing the map itself: there is no slot to fill,
+                // so hand back a static empty roster (not borrowed).
+                self.log.err("[Game] entitiesWith: roster cache OOM for key {d}: {s}", .{ key, @errorName(err) });
+                return &[_]Entity{};
+            };
+            if (!gop.found_existing) gop.value_ptr.* = .{};
+            const slot = gop.value_ptr;
+            // Cache hit: this tag-set's slot, filled at the current epoch.
+            if (slot.valid and slot.gen == self.roster_generation) {
                 return slot.list.items;
             }
-            // Stale, freshly evicted, or never filled — re-query.
+            // Stale or never filled — re-query. This slot belongs to
+            // `key` forever, so its buffer is never rewritten on behalf
+            // of a different tag-set.
             slot.list.clearRetainingCapacity();
             slot.valid = false;
             var view = self.ecs_backend.view(includes, .{});
@@ -904,7 +935,6 @@ pub fn GameConfigWithYAxis(
                     return slot.list.items;
                 };
             }
-            slot.key = key;
             slot.gen = self.roster_generation;
             slot.valid = true;
             return slot.list.items;
@@ -938,25 +968,6 @@ pub fn GameConfigWithYAxis(
                 }
                 return h.final();
             }
-        }
-
-        /// Pick the cache slot for `key`: the existing slot if one
-        /// holds this tag-set, else a free/invalid slot, else a
-        /// round-robin eviction victim (whose capacity is reused on
-        /// refill). Round-robin avoids the conflict-miss thrashing a
-        /// direct-mapped `key % slots` policy suffers when two hot
-        /// tag-sets collide modulo the slot count while other slots
-        /// sit empty.
-        fn rosterSlotFor(self: *Self, key: u64) *RosterSlot {
-            for (&self.roster_cache) |*s| {
-                if (s.valid and s.key == key) return s;
-            }
-            for (&self.roster_cache) |*s| {
-                if (!s.valid) return s;
-            }
-            const slot = &self.roster_cache[self.roster_evict_cursor];
-            self.roster_evict_cursor = (self.roster_evict_cursor + 1) % roster_cache_slots;
-            return slot;
         }
 
         /// Invalidate every cached roster by advancing the epoch. Cheap

--- a/src/game/lifecycle_mixin.zig
+++ b/src/game/lifecycle_mixin.zig
@@ -100,8 +100,12 @@ pub fn Mixin(comptime Game: type) type {
             while (emb_iter.next()) |entry| self.allocator.free(entry.key_ptr.*);
             self.embedded_scene_sources.deinit();
             self.atlas_manager.deinit();
-            // Free the borrowed-slice roster cache (#653).
-            for (&self.roster_cache) |*slot| slot.list.deinit(self.allocator);
+            // Free the borrowed-slice roster cache (#653, #657). The map
+            // owns every slot's list buffer (managed map `deinit()` takes
+            // no allocator; the lists do).
+            var roster_it = self.roster_cache.valueIterator();
+            while (roster_it.next()) |slot| slot.list.deinit(self.allocator);
+            self.roster_cache.deinit();
         }
 
         pub fn setHooks(self: *Game, receiver: Hooks) void {

--- a/test/entities_with_roster_test.zig
+++ b/test/entities_with_roster_test.zig
@@ -186,3 +186,144 @@ test "entitiesWith: tag-set order does not matter — same slot for .{A,B} and .
     try testing.expectEqual(ab.ptr, ba.ptr);
     try testing.expect(contains(ba, e1));
 }
+
+// ── #657 lifetime-contract regression coverage ────────────────────────
+//
+// Ten distinct marker tag-sets so we can drive more than the OLD fixed
+// 8-slot cache's capacity in a single mutation-free window. On the old
+// round-robin design the 9th/10th distinct read evicts an earlier slot
+// and rewrites its backing buffer *during a read* — silently clobbering a
+// slice a caller is still holding. The unbounded map has no eviction, so
+// each tag-set owns its buffer forever and borrows stay stable.
+
+const M0 = struct { v: u8 = 0 };
+const M1 = struct { v: u8 = 0 };
+const M2 = struct { v: u8 = 0 };
+const M3 = struct { v: u8 = 0 };
+const M4 = struct { v: u8 = 0 };
+const M5 = struct { v: u8 = 0 };
+const M6 = struct { v: u8 = 0 };
+const M7 = struct { v: u8 = 0 };
+const M8 = struct { v: u8 = 0 };
+const M9 = struct { v: u8 = 0 };
+
+const markers = .{ M0, M1, M2, M3, M4, M5, M6, M7, M8, M9 };
+
+test "entitiesWith (#657): a borrowed slice is not clobbered by reads of >8 other tag-sets" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    // Two entities hold M0; exactly one entity holds each of M1..M9.
+    const m0a = game.createEntity();
+    const m0b = game.createEntity();
+    game.addComponent(m0a, M0{});
+    game.addComponent(m0b, M0{});
+    inline for (1..markers.len) |i| {
+        const e = game.createEntity();
+        game.addComponent(e, markers[i]{});
+    }
+
+    // Borrow M0's roster (len 2) and snapshot its contents.
+    const a = game.entitiesWith(.{M0});
+    try testing.expectEqual(@as(usize, 2), a.len);
+    var snapshot: [2]TestGame.EntityType = undefined;
+    @memcpy(&snapshot, a[0..2]);
+
+    // Read M1..M9 — NINE further distinct tag-sets, zero structural
+    // mutations. On the old design the 9th read evicts M0's slot and
+    // rewrites the exact buffer `a` points into (to a len-1 roster).
+    inline for (1..markers.len) |i| {
+        const r = game.entitiesWith(.{markers[i]});
+        try testing.expectEqual(@as(usize, 1), r.len);
+    }
+
+    // `a` must still describe M0 element-for-element. (Compare CONTENTS,
+    // not just the pointer: the old design reuses the same buffer, so a
+    // pure pointer-equality check would pass while the data is wrong.)
+    try testing.expectEqual(@as(usize, 2), a.len);
+    try testing.expectEqualSlices(TestGame.EntityType, &snapshot, a);
+
+    // A fresh re-read of M0 must also still be correct.
+    const a2 = game.entitiesWith(.{M0});
+    try testing.expectEqual(@as(usize, 2), a2.len);
+    try testing.expect(contains(a2, m0a));
+    try testing.expect(contains(a2, m0b));
+}
+
+test "entitiesWith (#657): all tag-sets cache concurrently — no eviction, pure hits on re-read" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    // One entity per marker so every roster has a live, allocated buffer.
+    var owners: [markers.len]TestGame.EntityType = undefined;
+    inline for (0..markers.len) |i| {
+        const e = game.createEntity();
+        game.addComponent(e, markers[i]{});
+        owners[i] = e;
+    }
+
+    // First pass: read all 10 tag-sets, holding every returned slice.
+    var first: [markers.len][]const TestGame.EntityType = undefined;
+    inline for (0..markers.len) |i| {
+        first[i] = game.entitiesWith(.{markers[i]});
+        try testing.expectEqual(@as(usize, 1), first[i].len);
+        try testing.expect(contains(first[i], owners[i]));
+    }
+
+    // Every backing pointer is distinct — no two tag-sets share a slot.
+    for (0..markers.len) |i| {
+        for (i + 1..markers.len) |j| {
+            try testing.expect(first[i].ptr != first[j].ptr);
+        }
+    }
+
+    // Second pass (still mutation-free): every read is a pure cache hit —
+    // same backing pointer as the first pass, still content-correct. The
+    // held first-pass slices remain valid despite the intervening
+    // getOrPut inserts (which may rehash and move slot *values*, but the
+    // heap buffers a slice points at do not move).
+    inline for (0..markers.len) |i| {
+        const again = game.entitiesWith(.{markers[i]});
+        try testing.expectEqual(first[i].ptr, again.ptr);
+        try testing.expectEqual(@as(usize, 1), again.len);
+        try testing.expect(contains(again, owners[i]));
+        // The originally-held slice is still intact.
+        try testing.expectEqual(@as(usize, 1), first[i].len);
+        try testing.expect(contains(first[i], owners[i]));
+    }
+}
+
+test "entitiesWith (#657): roster-cache map OOM returns an empty roster and recovers" {
+    // No existing FailingAllocator idiom in this repo — established here.
+    //
+    // The default MockEcsBackend's `view()` allocates eagerly and
+    // `@panic("OOM")`s on failure, so the append-path OOM can't be driven
+    // without tripping the backend first. Instead we drive the map-level
+    // `getOrPut` OOM branch, which returns BEFORE `view()` is reached:
+    // fail the very next allocation while the roster map is still empty,
+    // so the first `getOrPut` (which must allocate the map's storage)
+    // fails. entitiesWith must hand back an empty, non-borrowed roster and
+    // not crash — then recover cleanly once the allocator is healthy.
+    var failing = std.testing.FailingAllocator.init(testing.allocator, .{});
+    var game = TestGame.init(failing.allocator());
+    defer game.deinit();
+
+    // Populate five Velocity entities BEFORE arming the allocator.
+    var i: usize = 0;
+    while (i < 5) : (i += 1) {
+        const e = game.createEntity();
+        game.addComponent(e, Velocity{});
+    }
+
+    // Arm: the next allocation fails. The roster map is still empty, so
+    // the upcoming read's `getOrPut` must allocate map storage → fails.
+    failing.fail_index = failing.alloc_index;
+    const under_oom = game.entitiesWith(.{Velocity});
+    try testing.expectEqual(@as(usize, 0), under_oom.len); // empty, no crash
+
+    // Heal the allocator; the same read must now succeed with all five —
+    // proving the OOM left no poisoned entry behind.
+    failing.fail_index = std.math.maxInt(usize);
+    const recovered = game.entitiesWith(.{Velocity});
+    try testing.expectEqual(@as(usize, 5), recovered.len);
+}


### PR DESCRIPTION
Fixes #657.

## Problem

`entitiesWith` documents its returned slice as "valid until the next structural mutation" (`src/game.zig`). But the roster cache was a fixed 8-slot array with round-robin eviction (`rosterSlotFor`), and eviction happened **during a read**: with more than 8 distinct live tag-sets, querying a 9th evicted a slot and reused its backing list via `clearRetainingCapacity` — same pointer, new contents. A slice borrowed for tag-set A could silently change contents (wrong data — the worst mode) or dangle (use-after-free if the buffer grew) from a purely *read-only* sequence of `entitiesWith` calls, with zero structural mutations in between. This breaks the Packs query-surface borrowing pattern.

## Fix — Option 1 from the ticket: unbounded, no-eviction map

Every roster key is a comptime `Wyhash` of the sorted tag-set names (`rosterKey`), so the key space is **statically bounded** by the compiled game's distinct tag-sets. That bound lets the map cache every tag-set with **zero eviction**, so a slot's buffer is only ever rewritten for the *same* tag-set after a generation bump — which is exactly what makes the borrowed-slice contract sound.

- Replace the `[8]RosterSlot` array + `roster_evict_cursor` with `std.AutoHashMap(u64, RosterSlot)`; init alongside `.worlds`.
- Drop `RosterSlot.key`, `roster_cache_slots`, and delete `rosterSlotFor`. `bumpRoster` and all 24 mutation call sites are unchanged.
- `getOrPut` OOM growing the map hands back a static empty roster and logs; the mid-fill append-OOM `valid=false` retry semantics are preserved verbatim.
- Teardown iterates the map values to free each list buffer, then the map.
- Idiom-consistent with `Game`'s other unbounded managed maps (`worlds`, `scenes`).

## Ride-along (docs only)

`ComponentRegistryMulti` (`scene/src/component.zig`) gets a 5-line note that it lacks `names()` and so can't drive `PackView`/`globalNames`; the real `names()` implementation is split to a follow-up per the ticket.

## Tests

All 8 existing tests kept byte-for-byte (their ptr-equality assertions still hold). Added 3 regression tests, each **verified to FAIL on `origin/main` and pass on this branch**:

1. **Lifetime regression** — hold `a = entitiesWith(.{M0})` (len 2), read 9 other tag-sets `M1..M9`, assert `a` still matches its snapshot **element-for-element** (content-compared, since the old design reuses the same buffer so a pointer check alone would pass). Old code: `slices differ at index 0`.
2. **No-eviction growth** — read all 10 tag-sets holding every slice; all buffers pairwise-distinct; a second pass is pure hits (same `.ptr`). Old code: pointer collision.
3. **Map-OOM** — `std.testing.FailingAllocator` (new idiom here): arm the next alloc to fail while the roster map is empty so the first `getOrPut` fails → assert empty roster + no crash, then heal and re-read → full result. Old code: abort.

### Deviation

The ticket's OOM recipe targets the append path, but the default `MockEcsBackend.view()` does `append(...) catch @panic("OOM")` and allocates eagerly, so a `FailingAllocator` trips the backend's panic before `entitiesWith`'s append catch is reached. The test instead drives the map-level `getOrPut` OOM branch (new code, returns before `view()` is called) and proves recovery — deterministic and crash-free.

## Verification

- `zig build` → exit 0
- `zig build test` → exit 0 (no leaks under `testing.allocator`)

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw