### PR TITLE
feat(scene): real ComponentRegistryMulti.names() (from #657 follow-up)

### DIFF
--- a/scene/src/component.zig
+++ b/scene/src/component.zig
@@ -101,11 +101,12 @@ pub fn ComponentRegistry(comptime component_map: anytype) type {
 ///       plugin_foo.Components,
 ///   });
 ///
-/// NOTE: this registry does not expose a `names()` decl, so it cannot be
-/// used with `PackView` / `globalNames` (those need the flat name list a
-/// single-source registry provides). Producing a deduplicated name list
-/// across the multiple maps is a follow-up (#657 ride-along); until then
-/// route Packs queries through a single-source `ComponentRegistry*`.
+/// Field names are the component names, so pack-composed games namespace
+/// them as `<pack>__<Pascal>` (e.g. `citizens__Worker`). `names()` returns
+/// the deduplicated union of every map's field names in map order (first
+/// occurrence wins, matching `getType`'s resolution), giving the same flat
+/// name list a single-source registry provides — so `PackView` / `globalNames`
+/// work on the multi-registry too.
 pub fn ComponentRegistryMulti(comptime component_maps: anytype) type {
     const maps_info = @typeInfo(@TypeOf(component_maps));
 
@@ -126,6 +127,62 @@ pub fn ComponentRegistryMulti(comptime component_maps: anytype) type {
                 }
             }
             @compileError("Unknown component: " ++ name);
+        }
+
+        /// True when `name` is a field of a map that comes *before* map index
+        /// `up_to` — i.e. an earlier map already owns this name. Field names are
+        /// unique within a single map, so an earlier hit is the only way a name
+        /// can be a duplicate.
+        fn nameInEarlierMap(comptime up_to: usize, comptime name: []const u8) bool {
+            inline for (maps_info.@"struct".fields, 0..) |field, mi| {
+                if (mi >= up_to) break;
+                const Map = @field(component_maps, field.name);
+                if (@hasField(@TypeOf(Map), name)) return true;
+            }
+            return false;
+        }
+
+        /// The deduplicated union of every map's field names, in map order
+        /// (first occurrence wins — the same order `getType` resolves). Backed
+        /// by a container-scoped const so the slice has static storage and is
+        /// valid when `names()` is called at runtime.
+        const _names = blk: {
+            // First pass: count the unique names.
+            var count: usize = 0;
+            for (maps_info.@"struct".fields, 0..) |field, mi| {
+                const Map = @field(component_maps, field.name);
+                for (@typeInfo(@TypeOf(Map)).@"struct".fields) |f| {
+                    if (!nameInEarlierMap(mi, f.name)) count += 1;
+                }
+            }
+
+            // Second pass: collect them.
+            var buf: [count][]const u8 = undefined;
+            var idx: usize = 0;
+            for (maps_info.@"struct".fields, 0..) |field, mi| {
+                const Map = @field(component_maps, field.name);
+                for (@typeInfo(@TypeOf(Map)).@"struct".fields) |f| {
+                    if (!nameInEarlierMap(mi, f.name)) {
+                        buf[idx] = f.name;
+                        idx += 1;
+                    }
+                }
+            }
+
+            const final = buf;
+            break :blk final;
+        };
+
+        /// Returns a comptime-built slice of every registered component name
+        /// across all composed maps, deduplicated, in map order.
+        pub fn names() []const []const u8 {
+            return &_names;
+        }
+
+        /// Check if an entity has a named component (runtime name, comptime dispatch).
+        pub fn entityHasNamed(ecs: anytype, entity: anytype, comptime name: []const u8) bool {
+            const T = getType(name);
+            return ecs.hasComponent(entity, T);
         }
     };
 }
@@ -322,8 +379,8 @@ pub fn globalNames(comptime FullRegistry: type) []const []const u8 {
     comptime {
         if (!@hasDecl(FullRegistry, "names")) {
             @compileError("PackView/globalNames require a registry type that exposes " ++
-                "names() (e.g. ComponentRegistry or ComponentRegistryWithPlugins). " ++
-                "ComponentRegistryMulti does not enumerate its names and is unsupported here.");
+                "names() — every built-in registry (ComponentRegistry, " ++
+                "ComponentRegistryMulti, ComponentRegistryWithPlugins) does.");
         }
     }
     // A struct nested in a generic fn is memoized per `FullRegistry`, giving

--- a/test/component_visibility_test.zig
+++ b/test/component_visibility_test.zig
@@ -172,3 +172,66 @@ test "view over the full registry with an empty allow-list resolves nothing" {
     try testing.expect(!Empty.has("Locked"));
     try testing.expectEqual(@as(usize, 0), Empty.names().len);
 }
