### PR TITLE
feat: editor_api — wasm editor control surface for studio Play mode (contract v1)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -171,6 +171,16 @@ pub fn build(b: *std.Build) void {
         // plugin render callback (the seam `labelle-spine` submits skinned
         // meshes through).
         "test/render_mesh_test.zig",
+        // labelle-studio Play mode (Phase 3) — wasm editor control
+        // surface: bind/dispatch vtable, pause/step tick gating, scene
+        // digest JSON (+ truncation validity), camera override state
+        // machine, pre-bind no-op safety.
+        "test/editor_api_test.zig",
+        // Runtime scene-source override map (editor_load_scene): set →
+        // load consults override (loadSceneFromSource by loading scene
+        // name, loadSceneFile includes by path stem); replace frees the
+        // previous source.
+        "test/scene_source_override_test.zig",
     };
 
     for (test_files) |test_file| {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xe8a81a8dc7f48c87,
     .name = .engine,
-    .version = "1.66.0",
+    .version = "1.67.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         // Requires labelle-core >= v1.20.0 — font_types aliases core's

--- a/src/editor_api.zig
+++ b/src/editor_api.zig
@@ -34,13 +34,21 @@
 //! ```zig
 //! editor_api.bind(&g, &runner);            // once, after Game init
 //! if (editor_api.shouldTick()) g.tick(dt); // gate the SIM half only
+//! editor_api.frame(&g);                    // AFTER the tick, BEFORE render
 //! g.render();
-//! editor_api.frame(&g);                    // AFTER the tick: re-assert camera
 //! ```
 //!
 //! `frame` re-asserts the editor camera override every frame because
 //! game scripts (e.g. FP's `camera_control`) re-assert the gameplay
-//! camera on every tick — the editor must win by writing last.
+//! camera on every tick — the editor must win by writing last. The
+//! tick → frame → render ordering is load-bearing: `frame` must run
+//! after the tick (so the script's camera write is already down) but
+//! BEFORE `g.render()`. If it ran after render, every unpaused frame
+//! would render the script's camera — the override would land
+//! post-render only to be overwritten by the next tick before the next
+//! render, so studio camera control would only work while paused.
+//! Call `frame` unconditionally (gated ticks included) so the override
+//! also holds while paused.
 //!
 //! Single-threaded by design (the wasm main thread); no atomics.
 
@@ -112,9 +120,10 @@ pub fn shouldTick() bool {
 }
 
 /// Per-frame editor pass, called by the generated main AFTER the sim
-/// tick (and its camera-writing scripts): re-asserts the editor camera
-/// while the override is engaged; a no-op otherwise, and a comptime
-/// no-op for games whose renderer has no camera.
+/// tick (and its camera-writing scripts) and BEFORE `g.render()`:
+/// re-asserts the editor camera while the override is engaged so the
+/// frame about to be rendered uses it; a no-op otherwise, and a
+/// comptime no-op for games whose renderer has no camera.
 pub fn frame(g: anytype) void {
     if (camera_override) |c| applyCameraTo(g, c);
 }
@@ -171,7 +180,10 @@ pub export fn editor_set_scene(name: [*]const u8, len: usize) i32 {
 /// Store `src` as the runtime source override for scene `name` (the
 /// override map is consulted before the embedded/compiled source on
 /// every subsequent load). If `name` is the current scene, it is
-/// reloaded immediately. 0 = ok.
+/// reloaded immediately — transactionally: when the new source fails
+/// to load, the override map is rolled back to its previous state and
+/// the scene is reloaded from the last-good source, so a malformed
+/// edit never blanks the preview. 0 = ok.
 pub export fn editor_load_scene(name: [*]const u8, nlen: usize, src: [*]const u8, slen: usize) i32 {
     const vt = vtable orelse return -1;
     return vt.load_scene(name[0..nlen], src[0..slen]);
@@ -196,7 +208,9 @@ pub export fn editor_pick(x: f32, y: f32) i64 {
 /// `cap`) and return the number of bytes written. Shape:
 /// `{"scene":"...","paused":0|1,"entity_count":N,
 ///   "entities":[{"id":<u64>,"prefab":"?","sprite":"?","x":f,"y":f},...]}`
-/// `prefab`/`sprite` appear only when known. The entity list is
+/// `prefab`/`sprite` appear only when known; `x`/`y` are WORLD
+/// coordinates (the same space `editor_set_entity_position` consumes).
+/// The entity list is
 /// truncated to fit `cap` while `entity_count` keeps the full count —
 /// the output is always valid JSON (worst case `{}`; 0 bytes only when
 /// `cap < 2`).
@@ -281,11 +295,47 @@ fn Holder(comptime GP: type, comptime RP: type) type {
         }
 
         fn loadSceneImpl(name: []const u8, src: []const u8) i32 {
-            game.setSceneSourceOverride(name, src) catch return -1;
-            if (game.getCurrentSceneName()) |cur| {
-                if (std.mem.eql(u8, cur, name)) return setSceneImpl(name);
+            const is_current = if (game.getCurrentSceneName()) |cur|
+                std.mem.eql(u8, cur, name)
+            else
+                false;
+
+            if (!is_current) {
+                // Not the running scene: just store; the override is
+                // picked up on the next load of `name`.
+                game.setSceneSourceOverride(name, src) catch return -1;
+                return 0;
             }
-            return 0;
+
+            // Reloading the RUNNING scene must be transactional: the
+            // engine unloads the current scene before the loader can
+            // fail, so a malformed/partially-typed source would blank
+            // the preview AND leave the bad override installed (a later
+            // corrected editor_load_scene would no longer auto-reload —
+            // there'd be no current scene to match). Snapshot the
+            // previous override (exact-key, ownership stays with the
+            // map — we copy), install the new source, and on reload
+            // failure roll the map back and reload the last-good source.
+            const prev: ?[]const u8 = if (game.scene_source_overrides.get(name)) |old|
+                (game.allocator.dupe(u8, old) catch return -1)
+            else
+                null;
+            defer if (prev) |p| game.allocator.free(p);
+
+            game.setSceneSourceOverride(name, src) catch return -1;
+            if (setSceneImpl(name) == 0) return 0;
+
+            // Bad source — restore the previous override state…
+            if (prev) |p| {
+                game.setSceneSourceOverride(name, p) catch {};
+            } else {
+                game.removeSceneSourceOverride(name);
+            }
+            // …and reload the scene from the last-good source so the
+            // preview doesn't stay blank. If even that fails we're no
+            // worse off than before this rollback existed.
+            _ = setSceneImpl(name);
+            return -1;
         }
 
         fn setEntityPositionImpl(id: u64, x: f32, y: f32) void {
@@ -365,10 +415,15 @@ fn Holder(comptime GP: type, comptime RP: type) type {
                     try appendJsonString(buf, cur, sp.sprite_name);
                 }
             }
-            const pos = game.getComponent(ent, core.Position);
-            const x: f32 = if (pos) |p| jsonSafeFloat(p.x) else 0;
-            const y: f32 = if (pos) |p| jsonSafeFloat(p.y) else 0;
-            try appendFmt(buf, cur, ",\"x\":{d},\"y\":{d}}}", .{ x, y });
+            // WORLD coordinates, not the raw (parent-relative) Position
+            // component — `editor_set_entity_position` consumes world
+            // coords, so the digest must publish the same space or the
+            // studio would draw/drag nested prefab children at their
+            // local offsets and write them back wrong.
+            const wp = game.getWorldPosition(ent);
+            try appendFmt(buf, cur, ",\"x\":{d},\"y\":{d}}}", .{
+                jsonSafeFloat(wp.x), jsonSafeFloat(wp.y),
+            });
         }
 
         fn entityId(ent: G.EntityType) u64 {

--- a/src/editor_api.zig
+++ b/src/editor_api.zig
@@ -1,0 +1,421 @@
+//! editor_api — the engine side of labelle-studio's Play mode (Phase 3).
+//!
+//! The studio runs the game compiled to wasm in an iframe and drives it
+//! through the plain `export fn editor_*` symbols in this file (emcc
+//! `-sEXPORTED_FUNCTIONS` keeps them alive on the wasm side).
+//!
+//! ## Bind pattern
+//!
+//! Module-scope `g` / `runner` in the assembler-generated `main.zig` are
+//! not visible to a sibling module, so the generated main hands them to
+//! `bind(&g, &runner)` once, right after `Game.init`. `bind` is
+//! comptime-generic: it instantiates a `Holder` for the concrete
+//! Game/Runner types, stores the pointers in that instantiation's
+//! container-level `var`s, and publishes a vtable of plain (non-generic)
+//! function pointers. The `export fn`s dispatch through that vtable —
+//! they carry no comptime type information themselves.
+//!
+//! Before `bind` runs, every export is a safe no-op: `editor_scene_digest`
+//! writes `{}`, the i32-returning scene ops return -1, and the void
+//! setters silently ignore. `editor_pause` / `editor_step` are pure
+//! editor-side state and work even before `bind`.
+//!
+//! ## No symbols in non-preview builds
+//!
+//! This file is reachable from the engine root only through
+//! `root.editor_api`, a lazily-analyzed `pub const`. The generated main
+//! `@import`s/binds it only under the assembler's preview flag; a build
+//! that never references the module never semantically analyzes this
+//! file, so none of the `editor_*` exports are emitted. (Verified by
+//! `nm`-ing two otherwise-identical executables — see the PR.)
+//!
+//! ## Generated-main touchpoints (the assembler splices exactly these)
+//!
+//! ```zig
+//! editor_api.bind(&g, &runner);            // once, after Game init
+//! if (editor_api.shouldTick()) g.tick(dt); // gate the SIM half only
+//! g.render();
+//! editor_api.frame(&g);                    // AFTER the tick: re-assert camera
+//! ```
+//!
+//! `frame` re-asserts the editor camera override every frame because
+//! game scripts (e.g. FP's `camera_control`) re-assert the gameplay
+//! camera on every tick — the editor must win by writing last.
+//!
+//! Single-threaded by design (the wasm main thread); no atomics.
+
+const std = @import("std");
+const core = @import("labelle-core");
+
+// ── Editor-local state (functional pre-bind) ────────────────────────
+
+var editor_paused: bool = false;
+var pending_steps: u32 = 0;
+
+pub const CameraOverride = struct { x: f32, y: f32, zoom: f32 };
+var camera_override: ?CameraOverride = null;
+
+// ── Type-erased dispatch ────────────────────────────────────────────
+
+const VTable = struct {
+    set_scene: *const fn (name: []const u8) i32,
+    load_scene: *const fn (name: []const u8, src: []const u8) i32,
+    set_entity_position: *const fn (id: u64, x: f32, y: f32) void,
+    scene_digest: *const fn (out: []u8) usize,
+    apply_camera: *const fn (x: f32, y: f32, zoom: f32) void,
+};
+
+var vtable: ?*const VTable = null;
+
+// ── Generated-main API (non-export) ─────────────────────────────────
+
+/// Store the concrete Game (and Runner) behind the type-erased vtable.
+/// Called once by the generated main, after `Game.init` (and scene
+/// registration). `g` must be a stable `*Game` pointer; `runner` is
+/// stored for future ops (v1 doesn't dispatch through it) and may be
+/// any value, typically `*ScriptRunner(...)`.
+pub fn bind(g: anytype, runner: anytype) void {
+    const GP = @TypeOf(g);
+    comptime {
+        const info = @typeInfo(GP);
+        if (info != .pointer or @typeInfo(info.pointer.child) != .@"struct")
+            @compileError("editor_api.bind expects a *Game pointer, got " ++ @typeName(GP));
+    }
+    const H = Holder(GP, @TypeOf(runner));
+    H.game = g;
+    H.runner = runner;
+    vtable = &H.vtable_impl;
+}
+
+/// Drop the bound game and reset all editor state (pause, pending
+/// steps, camera override). Exports revert to their pre-bind no-op
+/// behavior. Call before the Game is deinitialized if the module
+/// outlives it; tests use it to isolate the module-level state.
+pub fn unbind() void {
+    vtable = null;
+    editor_paused = false;
+    pending_steps = 0;
+    camera_override = null;
+}
+
+/// Gate for the SIM half of the generated main's frame loop.
+/// Unpaused: always true. Paused: consumes one pending `editor_step`
+/// count per call and returns true for it; false otherwise (render
+/// continues either way — only `g.tick` is gated on this).
+pub fn shouldTick() bool {
+    if (!editor_paused) return true;
+    if (pending_steps > 0) {
+        pending_steps -= 1;
+        return true;
+    }
+    return false;
+}
+
+/// Per-frame editor pass, called by the generated main AFTER the sim
+/// tick (and its camera-writing scripts): re-asserts the editor camera
+/// while the override is engaged; a no-op otherwise, and a comptime
+/// no-op for games whose renderer has no camera.
+pub fn frame(g: anytype) void {
+    if (camera_override) |c| applyCameraTo(g, c);
+}
+
+/// Current editor pause state (what `editor_scene_digest` reports).
+pub fn isPaused() bool {
+    return editor_paused;
+}
+
+/// The engaged camera override, if any. Introspection for tests/tools.
+pub fn cameraOverride() ?CameraOverride {
+    return camera_override;
+}
+
+// ── Exports (plain, non-generic; dispatch through the vtable) ───────
+
+/// Allocate `len` bytes the host can write into (scene names/sources)
+/// or read from. Uses the C allocator — on emscripten-wasm this IS
+/// `malloc`, so the JS side can pair it with the module's heap views.
+pub export fn editor_alloc(len: usize) ?[*]u8 {
+    if (len == 0) return null;
+    const mem = std.heap.c_allocator.alloc(u8, len) catch return null;
+    return mem.ptr;
+}
+
+/// Free a buffer obtained from `editor_alloc`. `len` must match.
+pub export fn editor_free(ptr: [*]u8, len: usize) void {
+    if (len == 0) return;
+    std.heap.c_allocator.free(ptr[0..len]);
+}
+
+/// 1 = freeze the simulation (rendering continues), 0 = resume.
+/// Resuming discards any unconsumed `editor_step` counts.
+pub export fn editor_pause(paused: i32) void {
+    editor_paused = paused != 0;
+    if (!editor_paused) pending_steps = 0;
+}
+
+/// While paused: advance N sim ticks (consumed one per frame by
+/// `shouldTick`). Ignored when not paused.
+pub export fn editor_step(frames: u32) void {
+    if (!editor_paused) return;
+    pending_steps +|= frames;
+}
+
+/// Switch to scene `name`. 0 = ok (including a swap deferred on the
+/// asset gate — a retry is queued), nonzero = unknown scene / error /
+/// not bound.
+pub export fn editor_set_scene(name: [*]const u8, len: usize) i32 {
+    const vt = vtable orelse return -1;
+    return vt.set_scene(name[0..len]);
+}
+
+/// Store `src` as the runtime source override for scene `name` (the
+/// override map is consulted before the embedded/compiled source on
+/// every subsequent load). If `name` is the current scene, it is
+/// reloaded immediately. 0 = ok.
+pub export fn editor_load_scene(name: [*]const u8, nlen: usize, src: [*]const u8, slen: usize) i32 {
+    const vt = vtable orelse return -1;
+    return vt.load_scene(name[0..nlen], src[0..slen]);
+}
+
+/// Move entity `id` to world coordinates (x, y). Marks the position
+/// dirty so the render pipeline re-syncs. Unknown/positionless ids are
+/// ignored.
+pub export fn editor_set_entity_position(id: u64, x: f32, y: f32) void {
+    const vt = vtable orelse return;
+    vt.set_entity_position(id, x, y);
+}
+
+/// v1: always -1 — the studio picks client-side from the scene digest.
+pub export fn editor_pick(x: f32, y: f32) i64 {
+    _ = x;
+    _ = y;
+    return -1;
+}
+
+/// Write a JSON digest of the current scene into `out` (capacity
+/// `cap`) and return the number of bytes written. Shape:
+/// `{"scene":"...","paused":0|1,"entity_count":N,
+///   "entities":[{"id":<u64>,"prefab":"?","sprite":"?","x":f,"y":f},...]}`
+/// `prefab`/`sprite` appear only when known. The entity list is
+/// truncated to fit `cap` while `entity_count` keeps the full count —
+/// the output is always valid JSON (worst case `{}`; 0 bytes only when
+/// `cap < 2`).
+pub export fn editor_scene_digest(out: [*]u8, cap: usize) usize {
+    const vt = vtable orelse return writeEmptyObject(out, cap);
+    return vt.scene_digest(out[0..cap]);
+}
+
+/// Engage the editor camera override: applied immediately and
+/// re-asserted after every sim tick (via `frame`) until released.
+pub export fn editor_set_camera(x: f32, y: f32, zoom: f32) void {
+    camera_override = .{ .x = x, .y = y, .zoom = zoom };
+    if (vtable) |vt| vt.apply_camera(x, y, zoom);
+}
+
+/// Release the camera override. The gameplay camera is NOT restored
+/// explicitly — camera-driving scripts re-assert it on their next tick.
+pub export fn editor_release_camera() void {
+    camera_override = null;
+}
+
+// ── Implementation ──────────────────────────────────────────────────
+
+fn writeEmptyObject(out: [*]u8, cap: usize) usize {
+    if (cap < 2) return 0;
+    out[0] = '{';
+    out[1] = '}';
+    return 2;
+}
+
+/// True when `G` (a Game type) exposes a settable camera. `Game`
+/// publishes `CameraType = void` for camera-less renderers (StubRender),
+/// which folds the whole override path away at comptime.
+fn gameHasCamera(comptime G: type) bool {
+    if (!@hasDecl(G, "CameraType")) return false;
+    if (G.CameraType == void) return false;
+    return @hasDecl(G.CameraType, "setPosition") and @hasDecl(G.CameraType, "setZoom");
+}
+
+fn applyCameraTo(g: anytype, c: CameraOverride) void {
+    const G = @typeInfo(@TypeOf(g)).pointer.child;
+    if (comptime !gameHasCamera(G)) return;
+    const cam = g.getCamera();
+    cam.setPosition(c.x, c.y);
+    cam.setZoom(c.zoom);
+}
+
+/// One instantiation per concrete (Game-pointer, Runner) pair. The
+/// container-level `var`s give the plain vtable fns a place to find
+/// the typed pointers without any runtime type erasure gymnastics.
+fn Holder(comptime GP: type, comptime RP: type) type {
+    return struct {
+        const G = @typeInfo(GP).pointer.child;
+
+        var game: GP = undefined;
+        var runner: RP = undefined;
+
+        const vtable_impl = VTable{
+            .set_scene = &setSceneImpl,
+            .load_scene = &loadSceneImpl,
+            .set_entity_position = &setEntityPositionImpl,
+            .scene_digest = &sceneDigestImpl,
+            .apply_camera = &applyCameraImpl,
+        };
+
+        fn setSceneImpl(name: []const u8) i32 {
+            // Validate BEFORE calling setScene: the engine tears the
+            // current scene down before it discovers an unknown target
+            // (SceneNotFound leaves no scene loaded). A typo'd editor
+            // request must not nuke the running scene.
+            if (game.scenes.get(name) == null and game.jsonc_scenes.get(name) == null)
+                return -1;
+            game.setScene(name) catch return -1;
+            // `setScene` DEFERS (returns without swapping, leaving
+            // `pending_scene_assets` set) while the target's asset
+            // manifest is still loading. Queue the change so the game
+            // loop's retrier (loop_mixin) commits it once the assets
+            // are ready — mirrors the pending-scene commit detection
+            // from #635.
+            if (game.pending_scene_assets != null) game.queueSceneChange(name);
+            return 0;
+        }
+
+        fn loadSceneImpl(name: []const u8, src: []const u8) i32 {
+            game.setSceneSourceOverride(name, src) catch return -1;
+            if (game.getCurrentSceneName()) |cur| {
+                if (std.mem.eql(u8, cur, name)) return setSceneImpl(name);
+            }
+            return 0;
+        }
+
+        fn setEntityPositionImpl(id: u64, x: f32, y: f32) void {
+            const Entity = G.EntityType;
+            if (comptime @typeInfo(Entity) != .int) return;
+            const ent = std.math.cast(Entity, id) orelse return;
+            // Positionless ids (stale/dead entities included) are
+            // ignored — the editor only drags positioned entities.
+            if (!game.hasComponent(ent, core.Position)) return;
+            // World coords; converts to local for parented entities and
+            // marks the position dirty for the render pipeline.
+            game.setWorldPosition(ent, .{ .x = x, .y = y });
+        }
+
+        fn applyCameraImpl(x: f32, y: f32, zoom: f32) void {
+            applyCameraTo(game, .{ .x = x, .y = y, .zoom = zoom });
+        }
+
+        fn sceneDigestImpl(out: []u8) usize {
+            if (out.len < 2) return 0;
+            return renderDigest(out) catch writeEmptyObject(out.ptr, out.len);
+        }
+
+        const NoSpace = error{NoSpace};
+
+        fn renderDigest(out: []u8) NoSpace!usize {
+            // Reserve the closing `]}` up front so entity truncation
+            // can never eat the bytes that keep the JSON valid.
+            const body = out[0 .. out.len - 2];
+            var cur: usize = 0;
+
+            var count: usize = 0;
+            {
+                var v = game.ecs_backend.view(.{core.Position}, .{});
+                defer v.deinit();
+                while (v.next()) |_| count += 1;
+            }
+
+            try appendLit(body, &cur, "{\"scene\":");
+            try appendJsonString(body, &cur, game.getCurrentSceneName() orelse "");
+            try appendFmt(body, &cur, ",\"paused\":{d},\"entity_count\":{d},\"entities\":[", .{
+                @intFromBool(editor_paused), count,
+            });
+
+            var first = true;
+            var v = game.ecs_backend.view(.{core.Position}, .{});
+            defer v.deinit();
+            while (v.next()) |ent| {
+                const mark = cur;
+                writeEntityJson(body, &cur, ent, first) catch {
+                    // Doesn't fit — roll back this entity (and its
+                    // leading comma) and stop; the closing `]}` below
+                    // keeps the truncated list valid JSON.
+                    cur = mark;
+                    break;
+                };
+                first = false;
+            }
+
+            out[cur] = ']';
+            out[cur + 1] = '}';
+            return cur + 2;
+        }
+
+        fn writeEntityJson(buf: []u8, cur: *usize, ent: G.EntityType, first: bool) NoSpace!void {
+            if (!first) try appendLit(buf, cur, ",");
+            try appendFmt(buf, cur, "{{\"id\":{d}", .{entityId(ent)});
+            if (comptime @hasDecl(G, "PrefabInstanceComp")) {
+                if (game.getComponent(ent, G.PrefabInstanceComp)) |pi| {
+                    try appendLit(buf, cur, ",\"prefab\":");
+                    try appendJsonString(buf, cur, pi.path);
+                }
+            }
+            if (comptime @hasDecl(G, "SpriteComp") and @hasField(G.SpriteComp, "sprite_name")) {
+                if (game.getComponent(ent, G.SpriteComp)) |sp| {
+                    try appendLit(buf, cur, ",\"sprite\":");
+                    try appendJsonString(buf, cur, sp.sprite_name);
+                }
+            }
+            const pos = game.getComponent(ent, core.Position);
+            const x: f32 = if (pos) |p| jsonSafeFloat(p.x) else 0;
+            const y: f32 = if (pos) |p| jsonSafeFloat(p.y) else 0;
+            try appendFmt(buf, cur, ",\"x\":{d},\"y\":{d}}}", .{ x, y });
+        }
+
+        fn entityId(ent: G.EntityType) u64 {
+            const info = @typeInfo(G.EntityType);
+            if (comptime info == .int and info.int.signedness == .unsigned and info.int.bits <= 64) {
+                return @intCast(ent);
+            }
+            return 0;
+        }
+    };
+}
+
+/// NaN/Inf would render as `nan`/`inf` — invalid JSON. Clamp to 0.
+fn jsonSafeFloat(v: f32) f32 {
+    return if (std.math.isFinite(v)) v else 0;
+}
+
+fn appendLit(buf: []u8, cur: *usize, lit: []const u8) error{NoSpace}!void {
+    if (buf.len - cur.* < lit.len) return error.NoSpace;
+    @memcpy(buf[cur.*..][0..lit.len], lit);
+    cur.* += lit.len;
+}
+
+fn appendFmt(buf: []u8, cur: *usize, comptime fmt: []const u8, args: anytype) error{NoSpace}!void {
+    const written = std.fmt.bufPrint(buf[cur.*..], fmt, args) catch return error.NoSpace;
+    cur.* += written.len;
+}
+
+fn appendJsonString(buf: []u8, cur: *usize, s: []const u8) error{NoSpace}!void {
+    try appendLit(buf, cur, "\"");
+    for (s) |ch| {
+        switch (ch) {
+            '"' => try appendLit(buf, cur, "\\\""),
+            '\\' => try appendLit(buf, cur, "\\\\"),
+            '\n' => try appendLit(buf, cur, "\\n"),
+            '\r' => try appendLit(buf, cur, "\\r"),
+            '\t' => try appendLit(buf, cur, "\\t"),
+            else => {
+                if (ch < 0x20) {
+                    try appendFmt(buf, cur, "\\u{x:0>4}", .{ch});
+                } else {
+                    if (cur.* >= buf.len) return error.NoSpace;
+                    buf[cur.*] = ch;
+                    cur.* += 1;
+                }
+            },
+        }
+    }
+    try appendLit(buf, cur, "\"");
+}

--- a/src/game.zig
+++ b/src/game.zig
@@ -420,6 +420,25 @@ pub fn GameConfigWithYAxis(
         /// program-lifetime borrows of `@embedFile` slices and are NOT
         /// freed by the map.
         embedded_scene_sources: std.StringHashMap([]const u8),
+        /// Runtime scene-source overrides (labelle-studio Play mode /
+        /// `editor_api`). Keyed by scene NAME (e.g. `"main"`); the JSONC
+        /// loader consults this map BEFORE the embedded/compiled source
+        /// on every load — `loadSceneFromSource` matches the name of the
+        /// scene currently being loaded (`loading_scene_name`),
+        /// `loadSceneFile` matches the include path exactly and then by
+        /// stem (so an override for `"frag"` also replaces
+        /// `"scenes/frag.jsonc"`). Unlike `embedded_scene_sources`, BOTH
+        /// keys and values are owned copies (dupe'd via `self.allocator`);
+        /// replacing an entry frees the previous source. See
+        /// `setSceneSourceOverride` / `sceneSourceOverride`.
+        scene_source_overrides: std.StringHashMap([]const u8),
+        /// Name of the scene whose registered `loader_fn` is currently
+        /// executing. Set by `setScene` / `setSceneAtomic` / the
+        /// hot-reload path around the loader call ONLY — a borrow of the
+        /// caller's name slice, valid strictly for the duration of the
+        /// load. Lets `loadSceneFromSource` (which receives bytes, not a
+        /// name) resolve the scene-source override for the right scene.
+        loading_scene_name: ?[]const u8 = null,
         /// Entities created by the active scene's loader (e.g. the JSONC
         /// bridge). `unloadCurrentScene` destroys everything in this list
         /// on scene swap so entities from the outgoing scene don't leak
@@ -765,6 +784,7 @@ pub fn GameConfigWithYAxis(
                 .scenes = std.StringHashMap(SceneEntry).init(allocator),
                 .jsonc_scenes = std.StringHashMap(JsoncSceneInfo).init(allocator),
                 .embedded_scene_sources = std.StringHashMap([]const u8).init(allocator),
+                .scene_source_overrides = std.StringHashMap([]const u8).init(allocator),
                 .gizmo_state = gizmo_draws_mod.GizmoState(Entity).init(allocator),
                 // `game_ctx` is a placeholder here (the not-yet-stable world
                 // pointer); `bindScheduler` fixes it once `self` is stable.
@@ -1136,6 +1156,12 @@ pub fn GameConfigWithYAxis(
         /// retains no ownership — the map dupes the key and borrows
         /// the source's program-lifetime slice.
         pub const addEmbeddedSceneSource = MiscMixin.addEmbeddedSceneSource;
+
+        /// Runtime scene-source override map (labelle-studio Play mode /
+        /// `editor_api`) — see `game/misc_mixin.zig` for the ownership
+        /// and lookup rules.
+        pub const setSceneSourceOverride = MiscMixin.setSceneSourceOverride;
+        pub const sceneSourceOverride = MiscMixin.sceneSourceOverride;
         pub const setSceneAssets = SceneMixin.setSceneAssets;
         pub const setSceneInitialState = SceneMixin.setSceneInitialState;
         pub const setScene = SceneMixin.setScene;

--- a/src/game.zig
+++ b/src/game.zig
@@ -1161,6 +1161,7 @@ pub fn GameConfigWithYAxis(
         /// `editor_api`) — see `game/misc_mixin.zig` for the ownership
         /// and lookup rules.
         pub const setSceneSourceOverride = MiscMixin.setSceneSourceOverride;
+        pub const removeSceneSourceOverride = MiscMixin.removeSceneSourceOverride;
         pub const sceneSourceOverride = MiscMixin.sceneSourceOverride;
         pub const setSceneAssets = SceneMixin.setSceneAssets;
         pub const setSceneInitialState = SceneMixin.setSceneInitialState;

--- a/src/game/lifecycle_mixin.zig
+++ b/src/game/lifecycle_mixin.zig
@@ -99,6 +99,14 @@ pub fn Mixin(comptime Game: type) type {
             var emb_iter = self.embedded_scene_sources.iterator();
             while (emb_iter.next()) |entry| self.allocator.free(entry.key_ptr.*);
             self.embedded_scene_sources.deinit();
+            // Scene-source overrides own BOTH keys and values (runtime
+            // copies from `setSceneSourceOverride`) — free them all.
+            var ovr_iter = self.scene_source_overrides.iterator();
+            while (ovr_iter.next()) |entry| {
+                self.allocator.free(entry.key_ptr.*);
+                self.allocator.free(entry.value_ptr.*);
+            }
+            self.scene_source_overrides.deinit();
             self.atlas_manager.deinit();
             // Free the borrowed-slice roster cache (#653, #657). The map
             // owns every slot's list buffer (managed map `deinit()` takes

--- a/src/game/loop_mixin.zig
+++ b/src/game/loop_mixin.zig
@@ -157,7 +157,11 @@ pub fn Mixin(comptime Game: type) type {
                         self.emitHook(.{ .scene_before_load = .{ .name = name, .allocator = self.allocator } });
                         // Engine `Events` dual-emit (#578).
                         self.emitEngineEvent("engine__scene_loading", .{ .name = name });
+                        // Scene-source override resolution (Play mode /
+                        // editor_api) — same pattern as `setScene`.
+                        self.loading_scene_name = name;
                         entry.loader_fn(self) catch {};
+                        self.loading_scene_name = null;
                         self.emitHook(.{ .scene_load = .{ .name = name } });
                         // Engine `Events` dual-emit (#578).
                         self.emitEngineEvent("engine__scene_loaded", .{ .name = name });

--- a/src/game/misc_mixin.zig
+++ b/src/game/misc_mixin.zig
@@ -8,6 +8,7 @@
 /// shells stay on `Game` — they fold to `void` on cameraless renderers —
 /// and forward here for the impl bodies.
 
+const std = @import("std");
 const core = @import("labelle-core");
 
 /// Returns the misc-accessors mixin for a given Game type.
@@ -86,6 +87,48 @@ pub fn Mixin(comptime Game: type) type {
                 gop.key_ptr.* = try self.allocator.dupe(u8, path);
             }
             gop.value_ptr.* = source;
+        }
+
+        /// Store (or replace) a runtime scene-source override
+        /// (labelle-studio Play mode / `editor_api.editor_load_scene`).
+        /// `name` is the scene name (e.g. `"main"`). Both key and value
+        /// are copied with `self.allocator`; replacing an existing entry
+        /// frees the previous source. The JSONC loader consults this map
+        /// before the embedded/compiled source on every subsequent load
+        /// — see `sceneSourceOverride` for the lookup rules.
+        pub fn setSceneSourceOverride(self: *Game, name: []const u8, source: []const u8) !void {
+            const value = try self.allocator.dupe(u8, source);
+            errdefer self.allocator.free(value);
+            const gop = try self.scene_source_overrides.getOrPut(name);
+            if (gop.found_existing) {
+                self.allocator.free(gop.value_ptr.*);
+            } else {
+                gop.key_ptr.* = self.allocator.dupe(u8, name) catch |err| {
+                    // Undo the half-inserted entry (its key is still the
+                    // caller's transient slice) before propagating.
+                    self.scene_source_overrides.removeByPtr(gop.key_ptr);
+                    return err;
+                };
+            }
+            gop.value_ptr.* = value;
+        }
+
+        /// Resolve a scene-source override for `key`, which may be either
+        /// a scene name (`"main"`, the `loadSceneFromSource` path) or an
+        /// include-relative path (`"scenes/frag.jsonc"`, the
+        /// `loadSceneFile` path). Exact key match first; otherwise the
+        /// path's stem (basename minus extension) is tried, so an
+        /// override stored under the scene name also replaces the
+        /// same-named include fragment. Returns a borrow of the stored
+        /// source — valid until the entry is replaced or the game
+        /// deinitializes.
+        pub fn sceneSourceOverride(self: *const Game, key: []const u8) ?[]const u8 {
+            if (self.scene_source_overrides.count() == 0) return null;
+            if (self.scene_source_overrides.get(key)) |src| return src;
+            const base = std.fs.path.basename(key);
+            const stem = if (std.mem.lastIndexOfScalar(u8, base, '.')) |i| base[0..i] else base;
+            if (stem.len == 0 or std.mem.eql(u8, stem, key)) return null;
+            return self.scene_source_overrides.get(stem);
         }
 
         /// Register a runtime JSONC scene by name.

--- a/src/game/misc_mixin.zig
+++ b/src/game/misc_mixin.zig
@@ -113,6 +113,18 @@ pub fn Mixin(comptime Game: type) type {
             gop.value_ptr.* = value;
         }
 
+        /// Remove a scene-source override previously stored under `name`
+        /// (exact key only — no stem fallback), freeing both the owned
+        /// key and source copies. No-op when absent. Used by
+        /// `editor_api`'s transactional current-scene reload to roll a
+        /// freshly-installed bad override back out.
+        pub fn removeSceneSourceOverride(self: *Game, name: []const u8) void {
+            if (self.scene_source_overrides.fetchRemove(name)) |kv| {
+                self.allocator.free(kv.key);
+                self.allocator.free(kv.value);
+            }
+        }
+
         /// Resolve a scene-source override for `key`, which may be either
         /// a scene name (`"main"`, the `loadSceneFromSource` path) or an
         /// include-relative path (`"scenes/frag.jsonc"`, the

--- a/src/game/scene_mixin.zig
+++ b/src/game/scene_mixin.zig
@@ -476,8 +476,15 @@ pub fn Mixin(comptime Game: type) type {
             self.emitEngineEvent("engine__scene_loading", .{ .name = name });
 
             if (self.scenes.get(name)) |entry| {
-                // Comptime-registered scene
-                try entry.loader_fn(self);
+                // Comptime-registered scene. `loading_scene_name` is set
+                // for the duration of the loader so the JSONC bridge can
+                // resolve scene-source overrides by scene name (Play
+                // mode / editor_api).
+                {
+                    self.loading_scene_name = name;
+                    defer self.loading_scene_name = null;
+                    try entry.loader_fn(self);
+                }
                 self.current_scene_name = self.allocator.dupe(u8, name) catch null;
                 self.emitHook(.{ .scene_load = .{ .name = name } });
                 // Engine `Events` dual-emit (#578).
@@ -643,7 +650,13 @@ pub fn Mixin(comptime Game: type) type {
             self.emitHook(.{ .scene_before_load = .{ .name = name, .allocator = self.allocator } });
             // Engine `Events` dual-emit (#578).
             self.emitEngineEvent("engine__scene_loading", .{ .name = name });
-            try entry.loader_fn(self);
+            // Scene-source override resolution — same rationale as the
+            // `setScene` loader block above.
+            {
+                self.loading_scene_name = name;
+                defer self.loading_scene_name = null;
+                try entry.loader_fn(self);
+            }
             self.current_scene_name = self.allocator.dupe(u8, name) catch null;
             self.emitHook(.{ .scene_load = .{ .name = name } });
             // Engine `Events` dual-emit (#578).

--- a/src/jsonc/scene_loader/scene_process.zig
+++ b/src/jsonc/scene_loader/scene_process.zig
@@ -102,7 +102,18 @@ pub fn SceneProcess(comptime GameType: type, comptime Components: type, comptime
             // ================================================================
             const prefab_cache = try prefab_cache_mod.getOrCreatePrefabCache(game, prefab_dir);
 
-            try loadSceneSource(game, source, prefab_cache);
+            // Runtime scene-source override (labelle-studio Play mode /
+            // editor_api). This entry point receives bytes, not a name,
+            // so the scene identity comes from `game.loading_scene_name`
+            // — set by `setScene`/`setSceneAtomic`/hot-reload around the
+            // registered loader call. When the editor has stored an
+            // override for that scene, it replaces the embedded source.
+            const effective_source: []const u8 = if (game.loading_scene_name) |scene_name|
+                (game.sceneSourceOverride(scene_name) orelse source)
+            else
+                source;
+
+            try loadSceneSource(game, effective_source, prefab_cache);
 
             game.prefab_dir = prefab_dir;
             game.spawn_prefab_fn = &Self.spawnPrefabImpl;
@@ -290,11 +301,14 @@ pub fn SceneProcess(comptime GameType: type, comptime Components: type, comptime
         /// Load a single scene/fragment file, processing includes
         /// recursively then its own entities.
         ///
-        /// Source resolution: check `game.embedded_scene_sources` first
-        /// (populated by the assembler-generated `addEmbeddedSceneSource`
-        /// calls — the only mechanism that works on WASM/Android where
-        /// the project directory isn't reachable from cwd), then fall
-        /// back to `std.fs.cwd().openFile(path)` for desktop dev runs.
+        /// Source resolution: check `game.scene_source_overrides` first
+        /// (runtime overrides stored by the labelle-studio editor via
+        /// `editor_api.editor_load_scene`), then
+        /// `game.embedded_scene_sources` (populated by the
+        /// assembler-generated `addEmbeddedSceneSource` calls — the only
+        /// mechanism that works on WASM/Android where the project
+        /// directory isn't reachable from cwd), then fall back to
+        /// `std.fs.cwd().openFile(path)` for desktop dev runs.
         /// Mirrors the embedded-first ordering established by
         /// `PrefabCache.get` for prefabs.
         fn loadSceneFile(game: *GameType, path: []const u8, prefab_cache: *PrefabCache, include_depth: usize) !void {
@@ -308,7 +322,14 @@ pub fn SceneProcess(comptime GameType: type, comptime Components: type, comptime
             defer parse_arena.deinit();
             const parse_alloc = parse_arena.allocator();
 
-            const source: []const u8 = if (game.embedded_scene_sources.get(path)) |embedded|
+            const source: []const u8 = if (game.sceneSourceOverride(path)) |override|
+                // Runtime override (labelle-studio Play mode / editor_api)
+                // outranks both the embedded source and the filesystem —
+                // matched by exact path first, then by the path's stem
+                // (an override stored under `"frag"` replaces
+                // `"scenes/frag.jsonc"`).
+                override
+            else if (game.embedded_scene_sources.get(path)) |embedded|
                 embedded
             else
                 try std.Io.Dir.cwd().readFileAlloc(io_helper.io(), path, parse_alloc, .limited(1024 * 1024));

--- a/src/root.zig
+++ b/src/root.zig
@@ -546,6 +546,16 @@ pub const preview_binary_magic = preview_mode_mod.binary_magic;
 // `endFrameStreamIOSurface` triple.
 pub const preview_iosurface_mod = preview_mode_mod.preview_iosurface;
 
+// ── Editor API (labelle-studio Play mode, Phase 3) ──
+// Wasm editor control surface: plain `export fn editor_*` symbols the
+// studio drives through emcc `-sEXPORTED_FUNCTIONS`, plus the three
+// touchpoints the assembler-generated main splices in under its
+// preview flag (`bind` / `shouldTick` / `frame`). Deliberately a lazy
+// `pub const` and NOT referenced anywhere else in the engine: a build
+// that never references `engine.editor_api` never analyzes the file,
+// so non-preview builds emit no `editor_*` symbols.
+pub const editor_api = @import("editor_api.zig");
+
 // ── Out-of-band screenshot request (labelle-cli#227) ──
 // Read by the assembler-generated `main.zig`'s frame loop after the
 // game enters its main loop — when `LABELLE_SCREENSHOT_PATH` is set

--- a/test/editor_api_test.zig
+++ b/test/editor_api_test.zig
@@ -1,0 +1,361 @@
+//! labelle-studio Play mode (Phase 3) — editor_api contract tests.
+//!
+//! The module keeps its dispatch state (vtable, pause/step counters,
+//! camera override) in module-scope vars, so every test starts and ends
+//! with `editor_api.unbind()` to stay isolated.
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+const core = @import("labelle-core");
+
+const editor_api = engine.editor_api;
+const Game = engine.Game;
+
+/// Dummy stand-in for the generated main's ScriptRunner pointer — the
+/// v1 contract stores it but dispatches nothing through it.
+const DummyRunner = struct { ticks: u32 = 0 };
+
+fn digestInto(buf: []u8) []const u8 {
+    const n = editor_api.editor_scene_digest(buf.ptr, buf.len);
+    return buf[0..n];
+}
+
+// ── Pause / step tick gating ────────────────────────────────────────
+
+test "shouldTick: unpaused always ticks; paused freezes; steps advance N ticks" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    // Unpaused: always tick.
+    try testing.expect(editor_api.shouldTick());
+    try testing.expect(editor_api.shouldTick());
+
+    // Paused: frozen.
+    editor_api.editor_pause(1);
+    try testing.expect(editor_api.isPaused());
+    try testing.expect(!editor_api.shouldTick());
+    try testing.expect(!editor_api.shouldTick());
+
+    // Step 3: exactly three ticks, then frozen again.
+    editor_api.editor_step(3);
+    try testing.expect(editor_api.shouldTick());
+    try testing.expect(editor_api.shouldTick());
+    try testing.expect(editor_api.shouldTick());
+    try testing.expect(!editor_api.shouldTick());
+
+    // Resume: ticking again.
+    editor_api.editor_pause(0);
+    try testing.expect(editor_api.shouldTick());
+}
+
+test "shouldTick: resume discards pending steps; step while unpaused is ignored" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    // Steps while unpaused don't accumulate.
+    editor_api.editor_step(5);
+    editor_api.editor_pause(1);
+    try testing.expect(!editor_api.shouldTick());
+
+    // Pending steps are cleared by resume.
+    editor_api.editor_step(5);
+    editor_api.editor_pause(0);
+    editor_api.editor_pause(1);
+    try testing.expect(!editor_api.shouldTick());
+}
+
+// ── Pre-bind no-op safety ───────────────────────────────────────────
+
+test "pre-bind: every export is a safe no-op" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    // Scene ops report failure (no game to act on).
+    try testing.expectEqual(@as(i32, -1), editor_api.editor_set_scene("main", 4));
+    try testing.expectEqual(@as(i32, -1), editor_api.editor_load_scene("main", 4, "{}", 2));
+
+    // Void setters silently ignore.
+    editor_api.editor_set_entity_position(42, 1.0, 2.0);
+
+    // Pick is the documented v1 stub.
+    try testing.expectEqual(@as(i64, -1), editor_api.editor_pick(10.0, 20.0));
+
+    // Digest degrades to the empty object…
+    var buf: [64]u8 = undefined;
+    try testing.expectEqualStrings("{}", digestInto(&buf));
+    // …and to zero bytes when even that doesn't fit.
+    var tiny: [1]u8 = undefined;
+    try testing.expectEqual(@as(usize, 0), editor_api.editor_scene_digest(&tiny, 1));
+
+    // Camera override state machine works without a bound game.
+    editor_api.editor_set_camera(5.0, 6.0, 2.0);
+    try testing.expect(editor_api.cameraOverride() != null);
+    editor_api.editor_release_camera();
+    try testing.expect(editor_api.cameraOverride() == null);
+}
+
+test "editor_alloc / editor_free round-trip" {
+    const ptr = editor_api.editor_alloc(128) orelse return error.TestUnexpectedResult;
+    ptr[0] = 0xAB;
+    ptr[127] = 0xCD;
+    editor_api.editor_free(ptr, 128);
+
+    // Zero-length requests are no-ops, not crashes.
+    try testing.expect(editor_api.editor_alloc(0) == null);
+}
+
+// ── Digest JSON shape ───────────────────────────────────────────────
+
+test "digest: JSON shape with scene name, paused flag, sprites, and positions" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const loader = struct {
+        fn load(_: *Game) anyerror!void {}
+    }.load;
+    game.registerSceneSimple("arena", loader);
+    try game.setScene("arena");
+
+    const e1 = game.createEntity();
+    game.setPosition(e1, .{ .x = 100, .y = 200 });
+    game.addSprite(e1, .{ .sprite_name = "player" });
+
+    const e2 = game.createEntity();
+    game.setPosition(e2, .{ .x = -3.5, .y = 0 });
+
+    var runner = DummyRunner{};
+    editor_api.bind(&game, &runner);
+    editor_api.editor_pause(1);
+
+    var buf: [4096]u8 = undefined;
+    const json = digestInto(&buf);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    const root = parsed.value.object;
+
+    try testing.expectEqualStrings("arena", root.get("scene").?.string);
+    try testing.expectEqual(@as(i64, 1), root.get("paused").?.integer);
+    try testing.expectEqual(@as(i64, 2), root.get("entity_count").?.integer);
+
+    const entities = root.get("entities").?.array;
+    try testing.expectEqual(@as(usize, 2), entities.items.len);
+
+    var saw_sprite = false;
+    var saw_bare = false;
+    for (entities.items) |item| {
+        const obj = item.object;
+        try testing.expect(obj.get("id") != null);
+        try testing.expect(obj.get("x") != null);
+        try testing.expect(obj.get("y") != null);
+        if (obj.get("sprite")) |sprite| {
+            try testing.expectEqualStrings("player", sprite.string);
+            try testing.expectEqual(@as(i64, 100), obj.get("x").?.integer);
+            try testing.expectEqual(@as(i64, 200), obj.get("y").?.integer);
+            saw_sprite = true;
+        } else {
+            try testing.expectEqual(@as(f64, -3.5), obj.get("x").?.float);
+            saw_bare = true;
+        }
+    }
+    try testing.expect(saw_sprite);
+    try testing.expect(saw_bare);
+
+    // Resuming flips the reported paused flag.
+    editor_api.editor_pause(0);
+    const json2 = digestInto(&buf);
+    var parsed2 = try std.json.parseFromSlice(std.json.Value, testing.allocator, json2, .{});
+    defer parsed2.deinit();
+    try testing.expectEqual(@as(i64, 0), parsed2.value.object.get("paused").?.integer);
+}
+
+test "digest: truncation keeps valid JSON and the full entity_count" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    var i: usize = 0;
+    while (i < 50) : (i += 1) {
+        const e = game.createEntity();
+        game.setPosition(e, .{ .x = @floatFromInt(i), .y = @floatFromInt(i * 2) });
+    }
+
+    var runner = DummyRunner{};
+    editor_api.bind(&game, &runner);
+
+    // Small cap: entity list must truncate, JSON must stay parseable.
+    var small: [160]u8 = undefined;
+    const json = digestInto(&small);
+    try testing.expect(json.len <= small.len);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    const root = parsed.value.object;
+    try testing.expectEqual(@as(i64, 50), root.get("entity_count").?.integer);
+    const listed = root.get("entities").?.array.items.len;
+    try testing.expect(listed < 50);
+
+    // Caps too small for even the prefix degrade to "{}" — still JSON.
+    var minimal: [8]u8 = undefined;
+    try testing.expectEqualStrings("{}", digestInto(&minimal));
+
+    // cap < 2: nothing written.
+    var one: [1]u8 = undefined;
+    try testing.expectEqual(@as(usize, 0), editor_api.editor_scene_digest(&one, 1));
+
+    // Every cap in between must yield valid JSON (never a torn tail).
+    var cap: usize = 2;
+    var sweep: [512]u8 = undefined;
+    while (cap <= 400) : (cap += 7) {
+        const n = editor_api.editor_scene_digest(&sweep, cap);
+        var p = try std.json.parseFromSlice(std.json.Value, testing.allocator, sweep[0..n], .{});
+        p.deinit();
+    }
+}
+
+// ── Entity ops through the bound vtable ─────────────────────────────
+
+test "editor_set_entity_position: moves the entity and ignores bad ids" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const e = game.createEntity();
+    game.setPosition(e, .{ .x = 1, .y = 2 });
+    const bare = game.createEntity(); // alive but positionless
+
+    var runner = DummyRunner{};
+    editor_api.bind(&game, &runner);
+
+    editor_api.editor_set_entity_position(@intCast(e), 320.0, 240.0);
+    const pos = game.getComponent(e, core.Position).?;
+    try testing.expectEqual(@as(f32, 320.0), pos.x);
+    try testing.expectEqual(@as(f32, 240.0), pos.y);
+
+    // Positionless and unknown ids are ignored, not crashes.
+    editor_api.editor_set_entity_position(@intCast(bare), 9.0, 9.0);
+    try testing.expect(game.getComponent(bare, core.Position) == null);
+    editor_api.editor_set_entity_position(999_999, 1.0, 1.0);
+    editor_api.editor_set_entity_position(std.math.maxInt(u64), 1.0, 1.0);
+}
+
+test "editor_set_scene: 0 on known scene, -1 on unknown" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const loader = struct {
+        fn load(g: *Game) anyerror!void {
+            const e = g.createEntity();
+            g.setPosition(e, .{ .x = 0, .y = 0 });
+            g.trackSceneEntity(e);
+        }
+    }.load;
+    game.registerSceneSimple("level1", loader);
+
+    var runner = DummyRunner{};
+    editor_api.bind(&game, &runner);
+
+    try testing.expectEqual(@as(i32, 0), editor_api.editor_set_scene("level1", 6));
+    try testing.expectEqualStrings("level1", game.getCurrentSceneName().?);
+    try testing.expectEqual(@as(usize, 1), game.entityCount());
+
+    // Unknown scene: rejected up front — the running scene survives
+    // (a raw setScene would have torn it down before erroring).
+    try testing.expectEqual(@as(i32, -1), editor_api.editor_set_scene("nope", 4));
+    try testing.expectEqualStrings("level1", game.getCurrentSceneName().?);
+    try testing.expectEqual(@as(usize, 1), game.entityCount());
+}
+
+// ── Camera override state machine ───────────────────────────────────
+
+const FakeCamera = struct {
+    x: f32 = 0,
+    y: f32 = 0,
+    zoom: f32 = 1,
+
+    pub fn setPosition(self: *FakeCamera, x: f32, y: f32) void {
+        self.x = x;
+        self.y = y;
+    }
+    pub fn setZoom(self: *FakeCamera, level: f32) void {
+        self.zoom = level;
+    }
+};
+
+/// Minimal Game-shaped stand-in for `editor_api.frame` — only the
+/// camera surface (`CameraType` + `getCamera`) is duck-typed there.
+const CameraGame = struct {
+    pub const CameraType = FakeCamera;
+    cam: FakeCamera = .{},
+
+    pub fn getCamera(self: *CameraGame) *FakeCamera {
+        return &self.cam;
+    }
+};
+
+test "camera override: engage → re-assert after tick → release" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var cg = CameraGame{};
+
+    // No override: frame leaves the gameplay camera alone.
+    cg.cam.setPosition(10, 10);
+    editor_api.frame(&cg);
+    try testing.expectEqual(@as(f32, 10), cg.cam.x);
+
+    // Engage: frame asserts the editor camera.
+    editor_api.editor_set_camera(100, 200, 2.5);
+    editor_api.frame(&cg);
+    try testing.expectEqual(@as(f32, 100), cg.cam.x);
+    try testing.expectEqual(@as(f32, 200), cg.cam.y);
+    try testing.expectEqual(@as(f32, 2.5), cg.cam.zoom);
+
+    // A camera_control-style script fights back during the tick; the
+    // post-tick frame() must win by writing last.
+    cg.cam.setPosition(0, 0);
+    cg.cam.setZoom(1);
+    editor_api.frame(&cg);
+    try testing.expectEqual(@as(f32, 100), cg.cam.x);
+    try testing.expectEqual(@as(f32, 2.5), cg.cam.zoom);
+
+    // Re-engaging with new values updates the override in place.
+    editor_api.editor_set_camera(-50, 60, 0.5);
+    editor_api.frame(&cg);
+    try testing.expectEqual(@as(f32, -50), cg.cam.x);
+
+    // Release: the game camera is left wherever its scripts put it.
+    editor_api.editor_release_camera();
+    cg.cam.setPosition(7, 8);
+    editor_api.frame(&cg);
+    try testing.expectEqual(@as(f32, 7), cg.cam.x);
+    try testing.expectEqual(@as(f32, 8), cg.cam.y);
+}
+
+test "camera override: comptime no-op for camera-less games (StubRender)" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    var runner = DummyRunner{};
+    editor_api.bind(&game, &runner);
+
+    // StubRender has no CameraType — both the immediate apply and the
+    // per-frame re-assert must fold away without touching anything.
+    editor_api.editor_set_camera(1, 2, 3);
+    editor_api.frame(&game);
+    editor_api.editor_release_camera();
+}

--- a/test/editor_api_test.zig
+++ b/test/editor_api_test.zig
@@ -219,6 +219,47 @@ test "digest: truncation keeps valid JSON and the full entity_count" {
     }
 }
 
+test "digest: parented entities report WORLD positions (the space editor_set_entity_position consumes)" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const parent = game.createEntity();
+    game.setPosition(parent, .{ .x = 100, .y = 200 });
+    const child = game.createEntity();
+    game.setPosition(child, .{ .x = 10, .y = 20 }); // local to parent
+    game.setParent(child, parent, .{});
+
+    var runner = DummyRunner{};
+    editor_api.bind(&game, &runner);
+
+    var buf: [1024]u8 = undefined;
+    const json = digestInto(&buf);
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+
+    var saw_child = false;
+    for (parsed.value.object.get("entities").?.array.items) |item| {
+        const obj = item.object;
+        if (obj.get("id").?.integer == @as(i64, @intCast(child))) {
+            // 100+10 / 200+20 — world, not the raw local Position.
+            try testing.expectEqual(@as(i64, 110), obj.get("x").?.integer);
+            try testing.expectEqual(@as(i64, 220), obj.get("y").?.integer);
+            saw_child = true;
+        }
+    }
+    try testing.expect(saw_child);
+
+    // Round-trip: what the digest reports is exactly what
+    // editor_set_entity_position accepts back.
+    editor_api.editor_set_entity_position(@intCast(child), 110, 220);
+    const local = game.getComponent(child, core.Position).?;
+    try testing.expectEqual(@as(f32, 10), local.x);
+    try testing.expectEqual(@as(f32, 20), local.y);
+}
+
 // ── Entity ops through the bound vtable ─────────────────────────────
 
 test "editor_set_entity_position: moves the entity and ignores bad ids" {
@@ -341,6 +382,33 @@ test "camera override: engage → re-assert after tick → release" {
     editor_api.frame(&cg);
     try testing.expectEqual(@as(f32, 7), cg.cam.x);
     try testing.expectEqual(@as(f32, 8), cg.cam.y);
+}
+
+test "camera override: documented loop order (tick → frame → render) shows the override on every rendered frame" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var cg = CameraGame{};
+    editor_api.editor_set_camera(100, 200, 2.0);
+
+    // Simulate the generated main's UNPAUSED loop: each tick a
+    // camera_control-style script re-asserts the gameplay camera, then
+    // editor_api.frame runs, then render reads the camera. Because
+    // frame() runs after the tick but BEFORE render, the override must
+    // be what every rendered frame observes — not just while paused.
+    var i: usize = 0;
+    while (i < 3) : (i += 1) {
+        try testing.expect(editor_api.shouldTick());
+        // tick: the script writes the gameplay camera.
+        cg.cam.setPosition(0, 0);
+        cg.cam.setZoom(1);
+        // frame: the editor writes last…
+        editor_api.frame(&cg);
+        // render: …so this is what reaches the screen.
+        try testing.expectEqual(@as(f32, 100), cg.cam.x);
+        try testing.expectEqual(@as(f32, 200), cg.cam.y);
+        try testing.expectEqual(@as(f32, 2.0), cg.cam.zoom);
+    }
 }
 
 test "camera override: comptime no-op for camera-less games (StubRender)" {

--- a/test/scene_source_override_test.zig
+++ b/test/scene_source_override_test.zig
@@ -185,3 +185,50 @@ test "editor_load_scene: stores the override and reloads the current scene now" 
     try testing.expectEqualStrings("main", game.getCurrentSceneName().?);
     try testing.expectEqual(@as(usize, 2), game.entityCount());
 }
+
+// Not JSONC at all — the bridge's parser must reject it.
+const malformed_src = "{ this is definitely not a scene";
+
+test "editor_load_scene: malformed source for the current scene rolls back instead of blanking" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    game.registerSceneSimple("main", mainLoader);
+    try game.setScene("main");
+    try testing.expectEqual(@as(usize, 1), game.entityCount());
+
+    var runner: u32 = 0;
+    editor_api.bind(&game, &runner);
+
+    // Case 1: no previous override. A bad reload must report failure,
+    // remove the bad override, and restore the scene from the embedded
+    // source — NOT leave a blank preview with no current scene.
+    try testing.expectEqual(
+        @as(i32, -1),
+        editor_api.editor_load_scene("main", 4, malformed_src, malformed_src.len),
+    );
+    try testing.expectEqualStrings("main", game.getCurrentSceneName().?);
+    try testing.expectEqual(@as(usize, 1), game.entityCount());
+    try testing.expect(game.sceneSourceOverride("main") == null);
+
+    // The corrected follow-up must auto-reload again (there IS still a
+    // current scene to match).
+    try testing.expectEqual(
+        @as(i32, 0),
+        editor_api.editor_load_scene("main", 4, override_src, override_src.len),
+    );
+    try testing.expectEqual(@as(usize, 2), game.entityCount());
+
+    // Case 2: a good override was already installed. A bad reload must
+    // restore BOTH the map entry and the loaded scene to the last-good
+    // override.
+    try testing.expectEqual(
+        @as(i32, -1),
+        editor_api.editor_load_scene("main", 4, malformed_src, malformed_src.len),
+    );
+    try testing.expectEqualStrings("main", game.getCurrentSceneName().?);
+    try testing.expectEqual(@as(usize, 2), game.entityCount());
+    try testing.expectEqualStrings(override_src, game.sceneSourceOverride("main").?);
+}

--- a/test/scene_source_override_test.zig
+++ b/test/scene_source_override_test.zig
@@ -1,0 +1,187 @@
+//! Runtime scene-source override map (labelle-studio Play mode /
+//! `editor_api.editor_load_scene`).
+//!
+//! Covers the two loader seams that consult `game.scene_source_overrides`:
+//!   - `loadSceneFromSource` (the assembler-generated per-scene loader)
+//!     resolves the override by the NAME of the scene being loaded
+//!     (`game.loading_scene_name`, set around `setScene`'s loader call);
+//!   - `loadSceneFile` (include fragments) resolves by exact path, then
+//!     by the path's stem (`"scenes/frag.jsonc"` → `"frag"`).
+//! Plus ownership: replacing an entry frees the previous copy (verified
+//! by std.testing.allocator's leak/double-free detection).
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+
+const Game = engine.Game;
+const editor_api = engine.editor_api;
+
+const Marker = struct { _: u8 = 1 };
+
+const Components = engine.ComponentRegistry(.{
+    .Marker = Marker,
+});
+
+const Bridge = engine.JsoncSceneBridge(Game, Components);
+
+// One entity in the compiled-in ("embedded") source…
+const base_src =
+    \\{ "entities": [
+    \\  { "components": { "Position": { "x": 1, "y": 1 } } }
+    \\] }
+;
+
+// …two in the editor's override.
+const override_src =
+    \\{ "entities": [
+    \\  { "components": { "Position": { "x": 10, "y": 10 } } },
+    \\  { "components": { "Position": { "x": 20, "y": 20 } } }
+    \\] }
+;
+
+// Three in a second override, to prove replacement takes effect (and
+// frees the first copy).
+const override2_src =
+    \\{ "entities": [
+    \\  { "components": { "Position": { "x": 1, "y": 0 } } },
+    \\  { "components": { "Position": { "x": 2, "y": 0 } } },
+    \\  { "components": { "Position": { "x": 3, "y": 0 } } }
+    \\] }
+;
+
+/// Mirrors the assembler-generated per-scene loader shape:
+/// `JsoncBridge.loadSceneFromSource(game, @embedFile(...), "prefabs")`.
+fn mainLoader(game: *Game) anyerror!void {
+    return Bridge.loadSceneFromSource(game, base_src, "prefabs");
+}
+
+test "loadSceneFromSource: override by scene name replaces the embedded source" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    game.registerSceneSimple("main", mainLoader);
+
+    // Without an override the embedded source loads.
+    try game.setScene("main");
+    try testing.expectEqual(@as(usize, 1), game.entityCount());
+
+    // Store an override for "main" and reload: the override wins.
+    try game.setSceneSourceOverride("main", override_src);
+    try game.setScene("main");
+    try testing.expectEqual(@as(usize, 2), game.entityCount());
+}
+
+test "setSceneSourceOverride: replacing an entry frees the old copy and takes effect" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    game.registerSceneSimple("main", mainLoader);
+
+    try game.setSceneSourceOverride("main", override_src);
+    try game.setSceneSourceOverride("main", override2_src);
+
+    // The second override is what loads…
+    try game.setScene("main");
+    try testing.expectEqual(@as(usize, 3), game.entityCount());
+
+    // …and the stored copy is the map's own memory, not the caller's.
+    const stored = game.sceneSourceOverride("main").?;
+    try testing.expect(stored.ptr != @as([]const u8, override2_src).ptr);
+    try testing.expectEqualStrings(override2_src, stored);
+    // (testing.allocator's leak check on deinit proves the replaced
+    // first copy was freed exactly once.)
+}
+
+test "sceneSourceOverride: exact key first, then path stem; no false positives" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    try testing.expect(game.sceneSourceOverride("main") == null);
+
+    try game.setSceneSourceOverride("frag", "override-bytes");
+    // Scene-name lookup (loadSceneFromSource path).
+    try testing.expectEqualStrings("override-bytes", game.sceneSourceOverride("frag").?);
+    // Include-path lookup falls back to the stem (loadSceneFile path).
+    try testing.expectEqualStrings("override-bytes", game.sceneSourceOverride("scenes/frag.jsonc").?);
+    // Different stem: miss.
+    try testing.expect(game.sceneSourceOverride("scenes/other.jsonc") == null);
+
+    // Exact path keys outrank the stem fallback.
+    try game.setSceneSourceOverride("scenes/frag.jsonc", "exact-bytes");
+    try testing.expectEqualStrings("exact-bytes", game.sceneSourceOverride("scenes/frag.jsonc").?);
+    try testing.expectEqualStrings("override-bytes", game.sceneSourceOverride("frag").?);
+}
+
+// Root scene that pulls in an include fragment — the fragment arrives
+// via `addEmbeddedSceneSource` exactly like the assembler emits it.
+const root_with_include_src =
+    \\{
+    \\  "include": ["scenes/frag.jsonc"],
+    \\  "entities": [
+    \\    { "components": { "Position": { "x": 0, "y": 0 } } }
+    \\  ]
+    \\}
+;
+
+const frag_src =
+    \\{ "entities": [
+    \\  { "components": { "Position": { "x": 5, "y": 5 } } }
+    \\] }
+;
+
+const frag_override_src =
+    \\{ "entities": [
+    \\  { "components": { "Position": { "x": 6, "y": 6 } } },
+    \\  { "components": { "Position": { "x": 7, "y": 7 } } }
+    \\] }
+;
+
+fn includeLoader(game: *Game) anyerror!void {
+    return Bridge.loadSceneFromSource(game, root_with_include_src, "prefabs");
+}
+
+test "loadSceneFile: include fragments consult the override map by stem" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    game.registerSceneSimple("world", includeLoader);
+    try game.addEmbeddedSceneSource("scenes/frag.jsonc", frag_src);
+
+    // Embedded fragment: 1 root entity + 1 fragment entity.
+    try game.setScene("world");
+    try testing.expectEqual(@as(usize, 2), game.entityCount());
+
+    // Override the fragment by its scene name ("frag"): the include
+    // path "scenes/frag.jsonc" resolves it via the stem fallback.
+    try game.setSceneSourceOverride("frag", frag_override_src);
+    try game.setScene("world");
+    try testing.expectEqual(@as(usize, 3), game.entityCount());
+}
+
+test "editor_load_scene: stores the override and reloads the current scene now" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    game.registerSceneSimple("main", mainLoader);
+    try game.setScene("main");
+    try testing.expectEqual(@as(usize, 1), game.entityCount());
+
+    var runner: u32 = 0;
+    editor_api.bind(&game, &runner);
+
+    // Overriding a NON-current scene stores without reloading.
+    try testing.expectEqual(
+        @as(i32, 0),
+        editor_api.editor_load_scene("other", 5, override_src, override_src.len),
+    );
+    try testing.expectEqual(@as(usize, 1), game.entityCount());
+    try testing.expect(game.sceneSourceOverride("other") != null);
+
+    // Overriding the CURRENT scene reloads immediately.
+    try testing.expectEqual(
+        @as(i32, 0),
+        editor_api.editor_load_scene("main", 4, override_src, override_src.len),
+    );
+    try testing.expectEqualStrings("main", game.getCurrentSceneName().?);
+    try testing.expectEqual(@as(usize, 2), game.entityCount());
+}


