### PR TITLE
feat: editor_api v1.1 — editor_set_state + state in digest

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -181,6 +181,10 @@ pub fn build(b: *std.Build) void {
         // name, loadSceneFile includes by path stem); replace frees the
         // previous source.
         "test/scene_source_override_test.zig",
+        // editor_api v1.1 — `Game.setStateOwned`: game-owned copy of
+        // runtime-sourced state names (loader meta.initial_state +
+        // editor_set_state share the PR #599 UAF-safe ordering).
+        "test/set_state_owned_test.zig",
     };
 
     for (test_files) |test_file| {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xe8a81a8dc7f48c87,
     .name = .engine,
-    .version = "1.67.0",
+    .version = "1.68.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         // Requires labelle-core >= v1.20.0 — font_types aliases core's

--- a/src/editor_api.zig
+++ b/src/editor_api.zig
@@ -16,8 +16,8 @@
 //! they carry no comptime type information themselves.
 //!
 //! Before `bind` runs, every export is a safe no-op: `editor_scene_digest`
-//! writes `{}`, the i32-returning scene ops return -1, and the void
-//! setters silently ignore. `editor_pause` / `editor_step` are pure
+//! writes `{}`, the i32-returning scene/state ops return -1, and the
+//! void setters silently ignore. `editor_pause` / `editor_step` are pure
 //! editor-side state and work even before `bind`.
 //!
 //! ## No symbols in non-preview builds
@@ -68,6 +68,7 @@ var camera_override: ?CameraOverride = null;
 const VTable = struct {
     set_scene: *const fn (name: []const u8) i32,
     load_scene: *const fn (name: []const u8, src: []const u8) i32,
+    set_state: *const fn (name: []const u8) i32,
     set_entity_position: *const fn (id: u64, x: f32, y: f32) void,
     scene_digest: *const fn (out: []u8) usize,
     apply_camera: *const fn (x: f32, y: f32, zoom: f32) void,
@@ -189,6 +190,25 @@ pub export fn editor_load_scene(name: [*]const u8, nlen: usize, src: [*]const u8
     return vt.load_scene(name[0..nlen], src[0..slen]);
 }
 
+/// Switch the game STATE machine to `name` (v1.1) — the axis
+/// `editor_set_scene` does not touch: scenes swap entities, states gate
+/// which scripts tick (e.g. FP's sky director / production / needs run
+/// only in "playing"). Without this, Play mode edits a scene whose
+/// state-gated systems are all frozen in "menu".
+///
+/// States are user-defined free-form strings (see `state_mixin.zig`);
+/// the engine has NO state registry to validate against — an unknown
+/// name is simply a state no script listens to, and it is trivially
+/// recoverable by another `editor_set_state` (unlike a scene typo,
+/// nothing is torn down). Only the empty name is rejected. The name is
+/// copied into game-owned memory (`setStateOwned`), so the caller may
+/// free the buffer immediately. 0 = ok; -1 = empty name / OOM / not
+/// bound.
+pub export fn editor_set_state(name: [*]const u8, len: usize) i32 {
+    const vt = vtable orelse return -1;
+    return vt.set_state(name[0..len]);
+}
+
 /// Move entity `id` to world coordinates (x, y). Marks the position
 /// dirty so the render pipeline re-syncs. Unknown/positionless ids are
 /// ignored.
@@ -206,7 +226,7 @@ pub export fn editor_pick(x: f32, y: f32) i64 {
 
 /// Write a JSON digest of the current scene into `out` (capacity
 /// `cap`) and return the number of bytes written. Shape:
-/// `{"scene":"...","paused":0|1,"entity_count":N,
+/// `{"scene":"...","state":"...","paused":0|1,"entity_count":N,
 ///   "entities":[{"id":<u64>,"prefab":"?","sprite":"?","x":f,"y":f},...]}`
 /// `prefab`/`sprite` appear only when known; `x`/`y` are WORLD
 /// coordinates (the same space `editor_set_entity_position` consumes).
@@ -271,6 +291,7 @@ fn Holder(comptime GP: type, comptime RP: type) type {
         const vtable_impl = VTable{
             .set_scene = &setSceneImpl,
             .load_scene = &loadSceneImpl,
+            .set_state = &setStateImpl,
             .set_entity_position = &setEntityPositionImpl,
             .scene_digest = &sceneDigestImpl,
             .apply_camera = &applyCameraImpl,
@@ -291,6 +312,23 @@ fn Holder(comptime GP: type, comptime RP: type) type {
             // are ready — mirrors the pending-scene commit detection
             // from #635.
             if (game.pending_scene_assets != null) game.queueSceneChange(name);
+            return 0;
+        }
+
+        fn setStateImpl(name: []const u8) i32 {
+            // No pre-validation registry exists for states (unlike
+            // scenes): they're free-form strings scripts gate on, so
+            // every non-empty name is "valid" by construction and a
+            // typo is recoverable in place. Reject only the empty name
+            // — never a meaningful state, most likely a host-side
+            // length bug.
+            if (name.len == 0) return -1;
+            // The name lives in a studio-owned wasm buffer that is
+            // freed right after this call, while `setState` stores its
+            // argument by reference — `setStateOwned` copies onto the
+            // game allocator (see state_mixin.zig for the UAF-ordering
+            // history it encodes).
+            game.setStateOwned(name) catch return -1;
             return 0;
         }
 
@@ -376,6 +414,8 @@ fn Holder(comptime GP: type, comptime RP: type) type {
 
             try appendLit(body, &cur, "{\"scene\":");
             try appendJsonString(body, &cur, game.getCurrentSceneName() orelse "");
+            try appendLit(body, &cur, ",\"state\":");
+            try appendJsonString(body, &cur, game.getState());
             try appendFmt(body, &cur, ",\"paused\":{d},\"entity_count\":{d},\"entities\":[", .{
                 @intFromBool(editor_paused), count,
             });

--- a/src/game.zig
+++ b/src/game.zig
@@ -618,9 +618,11 @@ pub fn GameConfigWithYAxis(
         /// name came from a runtime-parsed source whose backing storage
         /// has a shorter lifetime than the game (RFC #596 `meta.initial_state`
         /// reads through the loader's `parse_arena`, which is freed before
-        /// the load returns). When set, `game_state` aliases this slice.
-        /// Freed on `deinit` and replaced (with the previous slice freed)
-        /// each time the loader applies a new `meta.initial_state`.
+        /// the load returns; `editor_api.editor_set_state` hands in a
+        /// studio-owned wasm buffer freed right after the call). When
+        /// set, `game_state` aliases this slice. Freed on `deinit` and
+        /// replaced (with the previous slice freed) on every
+        /// `setStateOwned` call.
         owned_initial_state: ?[]u8 = null,
         /// Time scale factor: 0 = paused, 0.5 = slow-mo, 1.0 = normal, 2.0 = fast.
         /// When paused (0), rendering and GUI continue but tick logic stops.
@@ -1192,6 +1194,7 @@ pub fn GameConfigWithYAxis(
 
         // ── Game State Machine (mixin) ──────────────────────────────
         pub const setState = StateMixin.setState;
+        pub const setStateOwned = StateMixin.setStateOwned;
         pub const queueStateChange = StateMixin.queueStateChange;
         pub const getState = StateMixin.getState;
 

--- a/src/game/state_mixin.zig
+++ b/src/game/state_mixin.zig
@@ -27,6 +27,44 @@ pub fn Mixin(comptime Game: type) type {
             self.emitEngineEvent("engine__state_changed", .{ .old_state = old_state, .new_state = new_state });
         }
 
+        /// Set the game state from a RUNTIME-sourced name whose backing
+        /// storage may not outlive the game — loader parse arenas
+        /// (RFC #596 `meta.initial_state`) and the studio editor's wasm
+        /// buffers (`editor_api.editor_set_state`) both hand in slices
+        /// that are freed right after the call, while `setState` stores
+        /// its argument BY REFERENCE into `game.game_state`.
+        ///
+        /// Dupes onto the game allocator and stashes the owned backing
+        /// on `game.owned_initial_state` (freed on `deinit`, replaced —
+        /// with the previous slice freed — on every call). Extracted
+        /// from the scene loader's `applyFileMetaDirectives`, which
+        /// accumulated three UAF fixes (PR #599) this ordering encodes:
+        ///
+        ///   1. Dupe onto the game allocator — `new_owned`.
+        ///   2. Swap `owned_initial_state` to the fresh dupe BEFORE
+        ///      `setState`, so the field is consistent even if
+        ///      `setState` early-returns.
+        ///   3. `setState(new_owned)`. Its `eql` probe reads
+        ///      `game.game_state`, which still aliases the prior owned
+        ///      slot (still live at this point) or a default literal —
+        ///      safe either way.
+        ///   4. If `setState` short-circuited (state name unchanged),
+        ///      `game.game_state` may still alias the about-to-be-freed
+        ///      previous slot. Detect via pointer identity and re-point
+        ///      to `new_owned`. No state-change hooks re-fire — the
+        ///      visible value is unchanged, only the backing moves.
+        ///   5. Free the previous owned slot (no-op if null).
+        pub fn setStateOwned(self: *Game, state_name: []const u8) error{OutOfMemory}!void {
+            const new_owned = try self.allocator.dupe(u8, state_name);
+            const old_owned = self.owned_initial_state;
+            self.owned_initial_state = new_owned;
+            self.setState(new_owned);
+            if (self.game_state.ptr != new_owned.ptr) {
+                self.game_state = new_owned;
+            }
+            if (old_owned) |s| self.allocator.free(s);
+        }
+
         /// Queue a state change for next tick. The transition happens at
         /// the start of the next tick, before scripts run.
         pub fn queueStateChange(self: *Game, new_state: []const u8) void {

--- a/src/jsonc/scene_loader/scene_process.zig
+++ b/src/jsonc/scene_loader/scene_process.zig
@@ -181,86 +181,14 @@ pub fn SceneProcess(comptime GameType: type, comptime Components: type, comptime
                 // `state_name` aliases into the loader's `parse_arena`,
                 // which is freed in the `defer` at the top of
                 // `loadSceneFile` / `loadSceneSource` before the load
-                // function returns. `setState` (see `state_mixin.zig`)
-                // stores its argument by reference into `game.game_state`,
-                // so handing the arena-slice in directly would leave
-                // `game_state` dangling after the arena teardown.
-                //
-                // Dupe onto `game.allocator` and stash the owned backing
-                // on `game.owned_initial_state` so it lives as long as
-                // `game_state` itself.
-                //
-                // PR #599 history (three fixes):
-                //
-                //  Fix #1: dupe meta.initial_state so the slice survives
-                //          parse_arena.deinit (first-order UAF).
-                //
-                //  Fix #2: reorder dupe/setState/free so the prior owned
-                //          slot is still live while setState's
-                //          `std.mem.eql(self.game_state, …)` probe runs
-                //          (second-order UAF when game.game_state aliased
-                //          the slot we'd just freed).
-                //
-                //  Fix #3 (here): drop the no-churn short-circuit that
-                //          fix #2 added. The short-circuit
-                //          `if (existing == state_name content) return;`
-                //          assumed `game.game_state` still aliased the
-                //          owned slot — but an external `setState(...)`
-                //          call between two `applyFileMetaDirectives`
-                //          invocations could have re-pointed
-                //          `game.game_state` elsewhere, leaving the
-                //          directive silently ignored (cursor MEDIUM:
-                //          game stayed in the wrong state).
-                //
-                // The new contract: always dupe, always free the prior.
-                // The dupe + free churn per scene load is negligible
-                // compared to the bug surface of a clever short-circuit.
-                //
-                // Ordering (preserves fix #2's UAF guarantee):
-                //
-                //   1. Dupe onto the game allocator — `new_owned`.
-                //   2. Swap `owned_initial_state` to the fresh dupe
-                //      *before* `setState`. The field is consistent even
-                //      if `setState` early-returns.
-                //   3. `setState(new_owned)`. Its `eql` probe reads
-                //      `game.game_state`, which still aliases the prior
-                //      owned slot (still live) or a default literal.
-                //      Safe either way.
-                //   4. If `setState` short-circuited (because
-                //      `game.game_state` already content-equalled
-                //      `state_name`), `game.game_state` may still alias
-                //      the about-to-be-freed `old_owned`. Detect that
-                //      via pointer identity against `new_owned` and
-                //      explicitly re-point. Doing this only when the
-                //      pointer doesn't already match `new_owned` skips
-                //      the safe re-assign in the literal-aliasing case
-                //      where re-pointing to `new_owned` is also fine
-                //      (we just don't need to bother).
-                //
-                //      We do NOT re-fire state-change hooks here —
-                //      that's correct: the visible state value is
-                //      unchanged, we're only refreshing the backing
-                //      pointer.
-                //   5. Free the previous owned slot (no-op if null).
-                const new_owned = game.allocator.dupe(u8, state_name) catch {
-                    // Out of memory — keep the previous state rather than
-                    // crash the load. The directive is best-effort.
-                    return;
-                };
-                const old_owned = game.owned_initial_state;
-                game.owned_initial_state = new_owned;
-                game.setState(new_owned);
-                if (game.game_state.ptr != new_owned.ptr) {
-                    // setState short-circuited: game.game_state still
-                    // points at whatever it pointed at before (a literal
-                    // or, critically, `old_owned`). Re-point to
-                    // `new_owned` so the upcoming `free(old_owned)`
-                    // doesn't dangle game.game_state. Safe in the
-                    // literal-alias case too — the literal stays valid,
-                    // we just stop referencing it.
-                    game.game_state = new_owned;
-                }
-                if (old_owned) |s| game.allocator.free(s);
+                // function returns, while `setState` stores its argument
+                // by reference into `game.game_state`. `setStateOwned`
+                // (state_mixin.zig) encodes the dupe-swap-repoint-free
+                // ordering that PR #599's three UAF fixes converged on —
+                // see its doc comment for the full history. OOM keeps the
+                // previous state rather than crash the load; the
+                // directive is best-effort.
+                game.setStateOwned(state_name) catch return;
             }
             // Future engine-known keys (`scripts`, `include`) dispatch here.
             // `name` and any other lowercase keys are authoring-only.

--- a/test/editor_api_test.zig
+++ b/test/editor_api_test.zig
@@ -71,9 +71,10 @@ test "pre-bind: every export is a safe no-op" {
     editor_api.unbind();
     defer editor_api.unbind();
 
-    // Scene ops report failure (no game to act on).
+    // Scene/state ops report failure (no game to act on).
     try testing.expectEqual(@as(i32, -1), editor_api.editor_set_scene("main", 4));
     try testing.expectEqual(@as(i32, -1), editor_api.editor_load_scene("main", 4, "{}", 2));
+    try testing.expectEqual(@as(i32, -1), editor_api.editor_set_state("playing", 7));
 
     // Void setters silently ignore.
     editor_api.editor_set_entity_position(42, 1.0, 2.0);
@@ -139,6 +140,7 @@ test "digest: JSON shape with scene name, paused flag, sprites, and positions" {
     const root = parsed.value.object;
 
     try testing.expectEqualStrings("arena", root.get("scene").?.string);
+    try testing.expectEqualStrings("running", root.get("state").?.string);
     try testing.expectEqual(@as(i64, 1), root.get("paused").?.integer);
     try testing.expectEqual(@as(i64, 2), root.get("entity_count").?.integer);
 
@@ -165,12 +167,15 @@ test "digest: JSON shape with scene name, paused flag, sprites, and positions" {
     try testing.expect(saw_sprite);
     try testing.expect(saw_bare);
 
-    // Resuming flips the reported paused flag.
+    // Resuming flips the reported paused flag; a state switch shows
+    // up in the same digest (v1.1).
     editor_api.editor_pause(0);
+    try testing.expectEqual(@as(i32, 0), editor_api.editor_set_state("playing", 7));
     const json2 = digestInto(&buf);
     var parsed2 = try std.json.parseFromSlice(std.json.Value, testing.allocator, json2, .{});
     defer parsed2.deinit();
     try testing.expectEqual(@as(i64, 0), parsed2.value.object.get("paused").?.integer);
+    try testing.expectEqualStrings("playing", parsed2.value.object.get("state").?.string);
 }
 
 test "digest: truncation keeps valid JSON and the full entity_count" {
@@ -316,6 +321,41 @@ test "editor_set_scene: 0 on known scene, -1 on unknown" {
     try testing.expectEqual(@as(i32, -1), editor_api.editor_set_scene("nope", 4));
     try testing.expectEqualStrings("level1", game.getCurrentSceneName().?);
     try testing.expectEqual(@as(usize, 1), game.entityCount());
+}
+
+test "editor_set_state: switches the state machine, copies the name, rejects only empty" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    var runner = DummyRunner{};
+    editor_api.bind(&game, &runner);
+
+    // Happy path: default "running" -> "playing".
+    try testing.expectEqualStrings("running", game.getState());
+    try testing.expectEqual(@as(i32, 0), editor_api.editor_set_state("playing", 7));
+    try testing.expectEqualStrings("playing", game.getState());
+
+    // The name is copied into game-owned memory: hand in a transient
+    // buffer (the studio frees its wasm buffer right after the call).
+    const buf = try testing.allocator.dupe(u8, "combat");
+    try testing.expectEqual(@as(i32, 0), editor_api.editor_set_state(buf.ptr, buf.len));
+    testing.allocator.free(buf);
+    try testing.expectEqualStrings("combat", game.getState());
+    try testing.expect(game.getState().ptr != buf.ptr);
+
+    // Unknown states are VALID by construction — the engine has no
+    // state registry (free-form strings scripts gate on), so unlike
+    // editor_set_scene there is nothing to pre-validate against and
+    // nothing gets torn down; a typo is recoverable in place.
+    try testing.expectEqual(@as(i32, 0), editor_api.editor_set_state("no_script_listens_here", 22));
+    try testing.expectEqualStrings("no_script_listens_here", game.getState());
+
+    // Empty name: the one rejected input; state unchanged.
+    try testing.expectEqual(@as(i32, -1), editor_api.editor_set_state("x", 0));
+    try testing.expectEqualStrings("no_script_listens_here", game.getState());
 }
 
 // ── Camera override state machine ───────────────────────────────────

--- a/test/set_state_owned_test.zig
+++ b/test/set_state_owned_test.zig
@@ -1,0 +1,70 @@
+//! `Game.setStateOwned` — game-owned copy of RUNTIME-sourced state
+//! names. Extracted from the scene loader's `applyFileMetaDirectives`
+//! (PR #599's three UAF fixes) so `editor_api.editor_set_state` can
+//! share the exact same ordering. These tests pin the ownership
+//! contract; std.testing.allocator's leak/double-free detection is the
+//! primary oracle.
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+
+const Game = engine.Game;
+
+test "setStateOwned: copies the name — caller may free its buffer immediately" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const buf = try testing.allocator.dupe(u8, "playing");
+    try game.setStateOwned(buf);
+    testing.allocator.free(buf);
+
+    // The state survives the caller's free (game-owned backing) and
+    // is NOT the caller's pointer.
+    try testing.expectEqualStrings("playing", game.getState());
+    try testing.expect(game.getState().ptr != buf.ptr);
+}
+
+test "setStateOwned: replacing the state frees the previous owned backing" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    try game.setStateOwned("menu");
+    try game.setStateOwned("playing");
+    try game.setStateOwned("paused");
+    try testing.expectEqualStrings("paused", game.getState());
+    // testing.allocator's leak check on deinit proves each replaced
+    // backing was freed exactly once.
+}
+
+test "setStateOwned: same-content call re-points the backing without dangling" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    try game.setStateOwned("combat");
+    const first_ptr = game.getState().ptr;
+
+    // Same content from a DIFFERENT transient buffer: setState
+    // short-circuits (no hooks re-fire, count unchanged), but the
+    // backing must be re-pointed to the fresh dupe before the old one
+    // is freed — reading the state afterwards must not touch freed
+    // memory (PR #599 fix #2/#3).
+    const count_before = game.state_change_count;
+    const buf = try testing.allocator.dupe(u8, "combat");
+    try game.setStateOwned(buf);
+    testing.allocator.free(buf);
+
+    try testing.expectEqualStrings("combat", game.getState());
+    try testing.expect(game.getState().ptr != first_ptr);
+    try testing.expectEqual(count_before, game.state_change_count);
+}
+
+test "setStateOwned: fires the same state transition as setState" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    try testing.expectEqualStrings("running", game.getState());
+    const count_before = game.state_change_count;
+    try game.setStateOwned("menu");
+    try testing.expectEqual(count_before + 1, game.state_change_count);
+}


### PR DESCRIPTION
## The Play-mode gap this closes

`editor_set_scene` switches the scene but the game **state** machine stays wherever it was (e.g. `"menu"`), so state-gated scripts — FP's sky director, production, needs — never tick in Play mode: sun+moon sat frozen at spawn positions with the menu overlay drawn on top. Scenes swap entities; states gate which scripts run. v1.1 gives the studio the second axis.

## Contract additions (v1.1)

```zig
editor_set_state(name: [*]const u8, len: usize) i32   // 0 = ok; -1 = empty / OOM / not bound
```

`editor_scene_digest` now emits `"state":"<name>"` immediately after `"scene"`:

```json
{"scene":"...","state":"...","paused":0|1,"entity_count":N,"entities":[...]}
```

Same dispatch discipline as `editor_set_scene`: 6th vtable fn pointer, plain non-generic export, pre-bind → -1. Same cap/truncation discipline for the digest (the field rides the prefix; the existing cap-sweep test covers it).

## How setState / current-state are accessed

- **Write**: NOT via raw `Game.setState` — it stores its argument **by reference** into `game.game_state`, and the editor's name arrives in a studio-owned wasm buffer freed right after the call (the exact lifetime bug class the scene loader hit with parse-arena slices in PR #599, three UAF fixes deep). That dupe→swap-`owned_initial_state`→setState→repoint-on-short-circuit→free-old ordering is now extracted verbatim into **`Game.setStateOwned`** (`state_mixin.zig`, full history in its doc comment); the loader's `applyFileMetaDirectives` is refactored to call it, so both runtime-sourced paths share one battle-tested copy.
- **Read**: `game.getState()` (`game_state`), emitted through the existing escaped-JSON-string helper.

## On pre-validation (deliberate deviation from the set_scene pattern)

`editor_set_scene` pre-validates because the engine tears the current scene down before discovering `SceneNotFound`. States have **no equivalent hazard and no registry to validate against**: they are user-defined free-form strings (`state_mixin.zig` — "the engine doesn't need to know what states exist at compile time"); scripts gate on them by comparison. An unknown name is a valid state that no script happens to listen to, nothing is torn down, and it's recoverable in place by the next `editor_set_state`. The only rejected input is the empty name (never meaningful; most likely a host-side length bug). This is documented on the export and pinned by the `unknown-state accepted` test.

## Tests

`zig build` + `zig build test` exit 0 — 64/64 test binaries (the pre-existing RFC #596 `meta.initial_state` tests now exercise the refactored loader path).
- `test/set_state_owned_test.zig` (new, wired in build.zig): caller-frees-buffer copy semantics, replace-frees-previous (leak-checked), same-content call re-points the backing without dangling or re-firing hooks, transition parity with `setState`.
- `test/editor_api_test.zig`: `editor_set_state` dispatch + transient-buffer safety, pre-bind -1, digest `"state"` field (default `"running"` + reflects switches), unknown-state accepted, empty-name rejected with state unchanged.

Version bumped **1.67.0 → 1.68.0**.

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw