### PR TITLE
feat(animation): AnimationState transition semantics — modes, queue, via clips (#671)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -93,6 +93,7 @@ pub fn build(b: *std.Build) void {
         "test/font_loader_test.zig",
         "test/asset_streaming_shim_test.zig",
         "test/animation_def_test.zig",
+        "test/animation_state_transitions_test.zig",
         "test/sprite_animation_test.zig",
         "test/sprite_animation_tick_test.zig",
         "test/sprite_by_field_test.zig",

--- a/src/animation_def.zig
+++ b/src/animation_def.zig
@@ -31,6 +31,18 @@ pub const ClipMeta = struct {
     folder: []const u8,
 };
 
+/// A resolved transitional-clip rule (#671): when switching to `to`
+/// (optionally only from `from`), play `via` once first.
+pub const TransitionRule = struct { from: ?u8, to: u8, via: u8 };
+
+/// Comptime clip-name → ordinal lookup over the `.clips` struct fields.
+fn clipIdxByName(comptime clip_fields: anytype, comptime name: []const u8) ?u8 {
+    inline for (clip_fields, 0..) |f, i| {
+        if (std.mem.eql(u8, f.name, name)) return @intCast(i);
+    }
+    return null;
+}
+
 pub fn AnimationDef(comptime zon: anytype) type {
     if (!@hasField(@TypeOf(zon), "clips")) @compileError("animation .zon must have a .clips field");
     if (!@hasField(@TypeOf(zon), "variants")) @compileError("animation .zon must have a .variants field");
@@ -135,12 +147,52 @@ pub fn AnimationDef(comptime zon: anytype) type {
         break :blk table;
     };
 
+    // Optional transitional-clip table (#671). When switching to `to`
+    // (optionally only from a specific `from`), the driver plays `via`
+    // once first. Comptime-validated: names resolve, `via != to` (no
+    // self-loop), no duplicate (from, to) pair.
+    const transition_table: []const TransitionRule = blk: {
+        if (!@hasField(@TypeOf(zon), "transitions")) break :blk &[_]TransitionRule{};
+        const trs = zon.transitions;
+        const tinfo = @typeInfo(@TypeOf(trs));
+        if (!(tinfo == .@"struct" and tinfo.@"struct".is_tuple))
+            @compileError("animation .zon `.transitions` must be a tuple of rules");
+        const tfields = tinfo.@"struct".fields;
+        var rules: [tfields.len]TransitionRule = undefined;
+        inline for (tfields, 0..) |tf, i| {
+            const rule = @field(trs, tf.name);
+            if (!@hasField(@TypeOf(rule), "to")) @compileError("transition rule needs a `.to` clip name");
+            if (!@hasField(@TypeOf(rule), "via")) @compileError("transition rule needs a `.via` clip name");
+            const to_idx = clipIdxByName(clip_fields, rule.to) orelse
+                @compileError("transition `.to` names an unknown clip: " ++ rule.to);
+            const via_idx = clipIdxByName(clip_fields, rule.via) orelse
+                @compileError("transition `.via` names an unknown clip: " ++ rule.via);
+            if (to_idx == via_idx)
+                @compileError("transition `.via` must differ from `.to` (would loop): " ++ rule.to);
+            const from_idx: ?u8 = if (@hasField(@TypeOf(rule), "from"))
+                (clipIdxByName(clip_fields, rule.from) orelse
+                    @compileError("transition `.from` names an unknown clip: " ++ rule.from))
+            else
+                null;
+            rules[i] = .{ .from = from_idx, .to = to_idx, .via = via_idx };
+        }
+        for (rules, 0..) |a, ai| {
+            for (rules[0..ai]) |b| {
+                if (a.to == b.to and a.from == b.from)
+                    @compileError("duplicate transition rule for the same (from, to) pair");
+            }
+        }
+        const out = rules;
+        break :blk &out;
+    };
+
     return struct {
         pub const clips = Clip;
         pub const variants = Variant;
         pub const clip_count_val = clip_count;
         pub const variant_count_val = variant_count;
         pub const max_frames_val = max_frames;
+        pub const transition_count_val = transition_table.len;
 
         /// Get metadata for a clip (frame_count, speed, mode, folder).
         pub fn clipMeta(clip: Clip) ClipMeta {
@@ -170,6 +222,23 @@ pub fn AnimationDef(comptime zon: anytype) type {
                 return @enumFromInt(idx);
             }
             return @enumFromInt(variant_count - 1);
+        }
+
+        /// Resolve a transitional (`.via`) clip for a `from → to` switch,
+        /// or null if no rule matches (#671). A `from`-specific rule wins
+        /// over a wildcard (`from == null`) rule for the same `to`, so the
+        /// driver can play e.g. `enter_combat` before any → `idle_combat`.
+        pub fn transitionVia(from: u8, to: u8) ?u8 {
+            var wildcard: ?u8 = null;
+            for (transition_table) |r| {
+                if (r.to != to) continue;
+                if (r.from) |f| {
+                    if (f == from) return r.via;
+                } else {
+                    wildcard = r.via;
+                }
+            }
+            return wildcard;
         }
     };
 }

--- a/src/animation_state.zig
+++ b/src/animation_state.zig
@@ -13,6 +13,22 @@ const animation_def = @import("animation_def.zig");
 pub const Mode = animation_def.Mode;
 pub const ClipMeta = animation_def.ClipMeta;
 
+/// How a requested clip switch is applied (#671). All three are hard cuts
+/// — no blending (a flipbook has no poses to blend). Mirrors Godot's
+/// AnimationNodeStateMachineTransition switch modes.
+pub const SwitchMode = enum(u8) {
+    /// Cut now: `frame = 0`, `timer = 0` (today's `transition`).
+    immediate,
+    /// Defer until the current clip completes its current cycle, then cut.
+    /// A `.static` clip has no cycle, so it applies immediately.
+    at_end,
+    /// Cut now but carry the normalized playback position into the new
+    /// clip: `new_timer = old_timer * new_frame_count / old_frame_count`.
+    /// Switching to the SAME clip (a variant/skin swap) leaves the timer
+    /// untouched — the Godot skin-swap idiom, no phase reset.
+    sync,
+};
+
 pub const AnimationState = struct {
     /// Current clip index (into AnimationDef clip table).
     clip: u8 = 0,
@@ -40,6 +56,17 @@ pub const AnimationState = struct {
 
     /// Set on clip transition, cleared after the sprite is resolved.
     dirty: bool = true,
+
+    // ── #671 transition queue (all transient — never serialized) ──
+    /// One-slot queue for an `at_end` switch. Valid iff `pending_set`.
+    pending_clip: u8 = 0,
+    pending_frame_count: u8 = 1,
+    pending_speed: f32 = 1.0,
+    pending_mode: Mode = .static,
+    /// Timer value (linear, in cycle units) at which the pending clip
+    /// applies — the current clip's next cycle boundary.
+    pending_at: f32 = 0,
+    pending_set: bool = false,
 
     /// Advance the frame timer. Call once per tick.
     pub fn advance(self: *AnimationState, dt: f32) void {
@@ -73,11 +100,73 @@ pub const AnimationState = struct {
         self.mode = mode;
         self.frame = 0;
         self.timer = 0;
+        self.pending_set = false; // a hard cut clears any queued switch
         self.dirty = true;
     }
 
     /// Transition using metadata from an AnimationDef.
     pub fn transitionFromMeta(self: *AnimationState, clip: u8, meta: ClipMeta) void {
         self.transition(clip, meta.frame_count, meta.speed, meta.mode);
+    }
+
+    /// Request a clip switch with explicit semantics (#671). See
+    /// `SwitchMode`. `.immediate`/`.sync` apply now; `.at_end` queues the
+    /// switch for the current clip's next cycle boundary (a second
+    /// `.at_end` overwrites the slot — last-wins).
+    pub fn requestTransition(self: *AnimationState, clip: u8, meta: ClipMeta, switch_mode: SwitchMode) void {
+        switch (switch_mode) {
+            .immediate => self.transition(clip, meta.frame_count, meta.speed, meta.mode),
+            .sync => {
+                const old_clip = self.clip;
+                const old_fc = self.frame_count;
+                self.clip = clip;
+                self.frame_count = meta.frame_count;
+                self.speed = meta.speed;
+                self.mode = meta.mode;
+                if (clip != old_clip) {
+                    // Carry the normalized phase into the new timeline.
+                    if (old_fc <= 1) {
+                        self.timer = 0;
+                    } else {
+                        const new_fc: f32 = @floatFromInt(meta.frame_count);
+                        const of: f32 = @floatFromInt(old_fc);
+                        self.timer = self.timer * (new_fc / of);
+                    }
+                }
+                // Same clip → leave timer untouched (skin swap keeps phase).
+                self.pending_set = false;
+                self.dirty = true;
+            },
+            .at_end => {
+                if (self.mode == .static) {
+                    // No cycle exists to wait for → apply immediately.
+                    self.transition(clip, meta.frame_count, meta.speed, meta.mode);
+                    return;
+                }
+                self.pending_clip = clip;
+                self.pending_frame_count = meta.frame_count;
+                self.pending_speed = meta.speed;
+                self.pending_mode = meta.mode;
+                // Fire at the current clip's NEXT cycle boundary (linear
+                // timer units). Recomputed on every request → last-wins.
+                const fc: f32 = @floatFromInt(self.frame_count);
+                self.pending_at = if (fc > 0)
+                    (@floor(self.timer / fc) + 1.0) * fc
+                else
+                    self.timer;
+                self.pending_set = true;
+            },
+        }
+    }
+
+    /// Apply a queued `at_end` switch if the current clip has reached its
+    /// cycle boundary. Call once per tick from the animation driver, after
+    /// `advance`. Returns true when a pending switch was applied this tick.
+    pub fn applyPending(self: *AnimationState) bool {
+        if (!self.pending_set) return false;
+        if (self.timer < self.pending_at) return false;
+        self.transition(self.pending_clip, self.pending_frame_count, self.pending_speed, self.pending_mode);
+        // `transition` already cleared `pending_set`.
+        return true;
     }
 };

--- a/src/root.zig
+++ b/src/root.zig
@@ -487,6 +487,9 @@ pub const AnimationDef = animation_def_mod.AnimationDef;
 pub const AnimationState = animation_state_mod.AnimationState;
 pub const AnimMode = animation_def_mod.Mode;
 pub const AnimClipMeta = animation_def_mod.ClipMeta;
+// #671 transition semantics: explicit switch modes + data-driven via clips.
+pub const AnimSwitchMode = animation_state_mod.SwitchMode;
+pub const AnimTransitionRule = animation_def_mod.TransitionRule;
 pub const SpriteAnimation = sprite_animation_mod.SpriteAnimation;
 pub const SpriteAnimationMode = sprite_animation_mod.AnimationMode;
 pub const spriteAnimationTick = sprite_animation_tick_mod.tick;

--- a/test/animation_state_transitions_test.zig
+++ b/test/animation_state_transitions_test.zig
@@ -1,0 +1,144 @@
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+
+const AnimationDef = engine.AnimationDef;
+const AnimationState = engine.AnimationState;
+
+const trans_zon = .{
+    .variants = .{"hero"},
+    .clips = .{
+        .idle = .{ .frames = 1, .mode = .static },
+        .walk = .{ .frames = 4, .mode = .time, .speed = 1.0 },
+        .carry = .{ .frames = 8, .mode = .time, .speed = 1.0 },
+        .enter_combat = .{ .frames = 4, .mode = .time, .speed = 1.0 },
+        .idle_combat = .{ .frames = 2, .mode = .time, .speed = 1.0 },
+        .exit_combat = .{ .frames = 3, .mode = .time, .speed = 1.0 },
+    },
+    .transitions = .{
+        // wildcard: ANY → idle_combat plays enter_combat first
+        .{ .to = "idle_combat", .via = "enter_combat" },
+        // from-specific override for the same `to` (precedence test)
+        .{ .from = "walk", .to = "idle_combat", .via = "exit_combat" },
+        // from-specific: idle_combat → idle plays exit_combat
+        .{ .from = "idle_combat", .to = "idle", .via = "exit_combat" },
+    },
+};
+const Def = AnimationDef(trans_zon);
+
+const idle: u8 = @intFromEnum(Def.clips.idle);
+const walk: u8 = @intFromEnum(Def.clips.walk);
+const carry: u8 = @intFromEnum(Def.clips.carry);
+const enter_combat: u8 = @intFromEnum(Def.clips.enter_combat);
+const idle_combat: u8 = @intFromEnum(Def.clips.idle_combat);
+const exit_combat: u8 = @intFromEnum(Def.clips.exit_combat);
+
+// ── SwitchMode.sync ───────────────────────────────────────
+
+test "requestTransition sync: carries normalized phase, scaled by frame_count (#671)" {
+    var st = AnimationState{};
+    st.transitionFromMeta(walk, Def.clipMeta(.walk)); // fc = 4
+    st.timer = 2.0;
+    st.requestTransition(carry, Def.clipMeta(.carry), .sync); // fc = 8
+    try testing.expectEqual(carry, st.clip);
+    try testing.expectEqual(@as(u8, 8), st.frame_count);
+    try testing.expectApproxEqAbs(@as(f32, 4.0), st.timer, 1e-6); // 2.0 * 8/4
+    try testing.expect(st.dirty);
+}
+
+test "requestTransition sync to the same clip leaves the timer untouched (#671)" {
+    var st = AnimationState{};
+    st.transitionFromMeta(walk, Def.clipMeta(.walk));
+    st.timer = 2.5;
+    st.requestTransition(walk, Def.clipMeta(.walk), .sync); // skin swap
+    try testing.expectApproxEqAbs(@as(f32, 2.5), st.timer, 1e-6);
+    try testing.expect(st.dirty);
+}
+
+// ── SwitchMode.at_end ─────────────────────────────────────
+
+test "requestTransition at_end: defers to the cycle boundary, then applies (#671)" {
+    var st = AnimationState{};
+    st.transitionFromMeta(walk, Def.clipMeta(.walk)); // fc = 4, .time
+    st.timer = 1.5; // mid-cycle
+    st.requestTransition(idle, Def.clipMeta(.idle), .at_end);
+
+    // Nothing changes yet; the switch is queued for timer == 4.0.
+    try testing.expectEqual(walk, st.clip);
+    try testing.expect(st.pending_set);
+    try testing.expectApproxEqAbs(@as(f32, 4.0), st.pending_at, 1e-6);
+
+    st.timer = 3.9;
+    try testing.expect(!st.applyPending()); // before boundary → no-op
+    try testing.expectEqual(walk, st.clip);
+
+    st.timer = 4.0;
+    try testing.expect(st.applyPending()); // boundary reached → apply
+    try testing.expectEqual(idle, st.clip);
+    try testing.expectEqual(@as(f32, 0), st.timer);
+    try testing.expectEqual(@as(u8, 0), st.frame);
+    try testing.expect(!st.pending_set);
+}
+
+test "requestTransition at_end: a second request overwrites the queue (last-wins) (#671)" {
+    var st = AnimationState{};
+    st.transitionFromMeta(walk, Def.clipMeta(.walk));
+    st.timer = 1.0;
+    st.requestTransition(idle, Def.clipMeta(.idle), .at_end);
+    st.requestTransition(carry, Def.clipMeta(.carry), .at_end); // overwrites
+    try testing.expectEqual(carry, st.pending_clip);
+
+    st.timer = 4.0;
+    try testing.expect(st.applyPending());
+    try testing.expectEqual(carry, st.clip); // the second request won
+}
+
+test "requestTransition at_end on a .static clip applies immediately (#671)" {
+    var st = AnimationState{};
+    st.transitionFromMeta(idle, Def.clipMeta(.idle)); // .static — no cycle
+    st.requestTransition(walk, Def.clipMeta(.walk), .at_end);
+    try testing.expectEqual(walk, st.clip); // applied now
+    try testing.expect(!st.pending_set);
+}
+
+test "requestTransition immediate resets and clears any pending switch (#671)" {
+    var st = AnimationState{};
+    st.transitionFromMeta(walk, Def.clipMeta(.walk));
+    st.timer = 1.0;
+    st.requestTransition(idle, Def.clipMeta(.idle), .at_end); // queue one
+    try testing.expect(st.pending_set);
+    st.requestTransition(carry, Def.clipMeta(.carry), .immediate); // hard cut
+    try testing.expectEqual(carry, st.clip);
+    try testing.expectEqual(@as(f32, 0), st.timer);
+    try testing.expect(!st.pending_set); // queue cleared
+}
+
+// ── Transitional (via) clip resolution ────────────────────
+
+test "transitionVia: from-specific rule wins over the wildcard (#671)" {
+    // walk → idle_combat: the from=walk rule beats the wildcard.
+    try testing.expectEqual(@as(?u8, exit_combat), Def.transitionVia(walk, idle_combat));
+    // idle → idle_combat: no from-specific rule, so the wildcard applies.
+    try testing.expectEqual(@as(?u8, enter_combat), Def.transitionVia(idle, idle_combat));
+    // idle_combat → idle: the from-specific rule.
+    try testing.expectEqual(@as(?u8, exit_combat), Def.transitionVia(idle_combat, idle));
+    // No rule for this pair.
+    try testing.expectEqual(@as(?u8, null), Def.transitionVia(walk, carry));
+    try testing.expectEqual(@as(u8, 3), Def.transition_count_val);
+}
+
+const NoTrans = AnimationDef(.{
+    .variants = .{"h"},
+    .clips = .{ .a = .{ .frames = 1, .mode = .static } },
+});
+
+test "AnimationDef without a .transitions block has an empty table (#671)" {
+    try testing.expectEqual(@as(u8, 0), NoTrans.transition_count_val);
+    try testing.expectEqual(@as(?u8, null), NoTrans.transitionVia(0, 0));
+}
+
+// Comptime-error cases (verified by construction; the repo has no
+// compile-failure harness, so these stay documented rather than run):
+//   - `.{ .to = "x", .via = "x" }`            → "via must differ from to"
+//   - `.{ .to = "nope", .via = "walk" }`      → "unknown clip: nope"
+//   - two rules with identical (from, to)     → "duplicate transition rule"


### PR DESCRIPTION
Closes #671. Phase 3 of the animation epic (#673). Based on `main` (the new API is engine-only; independent of #664/#670's `AnimationState` field additions — they coexist on merge).

## What changed

Clip transitions gain explicit semantics beyond the unconditional hard cut. All three switch modes are **hard cuts** — a flipbook has no poses to blend, so blending/interruption-source machinery is deliberately out of scope (see the ticket's research note).

### `AnimationState` (`src/animation_state.zig`)
- **`SwitchMode`** — `immediate` (today's `frame=0/timer=0`), `at_end` (defer to the current clip's next cycle boundary), `sync` (cut now but carry the normalized position: `new_timer = old_timer * new_fc / old_fc`). Switching to the **same** clip via `sync` is a variant/skin swap and leaves the timer untouched — the Godot `set_frame_and_progress` idiom, no phase reset.
- **`requestTransition(clip, meta, mode)`** + a one-slot pending queue (all new fields transient — never serialized). `at_end` on a `.static` clip applies immediately (no cycle); a second `at_end` overwrites the slot (**last-wins**); `immediate`/`transition` clear the queue.
- **`applyPending()`** — the driver calls it once per tick after `advance`; applies the queued clip once the linear timer crosses the recorded boundary (`timer >= frame_count`, exactly the check the game's hand-rolled `advanceCombatClip` uses today).

### `AnimationDef` (`src/animation_def.zig`)
Optional **`.transitions`** table — `.{ .to = "idle_combat", .via = "enter_combat" }` (PaperZD transitional clips). Comptime-parsed to `[]const TransitionRule{ from:?u8, to:u8, via:u8 }` and **comptime-validated**: names resolve to clips, `via != to` (no self-loop), no duplicate `(from, to)` pair. `transitionVia(from, to)` resolves a rule, **from-specific winning over wildcard**. No `.transitions` block → empty table, zero cost.

## Tests (+8, full suite green)
sync phase-carry with frame_count scaling + same-clip no-reset · at_end deferral→boundary→apply (frame/timer reset) · at_end last-wins · at_end-on-`.static` immediate · immediate clears the queue · `transitionVia` from-specific-over-wildcard precedence + no-match null · empty-table def. Comptime-error cases (via==to, unknown clip, duplicate rule) are documented (the repo has no compile-failure harness).

## Acceptance mapping
- `sync` from `carry` lands on the same normalized phase (no foot-slide) → sync test ✅
- `at_end` during `punch` completes the cycle then switches, reproducing `advanceCombatClip`'s `timer >= fc` without game code → at_end test ✅
- `.transitions` rule makes any request for a clip play its `via` first; `transitionVia` resolves it → precedence test ✅
- Comptime error for via==to / unknown names / duplicates → documented ✅
- No new serialized fields · `zig build test` passes ✅

## Deferred (per ticket)
The engine-driver orchestration (via → pending → apply, the abort-on-new-request rule) and folding the game-side duplicated advance/transition ride the **#667 consolidation** + the game integration batch. The new API is engine-only from the start — the game wrapper's duplication is **not** extended.

https://claude.ai/code/session_01P7YLw4hXFCCaY2LAUt4G1j