### PR TITLE
feat(animation): explicit frame entries with per-slot holds (#664)

### DIFF
--- a/src/animation_def.zig
+++ b/src/animation_def.zig
@@ -3,14 +3,23 @@
 /// Parses a .zon struct with `.variants` and `.clips` fields and generates:
 ///   - A `Clip` enum with one tag per clip name
 ///   - A `Variant` enum with one tag per variant name
-///   - A `ClipMeta` array indexed by clip ordinal (frame_count, speed, mode)
-///   - A precomputed sprite name table: `[clips][variants][max_frames][]const u8`
+///   - A `ClipMeta` array indexed by clip ordinal (entry/beat counts, speed, mode)
+///   - A precomputed sprite name table: `[clips][variants][max_slots][]const u8`
 ///
 /// Usage:
 ///   const WorkerAnim = AnimationDef(@import("animations/worker.zon"));
 ///   const clip = WorkerAnim.Clip.walk;
 ///   const meta = WorkerAnim.clipMeta(clip);
 ///   const name = WorkerAnim.spriteName(.walk, .m_bald, 2); // "walk/m_bald_0003.png"
+///
+/// Frame schema (#664). A clip's `.frames` accepts three forms, all
+/// comptime-normalized to a list of slots (`FrameEntry{ f, run }`):
+///   .frames = 4                              // count: slots 1..4, run 1 each
+///   .frames = .{ 1, 2, 3, 2 }                // explicit indices (reorder/reuse), run 1
+///   .frames = .{ .{ .f = 1, .run = 2 }, 2 }  // per-slot holds; bare int == run 1
+/// `speed` is beats/unit (seconds for `.time`, distance units for `.distance`);
+/// a slot showing for `run` beats. The count form has run 1 everywhere, so
+/// `beat_count == slot_count` and playback is bit-identical to pre-#664.
 
 const std = @import("std");
 
@@ -23,13 +32,80 @@ pub const Mode = enum {
     static,
 };
 
+/// One slot in a clip: file index `f` (rendered into
+/// `"{folder}/{variant}_{f:04}.png"`) shown for `run` beats.
+pub const FrameEntry = struct {
+    f: u16,
+    run: u8,
+};
+
 pub const ClipMeta = struct {
+    /// Number of slots in the clip (`.frames` list length; the count
+    /// shorthand N gives N slots). This is what `frame` cycles over as
+    /// a slot index. Kept named `frame_count` for back-compat: callers
+    /// that predate #664 (transition, game FSMs) read this and, for the
+    /// count-shorthand clips they all use today, it equals `beat_count`,
+    /// so `AnimationState.advance` stays correct without a change.
     frame_count: u8,
+    /// Alias of `frame_count` under the #664 vocabulary (slots).
+    entry_count: u8,
+    /// Total beats in the clip = sum of every slot's `run`. The cycle
+    /// length for `advanceState`. Equals `entry_count` iff every run is 1.
+    beat_count: u16,
     speed: f32,
     mode: Mode,
     /// Sprite folder name (may differ from clip name, e.g. carry → "take").
     folder: []const u8,
 };
+
+/// Normalize any of the three `.frames` forms into a slot list. Pure
+/// comptime; the returned slice points at comptime memory. Rejects
+/// malformed data with a clear message (empty, run 0, f out of the
+/// 1–9999 filename range, >255 slots).
+fn normalizeFrames(comptime frames: anytype) []const FrameEntry {
+    const info = @typeInfo(@TypeOf(frames));
+    // Form 1 — bare count N → slots {1,1},{2,1},…,{N,1}.
+    if (info == .comptime_int or info == .int) {
+        if (frames < 1) @compileError("clip .frames count must be >= 1");
+        if (frames > 255) @compileError("clip .frames has more than 255 slots");
+        const n: usize = frames;
+        var entries: [n]FrameEntry = undefined;
+        for (0..n) |i| entries[i] = .{ .f = @intCast(i + 1), .run = 1 };
+        const out = entries;
+        return &out;
+    }
+    // Forms 2 & 3 — a tuple of ints and/or `.{ .f, .run }` structs.
+    if (info == .@"struct" and info.@"struct".is_tuple) {
+        const fields = info.@"struct".fields;
+        if (fields.len == 0) @compileError("clip .frames list must not be empty");
+        if (fields.len > 255) @compileError("clip .frames has more than 255 slots");
+        var entries: [fields.len]FrameEntry = undefined;
+        inline for (fields, 0..) |field, i| {
+            const elem = @field(frames, field.name);
+            const einfo = @typeInfo(@TypeOf(elem));
+            if (einfo == .comptime_int or einfo == .int) {
+                entries[i] = .{ .f = checkedF(elem), .run = 1 };
+            } else if (einfo == .@"struct") {
+                if (!@hasField(@TypeOf(elem), "f")) @compileError("frame entry struct needs an `.f` field");
+                const run = if (@hasField(@TypeOf(elem), "run")) elem.run else 1;
+                if (run < 1) @compileError("frame .run must be >= 1");
+                if (run > 255) @compileError("frame .run must be <= 255");
+                entries[i] = .{ .f = checkedF(elem.f), .run = @intCast(run) };
+            } else {
+                @compileError("frame entry must be an int index or a `.{ .f, .run }` struct");
+            }
+        }
+        const out = entries;
+        return &out;
+    }
+    @compileError("clip .frames must be an int count or a tuple of frame entries");
+}
+
+fn checkedF(comptime f: anytype) u16 {
+    if (f < 1) @compileError("frame index .f must be >= 1");
+    if (f > 9999) @compileError("frame index .f must be <= 9999 (4-digit filename field)");
+    return @intCast(f);
+}
 
 pub fn AnimationDef(comptime zon: anytype) type {
     if (!@hasField(@TypeOf(zon), "clips")) @compileError("animation .zon must have a .clips field");
@@ -71,6 +147,16 @@ pub fn AnimationDef(comptime zon: anytype) type {
 
     const Variant = @Enum(u8, .exhaustive, &VariantNames.names, &VariantNames.values);
 
+    // Per-clip normalized slot lists — the single source the meta table,
+    // name table, and beat table all derive from.
+    const clip_entries: [clip_count][]const FrameEntry = blk: {
+        var arr: [clip_count][]const FrameEntry = undefined;
+        for (clip_fields, 0..) |f, i| {
+            arr[i] = normalizeFrames(@field(zon.clips, f.name).frames);
+        }
+        break :blk arr;
+    };
+
     // Build ClipMeta table
     const clip_meta_table: [clip_count]ClipMeta = blk: {
         var table: [clip_count]ClipMeta = undefined;
@@ -88,8 +174,20 @@ pub fn AnimationDef(comptime zon: anytype) type {
                 clip_data.mode
             else
                 .static;
+            const entries = clip_entries[i];
+            var beats: u16 = 0;
+            for (entries) |e| beats += e.run;
+            // A .static clip only ever shows slot 0, so per-slot holds
+            // are meaningless — reject them rather than silently ignore.
+            if (mode == .static) {
+                for (entries) |e| {
+                    if (e.run != 1) @compileError("clip '" ++ f.name ++ "' is .static but declares a .run — holds are meaningless when frame is always slot 0");
+                }
+            }
             table[i] = .{
-                .frame_count = clip_data.frames,
+                .frame_count = @intCast(entries.len),
+                .entry_count = @intCast(entries.len),
+                .beat_count = beats,
                 .speed = speed,
                 .mode = mode,
                 .folder = folder,
@@ -98,39 +196,63 @@ pub fn AnimationDef(comptime zon: anytype) type {
         break :blk table;
     };
 
-    // Find max frames across all clips
-    const max_frames: usize = blk: {
+    // Max slots (name-table depth) and max beats (beat-table depth).
+    const max_slots: usize = blk: {
         var mx: usize = 1;
         for (&clip_meta_table) |meta| {
-            if (meta.frame_count > mx) mx = meta.frame_count;
+            if (meta.entry_count > mx) mx = meta.entry_count;
+        }
+        break :blk mx;
+    };
+    const max_beats: usize = blk: {
+        var mx: usize = 1;
+        for (&clip_meta_table) |meta| {
+            if (meta.beat_count > mx) mx = meta.beat_count;
         }
         break :blk mx;
     };
 
-    // Build precomputed sprite name table
-    // Format: "{folder}/{variant}_{frame:04}.png"
-    const SpriteNameTable = [clip_count][variant_count][max_frames][]const u8;
-
-    // Precompute all sprite name strings at comptime. The branch quota scales
-    // with the table size because comptimePrint uses Writer internals that
-    // consume many branches per formatted string.
+    // Precomputed sprite name table, keyed by SLOT. The name for slot i
+    // uses `entries[i].f` (not i+1), so reordered/reused frames resolve
+    // to the right file. Format: "{folder}/{variant}_{f:04}.png".
+    const SpriteNameTable = [clip_count][variant_count][max_slots][]const u8;
     const sprite_names: SpriteNameTable = blk: {
-        @setEvalBranchQuota(clip_count * variant_count * max_frames * 2000);
+        @setEvalBranchQuota(clip_count * variant_count * max_slots * 2000);
         var table: SpriteNameTable = undefined;
         for (0..clip_count) |ci| {
             const folder = clip_meta_table[ci].folder;
-            const fc = clip_meta_table[ci].frame_count;
+            const entries = clip_entries[ci];
             for (0..variant_count) |vi| {
                 const vname: []const u8 = variant_list[vi];
-                for (0..max_frames) |fi| {
-                    if (fi < fc) {
-                        const frame_1 = fi + 1;
-                        table[ci][vi][fi] = std.fmt.comptimePrint("{s}/{s}_{d:0>4}.png", .{ folder, vname, frame_1 });
+                for (0..max_slots) |si| {
+                    if (si < entries.len) {
+                        table[ci][vi][si] = std.fmt.comptimePrint("{s}/{s}_{d:0>4}.png", .{ folder, vname, entries[si].f });
                     } else {
-                        table[ci][vi][fi] = "";
+                        table[ci][vi][si] = "";
                     }
                 }
             }
+        }
+        break :blk table;
+    };
+
+    // Beat → slot table: slot j repeated `run_j` times, so a runtime
+    // `slot = beat_to_slot[clip][beat]` lookup is O(1) with no per-tick
+    // summation. Padded to `max_beats`; entries past a clip's beat_count
+    // are 0 (never read — `advanceState` mods by beat_count first).
+    const beat_to_slot: [clip_count][max_beats]u8 = blk: {
+        var table: [clip_count][max_beats]u8 = undefined;
+        for (0..clip_count) |ci| {
+            const entries = clip_entries[ci];
+            var b: usize = 0;
+            for (entries, 0..) |e, si| {
+                var r: usize = 0;
+                while (r < e.run) : (r += 1) {
+                    table[ci][b] = @intCast(si);
+                    b += 1;
+                }
+            }
+            while (b < max_beats) : (b += 1) table[ci][b] = 0;
         }
         break :blk table;
     };
@@ -140,18 +262,32 @@ pub fn AnimationDef(comptime zon: anytype) type {
         pub const variants = Variant;
         pub const clip_count_val = clip_count;
         pub const variant_count_val = variant_count;
-        pub const max_frames_val = max_frames;
+        /// Depth of the slot-keyed sprite-name table. Named `max_frames_val`
+        /// for back-compat (== max slot count).
+        pub const max_frames_val = max_slots;
+        pub const max_slots_val = max_slots;
+        pub const max_beats_val = max_beats;
 
-        /// Get metadata for a clip (frame_count, speed, mode, folder).
+        /// Get metadata for a clip (counts, speed, mode, folder).
         pub fn clipMeta(clip: Clip) ClipMeta {
             return clip_meta_table[@intFromEnum(clip)];
         }
 
-        /// Look up the precomputed sprite name for a clip/variant/frame combination.
-        /// Frame is 0-based.
+        /// Look up the precomputed sprite name for a clip/variant/SLOT.
+        /// `frame` is the slot index (0-based).
         pub fn spriteName(clip: Clip, variant: Variant, frame: u8) []const u8 {
-            if (frame >= max_frames) return "";
+            if (frame >= max_slots) return "";
             return sprite_names[@intFromEnum(clip)][@intFromEnum(variant)][frame];
+        }
+
+        /// The slot shown at a given beat of a clip (0-based beat). Beats
+        /// past the clip's `beat_count` wrap via the caller's mod; this
+        /// clamps defensively.
+        pub fn slotForBeat(clip: Clip, beat: u16) u8 {
+            const ci = @intFromEnum(clip);
+            const bc = clip_meta_table[ci].beat_count;
+            if (bc == 0) return 0;
+            return beat_to_slot[ci][beat % bc];
         }
 
         /// Get variant name string.
@@ -170,6 +306,42 @@ pub fn AnimationDef(comptime zon: anytype) type {
                 return @enumFromInt(idx);
             }
             return @enumFromInt(variant_count - 1);
+        }
+
+        /// Beat-aware advance for clips with per-slot holds. Mirrors
+        /// `AnimationState.advance` but cycles over BEATS (sum of runs)
+        /// and maps the current beat to a slot via the comptime beat
+        /// table, writing the slot into `state.frame`. `state` is
+        /// duck-typed (`.clip/.mode/.speed/.timer/.frame`) to avoid a
+        /// circular import with `animation_state.zig`.
+        ///
+        /// For count-shorthand clips (every run 1) `beat_count ==
+        /// entry_count` and this is identical to `advance`, so a game
+        /// can switch to it wholesale; only clips that declare runs
+        /// *need* it. Full advance-dedup is #667.
+        pub fn advanceState(state: anytype, dt: f32) void {
+            const ci = state.clip;
+            const meta = clip_meta_table[ci];
+            switch (meta.mode) {
+                .time => {
+                    state.timer += dt * state.speed;
+                    if (meta.beat_count > 0) {
+                        const bc: f32 = @floatFromInt(meta.beat_count);
+                        const beat: u16 = @intFromFloat(@mod(state.timer, bc));
+                        state.frame = beat_to_slot[ci][beat % meta.beat_count];
+                    }
+                },
+                .distance => {
+                    if (meta.beat_count > 0) {
+                        const bc: f32 = @floatFromInt(meta.beat_count);
+                        const beat: u16 = @intFromFloat(@mod(state.timer, bc));
+                        state.frame = beat_to_slot[ci][beat % meta.beat_count];
+                    }
+                },
+                .static => {
+                    state.frame = 0;
+                },
+            }
         }
     };
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -487,6 +487,7 @@ pub const AnimationDef = animation_def_mod.AnimationDef;
 pub const AnimationState = animation_state_mod.AnimationState;
 pub const AnimMode = animation_def_mod.Mode;
 pub const AnimClipMeta = animation_def_mod.ClipMeta;
+pub const AnimFrameEntry = animation_def_mod.FrameEntry;
 pub const SpriteAnimation = sprite_animation_mod.SpriteAnimation;
 pub const SpriteAnimationMode = sprite_animation_mod.AnimationMode;
 pub const spriteAnimationTick = sprite_animation_tick_mod.tick;

--- a/test/animation_def_test.zig
+++ b/test/animation_def_test.zig
@@ -140,3 +140,82 @@ test "AnimationState: advance in distance mode uses timer directly" {
     // mod(2.5, 4.0) = 2.5, frame = min(2, 3) = 2
     try testing.expectEqual(@as(u8, 2), state.frame);
 }
+
+// ── Explicit frame entries (#664) ─────────────────────────
+
+// Exercises all three `.frames` forms: bare count, explicit index list
+// (reorder + reuse), and per-slot runs (holds).
+const frames_zon = .{
+    .variants = .{"hero"},
+    .clips = .{
+        // Count shorthand — every slot runs one beat, so beat_count ==
+        // entry_count and playback is bit-identical to pre-#664.
+        .plain = .{ .frames = 4, .mode = .time, .speed = 1.0 },
+        // Explicit list — reorders and REUSES a file: slot 3 points back
+        // at file 2 (a 1-2-3-2 ping-pong).
+        .bounce = .{ .frames = .{ 1, 2, 3, 2 }, .mode = .time, .speed = 1.0 },
+        // Per-slot holds — slot 0 (file 1) shows for 2 beats, then slot 1
+        // (bare int → file 2, run 1) for 1 beat. beat_count 3, entry_count 2.
+        .hold = .{ .frames = .{ .{ .f = 1, .run = 2 }, 2 }, .mode = .time, .speed = 1.0 },
+    },
+};
+
+const FramesAnim = AnimationDef(frames_zon);
+
+test "AnimationDef: count shorthand yields unit-run beats (#664)" {
+    const m = FramesAnim.clipMeta(.plain);
+    try testing.expectEqual(@as(u8, 4), m.entry_count);
+    try testing.expectEqual(@as(u16, 4), m.beat_count);
+    // frame_count stays a back-compat alias of entry_count.
+    try testing.expectEqual(@as(u8, 4), m.frame_count);
+    // Slot i resolves to file i+1, exactly as the old count path did.
+    try testing.expectEqualStrings("plain/hero_0001.png", FramesAnim.spriteName(.plain, .hero, 0));
+    try testing.expectEqualStrings("plain/hero_0004.png", FramesAnim.spriteName(.plain, .hero, 3));
+    // Identity beat→slot mapping.
+    try testing.expectEqual(@as(u8, 0), FramesAnim.slotForBeat(.plain, 0));
+    try testing.expectEqual(@as(u8, 3), FramesAnim.slotForBeat(.plain, 3));
+}
+
+test "AnimationDef: explicit list reorders and reuses files (#664)" {
+    const m = FramesAnim.clipMeta(.bounce);
+    try testing.expectEqual(@as(u8, 4), m.entry_count);
+    try testing.expectEqual(@as(u16, 4), m.beat_count);
+    // .{ 1, 2, 3, 2 } — the name for each slot uses that slot's `f`, so
+    // slot 3 renders file 2 again (not file 4).
+    try testing.expectEqualStrings("bounce/hero_0001.png", FramesAnim.spriteName(.bounce, .hero, 0));
+    try testing.expectEqualStrings("bounce/hero_0002.png", FramesAnim.spriteName(.bounce, .hero, 1));
+    try testing.expectEqualStrings("bounce/hero_0003.png", FramesAnim.spriteName(.bounce, .hero, 2));
+    try testing.expectEqualStrings("bounce/hero_0002.png", FramesAnim.spriteName(.bounce, .hero, 3));
+}
+
+test "AnimationDef: per-slot runs expand the beat table (#664)" {
+    const m = FramesAnim.clipMeta(.hold);
+    try testing.expectEqual(@as(u8, 2), m.entry_count);
+    try testing.expectEqual(@as(u16, 3), m.beat_count);
+    // beat_to_slot == { 0, 0, 1 }: slot 0 held two beats, then slot 1.
+    try testing.expectEqual(@as(u8, 0), FramesAnim.slotForBeat(.hold, 0));
+    try testing.expectEqual(@as(u8, 0), FramesAnim.slotForBeat(.hold, 1));
+    try testing.expectEqual(@as(u8, 1), FramesAnim.slotForBeat(.hold, 2));
+    // slotForBeat wraps past beat_count.
+    try testing.expectEqual(@as(u8, 0), FramesAnim.slotForBeat(.hold, 3));
+    // The bare int 2 became slot 1 pointing at file 2.
+    try testing.expectEqualStrings("hold/hero_0001.png", FramesAnim.spriteName(.hold, .hero, 0));
+    try testing.expectEqualStrings("hold/hero_0002.png", FramesAnim.spriteName(.hold, .hero, 1));
+}
+
+test "AnimationDef: advanceState maps beats to held slots (#664)" {
+    var state = AnimationState{};
+    state.transitionFromMeta(@intFromEnum(FramesAnim.clips.hold), FramesAnim.clipMeta(.hold));
+
+    // beat_count 3, speed 1 → timer accumulates beats; the held slot 0
+    // spans beats 0 and 1, slot 1 is beat 2, then it wraps.
+    try testing.expectEqual(@as(u8, 0), state.frame);
+    FramesAnim.advanceState(&state, 0.5); // timer 0.5 → beat 0 → slot 0
+    try testing.expectEqual(@as(u8, 0), state.frame);
+    FramesAnim.advanceState(&state, 0.7); // timer 1.2 → beat 1 → slot 0 (still held)
+    try testing.expectEqual(@as(u8, 0), state.frame);
+    FramesAnim.advanceState(&state, 1.0); // timer 2.2 → beat 2 → slot 1
+    try testing.expectEqual(@as(u8, 1), state.frame);
+    FramesAnim.advanceState(&state, 1.0); // timer 3.2 → mod 3 = 0.2 → beat 0 → slot 0 (wrap)
+    try testing.expectEqual(@as(u8, 0), state.frame);
+}


### PR DESCRIPTION
Closes #664. Phase 2 of the animation epic (#673). Stacks cleanly on the AnimationDef surface; no dependency on #665's PR (#675).

## What changed

`AnimationDef` `.frames` now accepts three forms, all normalized to `[]const FrameEntry{ f, run }` at comptime:

```zig
.frames = 4                              // count: slots 1..4, run 1 each (unchanged behavior)
.frames = .{ 1, 2, 3, 2 }                // explicit indices — reorder / reuse a file
.frames = .{ .{ .f = 1, .run = 2 }, 2 }  // per-slot holds; a bare int is run 1
```

- **Slot-keyed name table.** The precomputed sprite-name table is now indexed by slot and renders each slot's `f` (not `i+1`), so `.{ 1, 2, 3, 2 }` resolves slot 3 back to file `_0002.png`.
- **Beat→slot table.** A per-clip `[beat_count]u8` (slot `j` repeated `run_j` times) turns runtime frame selection into an O(1) `slot = beat_to_slot[beat]` lookup — no per-tick run summation.
- **`ClipMeta` grows `entry_count` (slots) and `beat_count` (Σ runs).** `frame_count` stays as a back-compat alias of `entry_count`. Count-shorthand clips have every run = 1, so `beat_count == entry_count` and they play **bit-identical** to pre-#664 through the existing `AnimationState.advance` — no game change required.
- **`advanceState(state, dt)`** is the beat-aware advance for clips that declare holds: cycles over beats, writes the mapped slot into `state.frame`. It's `anytype` to avoid the `animation_state.zig` ↔ `animation_def.zig` import cycle. Wholesale advance-dedup is deferred to #667.

## Comptime validation

Malformed `.frames` fails the build with a clear message: empty list, `run == 0`, `f` outside 1–9999 (the 4-digit filename field), more than 255 slots, or a `.static` clip that declares a `.run` (meaningless — a static clip is always slot 0).

## Tests

`test/animation_def_test.zig` +4 (16 total in the file, full suite green):
- count shorthand → `entry_count == beat_count == N`, identity beat→slot, `frame_count` alias intact
- explicit `.{ 1, 2, 3, 2 }` → 4 slots, slot 3 renders `_0002.png`
- per-slot runs `.{ .{ .f = 1, .run = 2 }, 2 }` → `beat_count == 3`, `beat_to_slot == { 0, 0, 1 }`, bare int became slot 1 → file 2
- `advanceState` `.time` speed-1 sweep that holds across beats 0–1, steps to slot 1 at beat 2, then wraps

## Not in scope

- `worker.zon` / game-side authoring of holds — follow-up (no shipped clip declares runs yet).
- Per-frame animation events (#670) build on this slot vocabulary.

https://claude.ai/code/session_01P7YLw4hXFCCaY2LAUt4G1j