### PR TITLE
feat(animation): per-frame markers + clip lifecycle events (#670)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -93,6 +93,7 @@ pub fn build(b: *std.Build) void {
         "test/font_loader_test.zig",
         "test/asset_streaming_shim_test.zig",
         "test/animation_def_test.zig",
+        "test/animation_events_test.zig",
         "test/sprite_animation_test.zig",
         "test/sprite_animation_tick_test.zig",
         "test/sprite_by_field_test.zig",

--- a/src/animation_def.zig
+++ b/src/animation_def.zig
@@ -22,6 +22,13 @@
 /// `beat_count == slot_count` and playback is bit-identical to pre-#664.
 
 const std = @import("std");
+const anim_events = @import("animation_events.zig");
+
+/// Cap on beats traversed per `advanceStateEvents` call. A normal tick
+/// crosses 0–2 beats; only a pathological dt would exceed this. Beyond it,
+/// the tail of markers/loop-ends is dropped (the saturating repetition
+/// counter stays accurate arithmetically), bounding per-tick work.
+const max_traverse: u32 = 512;
 
 pub const Mode = enum {
     /// timer += dt * speed; frame cycles over time.
@@ -33,10 +40,13 @@ pub const Mode = enum {
 };
 
 /// One slot in a clip: file index `f` (rendered into
-/// `"{folder}/{variant}_{f:04}.png"`) shown for `run` beats.
+/// `"{folder}/{variant}_{f:04}.png"`) shown for `run` beats. An optional
+/// `marker` name (#670) fires an `AnimMarkerHit` when the slot becomes
+/// current — declared in `.zon` as `.{ .f = 4, .marker = "contact" }`.
 pub const FrameEntry = struct {
     f: u16,
     run: u8,
+    marker: ?[]const u8 = null,
 };
 
 pub const ClipMeta = struct {
@@ -90,7 +100,8 @@ fn normalizeFrames(comptime frames: anytype) []const FrameEntry {
                 const run = if (@hasField(@TypeOf(elem), "run")) elem.run else 1;
                 if (run < 1) @compileError("frame .run must be >= 1");
                 if (run > 255) @compileError("frame .run must be <= 255");
-                entries[i] = .{ .f = checkedF(elem.f), .run = @intCast(run) };
+                const marker: ?[]const u8 = if (@hasField(@TypeOf(elem), "marker")) elem.marker else null;
+                entries[i] = .{ .f = checkedF(elem.f), .run = @intCast(run), .marker = marker };
             } else {
                 @compileError("frame entry must be an int index or a `.{ .f, .run }` struct");
             }
@@ -257,6 +268,23 @@ pub fn AnimationDef(comptime zon: anytype) type {
         break :blk table;
     };
 
+    // Marker → beat table (#670): the marker name at each beat that is a
+    // slot's FIRST beat and carries a marker, else "". A held slot (run>1)
+    // fires its marker once, at entry. Padded to `max_beats` with "".
+    const marker_beats: [clip_count][max_beats][]const u8 = blk: {
+        var table: [clip_count][max_beats][]const u8 = undefined;
+        for (0..clip_count) |ci| {
+            for (0..max_beats) |bi| table[ci][bi] = "";
+            const entries = clip_entries[ci];
+            var b: usize = 0;
+            for (entries) |e| {
+                if (e.marker) |name| table[ci][b] = name;
+                b += e.run;
+            }
+        }
+        break :blk table;
+    };
+
     return struct {
         pub const clips = Clip;
         pub const variants = Variant;
@@ -342,6 +370,83 @@ pub fn AnimationDef(comptime zon: anytype) type {
                     state.frame = 0;
                 },
             }
+        }
+
+        /// The marker name at a beat of a clip, or "" if none (#670).
+        /// Markers fire at a slot's FIRST beat only.
+        pub fn markerAtBeat(clip: Clip, beat: u16) []const u8 {
+            const cci = @intFromEnum(clip);
+            const bc = clip_meta_table[cci].beat_count;
+            if (bc == 0) return "";
+            return marker_beats[cci][beat % bc];
+        }
+
+        /// Beat-aware advance that ALSO emits per-frame markers + loop-end
+        /// events (#670) into `out`. Superset of `advanceState`: use it for
+        /// entities whose clips carry markers or need lifecycle events; use
+        /// `advanceState` when events aren't wanted (the no-event overload).
+        ///
+        /// Traverses the beats crossed THIS tick in linear (unwrapped)
+        /// space, so a dt spike that skips frames still fires every skipped
+        /// marker — oldest first — and every loop boundary, never "latest
+        /// only" (a skipped `contact` marker is a silent punch). `state`
+        /// needs the transient `.event_pos` (last processed beat position)
+        /// and `.repetition` (saturating loop count) fields on top of what
+        /// `advanceState` reads. The driver adds the entity and forwards
+        /// `out` to `game.emit`.
+        pub fn advanceStateEvents(state: anytype, dt: f32, out: *anim_events.PendingBuf) void {
+            const ci = state.clip;
+            const meta = clip_meta_table[ci];
+            if (meta.mode == .static) {
+                state.frame = 0;
+                state.event_pos = 0;
+                return;
+            }
+            if (meta.mode == .time) state.timer += dt * state.speed;
+            // .distance: `state.timer` is written externally by the game.
+
+            const bc = meta.beat_count;
+            if (bc == 0) return;
+
+            var old_pos = state.event_pos;
+            if (old_pos < 0) old_pos = 0;
+            const new_pos = state.timer;
+
+            if (new_pos > old_pos) {
+                const bc_i: i64 = bc;
+                const old_lin: i64 = @intFromFloat(@floor(old_pos));
+                const new_lin: i64 = @intFromFloat(@floor(new_pos));
+
+                // Authoritative saturating repetition over the FULL span —
+                // stays correct even when per-beat emission is capped.
+                const wraps_full: i64 = @divFloor(new_lin, bc_i) - @divFloor(old_lin, bc_i);
+                const base_rep = state.repetition;
+
+                var rep = base_rep;
+                var b = old_lin + 1;
+                var guard: u32 = 0;
+                while (b <= new_lin and guard < max_traverse) : ({
+                    b += 1;
+                    guard += 1;
+                }) {
+                    const in_cycle: u16 = @intCast(@mod(b, bc_i));
+                    if (in_cycle == 0) {
+                        // Crossed a clip boundary — the prior cycle ended.
+                        rep = anim_events.satAddU16(rep, 1);
+                        _ = out.append(.{ .kind = .loop_end, .clip = ci, .repetition = rep });
+                    }
+                    const name = marker_beats[ci][in_cycle];
+                    if (name.len > 0) {
+                        _ = out.append(.{ .kind = .marker, .clip = ci, .frame = beat_to_slot[ci][in_cycle], .marker = name, .repetition = rep });
+                    }
+                }
+                const add: u16 = if (wraps_full > 0xFFFF) 0xFFFF else @intCast(@max(wraps_full, 0));
+                state.repetition = anim_events.satAddU16(base_rep, add);
+            }
+
+            state.event_pos = new_pos;
+            const final_beat: u16 = @intCast(@mod(@as(i64, @intFromFloat(@floor(new_pos))), @as(i64, bc)));
+            state.frame = beat_to_slot[ci][final_beat];
         }
     };
 }