+
+// ─── ComponentRegistryMulti.names() (#657 follow-up) ────────────────────────
+//
+// The multi-source registry composes several maps (one per pack, typically),
+// with field names namespaced as `<pack>__<Pascal>`. `names()` returns the
+// deduplicated union of every map's field names, in map order (first
+// occurrence wins — matching `getType`'s resolution), matching the flat name
+// list a single-source `ComponentRegistry.names()` provides. That flat list is
+// what makes `PackView` / `globalNames` usable over the multi registry.
+
+const ComponentRegistryMulti = engine.ComponentRegistryMulti;
+
+/// Two notional packs contributing namespaced maps, plus shared global facets
+/// (`Locked` in map 0, `Position` in map 1).
+const MultiRegistry = ComponentRegistryMulti(.{
+    .{ .Locked = Locked, .citizens__Worker = Worker, .citizens__Home = Home },
+    .{ .ships__Ship = Ship, .Position = Position },
+});
+
+test "ComponentRegistryMulti.names lists every composed map's names in order" {
+    const names = MultiRegistry.names();
+    try testing.expectEqual(@as(usize, 5), names.len);
+    // Map order, then field order within each map.
+    try testing.expectEqualStrings("Locked", names[0]);
+    try testing.expectEqualStrings("citizens__Worker", names[1]);
+    try testing.expectEqualStrings("citizens__Home", names[2]);
+    try testing.expectEqualStrings("ships__Ship", names[3]);
+    try testing.expectEqualStrings("Position", names[4]);
+}
+
+test "ComponentRegistryMulti.names deduplicates, first map wins" {
+    const DupRegistry = ComponentRegistryMulti(.{
+        .{ .Position = Position, .Worker = Worker },
+        .{ .Worker = Ship, .Home = Home }, // Worker duplicated → first map wins
+    });
+    const names = DupRegistry.names();
+    try testing.expectEqual(@as(usize, 3), names.len);
+    try testing.expectEqualStrings("Position", names[0]);
+    try testing.expectEqualStrings("Worker", names[1]);
+    try testing.expectEqualStrings("Home", names[2]);
+    // The deduped name resolves to the FIRST map's type, matching getType order.
+    try testing.expect(Worker == DupRegistry.getType("Worker"));
+}
+
+test "globalNames works over a ComponentRegistryMulti" {
+    const globals = engine.globalComponentNames(MultiRegistry);
+    // Only Locked (map 0) and Position (map 1) are `.global`.
+    try testing.expectEqual(@as(usize, 2), globals.len);
+    try testing.expectEqualStrings("Locked", globals[0]);
+    try testing.expectEqualStrings("Position", globals[1]);
+}
+
+test "PackView composes over a ComponentRegistryMulti" {
+    const CitizensMulti = PackView(MultiRegistry, &.{ "citizens__Worker", "citizens__Home" });
+    // Own private components + all globals resolve...
+    try testing.expect(CitizensMulti.has("citizens__Worker"));
+    try testing.expect(CitizensMulti.has("citizens__Home"));
+    try testing.expect(CitizensMulti.has("Locked"));
+    try testing.expect(CitizensMulti.has("Position"));
+    // ...the foreign pack's private component does not.
+    try testing.expect(!CitizensMulti.has("ships__Ship"));
+    try testing.expect(!CitizensMulti.isAllowed("ships__Ship"));
+}


### PR DESCRIPTION
## What

Implements a real `names()` on `ComponentRegistryMulti`, the multi-source
(pack-composed) component registry. It previously exposed only `has` / `getType`;
a 5-line deferral note (left during #657) tracked that the multi path lacked the
flat name list that `PackView` / `globalNames` require — so pack-composed games
could not use per-pack registry views, and had to route Packs queries through a
single-source `ComponentRegistry*`.

## How

- `names()` returns the **deduplicated union** of every composed map's field
  names, in map order with **first occurrence winning** — the same order
  `getType` resolves. Field names are the component names, namespaced as
  `<pack>__<Pascal>` for pack-composed games.
- Backed by a container-scoped `const _names` (memoized per instantiation) so the
  returned slice has static storage and is valid when `names()` is called at
  runtime — mirroring `ComponentView._names`. (A `return &result` out of a bare
  `comptime {}` block only survives comptime call sites.)
- Softened the now-stale `globalNames` compile-error that named
  `ComponentRegistryMulti` as unsupported; every built-in registry now exposes
  `names()`.

## Tests

Extended `test/component_visibility_test.zig`:
- order/composition across two namespaced maps,
- dedup (name in an earlier map wins, resolves to the first map's type),
- `globalNames` and `PackView` composing over a `ComponentRegistryMulti`.

`zig build` and `zig build test` both exit 0 (613 pre-existing + new tests pass).

**Consumer vs proof:** no in-tree code calls `names()` on the multi path yet
(only re-exports through `scene/root.zig` and `src/root.zig`); the tests are the
proof. Pack-composed games (assembler / Flying-Platform side) are the intended
consumer.

Follow-up to #657.

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw