### PR TITLE
feat(easing): (curve × placement) interpolation catalog (#668)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -69,6 +69,7 @@ pub fn build(b: *std.Build) void {
     // Test files in test/ directory
     const test_files = [_][]const u8{
         "test/root_test.zig",
+        "test/easing_test.zig",
         "test/scene_test.zig",
         "test/gestures_test.zig",
         "test/sparse_set_test.zig",

--- a/src/easing.zig
+++ b/src/easing.zig
@@ -1,0 +1,152 @@
+//! easing — pure interpolation catalog. No allocations, no dependencies
+//! on ECS / renderer / game state. Every function is a pure `f32→f32`
+//! (or small-scalar) map, so scripts, the future tween system, and
+//! camera smoothing can all call it directly.
+//!
+//! Design (labelle-engine#668, after Godot 4's Tween): two orthogonal
+//! axes — a `Curve` (the shape) crossed with a `Placement` (where the
+//! shape sits in the [0,1] interval) — instead of a flat list of named
+//! eases. 12 curves × 4 placements ≈ 45 useful combinations from 16
+//! enum values, and the two enum fields serialize trivially into
+//! ZON/JSONC for future data-driven tweens.
+//!
+//! Only the `in` form of each curve is written out (`curveIn`); the
+//! other three placements are derived generically, so a new curve is
+//! one arm of one switch. Endpoints are forced exact in `ease` (t=0→0,
+//! t=1→1) for every combination; the `back`/`elastic` mid-range
+//! overshoot is preserved (output is never clamped, only input t).
+
+const std = @import("std");
+
+pub const Curve = enum(u8) {
+    linear, // t
+    sine, // 1 - cos(t·π/2)
+    quad, // t²
+    cubic, // t³
+    quart, // t⁴
+    quint, // t⁵
+    expo, // 2^(10(t-1)), with expo(0)==0 special case
+    circ, // 1 - √(1 - t²)
+    back, // overshoot: c3·t³ - c1·t², c1=1.70158, c3=c1+1
+    elastic, // damped sine overshoot
+    bounce, // piecewise parabolic bounce
+    spring, // damped spring settle (Godot TRANS_SPRING)
+};
+
+pub const Placement = enum(u8) {
+    in, // curve applied at the start
+    out, // curve mirrored to the end: 1 - f(1 - t)
+    in_out, // f scaled into [0,0.5), mirrored into [0.5,1]
+    out_in, // mirror of in_out
+};
+
+// `back` overshoot constant (Penner / easings.net canonical value).
+const back_c1: f32 = 1.70158;
+const back_c3: f32 = back_c1 + 1.0;
+
+// `elastic` period (Penner default). s = period/4 = 0.075 is the phase
+// shift that lands the in-form on 1.0 at t=1.
+const elastic_period: f32 = 0.3;
+
+/// Map normalized `t` through `(curve, placement)`. Pure function.
+/// `t` is clamped to [0,1]; the OUTPUT is not clamped, so `back` and
+/// `elastic` keep their mid-range overshoot. Endpoints are exact for
+/// every combination. `placement` is a no-op for `.linear`.
+pub fn ease(curve: Curve, placement: Placement, t: f32) f32 {
+    const ct = std.math.clamp(t, 0.0, 1.0);
+    // Force exact endpoints — the raw formulas drift by an ULP or two
+    // in f32 (e.g. cos(π/2) ≠ 0 exactly), and callers rely on 0/1.
+    if (ct == 0.0) return 0.0;
+    if (ct == 1.0) return 1.0;
+    return switch (placement) {
+        .in => curveIn(curve, ct),
+        .out => 1.0 - curveIn(curve, 1.0 - ct),
+        .in_out => if (ct < 0.5)
+            curveIn(curve, 2.0 * ct) / 2.0
+        else
+            1.0 - curveIn(curve, 2.0 - 2.0 * ct) / 2.0,
+        .out_in => if (ct < 0.5)
+            (1.0 - curveIn(curve, 1.0 - 2.0 * ct)) / 2.0
+        else
+            0.5 + curveIn(curve, 2.0 * ct - 1.0) / 2.0,
+    };
+}
+
+/// Godot `Tween.interpolate_value` equivalent:
+/// `start + delta · ease(curve, placement, elapsed / duration)`.
+/// `duration <= 0` returns `start + delta` (treated as instantly done),
+/// so there is no division by zero.
+pub fn interpolate(
+    start: f32,
+    delta: f32,
+    elapsed: f32,
+    duration: f32,
+    curve: Curve,
+    placement: Placement,
+) f32 {
+    if (duration <= 0.0) return start + delta;
+    return start + delta * ease(curve, placement, elapsed / duration);
+}
+
+/// Frame-rate-independent exponential approach factor: `1 - exp(-rate·dt)`.
+/// For "chase a moving target" smoothing (`x += (target - x) * factor`) —
+/// NOT a normalized-t ease. Extracted from the hand-rolled camera pattern
+/// (`camera_control.zig`).
+pub fn expApproach(rate: f32, dt: f32) f32 {
+    return 1.0 - @exp(-rate * dt);
+}
+
+/// The `in` form of each curve on t ∈ [0,1]. All other placements in
+/// `ease` derive from this. Endpoints here are near-exact but `ease`
+/// forces them; the mid-range shape is what matters.
+fn curveIn(curve: Curve, t: f32) f32 {
+    return switch (curve) {
+        .linear => t,
+        .sine => 1.0 - @cos(t * std.math.pi / 2.0),
+        .quad => t * t,
+        .cubic => t * t * t,
+        .quart => t * t * t * t,
+        .quint => t * t * t * t * t,
+        .expo => if (t == 0.0) 0.0 else std.math.pow(f32, 2.0, 10.0 * (t - 1.0)),
+        .circ => 1.0 - @sqrt(1.0 - t * t),
+        .back => back_c3 * t * t * t - back_c1 * t * t,
+        .elastic => elasticIn(t),
+        .bounce => 1.0 - bounceOut(1.0 - t), // canonical bounce is an OUT shape
+        .spring => 1.0 - springOut(1.0 - t), // Godot: spring in = c - out(d - t)
+    };
+}
+
+fn elasticIn(t: f32) f32 {
+    if (t == 0.0) return 0.0;
+    if (t == 1.0) return 1.0;
+    const s = elastic_period / 4.0; // 0.075
+    return -std.math.pow(f32, 2.0, 10.0 * (t - 1.0)) *
+        @sin((t - 1.0 - s) * 2.0 * std.math.pi / elastic_period);
+}
+
+fn bounceOut(t: f32) f32 {
+    const n1: f32 = 7.5625;
+    const d1: f32 = 2.75;
+    if (t < 1.0 / d1) {
+        return n1 * t * t;
+    } else if (t < 2.0 / d1) {
+        const u = t - 1.5 / d1;
+        return n1 * u * u + 0.75;
+    } else if (t < 2.5 / d1) {
+        const u = t - 2.25 / d1;
+        return n1 * u * u + 0.9375;
+    } else {
+        const u = t - 2.625 / d1;
+        return n1 * u * u + 0.984375;
+    }
+}
+
+// Godot's TRANS_SPRING out-equation (scene/animation/easing_equations.h),
+// normalized to b=0, c=1, d=1. Constants (0.2, 2.5, 2.2, 1.2) are Godot's;
+// determinism matters more than matching bit-for-bit, so they're pinned
+// here. Exact at both ends: springOut(0)=0, springOut(1)=1.
+fn springOut(t: f32) f32 {
+    const s = 1.0 - t;
+    return (@sin(t * std.math.pi * (0.2 + 2.5 * t * t * t)) *
+        std.math.pow(f32, s, 2.2) + t) * (1.0 + 1.2 * s);
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -494,6 +494,12 @@ pub const SpriteByField = sprite_by_field_mod.SpriteByField;
 pub const SpriteByFieldSource = sprite_by_field_mod.SpriteByFieldSource;
 pub const spriteByFieldTick = sprite_by_field_tick_mod.tick;
 
+// ── Easing ──
+// Pure (curve × placement) interpolation catalog — `engine.easing.ease`,
+// `.interpolate`, `.expApproach`, plus the `Curve`/`Placement` enums.
+// Zero deps; the future tween system + scripts consume it (#668).
+pub const easing = @import("easing.zig");
+
 // ── Atlas ──
 pub const SpriteData = atlas_mod.SpriteData;
 pub const FindSpriteResult = atlas_mod.FindSpriteResult;

--- a/test/easing_test.zig
+++ b/test/easing_test.zig
@@ -1,0 +1,101 @@
+const std = @import("std");
+
+const engine = @import("engine");
+const easing = engine.easing;
+const Curve = easing.Curve;
+const Placement = easing.Placement;
+
+const all_curves = [_]Curve{ .linear, .sine, .quad, .cubic, .quart, .quint, .expo, .circ, .back, .elastic, .bounce, .spring };
+const all_placements = [_]Placement{ .in, .out, .in_out, .out_in };
+
+// Curves that rise monotonically in their `.in` form (no overshoot).
+const monotonic_in = [_]Curve{ .linear, .sine, .quad, .cubic, .quart, .quint, .expo, .circ };
+
+test "endpoints are exact for every (curve, placement)" {
+    for (all_curves) |c| {
+        for (all_placements) |p| {
+            // Exact 0/1 — callers rely on it; 0 tolerance is the point.
+            try std.testing.expectEqual(@as(f32, 0.0), easing.ease(c, p, 0.0));
+            try std.testing.expectEqual(@as(f32, 1.0), easing.ease(c, p, 1.0));
+        }
+    }
+}
+
+test "monotonic curves are non-decreasing in .in placement" {
+    for (monotonic_in) |c| {
+        var prev: f32 = -1.0;
+        var i: usize = 0;
+        while (i <= 100) : (i += 1) {
+            const t = @as(f32, @floatFromInt(i)) / 100.0;
+            const v = easing.ease(c, .in, t);
+            try std.testing.expect(v >= prev - 1e-6);
+            prev = v;
+        }
+    }
+}
+
+test "quad/.out is bit-identical to the game's easeOutQuad" {
+    // ship_animation.zig: easeOutQuad(t) = 1 - (1-t)^2.
+    const samples = [_]f32{ 0.0, 0.25, 0.5, 0.75, 1.0 };
+    for (samples) |t| {
+        const u = 1.0 - t;
+        const expected = 1.0 - u * u;
+        try std.testing.expectEqual(expected, easing.ease(.quad, .out, t));
+    }
+}
+
+test "out placement mirrors in: ease(c,.out,t) == 1 - ease(c,.in,1-t)" {
+    for (all_curves) |c| {
+        // Sample the open interval so neither t nor 1-t hits the forced endpoints.
+        var i: usize = 1;
+        while (i < 100) : (i += 1) {
+            const t = @as(f32, @floatFromInt(i)) / 100.0;
+            const lhs = easing.ease(c, .out, t);
+            const rhs = 1.0 - easing.ease(c, .in, 1.0 - t);
+            try std.testing.expectApproxEqAbs(lhs, rhs, 1e-5);
+        }
+    }
+}
+
+test "in_out midpoint is 0.5 for every curve" {
+    // curveIn(c, 1.0) == 1 for all curves, so in_out(0.5) = 1 - 1/2 = 0.5.
+    for (all_curves) |c| {
+        try std.testing.expectApproxEqAbs(@as(f32, 0.5), easing.ease(c, .in_out, 0.5), 1e-5);
+    }
+}
+
+test "input t is clamped, output is not (overshoot preserved)" {
+    // Clamp of the INPUT.
+    try std.testing.expectEqual(@as(f32, 0.0), easing.ease(.quad, .in, -1.0));
+    try std.testing.expectEqual(@as(f32, 1.0), easing.ease(.quad, .in, 2.0));
+    // back overshoots below 0 in .in near the start — output must NOT clamp.
+    try std.testing.expect(easing.ease(.back, .in, 0.2) < 0.0);
+    // elastic overshoots above 1 in .out near the end.
+    var over = false;
+    var i: usize = 1;
+    while (i < 100) : (i += 1) {
+        const t = @as(f32, @floatFromInt(i)) / 100.0;
+        if (easing.ease(.elastic, .out, t) > 1.0) over = true;
+    }
+    try std.testing.expect(over);
+}
+
+test "interpolate maps through start + delta * ease" {
+    // linear halfway: 10 + 20 * 0.5 == 20.
+    try std.testing.expectEqual(@as(f32, 20.0), easing.interpolate(10, 20, 1, 2, .linear, .in));
+    // duration <= 0 → instantly finished (start + delta), no div-by-zero.
+    try std.testing.expectEqual(@as(f32, 30.0), easing.interpolate(10, 20, 5, 0, .quad, .out));
+    try std.testing.expectEqual(@as(f32, 30.0), easing.interpolate(10, 20, 5, -1, .quad, .out));
+    // endpoints.
+    try std.testing.expectEqual(@as(f32, 10.0), easing.interpolate(10, 20, 0, 2, .cubic, .in_out));
+    try std.testing.expectEqual(@as(f32, 30.0), easing.interpolate(10, 20, 2, 2, .cubic, .in_out));
+}
+
+test "expApproach reproduces 1 - exp(-rate*dt)" {
+    const dts = [_]f32{ 0.0, 0.008, 0.016, 0.033, 0.1 };
+    for (dts) |dt| {
+        try std.testing.expectEqual(1.0 - @exp(-8.0 * dt), easing.expApproach(8.0, dt));
+    }
+    // dt == 0 → no movement.
+    try std.testing.expectEqual(@as(f32, 0.0), easing.expApproach(8.0, 0.0));
+}


### PR DESCRIPTION
Closes #668 (Phase 1 foundation of the animation epic #673 — the standalone quick win with no inbound deps).

## What

A pure easing module: two orthogonal enums after Godot 4's Tween factoring, plus free functions with **zero dependencies on ECS, renderer, or game state**.

```zig
pub const Curve = enum(u8) { linear, sine, quad, cubic, quart, quint, expo, circ, back, elastic, bounce, spring };
pub const Placement = enum(u8) { in, out, in_out, out_in };

pub fn ease(curve: Curve, placement: Placement, t: f32) f32;
pub fn interpolate(start, delta, elapsed, duration, curve, placement) f32; // Godot interpolate_value
pub fn expApproach(rate: f32, dt: f32) f32;                                 // camera-smoothing factor
```

Re-exported as `engine.easing` under a `// ── Easing ──` heading in `root.zig`.

## Design notes

- **Only `curveIn` is written per curve** (the 12 `.in`-form formulas); `out` / `in_out` / `out_in` derive generically, so adding a curve is one switch arm.
- **Exact endpoints**: `ease` forces `t=0→0` and `t=1→1` for all 48 combinations (the raw f32 formulas drift by an ULP, e.g. `cos(π/2) ≠ 0`).
- **Input clamped, output not**: `t` is clamped to `[0,1]`; the output is never clamped, so `back`/`elastic` mid-range overshoot is preserved (per the acceptance criteria).
- `quad/.out` is **bit-identical** to the game's hand-rolled `easeOutQuad` (`1 - (1-t)²`).
- `spring` uses Godot's `TRANS_SPRING` out-equation constants (`0.2, 2.5, 2.2, 1.2`), pinned and commented — determinism over bit-matching, as the ticket allows.
- `duration <= 0` in `interpolate` returns `start + delta` (no div-by-zero).

## Tests (`test/easing_test.zig`, wired into `build.zig`)

8 tests covering the ticket's full plan: endpoint exactness across all 48 combos, monotonicity of the non-overshooting curves, `easeOutQuad` equivalence, `out == 1 - in(1-t)` symmetry, `in_out` midpoint, input-clamping + overshoot preservation, `interpolate` (incl. `duration<=0`), and `expApproach`. `zig build test` passes.

## Scope

Per the ticket: this is the module only. Migrating the game call sites (`ship_animation.zig`'s `easeOutQuad`, `camera_control.zig`'s exponential approach, the linear fades in build-toast / sleep / sky) is follow-up work, and the tween runtime (#669) consumes this module separately.

https://claude.ai/code/session_01P7YLw4hXFCCaY2LAUt4G1j