### PR TITLE
feat(engine): game.loadTextureFromMemory → u32 (in-memory texture upload for plugins, gfx#290)

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -1329,6 +1329,13 @@ pub fn GameConfigWithYAxis(
         pub const registerAtlasFromMemory = if (has_load_from_memory) AtlasMixin.registerAtlasFromMemoryImpl else @compileError("Renderer does not support loadTextureFromMemory");
         pub const loadAtlasIfNeeded = if (has_load_from_memory) AtlasMixin.loadAtlasIfNeededImpl else @compileError("Renderer does not support loadTextureFromMemory");
 
+        /// Upload a standalone in-memory texture (e.g. a plugin's atlas PNG)
+        /// and get back its renderer texture id as a plain `u32` — the numeric
+        /// handle `drawMesh` expects. Forwards to `renderer.loadTextureFromMemory`
+        /// and normalises the returned `TextureId`. Gated on the renderer
+        /// exposing `loadTextureFromMemory` (render-mesh seam, labelle-gfx#290).
+        pub const loadTextureFromMemory = if (has_load_from_memory) AtlasMixin.loadTextureFromMemoryU32 else @compileError("Renderer does not support loadTextureFromMemory");
+
         // ── Audio asset shims (Phase 4 of Asset Streaming RFC, #447) ──
         pub const registerSoundFromMemory = AtlasMixin.registerSoundFromMemory;
         pub const loadSoundFromMemory = AtlasMixin.loadSoundFromMemory;

--- a/src/game/atlas_mixin.zig
+++ b/src/game/atlas_mixin.zig
@@ -45,6 +45,18 @@ pub fn Mixin(comptime Game: type) type {
             _ = try self.loadAtlasIfNeeded(name);
         }
 
+        /// Upload a standalone texture from an in-memory image blob, returning
+        /// its renderer texture id as a plain `u32` (render-mesh seam companion,
+        /// labelle-gfx#290). Forwards straight to the renderer's
+        /// `loadTextureFromMemory` (the gfx `GfxRenderer` → `RetainedEngine` →
+        /// backend decode+upload path) and normalises the returned `TextureId`
+        /// enum/int to `u32` so the caller can hand it back to `game.drawMesh`.
+        /// Same `TextureId` → `u32` conversion the atlas loaders use.
+        pub fn loadTextureFromMemoryU32(self: *Game, file_type: [:0]const u8, data: []const u8) !u32 {
+            const tex_id = try self.renderer.loadTextureFromMemory(file_type, data);
+            return if (@typeInfo(@TypeOf(tex_id)) == .@"enum") @intFromEnum(tex_id) else tex_id;
+        }
+
         pub fn registerAtlasFromMemoryImpl(self: *Game, name: []const u8, json_content: []const u8, image_data: []const u8, file_type: [:0]const u8) !void {
             // Keep the legacy TextureManager side-effects: parse JSON
             // eagerly so `findSprite` works after the catalog finishes

--- a/test/asset_streaming_shim_test.zig
+++ b/test/asset_streaming_shim_test.zig
@@ -82,12 +82,15 @@ fn MockRenderer(comptime Entity: type) type {
             return false;
         }
 
-        // Present only so the atlas shim's `has_load_from_memory`
-        // gate flips to `true`. The shim no longer invokes it — the
-        // catalog owns the upload — but removing it would disable the
-        // shim entirely on this Game type.
+        // Flips the atlas shim's `has_load_from_memory` gate to `true`.
+        // The atlas shim no longer invokes it (the catalog owns the
+        // upload), but `Game.loadTextureFromMemory` — the standalone
+        // in-memory texture uploader (render-mesh seam, gfx#290) — does
+        // forward straight to it, so return a recognisable non-invalid
+        // id the round-trip test can assert against.
+        pub const mock_tex_id: u32 = 77;
         pub fn loadTextureFromMemory(_: *Self, _: [:0]const u8, _: []const u8) !TextureId {
-            return .invalid;
+            return @enumFromInt(mock_tex_id);
         }
 
         // Not used on the catalog path (the catalog-managed upload
@@ -370,6 +373,31 @@ test "shim: double register through the shim is tolerated" {
 
     _ = try game.loadAtlasIfNeeded("shared");
     try testing.expect(game.isAtlasLoaded("shared"));
+}
+
+// ── Standalone in-memory texture upload (render-mesh seam, gfx#290) ──
+//
+// `Game.loadTextureFromMemory(file_type, data) → u32` is the plugin
+// entry point (labelle-spine uploads an atlas PNG and hands the numeric
+// id to `game.drawMesh`). Unlike the atlas shim it does NOT go through
+// the catalog — it forwards straight to `renderer.loadTextureFromMemory`
+// and normalises the returned `TextureId` enum to a plain `u32`.
+
+test "texture: loadTextureFromMemory forwards to renderer and returns u32 id" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const png_bytes: []const u8 = "fake-atlas-png";
+    const id: u32 = try game.loadTextureFromMemory(file_type, png_bytes);
+
+    // The mock renderer hands back `TextureId(77)`; the wrapper must
+    // normalise the enum to the raw u32 `drawMesh` expects.
+    try testing.expectEqual(
+        MockRenderer(MockEcs.Entity).mock_tex_id,
+        id,
+    );
+    // Sanity: the returned handle is a valid (non-`invalid`) id.
+    try testing.expect(id != 0);
 }
 
 // ── Audio shim (Phase 4, #447) ──


### PR DESCRIPTION
## What

Adds a public `Game` method:

```zig
pub fn loadTextureFromMemory(file_type: [:0]const u8, data: []const u8) !u32
```

It forwards straight to `renderer.loadTextureFromMemory` (the gfx `GfxRenderer` → `RetainedEngine` → backend decode+upload path) and normalises the returned `TextureId` enum/int to a plain `u32` — the same `TextureId` → `u32` conversion the atlas loaders (`loadAtlas`, `loadAtlasComptime`) already use. Gated on `@hasDecl(RenderImpl, "loadTextureFromMemory")`, folding to a `@compileError` shell on renderers that lack the hook.

## Why

Enables plugins like **labelle-spine** to upload an in-memory atlas PNG and get back the numeric texture id that `game.drawMesh` expects. Found needed by the Spine end-to-end validation. Refs gfx#290 (render-mesh seam).

## Files changed

- `src/game/atlas_mixin.zig` — new `loadTextureFromMemoryU32` impl body
- `src/game.zig` — exposes `pub const loadTextureFromMemory` (capability-gated)
- `test/asset_streaming_shim_test.zig` — mock-renderer test asserting a memory upload returns a valid u32 id (mock renderer now returns a recognisable non-invalid `TextureId`)

## Verification

`zig build` and `zig build test` both pass (634/634 tests).

Claude-Session: https://claude.ai/code/session_01P7B7UzgrWEbBYLT3YBrAog

https://claude.ai/code/session_01P7B7UzgrWEbBYLT3YBrAog