--- a/src/animation_def.zig
+++ b/src/animation_def.zig
@@ -422,6 +422,18 @@ pub fn AnimationDef(comptime zon: anytype) type {
                 const wraps_full: i64 = @divFloor(new_lin, bc_i) - @divFloor(old_lin, bc_i);
                 const base_rep = state.repetition;
 
+                // Beat 0 of the FIRST play-through: the traversal below
+                // walks beats old_lin+1..new_lin, so the clip's entry beat
+                // (displayed the moment the clip started) would never fire
+                // its marker on the first cycle — only on wraps. Fire it
+                // here exactly once, on the first forward advance.
+                if (old_pos == 0 and old_lin == 0) {
+                    const entry_name = marker_beats[ci][0];
+                    if (entry_name.len > 0) {
+                        _ = out.append(.{ .kind = .marker, .clip = ci, .frame = beat_to_slot[ci][0], .marker = entry_name, .repetition = base_rep });
+                    }
+                }
+
                 var rep = base_rep;
                 var b = old_lin + 1;
                 var guard: u32 = 0;

--- a/src/animation_def.zig
+++ b/src/animation_def.zig
@@ -3,14 +3,23 @@
 /// Parses a .zon struct with `.variants` and `.clips` fields and generates:
 ///   - A `Clip` enum with one tag per clip name
 ///   - A `Variant` enum with one tag per variant name
-///   - A `ClipMeta` array indexed by clip ordinal (frame_count, speed, mode)
-///   - A precomputed sprite name table: `[clips][variants][max_frames][]const u8`
+///   - A `ClipMeta` array indexed by clip ordinal (entry/beat counts, speed, mode)
+///   - A precomputed sprite name table: `[clips][variants][max_slots][]const u8`
 ///
 /// Usage:
 ///   const WorkerAnim = AnimationDef(@import("animations/worker.zon"));
 ///   const clip = WorkerAnim.Clip.walk;
 ///   const meta = WorkerAnim.clipMeta(clip);
 ///   const name = WorkerAnim.spriteName(.walk, .m_bald, 2); // "walk/m_bald_0003.png"
+///
+/// Frame schema (#664). A clip's `.frames` accepts three forms, all
+/// comptime-normalized to a list of slots (`FrameEntry{ f, run }`):
+///   .frames = 4                              // count: slots 1..4, run 1 each
+///   .frames = .{ 1, 2, 3, 2 }                // explicit indices (reorder/reuse), run 1
+///   .frames = .{ .{ .f = 1, .run = 2 }, 2 }  // per-slot holds; bare int == run 1
+/// `speed` is beats/unit (seconds for `.time`, distance units for `.distance`);
+/// a slot showing for `run` beats. The count form has run 1 everywhere, so
+/// `beat_count == slot_count` and playback is bit-identical to pre-#664.
 
 const std = @import("std");
 
@@ -23,13 +32,80 @@ pub const Mode = enum {
     static,
 };
 
+/// One slot in a clip: file index `f` (rendered into
+/// `"{folder}/{variant}_{f:04}.png"`) shown for `run` beats.
+pub const FrameEntry = struct {
+    f: u16,
+    run: u8,
+};
+
 pub const ClipMeta = struct {
+    /// Number of slots in the clip (`.frames` list length; the count
+    /// shorthand N gives N slots). This is what `frame` cycles over as
+    /// a slot index. Kept named `frame_count` for back-compat: callers
+    /// that predate #664 (transition, game FSMs) read this and, for the
+    /// count-shorthand clips they all use today, it equals `beat_count`,
+    /// so `AnimationState.advance` stays correct without a change.
     frame_count: u8,
+    /// Alias of `frame_count` under the #664 vocabulary (slots).
+    entry_count: u8,
+    /// Total beats in the clip = sum of every slot's `run`. The cycle
+    /// length for `advanceState`. Equals `entry_count` iff every run is 1.
+    beat_count: u16,
     speed: f32,
     mode: Mode,
     /// Sprite folder name (may differ from clip name, e.g. carry → "take").
     folder: []const u8,
 };
+
+/// Normalize any of the three `.frames` forms into a slot list. Pure
+/// comptime; the returned slice points at comptime memory. Rejects
+/// malformed data with a clear message (empty, run 0, f out of the
+/// 1–9999 filename range, >255 slots).
+fn normalizeFrames(comptime frames: anytype) []const FrameEntry {
+    const info = @typeInfo(@TypeOf(frames));
+    // Form 1 — bare count N → slots {1,1},{2,1},…,{N,1}.
+    if (info == .comptime_int or info == .int) {
+        if (frames < 1) @compileError("clip .frames count must be >= 1");
+        if (frames > 255) @compileError("clip .frames has more than 255 slots");
+        const n: usize = frames;
+        var entries: [n]FrameEntry = undefined;
+        for (0..n) |i| entries[i] = .{ .f = @intCast(i + 1), .run = 1 };
+        const out = entries;
+        return &out;
+    }
+    // Forms 2 & 3 — a tuple of ints and/or `.{ .f, .run }` structs.
+    if (info == .@"struct" and info.@"struct".is_tuple) {
+        const fields = info.@"struct".fields;
+        if (fields.len == 0) @compileError("clip .frames list must not be empty");
+        if (fields.len > 255) @compileError("clip .frames has more than 255 slots");
+        var entries: [fields.len]FrameEntry = undefined;
+        inline for (fields, 0..) |field, i| {
+            const elem = @field(frames, field.name);
+            const einfo = @typeInfo(@TypeOf(elem));
+            if (einfo == .comptime_int or einfo == .int) {
+                entries[i] = .{ .f = checkedF(elem), .run = 1 };
+            } else if (einfo == .@"struct") {
+                if (!@hasField(@TypeOf(elem), "f")) @compileError("frame entry struct needs an `.f` field");
+                const run = if (@hasField(@TypeOf(elem), "run")) elem.run else 1;
+                if (run < 1) @compileError("frame .run must be >= 1");
+                if (run > 255) @compileError("frame .run must be <= 255");
+                entries[i] = .{ .f = checkedF(elem.f), .run = @intCast(run) };
+            } else {
+                @compileError("frame entry must be an int index or a `.{ .f, .run }` struct");
+            }
+        }
+        const out = entries;
+        return &out;
+    }
+    @compileError("clip .frames must be an int count or a tuple of frame entries");
+}
+
+fn checkedF(comptime f: anytype) u16 {
+    if (f < 1) @compileError("frame index .f must be >= 1");
+    if (f > 9999) @compileError("frame index .f must be <= 9999 (4-digit filename field)");
+    return @intCast(f);
+}
 
 pub fn AnimationDef(comptime zon: anytype) type {
     if (!@hasField(@TypeOf(zon), "clips")) @compileError("animation .zon must have a .clips field");
@@ -71,6 +147,16 @@ pub fn AnimationDef(comptime zon: anytype) type {
 
     const Variant = @Enum(u8, .exhaustive, &VariantNames.names, &VariantNames.values);
 
+    // Per-clip normalized slot lists — the single source the meta table,
+    // name table, and beat table all derive from.
+    const clip_entries: [clip_count][]const FrameEntry = blk: {
+        var arr: [clip_count][]const FrameEntry = undefined;
+        for (clip_fields, 0..) |f, i| {
+            arr[i] = normalizeFrames(@field(zon.clips, f.name).frames);
+        }
+        break :blk arr;
+    };
+
     // Build ClipMeta table
     const clip_meta_table: [clip_count]ClipMeta = blk: {
         var table: [clip_count]ClipMeta = undefined;
@@ -88,8 +174,20 @@ pub fn AnimationDef(comptime zon: anytype) type {
                 clip_data.mode
             else
                 .static;
+            const entries = clip_entries[i];
+            var beats: u16 = 0;
+            for (entries) |e| beats += e.run;
+            // A .static clip only ever shows slot 0, so per-slot holds
+            // are meaningless — reject them rather than silently ignore.
+            if (mode == .static) {
+                for (entries) |e| {
+                    if (e.run != 1) @compileError("clip '" ++ f.name ++ "' is .static but declares a .run — holds are meaningless when frame is always slot 0");
+                }
+            }
             table[i] = .{
-                .frame_count = clip_data.frames,
+                .frame_count = @intCast(entries.len),
+                .entry_count = @intCast(entries.len),
+                .beat_count = beats,
                 .speed = speed,
                 .mode = mode,
                 .folder = folder,
@@ -98,39 +196,63 @@ pub fn AnimationDef(comptime zon: anytype) type {
         break :blk table;
     };
 
-    // Find max frames across all clips
-    const max_frames: usize = blk: {
+    // Max slots (name-table depth) and max beats (beat-table depth).
+    const max_slots: usize = blk: {
         var mx: usize = 1;
         for (&clip_meta_table) |meta| {
-            if (meta.frame_count > mx) mx = meta.frame_count;
+            if (meta.entry_count > mx) mx = meta.entry_count;
+        }
+        break :blk mx;
+    };
+    const max_beats: usize = blk: {
+        var mx: usize = 1;
+        for (&clip_meta_table) |meta| {
+            if (meta.beat_count > mx) mx = meta.beat_count;
         }
         break :blk mx;
     };
 
-    // Build precomputed sprite name table
-    // Format: "{folder}/{variant}_{frame:04}.png"
-    const SpriteNameTable = [clip_count][variant_count][max_frames][]const u8;
-
-    // Precompute all sprite name strings at comptime. The branch quota scales
-    // with the table size because comptimePrint uses Writer internals that
-    // consume many branches per formatted string.
+    // Precomputed sprite name table, keyed by SLOT. The name for slot i
+    // uses `entries[i].f` (not i+1), so reordered/reused frames resolve
+    // to the right file. Format: "{folder}/{variant}_{f:04}.png".
+    const SpriteNameTable = [clip_count][variant_count][max_slots][]const u8;
     const sprite_names: SpriteNameTable = blk: {
-        @setEvalBranchQuota(clip_count * variant_count * max_frames * 2000);
+        @setEvalBranchQuota(clip_count * variant_count * max_slots * 2000);
         var table: SpriteNameTable = undefined;
         for (0..clip_count) |ci| {
             const folder = clip_meta_table[ci].folder;
-            const fc = clip_meta_table[ci].frame_count;
+            const entries = clip_entries[ci];
             for (0..variant_count) |vi| {
                 const vname: []const u8 = variant_list[vi];
-                for (0..max_frames) |fi| {
-                    if (fi < fc) {
-                        const frame_1 = fi + 1;
-                        table[ci][vi][fi] = std.fmt.comptimePrint("{s}/{s}_{d:0>4}.png", .{ folder, vname, frame_1 });
+                for (0..max_slots) |si| {
+                    if (si < entries.len) {
+                        table[ci][vi][si] = std.fmt.comptimePrint("{s}/{s}_{d:0>4}.png", .{ folder, vname, entries[si].f });
                     } else {
-                        table[ci][vi][fi] = "";
+                        table[ci][vi][si] = "";
                     }
                 }
             }
+        }
+        break :blk table;
+    };
+
+    // Beat → slot table: slot j repeated `run_j` times, so a runtime
+    // `slot = beat_to_slot[clip][beat]` lookup is O(1) with no per-tick
+    // summation. Padded to `max_beats`; entries past a clip's beat_count
+    // are 0 (never read — `advanceState` mods by beat_count first).
+    const beat_to_slot: [clip_count][max_beats]u8 = blk: {
+        var table: [clip_count][max_beats]u8 = undefined;
+        for (0..clip_count) |ci| {
+            const entries = clip_entries[ci];
+            var b: usize = 0;
+            for (entries, 0..) |e, si| {
+                var r: usize = 0;
+                while (r < e.run) : (r += 1) {
+                    table[ci][b] = @intCast(si);
+                    b += 1;
+                }
+            }
+            while (b < max_beats) : (b += 1) table[ci][b] = 0;
         }
         break :blk table;
     };
@@ -140,18 +262,32 @@ pub fn AnimationDef(comptime zon: anytype) type {
         pub const variants = Variant;
         pub const clip_count_val = clip_count;
         pub const variant_count_val = variant_count;
-        pub const max_frames_val = max_frames;
+        /// Depth of the slot-keyed sprite-name table. Named `max_frames_val`
+        /// for back-compat (== max slot count).
+        pub const max_frames_val = max_slots;
+        pub const max_slots_val = max_slots;
+        pub const max_beats_val = max_beats;
 
-        /// Get metadata for a clip (frame_count, speed, mode, folder).
+        /// Get metadata for a clip (counts, speed, mode, folder).
         pub fn clipMeta(clip: Clip) ClipMeta {
             return clip_meta_table[@intFromEnum(clip)];
         }
 
-        /// Look up the precomputed sprite name for a clip/variant/frame combination.
-        /// Frame is 0-based.
+        /// Look up the precomputed sprite name for a clip/variant/SLOT.
+        /// `frame` is the slot index (0-based).
         pub fn spriteName(clip: Clip, variant: Variant, frame: u8) []const u8 {
-            if (frame >= max_frames) return "";
+            if (frame >= max_slots) return "";
             return sprite_names[@intFromEnum(clip)][@intFromEnum(variant)][frame];
+        }
+
+        /// The slot shown at a given beat of a clip (0-based beat). Beats
+        /// past the clip's `beat_count` wrap via the caller's mod; this
+        /// clamps defensively.
+        pub fn slotForBeat(clip: Clip, beat: u16) u8 {
+            const ci = @intFromEnum(clip);
+            const bc = clip_meta_table[ci].beat_count;
+            if (bc == 0) return 0;
+            return beat_to_slot[ci][beat % bc];
         }
 
         /// Get variant name string.
@@ -170,6 +306,42 @@ pub fn AnimationDef(comptime zon: anytype) type {
                 return @enumFromInt(idx);
             }
             return @enumFromInt(variant_count - 1);
+        }
+
+        /// Beat-aware advance for clips with per-slot holds. Mirrors
+        /// `AnimationState.advance` but cycles over BEATS (sum of runs)
+        /// and maps the current beat to a slot via the comptime beat
+        /// table, writing the slot into `state.frame`. `state` is
+        /// duck-typed (`.clip/.mode/.speed/.timer/.frame`) to avoid a
+        /// circular import with `animation_state.zig`.
+        ///
+        /// For count-shorthand clips (every run 1) `beat_count ==
+        /// entry_count` and this is identical to `advance`, so a game
+        /// can switch to it wholesale; only clips that declare runs
+        /// *need* it. Full advance-dedup is #667.
+        pub fn advanceState(state: anytype, dt: f32) void {
+            const ci = state.clip;
+            const meta = clip_meta_table[ci];
+            switch (meta.mode) {
+                .time => {
+                    state.timer += dt * state.speed;
+                    if (meta.beat_count > 0) {
+                        const bc: f32 = @floatFromInt(meta.beat_count);
+                        const beat: u16 = @intFromFloat(@mod(state.timer, bc));
+                        state.frame = beat_to_slot[ci][beat % meta.beat_count];
+                    }
+                },
+                .distance => {
+                    if (meta.beat_count > 0) {
+                        const bc: f32 = @floatFromInt(meta.beat_count);
+                        const beat: u16 = @intFromFloat(@mod(state.timer, bc));
+                        state.frame = beat_to_slot[ci][beat % meta.beat_count];
+                    }
+                },
+                .static => {
+                    state.frame = 0;
+                },
+            }
         }
     };
 }

--- a/src/animation_events.zig
+++ b/src/animation_events.zig
@@ -1,0 +1,114 @@
+/// Animation events (#670) — per-frame markers + clip lifecycle events,
+/// delivered through the game's buffered event bus (`game.emit`).
+///
+/// Today gameplay cannot react to "frame N of clip X was shown" without a
+/// hand-rolled timer (see `worker_animation.zig`'s combat cadence). This
+/// module defines the event payloads and the transport-agnostic scratch
+/// buffer the pure animation `advance` methods append to; the engine
+/// driver that ticks animations forwards them to `game.emit` (adding the
+/// entity, which the component methods don't know).
+///
+/// Design follows bevy_spritesheet_animation: a small event vocabulary
+/// (marker hit, clip end, loop end) carrying entity + clip + repetition
+/// context, dispatched through the native event bus rather than closures
+/// owned by the animation. Marker NAMES live in the `.zon` clip data;
+/// their HANDLERS live in the game's `hooks/` files (PaperZD's
+/// define-once/receive-everywhere).
+///
+/// ## Transient by design
+/// All event bookkeeping (pending buffers, `finished_emitted` bits,
+/// repetition counters) is runtime-only and never serialized — mirrors
+/// the existing frame/timer save policy.
+
+const std = @import("std");
+
+/// Fired when a clip-frame carrying a marker becomes current.
+/// `repetition` is the loop count at the moment it fired (saturating).
+pub fn AnimMarkerHit(comptime Entity: type) type {
+    return struct {
+        entity: Entity,
+        clip: u8,
+        frame: u8,
+        marker: []const u8,
+        repetition: u16,
+    };
+}
+
+/// Fired when a non-looping clip reaches its final frame (`AnimationState`
+/// on a `.static`/one-shot clip) or a `.once` `SpriteAnimation` finishes.
+/// Fires exactly once per play-through.
+pub fn AnimClipEnd(comptime Entity: type) type {
+    return struct {
+        entity: Entity,
+        clip: u8,
+    };
+}
+
+/// Fired at every wrap of a looping clip (and at each `.ping_pong`
+/// endpoint reversal). `repetition` is the saturating loop count.
+pub fn AnimLoopEnd(comptime Entity: type) type {
+    return struct {
+        entity: Entity,
+        clip: u8,
+        repetition: u16,
+    };
+}
+
+pub const PendingKind = enum(u8) { marker, clip_end, loop_end };
+
+/// Entity-less intermediate produced by the pure `advance` methods (which
+/// don't know the entity). The driver reads `PendingBuf.slice()` and emits
+/// the matching `Anim*` payload, filling in the entity.
+pub const PendingAnimEvent = struct {
+    kind: PendingKind,
+    clip: u8 = 0,
+    /// For `.marker`: the slot the marker sits on. Else unused.
+    frame: u8 = 0,
+    /// For `.marker`: the marker name (borrowed from comptime clip data).
+    marker: []const u8 = "",
+    /// For `.marker`/`.loop_end`: the loop count when it fired.
+    repetition: u16 = 0,
+};
+
+/// Max events one `advance` call can queue. A single tick crosses only a
+/// handful of frames in practice; a pathological dt that would exceed this
+/// is capped (the tail of markers/loop-ends is dropped) so the buffer and
+/// the traversal both stay bounded. The saturating repetition counter is
+/// still updated arithmetically across the full span, so `AnimLoopEnd`
+/// counts stay accurate even when emission is capped.
+pub const max_pending = 32;
+
+/// Fixed-capacity append buffer (inline; `std.BoundedArray` was removed in
+/// Zig 0.16). Overflow is silently capped — see `max_pending`.
+pub const PendingBuf = struct {
+    items: [max_pending]PendingAnimEvent = undefined,
+    len: u8 = 0,
+
+    /// Append if there is room; returns false when the buffer is full
+    /// (caller may use this to note a capped tick).
+    pub fn append(self: *PendingBuf, e: PendingAnimEvent) bool {
+        if (self.len >= max_pending) return false;
+        self.items[self.len] = e;
+        self.len += 1;
+        return true;
+    }
+
+    pub fn slice(self: *const PendingBuf) []const PendingAnimEvent {
+        return self.items[0..self.len];
+    }
+
+    pub fn clear(self: *PendingBuf) void {
+        self.len = 0;
+    }
+
+    pub fn isFull(self: *const PendingBuf) bool {
+        return self.len >= max_pending;
+    }
+};
+
+/// Saturating u16 add — the repetition counter never wraps (a 60fps loop
+/// of a 4-frame clip would overflow u16 in ~1.2h; saturate, don't wrap).
+pub fn satAddU16(a: u16, b: u16) u16 {
+    const sum: u32 = @as(u32, a) + @as(u32, b);
+    return if (sum > std.math.maxInt(u16)) std.math.maxInt(u16) else @intCast(sum);
+}

--- a/src/animation_state.zig
+++ b/src/animation_state.zig
@@ -35,6 +35,15 @@ pub const AnimationState = struct {
     /// Accumulated time/distance for cycling.
     timer: f32 = 0.0,
 
+    /// Last beat position processed by `advanceStateEvents` (#670). Transient
+    /// event-tracking state — never serialized; resets to 0 on transition so
+    /// a new clip never fires stale markers from the abandoned one.
+    event_pos: f32 = 0.0,
+
+    /// Saturating loop count for `AnimLoopEnd` (#670). Transient; resets on
+    /// transition.
+    repetition: u16 = 0,
+
     /// Whether the sprite should be flipped horizontally.
     flip_x: bool = false,
 
@@ -73,6 +82,9 @@ pub const AnimationState = struct {
         self.mode = mode;
         self.frame = 0;
         self.timer = 0;
+        // Reset #670 event tracking — no marker catch-up across a cut clip.
+        self.event_pos = 0;
+        self.repetition = 0;
         self.dirty = true;
     }
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -487,6 +487,7 @@ pub const AnimationDef = animation_def_mod.AnimationDef;
 pub const AnimationState = animation_state_mod.AnimationState;
 pub const AnimMode = animation_def_mod.Mode;
 pub const AnimClipMeta = animation_def_mod.ClipMeta;
+pub const AnimFrameEntry = animation_def_mod.FrameEntry;
 pub const SpriteAnimation = sprite_animation_mod.SpriteAnimation;
 pub const SpriteAnimationMode = sprite_animation_mod.AnimationMode;
 pub const spriteAnimationTick = sprite_animation_tick_mod.tick;

--- a/src/root.zig
+++ b/src/root.zig
@@ -488,6 +488,16 @@ pub const AnimationState = animation_state_mod.AnimationState;
 pub const AnimMode = animation_def_mod.Mode;
 pub const AnimClipMeta = animation_def_mod.ClipMeta;
 pub const AnimFrameEntry = animation_def_mod.FrameEntry;
+// Per-frame animation events (#670): marker/clip-end/loop-end payloads +
+// the entity-less `PendingBuf` the pure advance methods append to.
+pub const animation_events_mod = @import("animation_events.zig");
+pub const AnimMarkerHit = animation_events_mod.AnimMarkerHit;
+pub const AnimClipEnd = animation_events_mod.AnimClipEnd;
+pub const AnimLoopEnd = animation_events_mod.AnimLoopEnd;
+pub const PendingAnimEvent = animation_events_mod.PendingAnimEvent;
+pub const AnimPendingBuf = animation_events_mod.PendingBuf;
+pub const AnimEventKind = animation_events_mod.PendingKind;
+pub const anim_pending_cap = animation_events_mod.max_pending;
 pub const SpriteAnimation = sprite_animation_mod.SpriteAnimation;
 pub const SpriteAnimationMode = sprite_animation_mod.AnimationMode;
 pub const spriteAnimationTick = sprite_animation_tick_mod.tick;

--- a/src/sprite_animation.zig
+++ b/src/sprite_animation.zig
@@ -22,6 +22,7 @@
 
 const std = @import("std");
 const save_policy = @import("labelle-core").save_policy;
+const anim_events = @import("animation_events.zig");
 
 /// How the frame index advances past `frames.len - 1`.
 pub const AnimationMode = enum {
@@ -79,6 +80,14 @@ pub const SpriteAnimation = struct {
     /// Direction of travel in `.ping_pong`. Unused for `.loop` / `.once`.
     forward: bool = true,
 
+    /// #670 lifecycle-event tracking. Transient (the whole component is
+    /// `.transient`, so these reset on respawn — never serialized).
+    /// `finished_emitted` makes `.once` fire `AnimClipEnd` exactly once;
+    /// `repetition` is the saturating `.loop`-wrap / `.ping_pong`-reversal
+    /// count carried on `AnimLoopEnd`.
+    finished_emitted: bool = false,
+    repetition: u16 = 0,
+
     /// Advance the animation by `dt` seconds. Pure state machine —
     /// does not touch the entity's Sprite. The caller (a tick system
     /// that walks `view(.{SpriteAnimation, Sprite}, .{})`) decides
@@ -90,6 +99,19 @@ pub const SpriteAnimation = struct {
     /// which is the common case for single-frame animations or ticks
     /// that fall within the same frame.
     pub fn advance(self: *SpriteAnimation, dt: f32) bool {
+        return self.advanceImpl(dt, null);
+    }
+
+    /// Like `advance`, but appends lifecycle events (#670) to `out`:
+    /// `AnimClipEnd` once when a `.once` clip finishes, `AnimLoopEnd` on
+    /// each `.loop` wrap and each `.ping_pong` endpoint reversal. The
+    /// driver adds the entity and forwards `out` to `game.emit`. Props
+    /// have no per-frame markers in v1 (lifecycle only).
+    pub fn advanceEvents(self: *SpriteAnimation, dt: f32, out: *anim_events.PendingBuf) bool {
+        return self.advanceImpl(dt, out);
+    }
+
+    fn advanceImpl(self: *SpriteAnimation, dt: f32, out: ?*anim_events.PendingBuf) bool {
         // Degenerate case: empty frames or zero/negative fps. No
         // advance, no mutation. Protects against malformed data
         // (e.g. a prefab with `"frames": []`) without a compile-time
@@ -124,16 +146,31 @@ pub const SpriteAnimation = struct {
         const len_u8: u8 = @intCast(self.frames.len);
         switch (self.mode) {
             .loop => {
-                const base: u32 = self.frame;
-                self.frame = @intCast((base + steps) % self.frames.len);
+                const total: usize = @as(usize, self.frame) + steps;
+                self.frame = @intCast(total % self.frames.len);
+                if (out) |o| {
+                    // One AnimLoopEnd per boundary crossed this tick.
+                    var wraps: usize = total / self.frames.len;
+                    while (wraps > 0 and !o.isFull()) : (wraps -= 1) {
+                        self.repetition = anim_events.satAddU16(self.repetition, 1);
+                        _ = o.append(.{ .kind = .loop_end, .repetition = self.repetition });
+                    }
+                }
             },
             .once => {
-                const base: u32 = self.frame;
-                const target = base + steps;
+                const target: usize = @as(usize, self.frame) + steps;
                 self.frame = if (target >= self.frames.len)
                     len_u8 - 1
                 else
                     @intCast(target);
+                if (out) |o| {
+                    // Fire AnimClipEnd exactly once, the tick it lands on
+                    // the final frame.
+                    if (self.frame + 1 >= len_u8 and !self.finished_emitted) {
+                        self.finished_emitted = true;
+                        _ = o.append(.{ .kind = .clip_end });
+                    }
+                }
             },
             .ping_pong => {
                 // Iterate per-step so the `forward` flag preserves the
@@ -156,6 +193,7 @@ pub const SpriteAnimation = struct {
                             if (self.frame + 1 >= len_u8) {
                                 self.forward = false;
                                 self.frame -= 1;
+                                self.emitReversal(out); // #670: endpoint reversal
                             } else {
                                 self.frame += 1;
                             }
@@ -163,6 +201,7 @@ pub const SpriteAnimation = struct {
                             if (self.frame == 0) {
                                 self.forward = true;
                                 self.frame += 1;
+                                self.emitReversal(out);
                             } else {
                                 self.frame -= 1;
                             }
@@ -172,6 +211,14 @@ pub const SpriteAnimation = struct {
             },
         }
         return self.frame != old_frame;
+    }
+
+    fn emitReversal(self: *SpriteAnimation, out: ?*anim_events.PendingBuf) void {
+        if (out) |o| {
+            if (o.isFull()) return;
+            self.repetition = anim_events.satAddU16(self.repetition, 1);
+            _ = o.append(.{ .kind = .loop_end, .repetition = self.repetition });
+        }
     }
 
     /// Current frame's sprite name. Returns `null` for a degenerate

--- a/src/sprite_animation.zig
+++ b/src/sprite_animation.zig
@@ -149,9 +149,12 @@ pub const SpriteAnimation = struct {
                 const total: usize = @as(usize, self.frame) + steps;
                 self.frame = @intCast(total % self.frames.len);
                 if (out) |o| {
-                    // One AnimLoopEnd per boundary crossed this tick.
+                    // One AnimLoopEnd per boundary crossed this tick. The
+                    // repetition counter advances for EVERY wrap even when
+                    // the buffer caps emission — it must stay arithmetically
+                    // accurate across the full span.
                     var wraps: usize = total / self.frames.len;
-                    while (wraps > 0 and !o.isFull()) : (wraps -= 1) {
+                    while (wraps > 0) : (wraps -= 1) {
                         self.repetition = anim_events.satAddU16(self.repetition, 1);
                         _ = o.append(.{ .kind = .loop_end, .repetition = self.repetition });
                     }
@@ -215,7 +218,8 @@ pub const SpriteAnimation = struct {
 
     fn emitReversal(self: *SpriteAnimation, out: ?*anim_events.PendingBuf) void {
         if (out) |o| {
-            if (o.isFull()) return;
+            // Count the reversal even when the buffer is full — the
+            // repetition counter must not lag actual playback.
             self.repetition = anim_events.satAddU16(self.repetition, 1);
             _ = o.append(.{ .kind = .loop_end, .repetition = self.repetition });
         }

--- a/test/animation_def_test.zig
+++ b/test/animation_def_test.zig
@@ -140,3 +140,82 @@ test "AnimationState: advance in distance mode uses timer directly" {
     // mod(2.5, 4.0) = 2.5, frame = min(2, 3) = 2
     try testing.expectEqual(@as(u8, 2), state.frame);
 }
+
+// ── Explicit frame entries (#664) ─────────────────────────
+
+// Exercises all three `.frames` forms: bare count, explicit index list
+// (reorder + reuse), and per-slot runs (holds).
+const frames_zon = .{
+    .variants = .{"hero"},
+    .clips = .{
+        // Count shorthand — every slot runs one beat, so beat_count ==
+        // entry_count and playback is bit-identical to pre-#664.
+        .plain = .{ .frames = 4, .mode = .time, .speed = 1.0 },
+        // Explicit list — reorders and REUSES a file: slot 3 points back
+        // at file 2 (a 1-2-3-2 ping-pong).
+        .bounce = .{ .frames = .{ 1, 2, 3, 2 }, .mode = .time, .speed = 1.0 },
+        // Per-slot holds — slot 0 (file 1) shows for 2 beats, then slot 1
+        // (bare int → file 2, run 1) for 1 beat. beat_count 3, entry_count 2.
+        .hold = .{ .frames = .{ .{ .f = 1, .run = 2 }, 2 }, .mode = .time, .speed = 1.0 },
+    },
+};
+
+const FramesAnim = AnimationDef(frames_zon);
+
+test "AnimationDef: count shorthand yields unit-run beats (#664)" {
+    const m = FramesAnim.clipMeta(.plain);
+    try testing.expectEqual(@as(u8, 4), m.entry_count);
+    try testing.expectEqual(@as(u16, 4), m.beat_count);
+    // frame_count stays a back-compat alias of entry_count.
+    try testing.expectEqual(@as(u8, 4), m.frame_count);
+    // Slot i resolves to file i+1, exactly as the old count path did.
+    try testing.expectEqualStrings("plain/hero_0001.png", FramesAnim.spriteName(.plain, .hero, 0));
+    try testing.expectEqualStrings("plain/hero_0004.png", FramesAnim.spriteName(.plain, .hero, 3));
+    // Identity beat→slot mapping.
+    try testing.expectEqual(@as(u8, 0), FramesAnim.slotForBeat(.plain, 0));
+    try testing.expectEqual(@as(u8, 3), FramesAnim.slotForBeat(.plain, 3));
+}
+
+test "AnimationDef: explicit list reorders and reuses files (#664)" {
+    const m = FramesAnim.clipMeta(.bounce);
+    try testing.expectEqual(@as(u8, 4), m.entry_count);
+    try testing.expectEqual(@as(u16, 4), m.beat_count);
+    // .{ 1, 2, 3, 2 } — the name for each slot uses that slot's `f`, so
+    // slot 3 renders file 2 again (not file 4).
+    try testing.expectEqualStrings("bounce/hero_0001.png", FramesAnim.spriteName(.bounce, .hero, 0));
+    try testing.expectEqualStrings("bounce/hero_0002.png", FramesAnim.spriteName(.bounce, .hero, 1));
+    try testing.expectEqualStrings("bounce/hero_0003.png", FramesAnim.spriteName(.bounce, .hero, 2));
+    try testing.expectEqualStrings("bounce/hero_0002.png", FramesAnim.spriteName(.bounce, .hero, 3));
+}
+
+test "AnimationDef: per-slot runs expand the beat table (#664)" {
+    const m = FramesAnim.clipMeta(.hold);
+    try testing.expectEqual(@as(u8, 2), m.entry_count);
+    try testing.expectEqual(@as(u16, 3), m.beat_count);
+    // beat_to_slot == { 0, 0, 1 }: slot 0 held two beats, then slot 1.
+    try testing.expectEqual(@as(u8, 0), FramesAnim.slotForBeat(.hold, 0));
+    try testing.expectEqual(@as(u8, 0), FramesAnim.slotForBeat(.hold, 1));
+    try testing.expectEqual(@as(u8, 1), FramesAnim.slotForBeat(.hold, 2));
+    // slotForBeat wraps past beat_count.
+    try testing.expectEqual(@as(u8, 0), FramesAnim.slotForBeat(.hold, 3));
+    // The bare int 2 became slot 1 pointing at file 2.
+    try testing.expectEqualStrings("hold/hero_0001.png", FramesAnim.spriteName(.hold, .hero, 0));
+    try testing.expectEqualStrings("hold/hero_0002.png", FramesAnim.spriteName(.hold, .hero, 1));
+}
+
+test "AnimationDef: advanceState maps beats to held slots (#664)" {
+    var state = AnimationState{};
+    state.transitionFromMeta(@intFromEnum(FramesAnim.clips.hold), FramesAnim.clipMeta(.hold));
+
+    // beat_count 3, speed 1 → timer accumulates beats; the held slot 0
+    // spans beats 0 and 1, slot 1 is beat 2, then it wraps.
+    try testing.expectEqual(@as(u8, 0), state.frame);
+    FramesAnim.advanceState(&state, 0.5); // timer 0.5 → beat 0 → slot 0
+    try testing.expectEqual(@as(u8, 0), state.frame);
+    FramesAnim.advanceState(&state, 0.7); // timer 1.2 → beat 1 → slot 0 (still held)
+    try testing.expectEqual(@as(u8, 0), state.frame);
+    FramesAnim.advanceState(&state, 1.0); // timer 2.2 → beat 2 → slot 1
+    try testing.expectEqual(@as(u8, 1), state.frame);
+    FramesAnim.advanceState(&state, 1.0); // timer 3.2 → mod 3 = 0.2 → beat 0 → slot 0 (wrap)
+    try testing.expectEqual(@as(u8, 0), state.frame);
+}

--- a/test/animation_events_test.zig
+++ b/test/animation_events_test.zig
@@ -1,0 +1,169 @@
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+
+const AnimationDef = engine.AnimationDef;
+const AnimationState = engine.AnimationState;
+const SpriteAnimation = engine.SpriteAnimation;
+const PendingBuf = engine.AnimPendingBuf;
+const Kind = engine.AnimEventKind;
+
+// A clip with a marker on slot 2 (0-based), .time @ speed 1 so beats map
+// 1:1 to seconds and to slots (all runs 1 → beat_count == slot_count).
+const marker_zon = .{
+    .variants = .{"hero"},
+    .clips = .{
+        .punch = .{ .frames = .{ 1, 2, .{ .f = 3, .marker = "contact" }, 4 }, .mode = .time, .speed = 1.0 },
+        .idle = .{ .frames = 1, .mode = .static },
+    },
+};
+const Def = AnimationDef(marker_zon);
+const punch: u8 = @intFromEnum(Def.clips.punch);
+
+fn mkPunch() AnimationState {
+    const meta = Def.clipMeta(.punch);
+    return .{ .clip = punch, .frame_count = meta.frame_count, .speed = meta.speed, .mode = .time };
+}
+
+fn countKind(buf: *const PendingBuf, kind: Kind) usize {
+    var c: usize = 0;
+    for (buf.slice()) |e| {
+        if (e.kind == kind) c += 1;
+    }
+    return c;
+}
+
+// ── Marker table (comptime) ───────────────────────────────
+
+test "AnimationDef.markerAtBeat: marker sits on its slot's beat (#670)" {
+    try testing.expectEqualStrings("", Def.markerAtBeat(.punch, 0));
+    try testing.expectEqualStrings("", Def.markerAtBeat(.punch, 1));
+    try testing.expectEqualStrings("contact", Def.markerAtBeat(.punch, 2));
+    try testing.expectEqualStrings("", Def.markerAtBeat(.punch, 3));
+    // Wraps past beat_count.
+    try testing.expectEqualStrings("contact", Def.markerAtBeat(.punch, 6));
+}
+
+// ── AnimationState marker + loop-end dispatch ─────────────
+
+test "advanceStateEvents: a dt spike that skips frames still fires the marker once (#670)" {
+    var state = mkPunch();
+    var buf = PendingBuf{};
+    // dt 3.5 crosses beats 1,2,3 in one tick (no wrap: beat 4 not reached).
+    Def.advanceStateEvents(&state, 3.5, &buf);
+
+    try testing.expectEqual(@as(usize, 1), buf.len);
+    const e = buf.slice()[0];
+    try testing.expectEqual(Kind.marker, e.kind);
+    try testing.expectEqual(@as(u8, 2), e.frame); // slot 2
+    try testing.expectEqualStrings("contact", e.marker);
+    try testing.expectEqual(@as(u16, 0), e.repetition);
+    try testing.expectEqual(@as(u8, 3), state.frame); // landed on slot 3
+}
+
+test "advanceStateEvents: two skipped loops emit interleaved markers + loop-ends in order (#670)" {
+    var state = mkPunch();
+    var buf = PendingBuf{};
+    // dt 8.5 → beats 1..8: marker@2, wrap@4, marker@6, wrap@8.
+    Def.advanceStateEvents(&state, 8.5, &buf);
+
+    const evs = buf.slice();
+    try testing.expectEqual(@as(usize, 4), evs.len);
+    // Oldest first, interleaved: marker(rep0), loop(rep1), marker(rep1), loop(rep2).
+    try testing.expectEqual(Kind.marker, evs[0].kind);
+    try testing.expectEqual(@as(u16, 0), evs[0].repetition);
+    try testing.expectEqual(Kind.loop_end, evs[1].kind);
+    try testing.expectEqual(@as(u16, 1), evs[1].repetition);
+    try testing.expectEqual(Kind.marker, evs[2].kind);
+    try testing.expectEqual(@as(u16, 1), evs[2].repetition);
+    try testing.expectEqual(Kind.loop_end, evs[3].kind);
+    try testing.expectEqual(@as(u16, 2), evs[3].repetition);
+    // Authoritative loop count after two wraps.
+    try testing.expectEqual(@as(u16, 2), state.repetition);
+}
+
+test "advanceStateEvents: repetition saturates instead of wrapping (#670)" {
+    var state = mkPunch();
+    state.repetition = std.math.maxInt(u16) - 1; // 0xFFFE
+    var buf = PendingBuf{};
+    // Two wraps would push 0xFFFE + 2 = 0x10000 → must saturate at 0xFFFF.
+    Def.advanceStateEvents(&state, 8.5, &buf);
+    try testing.expectEqual(@as(u16, std.math.maxInt(u16)), state.repetition);
+}
+
+test "advanceStateEvents: transition resets tracking — no stale marker catch-up (#670)" {
+    var state = mkPunch();
+    var buf = PendingBuf{};
+    Def.advanceStateEvents(&state, 3.5, &buf); // fires the contact marker
+    try testing.expectEqual(@as(usize, 1), buf.len);
+
+    // Re-enter the clip: transition clears event_pos/timer/repetition.
+    buf.clear();
+    state.transitionFromMeta(punch, Def.clipMeta(.punch));
+    try testing.expectEqual(@as(f32, 0), state.event_pos);
+    try testing.expectEqual(@as(u16, 0), state.repetition);
+
+    // Advancing only to beat 1 must NOT replay beat 2's marker.
+    Def.advanceStateEvents(&state, 1.5, &buf);
+    try testing.expectEqual(@as(usize, 0), buf.len);
+}
+
+test "advanceStateEvents: a static clip emits nothing and holds frame 0 (#670)" {
+    const meta = Def.clipMeta(.idle);
+    var state = AnimationState{ .clip = @intFromEnum(Def.clips.idle), .frame_count = meta.frame_count, .mode = .static };
+    var buf = PendingBuf{};
+    Def.advanceStateEvents(&state, 5.0, &buf);
+    try testing.expectEqual(@as(usize, 0), buf.len);
+    try testing.expectEqual(@as(u8, 0), state.frame);
+}
+
+// ── SpriteAnimation lifecycle events (props) ──────────────
+
+test "SpriteAnimation.advanceEvents: .once fires AnimClipEnd exactly once (#670)" {
+    var sa = SpriteAnimation{ .frames = &.{ "a", "b", "c" }, .fps = 10, .mode = .once };
+    var buf = PendingBuf{};
+    _ = sa.advanceEvents(1.0, &buf); // 10 steps → clamps to last frame
+    try testing.expectEqual(@as(usize, 1), countKind(&buf, .clip_end));
+    try testing.expectEqual(@as(u8, 2), sa.frame);
+
+    buf.clear();
+    _ = sa.advanceEvents(1.0, &buf); // already finished → silent
+    try testing.expectEqual(@as(usize, 0), countKind(&buf, .clip_end));
+}
+
+test "SpriteAnimation.advanceEvents: .loop fires AnimLoopEnd once per wrap (#670)" {
+    var sa = SpriteAnimation{ .frames = &.{ "a", "b", "c", "d" }, .fps = 10, .mode = .loop };
+    var buf = PendingBuf{};
+    _ = sa.advanceEvents(0.85, &buf); // 8 steps over 4 frames → 2 wraps
+    try testing.expectEqual(@as(usize, 2), countKind(&buf, .loop_end));
+    const evs = buf.slice();
+    try testing.expectEqual(@as(u16, 1), evs[0].repetition);
+    try testing.expectEqual(@as(u16, 2), evs[1].repetition);
+}
+
+test "SpriteAnimation.advanceEvents: .ping_pong fires on each endpoint reversal (#670)" {
+    var sa = SpriteAnimation{ .frames = &.{ "a", "b", "c" }, .fps = 10, .mode = .ping_pong };
+    var buf = PendingBuf{};
+    // 5 steps from frame 0 forward: 0→1→2, peak-reverse, →1→0, trough-reverse.
+    _ = sa.advanceEvents(0.55, &buf);
+    try testing.expectEqual(@as(usize, 2), countKind(&buf, .loop_end));
+}
+
+test "SpriteAnimation.advance: the no-event overload still works unchanged (#670)" {
+    var sa = SpriteAnimation{ .frames = &.{ "a", "b" }, .fps = 10, .mode = .loop };
+    const changed = sa.advance(0.1); // 1 step
+    try testing.expect(changed);
+    try testing.expectEqual(@as(u8, 1), sa.frame);
+}
+
+// ── PendingBuf overflow safety ────────────────────────────
+
+test "PendingBuf: append caps at capacity without UB (#670)" {
+    var buf = PendingBuf{};
+    var i: usize = 0;
+    while (i < engine.anim_pending_cap + 10) : (i += 1) {
+        _ = buf.append(.{ .kind = .marker });
+    }
+    try testing.expectEqual(@as(u8, @intCast(engine.anim_pending_cap)), buf.len);
+    try testing.expect(buf.isFull());
+}

--- a/test/animation_events_test.zig
+++ b/test/animation_events_test.zig
@@ -108,6 +108,60 @@ test "advanceStateEvents: transition resets tracking — no stale marker catch-u
     try testing.expectEqual(@as(usize, 0), buf.len);
 }
 
+test "advanceStateEvents: a marker on slot 0 fires on the FIRST play-through (#670)" {
+    // Marker on the clip's entry slot — displayed the moment the clip
+    // starts. The linear traversal starts at beat 1, so without the
+    // explicit entry-beat emit this marker would only fire on wraps.
+    const zon = .{
+        .variants = .{"h"},
+        .clips = .{
+            .kick = .{ .frames = .{ .{ .f = 1, .marker = "windup" }, 2, 3 }, .mode = .time, .speed = 1.0 },
+        },
+    };
+    const D = AnimationDef(zon);
+    const meta = D.clipMeta(.kick);
+    var state = AnimationState{ .clip = 0, .frame_count = meta.frame_count, .speed = meta.speed, .mode = .time };
+    var buf = PendingBuf{};
+
+    // First advance (mid-beat): the entry marker fires once, rep 0.
+    D.advanceStateEvents(&state, 0.5, &buf);
+    try testing.expectEqual(@as(usize, 1), buf.len);
+    try testing.expectEqualStrings("windup", buf.slice()[0].marker);
+    try testing.expectEqual(@as(u16, 0), buf.slice()[0].repetition);
+
+    // Second advance, still inside the first cycle: no re-fire.
+    buf.clear();
+    D.advanceStateEvents(&state, 1.0, &buf); // timer 1.5, beat 1
+    try testing.expectEqual(@as(usize, 0), buf.len);
+
+    // Crossing the wrap fires loop_end + the entry marker again (rep 1).
+    buf.clear();
+    D.advanceStateEvents(&state, 2.0, &buf); // timer 3.5 → beats 2,3(wrap→0)
+    try testing.expectEqual(@as(usize, 2), buf.len);
+    try testing.expectEqual(@as(@TypeOf(buf.slice()[0].kind), .loop_end), buf.slice()[0].kind);
+    try testing.expectEqualStrings("windup", buf.slice()[1].marker);
+    try testing.expectEqual(@as(u16, 1), buf.slice()[1].repetition);
+}
+
+test "advanceStateEvents: transition re-arms the entry marker (#670)" {
+    const zon = .{
+        .variants = .{"h"},
+        .clips = .{ .kick = .{ .frames = .{ .{ .f = 1, .marker = "windup" }, 2 }, .mode = .time, .speed = 1.0 } },
+    };
+    const D = AnimationDef(zon);
+    const meta = D.clipMeta(.kick);
+    var state = AnimationState{ .clip = 0, .frame_count = meta.frame_count, .speed = meta.speed, .mode = .time };
+    var buf = PendingBuf{};
+    D.advanceStateEvents(&state, 0.5, &buf);
+    try testing.expectEqual(@as(usize, 1), buf.len); // fired
+
+    state.transitionFromMeta(0, meta); // re-enter the clip
+    buf.clear();
+    D.advanceStateEvents(&state, 0.5, &buf);
+    try testing.expectEqual(@as(usize, 1), buf.len); // fires again after re-entry
+    try testing.expectEqual(@as(u16, 0), buf.slice()[0].repetition);
+}
+
 test "advanceStateEvents: a static clip emits nothing and holds frame 0 (#670)" {
     const meta = Def.clipMeta(.idle);
     var state = AnimationState{ .clip = @intFromEnum(Def.clips.idle), .frame_count = meta.frame_count, .mode = .static };


### PR DESCRIPTION
Closes #670. Phase 2 of the animation epic (#673).

> **Stacked on #676 (#664 frame entries)** — markers attach to explicit frame entries, so this targets `feat/664-frame-entries`. Merge #676 first, then this retargets to `main`. The diff here is #670-only (+464 lines).

## What changed

Clips can now declare **named per-frame markers** plus built-in **lifecycle events** (loop boundary, clip end), dispatched through the buffered event bus — so gameplay reacts to "frame N of clip X was shown" instead of hand-rolling timers. The motivating case is `worker_animation.zig`'s combat cadence (`enter_combat → idle_combat` timer, punch-contact guessing).

### `src/animation_events.zig`
- `AnimMarkerHit` / `AnimClipEnd` / `AnimLoopEnd` — event payloads (generic over the game's `Entity`), carrying entity + clip + repetition context (bevy_spritesheet_animation's vocabulary).
- `PendingAnimEvent` + `PendingBuf` — an entity-less, fixed-capacity scratch buffer (inline; `std.BoundedArray` is gone in 0.16) that the **pure** advance methods append to. The engine driver adds the entity and forwards to `game.emit`. Marker NAMES live in `.zon`; HANDLERS live in `hooks/` (PaperZD's define-once/receive-everywhere).
- `satAddU16` — saturating repetition (a 60fps 4-frame loop overflows u16 in ~1.2h; saturate, never wrap).

### AnimationDef (#664)
- `FrameEntry` gains an optional `marker`: `.{ .f = 4, .marker = "contact" }`.
- A comptime **marker→beat table** maps each marked slot's FIRST beat to its name (a held slot fires once, on entry).
- `advanceStateEvents(state, dt, out)` traverses the beats crossed **this tick in linear (unwrapped) space**, so a dt spike that skips frames fires **every** skipped marker (oldest-first) and every loop boundary — never "latest only". It's a superset of #664's `advanceState`, which stays as the **no-event overload**. Per-tick work is bounded (`max_traverse`); the saturating repetition stays accurate arithmetically across the full span even if emission is capped.

### AnimationState
Two transient fields — `event_pos` (last processed beat position) and `repetition` (saturating loop count) — reset on `transition`, so a cut clip never replays the abandoned one's markers (the ticket's "no catch-up across clips").

### SpriteAnimation (props — lifecycle only in v1)
`advance` refactors to a shared `advanceImpl`; new `advanceEvents` emits `AnimClipEnd` **exactly once** when a `.once` clip lands on its final frame, `AnimLoopEnd` per `.loop` wrap, and one per `.ping_pong` endpoint reversal. New `finished_emitted`/`repetition` fields are transient (the component is `.transient`).

## Save/load
All event bookkeeping is transient — **no new serialized fields** (mirrors the existing frame/timer save policy).

## Tests (+11, full suite green)
comptime marker table · dt-spike fires a skipped marker once · two skipped loops emit **interleaved marker/loop-end in oldest-first order** · repetition saturates (0xFFFE+2 → 0xFFFF, not wrap) · transition resets tracking · static clip silent · SpriteAnimation `.once` ClipEnd-exactly-once / `.loop` per-wrap / `.ping_pong` per-reversal / no-event overload intact · PendingBuf overflow caps without UB.

## Acceptance mapping
- `.zon` clip declares a named marker; displaying that frame produces exactly one `AnimMarkerHit` → dt-spike test ✅
- dt spike fires every skipped marker in order → interleaved test ✅
- Looping clips emit `AnimLoopEnd` per wrap with accurate saturating repetition → interleaved + saturation tests ✅
- `.once` SpriteAnimation emits `AnimClipEnd` exactly once → lifecycle test ✅
- No new serialized fields ✅ · `zig build test` passes ✅

## Note on ping_pong markers
The ticket's "ping_pong marker fires on both direction passes" applies to a ping_pong **AnimationState**, but AnimationState's modes are `.time`/`.distance`/`.static` (no ping_pong — those clips loop). SpriteAnimation is the ping_pong carrier and has no markers in v1, so its reversal is covered via `AnimLoopEnd` per reversal instead. Documented.

## Deferred (per ticket)
- Forwarding pending events to `game.emit` in the animation driver tick (game.zig integration).
- The flying-platform-labelle migration of `advanceCombatClip` to ClipEnd/marker handlers — a separate game-repo ticket.

https://claude.ai/code/session_01P7YLw4hXFCCaY2LAUt4G1j