### PR DESCRIPTION
Engine side of **labelle-studio's Play mode (Phase 3)**. The studio runs the game compiled to wasm in an iframe and drives it via exported functions (validated by the working spike on FP's bgfx-wasm build: plain `export fn` + emcc `-sEXPORTED_FUNCTIONS`).

## The contract (v1 — assembler + studio build against exactly this)

`src/editor_api.zig`, exported from the root as `pub const editor_api`. Non-preview builds emit **no** `editor_*` symbols (see verification below).

```zig
// Exports (all plain `export fn`):
editor_alloc(len: usize) ?[*]u8            // c_allocator (== emscripten malloc on wasm)
editor_free(ptr: [*]u8, len: usize) void
editor_pause(paused: i32) void             // 1 = freeze SIM (render continues), 0 = resume
editor_step(frames: u32) void              // while paused: advance N sim ticks
editor_set_scene(name: [*]const u8, len: usize) i32                       // 0 = ok
editor_load_scene(name: [*]const u8, nlen: usize, src: [*]const u8, slen: usize) i32
   // copy + store src in a runtime scene-source override map; if `name` is the
   // current scene, reload it now; 0 = ok
editor_set_entity_position(id: u64, x: f32, y: f32) void  // world coords + markPositionDirty
editor_pick(x: f32, y: f32) i64            // v1: always -1 (studio picks client-side)
editor_scene_digest(out: [*]u8, cap: usize) usize
   // JSON: {"scene":"...","paused":0|1,"entity_count":N,
   //        "entities":[{"id":<u64>,"prefab":"?","sprite":"?","x":f,"y":f},...]}
   // prefab/sprite included when known; entity list truncated to fit cap
   // (always valid JSON); returns bytes written
editor_set_camera(x: f32, y: f32, zoom: f32) void   // engages override
editor_release_camera() void

// Non-export API for the generated main (the assembler splices these 3 touchpoints):
pub fn bind(g: anytype, runner: anytype) void   // once, after Game init
pub fn shouldTick() bool                        // gate the SIM half of the frame loop
pub fn frame(g: anytype) void                   // AFTER the sim tick: re-asserts editor camera
```

