### PR TITLE
feat(engine): render-phase drawMesh + plugin render-callback seam (Spine Stage 4, gfx#290)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -166,6 +166,11 @@ pub fn build(b: *std.Build) void {
         // `yAxis()` accessor + additive `screenToLogical` picking path
         // (RFC §3, Q1→(b), Q3). Raw `screenToDesign` stays unchanged.
         "test/y_axis_test.zig",
+        // labelle-gfx#290 Stage 4 — render-phase custom-mesh seam:
+        // `game.drawMesh(...)` forwarding + `SystemRegistry.renderMeshes`
+        // plugin render callback (the seam `labelle-spine` submits skinned
+        // meshes through).
+        "test/render_mesh_test.zig",
     };
 
     for (test_files) |test_file| {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -11,6 +11,13 @@
         // `screenToLogical` picking path routes through, labelle-engine#639).
         // A path dependency, so CI clones core `main` (>= v1.20.0) as the
         // sibling `../labelle-core`.
+        //
+        // The render-phase `drawMesh` seam (labelle-gfx#290 Stage 4) re-exports
+        // core's `BlendMode` and rides core's optional backend `drawMesh`
+        // contract, both of which landed in core >= v1.24.0 — the effective
+        // floor for this engine version. (The engine takes no direct
+        // labelle-gfx dependency; the textured-mesh primitive reaches it
+        // through the `RenderImpl` renderer via `@hasDecl`.)
         .labelle_core = .{
             .path = "../labelle-core",
         },

--- a/scene/src/system.zig
+++ b/scene/src/system.zig
@@ -10,6 +10,7 @@
 ///       pub fn tick(game: anytype, dt: f32) void { ... }
 ///       pub fn postTick(game: anytype, dt: f32) void { ... }
 ///       pub fn drawGui(game: anytype) void { ... }
+///       pub fn renderMeshes(game: anytype) void { ... }
 ///       pub fn deinit() void { ... }
 ///   };
 ///
@@ -178,6 +179,34 @@ pub fn SystemRegistry(comptime plugin_modules: anytype) type {
                         }
                     }
                     pidx += 1;
+                }
+            }
+        }
+
+        /// Call renderMeshes() on all plugin systems that declare it — the
+        /// render-phase custom-mesh seam (labelle-gfx#290 Stage 4). Invoked
+        /// during the render phase AFTER the world sprite pass (`g.render()`),
+        /// so plugin-submitted textured meshes composite over sprites; a
+        /// plugin's callback iterates its own components and calls
+        /// `game.drawMesh(...)` (see `mesh_mixin`). This is the immediate
+        /// sibling of `drawGui` for world-space textured geometry — e.g. the
+        /// future `labelle-spine` plugin's `SpineSkeleton` system submits its
+        /// per-frame skinned meshes here.
+        ///
+        /// Respects game_states like the other lifecycle phases, and is
+        /// zero-cost when no plugin declares `renderMeshes` (the `@hasDecl`
+        /// branch folds away at comptime, leaving an empty `inline for`).
+        pub fn renderMeshes(game: anytype) void {
+            const current_state = getGameState(game);
+            inline for (info.@"struct".fields) |field| {
+                const mod = @field(plugin_modules, field.name);
+                if (@hasDecl(mod, "Systems")) {
+                    const Sys = @field(mod, "Systems");
+                    if (@hasDecl(Sys, "renderMeshes")) {
+                        if (isStateAllowed(Sys, current_state)) {
+                            Sys.renderMeshes(game);
+                        }
+                    }
                 }
             }
         }

--- a/src/game.zig
+++ b/src/game.zig
@@ -38,6 +38,7 @@ const audio_mixin = @import("game/audio_mixin.zig");
 const video_mixin = @import("game/video_mixin.zig");
 const gui_mixin = @import("game/gui_mixin.zig");
 const gizmo_mixin = @import("game/gizmo_mixin.zig");
+const mesh_mixin = @import("game/mesh_mixin.zig");
 const scene_mixin = @import("game/scene_mixin.zig");
 const save_load_mixin = @import("game/save_load_mixin.zig");
 const state_mixin = @import("game/state_mixin.zig");
@@ -262,6 +263,10 @@ pub fn GameConfigWithYAxis(
         pub const Video = core.VideoInterface(VideoImpl);
         pub const Gui = @import("gui.zig").GuiInterface(GuiImpl);
         pub const GizmoDraw = gizmo_draws_mod.GizmoDraw;
+        /// Blend mode for `drawMesh` — re-exported from labelle-core's backend
+        /// contract (labelle-gfx#290). `labelle-spine` maps `spBlendMode`
+        /// straight onto this enum.
+        pub const BlendMode = core.BlendMode;
         pub const Log = game_log_mod.GameLog(LogSinkImpl, core.log.default_min_level);
         /// Component registry — for debug introspection by plugins.
         pub const ComponentRegistry = ComponentsType;
@@ -286,6 +291,7 @@ pub fn GameConfigWithYAxis(
         const VideoMixin = video_mixin.Mixin(Self);
         const GuiMixin = gui_mixin.Mixin(Self);
         const GizmoMixin = gizmo_mixin.Mixin(Self);
+        const MeshMixin = mesh_mixin.Mixin(Self);
         const SceneMixin = scene_mixin.Mixin(Self);
         const SaveLoadMixin = save_load_mixin.Mixin(Self);
         const StateMixin = state_mixin.Mixin(Self);
@@ -1105,6 +1111,14 @@ pub fn GameConfigWithYAxis(
         pub const isEntitySelected = GizmoMixin.isEntitySelected;
         pub const clearSelection = GizmoMixin.clearSelection;
         pub const renderGizmos = GizmoMixin.renderGizmos;
+
+        // ── Render-phase custom meshes (mixin) ───────────────────
+        /// Immediate textured-mesh submission for the render phase — the seam
+        /// `labelle-spine` submits skinned meshes through (labelle-gfx#290
+        /// Stage 4). Forwards to the renderer's optional `drawMesh`; a no-op
+        /// on renderers/backends that don't declare it. Plugins call this from
+        /// a `Systems.renderMeshes(game)` callback (see `SystemRegistry`).
+        pub const drawMesh = MeshMixin.drawMesh;
 
         // ── Scene Management (mixin) ─────────────────────────────
         pub const registerScene = SceneMixin.registerScene;

--- a/src/game/mesh_mixin.zig
+++ b/src/game/mesh_mixin.zig
@@ -1,0 +1,53 @@
+/// Mesh mixin — render-phase custom textured-mesh drawing.
+///
+/// This is the immediate-mode seam the future `labelle-spine` plugin
+/// (Spine skeletal animation, labelle-gfx#290 Stage 4) submits its
+/// per-frame skinned meshes through: during the render phase a plugin
+/// iterates its own components and calls `game.drawMesh(...)` once per
+/// mesh, forwarding straight to the renderer.
+///
+/// Mirrors the gizmo forwarding seam (`renderGizmos` → renderer's optional
+/// `renderGizmoDraws`): `drawMesh` forwards to the renderer's optional
+/// `drawMesh` (the gfx `RetainedEngine` public API, labelle-gfx#291), gated
+/// on `@hasDecl` so backends/renderers that don't declare it (raylib/sokol/
+/// wgpu/sdl today, and the engine's `StubRender`) compile to a no-op. Adding
+/// it is therefore non-breaking for every existing game and backend.
+const std = @import("std");
+
+/// Returns the mesh mixin for a given Game type.
+pub fn Mixin(comptime Game: type) type {
+    return struct {
+        /// Submit one textured triangle mesh, immediately, during the render
+        /// phase. A no-op unless the active renderer declares `drawMesh`.
+        ///
+        /// Coordinate + buffer conventions match labelle-core's backend
+        /// `drawMesh` contract (the renderer converts Y-up→screen):
+        ///   - `texture_id`: renderer texture handle to sample.
+        ///   - `positions`: xy pairs in game space (position+scale applied by
+        ///     the caller). `len == 2 * numVerts`.
+        ///   - `uvs`: uv pairs normalised [0,1] into the texture, parallel to
+        ///     `positions`. `len == 2 * numVerts`.
+        ///   - `colors`: per-vertex RGBA8 packed one u32 per vertex (a tint
+        ///     multiplied with the sampled texel). `len == numVerts`.
+        ///   - `indices`: triangle-list into the vertex arrays (every 3 form
+        ///     one triangle). `len == 3 * numTris`.
+        ///   - `blend`: how the mesh composites over what's already drawn.
+        ///
+        /// The slices are borrowed for the duration of the call only; the
+        /// renderer copies/uploads whatever it needs before returning.
+        pub fn drawMesh(
+            self: *Game,
+            texture_id: u32,
+            positions: []const f32,
+            uvs: []const f32,
+            colors: []const u32,
+            indices: []const u16,
+            blend: Game.BlendMode,
+        ) void {
+            const Renderer = @TypeOf(self.renderer.*);
+            if (@hasDecl(Renderer, "drawMesh")) {
+                self.renderer.drawMesh(texture_id, positions, uvs, colors, indices, blend);
+            }
+        }
+    };
+}

--- a/test/render_mesh_test.zig
+++ b/test/render_mesh_test.zig
@@ -1,0 +1,231 @@
+//! Render-phase custom-mesh seam (labelle-gfx#290 Stage 4).
+//!
+//! Covers the two halves of the seam the future `labelle-spine` plugin uses:
+//!   1. `game.drawMesh(...)` — a public Game method that forwards a textured
+//!      triangle mesh to the renderer's optional `drawMesh`, gated on
+//!      `@hasDecl` so it is a no-op on renderers/backends without it.
+//!   2. `SystemRegistry.renderMeshes(&game)` — the render-phase plugin
+//!      callback: a plugin exports `Systems.renderMeshes(game)` which
+//!      iterates its own components and calls `game.drawMesh(...)`.
+//!
+//! Both are asserted headlessly via a recording renderer that stands in for
+//! the mock backend — it records each `drawMesh` call plus whether it landed
+//! after the world sprite pass (`render()`), i.e. genuinely in the render
+//! phase.
+
+const std = @import("std");
+const testing = std.testing;
+
+const engine = @import("engine");
+const core = @import("labelle-core");
+const BlendMode = core.BlendMode;
+
+const GameConfig = engine.GameConfig;
+const MockEcsBackend = engine.MockEcsBackend;
+const StubInput = engine.StubInput;
+const StubAudio = engine.StubAudio;
+const StubVideo = engine.StubVideo;
+const StubGui = engine.StubGui;
+const StubLogSink = engine.StubLogSink;
+const SystemRegistry = engine.SystemRegistry;
+
+/// A renderer that satisfies the engine's RenderInterface (mirrors
+/// `StubRender`) but additionally records `drawMesh` submissions — standing
+/// in for the mock/gfx backend so the render-phase seam is testable headless.
+fn RecordingRender(comptime Entity: type) type {
+    return struct {
+        const Self = @This();
+
+        pub const Sprite = struct {
+            sprite_name: []const u8 = "",
+            visible: bool = true,
+            z_index: i16 = 0,
+            layer: enum { default } = .default,
+        };
+        pub const Shape = struct {
+            shape: union(enum) {
+                rectangle: struct { width: f32 = 10, height: f32 = 10 },
+                circle: struct { radius: f32 = 10 },
+            } = .{ .rectangle = .{} },
+            color: struct { r: u8 = 255, g: u8 = 255, b: u8 = 255, a: u8 = 255 } = .{},
+            visible: bool = true,
+            z_index: i16 = 0,
+            layer: enum { default } = .default,
+        };
+
+        const MeshCall = struct {
+            texture_id: u32,
+            vertex_count: usize,
+            index_count: usize,
+            blend: BlendMode,
+            /// True when the world sprite pass (`render()`) had already run
+            /// this frame — proves the mesh was submitted in the render phase.
+            after_render: bool,
+        };
+
+        render_count: usize = 0,
+        mesh_calls: std.ArrayListUnmanaged(MeshCall) = .empty,
+        alloc: std.mem.Allocator = undefined,
+
+        pub fn init(allocator: std.mem.Allocator) Self {
+            return .{ .alloc = allocator };
+        }
+        pub fn deinit(self: *Self) void {
+            self.mesh_calls.deinit(self.alloc);
+        }
+
+        pub fn trackEntity(_: *Self, _: Entity, _: core.render.VisualType) void {}
+        pub fn untrackEntity(_: *Self, _: Entity) void {}
+        pub fn markPositionDirty(_: *Self, _: Entity) void {}
+        pub fn markPositionDirtyWithChildren(_: *Self, comptime _: type, _: anytype, _: Entity) void {}
+        pub fn updateHierarchyFlag(_: *Self, _: Entity, _: bool) void {}
+        pub fn markVisualDirty(_: *Self, _: Entity) void {}
+        pub fn sync(_: *Self, comptime _: type, _: anytype) void {}
+        pub fn setScreenHeight(_: *Self, _: f32) void {}
+        pub fn renderGizmoDraws(_: *Self, _: []const core.gizmos.GizmoDraw) void {}
+        pub fn hasEntity(_: *const Self, _: Entity) bool {
+            return false;
+        }
+
+        pub fn render(self: *Self) void {
+            self.render_count += 1;
+        }
+        pub fn clear(self: *Self) void {
+            self.render_count = 0;
+        }
+
+        /// The optional textured-mesh primitive. Records the call.
+        pub fn drawMesh(
+            self: *Self,
+            texture_id: u32,
+            positions: []const f32,
+            _: []const f32,
+            _: []const u32,
+            indices: []const u16,
+            blend: BlendMode,
+        ) void {
+            self.mesh_calls.append(self.alloc, .{
+                .texture_id = texture_id,
+                .vertex_count = positions.len / 2,
+                .index_count = indices.len,
+                .blend = blend,
+                .after_render = self.render_count > 0,
+            }) catch {};
+        }
+    };
+}
+
+const EmptyComponents = struct {
+    pub fn has(comptime _: []const u8) bool {
+        return false;
+    }
+    pub fn names() []const []const u8 {
+        return &.{};
+    }
+};
+
+fn RecordingGame() type {
+    return GameConfig(
+        RecordingRender(u32),
+        MockEcsBackend(u32),
+        StubInput,
+        StubAudio,
+        StubVideo,
+        StubGui,
+        void, // Hooks
+        StubLogSink,
+        EmptyComponents,
+        &.{}, // gizmo categories
+        void, // game events
+    );
+}
+
+// A stand-in `labelle-spine`-style plugin: its render-phase callback iterates
+// its (here, hard-coded) meshes and submits each via `game.drawMesh(...)`.
+const FakeMeshPlugin = struct {
+    pub const Systems = struct {
+        // One unit quad: 4 verts, 2 triangles.
+        const positions = [_]f32{ 0, 0, 10, 0, 10, 10, 0, 10 };
+        const uvs = [_]f32{ 0, 0, 1, 0, 1, 1, 0, 1 };
+        const colors = [_]u32{ 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff };
+        const indices = [_]u16{ 0, 1, 2, 0, 2, 3 };
+
+        pub fn renderMeshes(game: anytype) void {
+            game.drawMesh(77, &positions, &uvs, &colors, &indices, .additive);
+        }
+    };
+};
+
+test "drawMesh forwards a textured mesh to the renderer" {
+    const RGame = RecordingGame();
+    var game = RGame.init(testing.allocator);
+    defer game.deinit();
+
+    const pos = [_]f32{ 0, 0, 1, 0, 1, 1 }; // 3 verts
+    const uv = [_]f32{ 0, 0, 1, 0, 1, 1 };
+    const col = [_]u32{ 0, 0, 0 };
+    const idx = [_]u16{ 0, 1, 2 }; // 1 triangle
+
+    game.drawMesh(42, &pos, &uv, &col, &idx, .normal);
+
+    const calls = game.renderer.mesh_calls.items;
+    try testing.expectEqual(@as(usize, 1), calls.len);
+    try testing.expectEqual(@as(u32, 42), calls[0].texture_id);
+    try testing.expectEqual(@as(usize, 3), calls[0].vertex_count);
+    try testing.expectEqual(@as(usize, 3), calls[0].index_count);
+    try testing.expectEqual(BlendMode.normal, calls[0].blend);
+}
+
+test "SystemRegistry.renderMeshes drives a plugin drawMesh in the render phase" {
+    const RGame = RecordingGame();
+    var game = RGame.init(testing.allocator);
+    defer game.deinit();
+
+    const PluginSystems = SystemRegistry(.{FakeMeshPlugin});
+
+    // Mirror the generated render sequence: world sprite pass, then the
+    // render-phase mesh callbacks composite over it.
+    game.render();
+    PluginSystems.renderMeshes(&game);
+
+    const calls = game.renderer.mesh_calls.items;
+    try testing.expectEqual(@as(usize, 1), calls.len);
+    try testing.expectEqual(@as(u32, 77), calls[0].texture_id);
+    try testing.expectEqual(@as(usize, 4), calls[0].vertex_count); // quad
+    try testing.expectEqual(@as(usize, 6), calls[0].index_count); // 2 tris
+    try testing.expectEqual(BlendMode.additive, calls[0].blend);
+    // The mesh landed after render() — i.e. genuinely in the render phase.
+    try testing.expect(calls[0].after_render);
+}
+
+test "renderMeshes is a comptime no-op when no plugin declares it" {
+    const RGame = RecordingGame();
+    var game = RGame.init(testing.allocator);
+    defer game.deinit();
+
+    // A plugin that exports Systems but no renderMeshes must be skipped.
+    const NoMeshPlugin = struct {
+        pub const Systems = struct {
+            pub fn tick(_: anytype, _: f32) void {}
+        };
+    };
+    const PluginSystems = SystemRegistry(.{NoMeshPlugin});
+
+    game.render();
+    PluginSystems.renderMeshes(&game);
+
+    try testing.expectEqual(@as(usize, 0), game.renderer.mesh_calls.items.len);
+}
+
+test "drawMesh is a no-op on a renderer without drawMesh (back-compat)" {
+    // The default engine.Game uses StubRender, which has no `drawMesh` — the
+    // call must compile and do nothing (zero-cost, non-breaking).
+    var game = engine.Game.init(testing.allocator);
+    defer game.deinit();
+
+    const pos = [_]f32{ 0, 0, 1, 0, 1, 1 };
+    const uv = [_]f32{ 0, 0, 1, 0, 1, 1 };
+    const col = [_]u32{ 0, 0, 0 };
+    const idx = [_]u16{ 0, 1, 2 };
+    game.drawMesh(1, &pos, &uv, &col, &idx, .normal); // no crash, no effect
+}


### PR DESCRIPTION
## What

Adds the **render-phase custom-mesh drawing seam** — Stage 4 of Spine skeletal animation (epic labelle-gfx#290). This is the seam the future `labelle-spine` plugin's `SpineSkeleton` system submits per-frame skinned textured meshes through. Mirrors the gizmo mechanism, but for **real textured rendering** (not debug viz).

Two halves:

### 1. `game.drawMesh(...)` — public immediate render-phase method
```zig
pub fn drawMesh(
    self: *Game,
    texture_id: u32,
    positions: []const f32,   // xy pairs, len == 2*numVerts (game space)
    uvs: []const f32,         // uv pairs, len == 2*numVerts, [0,1]
    colors: []const u32,      // RGBA8 packed, one u32 per vert, len == numVerts
    indices: []const u16,     // triangle list, len == 3*numTris
    blend: Game.BlendMode,
) void
```
New `src/game/mesh_mixin.zig`. Forwards to the renderer's optional `drawMesh` (the gfx `RetainedEngine` public API, gfx#291), gated on `@hasDecl` — a **no-op** on renderers/backends that don't declare it (raylib/sokol/wgpu/sdl today, and the engine's `StubRender`). Buffer/coordinate conventions match labelle-core's backend `drawMesh` contract. `Game.BlendMode` is re-exported from `labelle-core` (`core.BlendMode` = `enum { normal, additive, multiply, screen }`). This is the direct analog of the `renderGizmos` → `renderer.renderGizmoDraws` forwarding seam.

### 2. `SystemRegistry.renderMeshes(game)` — plugin render-callback seam
A new plugin render-phase lifecycle dispatcher in `scene/src/system.zig`, the **immediate sibling of `drawGui`** for world-space textured geometry. Discovered at comptime exactly like the other plugin lifecycle phases (iterate `plugin_modules`, `@hasDecl`-gated); **zero-cost** (folds to an empty `inline for`) when no plugin declares it. Respects `game_states`.

**The convention labelle-spine will implement** (add to the plugin's existing `Systems`):
```zig
pub const Systems = struct {
    // ...existing setup/tick/deinit...
    pub fn renderMeshes(game: anytype) void {
        // iterate this plugin's own components (skeletons) and submit each mesh
        for (skeletons) |skel| {
            game.drawMesh(skel.texture_id, skel.positions, skel.uvs,
                          skel.colors, skel.indices, .normal);
        }
    }
};
```

Invoked in the **render phase AFTER the world sprite pass** (`g.render()`), so meshes composite over sprites (and under the GUI overlay). Everything is optional/gated, so existing games and backends compile unchanged.

## Design note — invocation site (assembler follow-up)

`Game.render()` is comptime-blind to the plugin set (the engine is generic over `RenderImpl` and never sees `plugin_modules`), so — exactly like the existing render-phase plugin callback `drawGui` — invocation lives in the **generated render sequence**, not inside `Game.render()`. The engine seam (`SystemRegistry.renderMeshes` + `game.drawMesh`) is complete and fully tested here. Wiring it into the generated loop is a one-line assembler follow-up, mirroring `drawGui`:

```
g.render();
PluginSystems.renderMeshes(&g);   // <-- new, right after g.render(), before the GUI block
// ...guiBegin / drawGui / guiEnd...
```

## Release-time dependency notes

- **The engine takes NO direct labelle-gfx dependency.** The textured-mesh primitive reaches the engine through the `RenderImpl` renderer via `@hasDecl` — nothing to repin in `build.zig.zon`. For the seam to actually render at runtime, the production renderer (gfx's `GfxRenderer`/`RetainedEngine`) must expose `drawMesh` — that's **labelle-gfx#291**, which needs a labelle-gfx release before end-to-end Spine rendering works. Local gfx `main` is still v1.18.1 (no `drawMesh`).
- **labelle-core:** `BlendMode` + the optional backend `drawMesh` contract + the mock-backend `drawMesh`/`MeshCall` recording landed in **core v1.24.0** (already on `main`); the `build.zig.zon` path-dep note now records v1.24.0 as the effective floor for this engine version. No pin change needed (CI clones core `main`).

## Tests

`test/render_mesh_test.zig` (4 new), using a headless recording renderer + a fake `labelle-spine`-style plugin:
- `drawMesh` forwards a textured mesh to the renderer.
- `SystemRegistry.renderMeshes` drives a plugin `drawMesh` in the render phase (asserts texture/vertex/index/blend + that the mesh landed **after** `render()`).
- `renderMeshes` is a comptime no-op when no plugin declares it.
- `drawMesh` is a no-op on a renderer without `drawMesh` (back-compat).

`zig build` + `zig build test` green (against local core v1.24.0).

Refs labelle-gfx#290.

Claude-Session: https://claude.ai/code/session_01P7B7UzgrWEbBYLT3YBrAog
https://claude.ai/code/session_01P7B7UzgrWEbBYLT3YBrAog
