### PR TITLE
feat(animation_def): variantFromName — stable variant identity (engine half of #665)

### DIFF
--- a/src/animation_def.zig
+++ b/src/animation_def.zig
@@ -188,10 +188,7 @@ pub fn AnimationDef(comptime zon: anytype) type {
         /// (e.g. variant 0 + a warning) since the engine can't know the
         /// game's default skin.
         pub fn variantFromName(name: []const u8) ?Variant {
-            inline for (@typeInfo(Variant).@"enum".fields) |field| {
-                if (std.mem.eql(u8, field.name, name)) return @field(Variant, field.name);
-            }
-            return null;
+            return std.meta.stringToEnum(Variant, name);
         }
     };
 }

--- a/src/animation_def.zig
+++ b/src/animation_def.zig
@@ -165,11 +165,33 @@ pub fn AnimationDef(comptime zon: anytype) type {
         }
 
         /// Map an index to a variant, with fallback to the last variant.
+        ///
+        /// Deprecated as a *persistence* path (#665): a raw index makes
+        /// the `.variants` order load-bearing, so any reorder/rename
+        /// silently corrupts saves. Persist the variant NAME and resolve
+        /// via `variantFromName` instead. `variantFromIndex` remains only
+        /// for migrating pre-manifest saves (translate a saved index
+        /// through the save-time name manifest, then re-resolve by name).
         pub fn variantFromIndex(idx: usize) Variant {
             if (idx < variant_count) {
                 return @enumFromInt(idx);
             }
             return @enumFromInt(variant_count - 1);
+        }
+
+        /// Resolve a variant NAME to its `Variant`, or `null` when no
+        /// variant carries that name (renamed or deleted). This is the
+        /// stable-identity persistence path (#665): unlike an index, a
+        /// name survives reordering the `.variants` list. Comptime-
+        /// unrolled string compare — one branch per variant, no
+        /// allocation. Callers translate `null` into their own fallback
+        /// (e.g. variant 0 + a warning) since the engine can't know the
+        /// game's default skin.
+        pub fn variantFromName(name: []const u8) ?Variant {
+            inline for (@typeInfo(Variant).@"enum".fields) |field| {
+                if (std.mem.eql(u8, field.name, name)) return @field(Variant, field.name);
+            }
+            return null;
         }
     };
 }

--- a/test/animation_def_test.zig
+++ b/test/animation_def_test.zig
@@ -67,6 +67,22 @@ test "AnimationDef: variantFromIndex with valid and out-of-range" {
     try testing.expectEqual(TestAnim.variants.w_india, TestAnim.variantFromIndex(99));
 }
 
+test "AnimationDef: variantFromName hit, miss, round-trip (#665)" {
+    const V = TestAnim.variants;
+    // Hit — resolves each name to its variant regardless of position.
+    try testing.expectEqual(@as(?V, V.m_bald), TestAnim.variantFromName("m_bald"));
+    try testing.expectEqual(@as(?V, V.m_beard), TestAnim.variantFromName("m_beard"));
+    try testing.expectEqual(@as(?V, V.w_india), TestAnim.variantFromName("w_india"));
+    // Miss — a renamed/deleted variant resolves to null (caller falls back).
+    try testing.expectEqual(@as(?V, null), TestAnim.variantFromName("does_not_exist"));
+    try testing.expectEqual(@as(?V, null), TestAnim.variantFromName(""));
+    // Round-trip: name → variant → name is the identity for every variant.
+    inline for (.{ "m_bald", "m_beard", "w_india" }) |nm| {
+        const v = TestAnim.variantFromName(nm).?;
+        try testing.expectEqualStrings(nm, TestAnim.variantName(v));
+    }
+}
+
 test "AnimationDef: clipName and variantName" {
     try testing.expectEqualStrings("walk", TestAnim.clipName(.walk));
     try testing.expectEqualStrings("m_beard", TestAnim.variantName(.m_beard));


### PR DESCRIPTION
Engine half of #665 (animation epic #673, Phase 1 foundation — unblocks #666 variant overrides and studio#20).

## What

Adds `AnimationDef(...).variantFromName(name: []const u8) ?Variant`: a comptime-unrolled string compare over the variant names (one branch per variant, no allocation). Returns `null` for a name no variant carries (renamed/deleted), leaving the fallback choice to the caller — the engine can't know the game's default skin.

`variantFromIndex` keeps working but its doc comment now flags it as deprecated **for persistence**: a raw index makes the `.variants` order load-bearing, so any reorder/rename silently corrupts saves. It stays for migrating pre-manifest saves.

## Why

Today `Worker.variant` persists as a raw `u8` index into `.variants`, so `worker.zon` carries a "order is load-bearing" warning and every reorder is a save-corruption risk. Name-based identity (Unity 2D Sprite Library's model) fixes that. This is the reusable engine primitive; the game-side save-time **name manifest** + load-time translation + legacy-order fallback + golden snapshot are a separate flying-platform-labelle PR (ticket step 3), which consumes this function.

## Tests

Extended `test/animation_def_test.zig`: hit (each name → its variant), miss (`"does_not_exist"`, `""` → null), and name→variant→name round-trip. `zig build test` passes.

## Scope

Engine primitive only. The game-side manifest/migration and the golden-snapshot test are the game half of #665.

https://claude.ai/code/session_01P7YLw4hXFCCaY2LAUt4G1j