## How bind/dispatch works

`bind` is comptime-generic: it instantiates `Holder(GP, RP)` for the concrete `*Game`/Runner types, stores the pointers in that instantiation's container-level `var`s, and publishes a `*const VTable` of plain function pointers (`set_scene` / `load_scene` / `set_entity_position` / `scene_digest` / `apply_camera`). The exports are non-generic and dispatch through the vtable; before `bind`, every export is a safe no-op (digest writes `{}`, scene ops return -1, void setters ignore; `editor_pause`/`editor_step` are pure editor state and work pre-bind).

Details worth noting:
- **Camera**: `editor_set_camera` stores the override and applies immediately; `frame(g)` re-asserts it after every tick (FP's `camera_control` re-asserts the gameplay camera each tick — the editor wins by writing last). Comptime no-op for camera-less games (`Game.CameraType == void`).
- **`editor_set_scene`** validates the name against the scene registries *before* calling `setScene` — a raw `setScene` tears the current scene down before discovering `SceneNotFound`, so a typo'd editor request must not nuke the running scene. Asset-gate deferrals queue a retry via `queueSceneChange` (same commit detection as #635).
- **Entity move** goes through `setWorldPosition` (world coords → local for parented entities), which routes through `setPosition` → `markPositionDirtyWithChildren`.

## Scene-source override map

New Game-owned `scene_source_overrides` (keys **and** values are allocator-owned copies; replacing an entry frees the previous source, freed on deinit). Consulted before the embedded source at both loader seams:
- `loadSceneFromSource` (the assembler-generated per-scene loader) resolves by the **name** of the scene being loaded — a new `loading_scene_name` is set around the three `loader_fn` call sites (`setScene`, `setSceneAtomic`, hot-reload).
- `loadSceneFile` (include fragments) resolves by exact path, then by the path's **stem** (an override stored under `"frag"` also replaces `"scenes/frag.jsonc"`).

## How "no editor symbols in non-preview builds" was verified

`root.zig` exposes the module only as a lazy `pub const editor_api = @import("editor_api.zig")` and nothing else in the engine references it. Built two otherwise-identical probe executables against this branch's engine module:
- `noeditor` (uses `Game` init/tick/render, never references `editor_api`): `nm` shows **0** `editor_*` symbols.
- `witheditor` (calls `bind`/`shouldTick`/`frame`): `nm` shows all 10 exports as global `T _editor_*` symbols.

Both binaries also run correctly.

## Tests

`zig build` + `zig build test` exit 0 (all 63 test binaries green).
- `test/editor_api_test.zig` — pause/step tick gating, pre-bind no-op safety, alloc/free round-trip, digest JSON shape (parsed with `std.json`), truncation validity (including a cap sweep 2..400, every output parses), `editor_set_entity_position` (incl. bad ids), `editor_set_scene`, camera override state machine (engage → re-assert-after-tick → release; comptime no-op on StubRender).
- `test/scene_source_override_test.zig` — set → load consults override (both loader seams), replace frees old + takes effect (leak-checked), exact-key-vs-stem lookup rules, `editor_load_scene` end-to-end (stores + reloads current scene now).

## Deviations from the task spec

- Version was bumped **1.66.0 → 1.67.0** (main had already released 1.66.0).
- The digest hand-rolls JSON into the caller buffer instead of the repo's `std.json.Stringify.valueAlloc` convention — the export is allocation-free with cap-bounded truncation semantics; escaping is implemented explicitly and validated by parsing every emitted digest in tests.
- `editor_load_scene`/`editor_set_scene` return `-1` pre-bind (the contract's "setters return/ignore" left the i32 value open).

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw