### PR TITLE
feat(animation): per-variant clip overrides (#666)

### DIFF
--- a/src/animation_def.zig
+++ b/src/animation_def.zig
@@ -55,6 +55,9 @@ fn clipIdxByName(comptime clip_fields: anytype, comptime name: []const u8) ?usiz
 /// Reject any override field that isn't `frames`/`speed`/`mode`/`folder`
 /// — overrides may change clip content, never its identity (#666).
 fn validateOverrideFields(comptime T: type, comptime clip_name: []const u8, comptime variant_name: []const u8) void {
+    if (@typeInfo(T) != .@"struct")
+        @compileError("variant '" ++ variant_name ++ "' override for clip '" ++ clip_name ++
+            "' must be a struct like `.{ .frames = 4 }`");
     inline for (@typeInfo(T).@"struct".fields) |f| {
         const ok = std.mem.eql(u8, f.name, "frames") or
             std.mem.eql(u8, f.name, "speed") or
@@ -148,6 +151,9 @@ pub fn AnimationDef(comptime zon: anytype) type {
             const vinfo = @typeInfo(@TypeOf(velem));
             if (vinfo == .@"struct" and @hasField(@TypeOf(velem), "overrides")) {
                 const ov = velem.overrides;
+                if (@typeInfo(@TypeOf(ov)) != .@"struct")
+                    @compileError("variant '" ++ variantNameOf(velem) ++
+                        "' `.overrides` must be a struct of clip overrides");
                 inline for (@typeInfo(@TypeOf(ov)).@"struct".fields) |of| {
                     const cidx = clipIdxByName(clip_fields, of.name) orelse
                         @compileError("variant '" ++ variantNameOf(velem) ++

--- a/src/animation_def.zig
+++ b/src/animation_def.zig
@@ -165,11 +165,33 @@ pub fn AnimationDef(comptime zon: anytype) type {
         }
 
         /// Map an index to a variant, with fallback to the last variant.
+        ///
+        /// Deprecated as a *persistence* path (#665): a raw index makes
+        /// the `.variants` order load-bearing, so any reorder/rename
+        /// silently corrupts saves. Persist the variant NAME and resolve
+        /// via `variantFromName` instead. `variantFromIndex` remains only
+        /// for migrating pre-manifest saves (translate a saved index
+        /// through the save-time name manifest, then re-resolve by name).
         pub fn variantFromIndex(idx: usize) Variant {
             if (idx < variant_count) {
                 return @enumFromInt(idx);
             }
             return @enumFromInt(variant_count - 1);
+        }
+
+        /// Resolve a variant NAME to its `Variant`, or `null` when no
+        /// variant carries that name (renamed or deleted). This is the
+        /// stable-identity persistence path (#665): unlike an index, a
+        /// name survives reordering the `.variants` list. Comptime-
+        /// unrolled string compare — one branch per variant, no
+        /// allocation. Callers translate `null` into their own fallback
+        /// (e.g. variant 0 + a warning) since the engine can't know the
+        /// game's default skin.
+        pub fn variantFromName(name: []const u8) ?Variant {
+            inline for (@typeInfo(Variant).@"enum".fields) |field| {
+                if (std.mem.eql(u8, field.name, name)) return @field(Variant, field.name);
+            }
+            return null;
         }
     };
 }

--- a/src/animation_def.zig
+++ b/src/animation_def.zig
@@ -31,6 +31,40 @@ pub const ClipMeta = struct {
     folder: []const u8,
 };
 
+/// A `.variants` element is either a string (`"m_bald"`) or a struct
+/// `.{ .name = "w_ginger", .overrides = .{ ... } }` (#666). Resolve its
+/// display name either way.
+fn variantNameOf(comptime elem: anytype) []const u8 {
+    const info = @typeInfo(@TypeOf(elem));
+    if (info == .pointer) return elem; // string literal (*const [N:0]u8)
+    if (info == .@"struct") {
+        if (!@hasField(@TypeOf(elem), "name")) @compileError("variant struct needs a `.name` field");
+        return elem.name;
+    }
+    @compileError("variant must be a string or a `.{ .name, .overrides }` struct");
+}
+
+/// Comptime clip-name → ordinal lookup over the `.clips` struct fields.
+fn clipIdxByName(comptime clip_fields: anytype, comptime name: []const u8) ?usize {
+    inline for (clip_fields, 0..) |f, i| {
+        if (std.mem.eql(u8, f.name, name)) return i;
+    }
+    return null;
+}
+
+/// Reject any override field that isn't `frames`/`speed`/`mode`/`folder`
+/// — overrides may change clip content, never its identity (#666).
+fn validateOverrideFields(comptime T: type, comptime clip_name: []const u8, comptime variant_name: []const u8) void {
+    inline for (@typeInfo(T).@"struct".fields) |f| {
+        const ok = std.mem.eql(u8, f.name, "frames") or
+            std.mem.eql(u8, f.name, "speed") or
+            std.mem.eql(u8, f.name, "mode") or
+            std.mem.eql(u8, f.name, "folder");
+        if (!ok) @compileError("variant '" ++ variant_name ++ "' override for clip '" ++ clip_name ++
+            "' has unknown field '" ++ f.name ++ "' (only frames/speed/mode/folder allowed)");
+    }
+}
+
 pub fn AnimationDef(comptime zon: anytype) type {
     if (!@hasField(@TypeOf(zon), "clips")) @compileError("animation .zon must have a .clips field");
     if (!@hasField(@TypeOf(zon), "variants")) @compileError("animation .zon must have a .variants field");
@@ -58,12 +92,12 @@ pub fn AnimationDef(comptime zon: anytype) type {
 
     const Clip = @Enum(u8, .exhaustive, &ClipNames.names, &ClipNames.values);
 
-    // Build Variant enum fields
+    // Build Variant enum fields (name from a string element or its `.name`).
     const VariantNames = blk: {
         var names: [variant_count][]const u8 = undefined;
         var values: [variant_count]u8 = undefined;
-        for (0..variant_count) |i| {
-            names[i] = variant_list[i];
+        inline for (variant_list, 0..) |velem, i| {
+            names[i] = variantNameOf(velem);
             values[i] = i;
         }
         break :blk .{ .names = names, .values = values };
@@ -71,8 +105,9 @@ pub fn AnimationDef(comptime zon: anytype) type {
 
     const Variant = @Enum(u8, .exhaustive, &VariantNames.names, &VariantNames.values);
 
-    // Build ClipMeta table
-    const clip_meta_table: [clip_count]ClipMeta = blk: {
+    // Base ClipMeta per clip (variant-independent). `clipMeta(clip)`
+    // returns this row; a plain-string variant sees exactly this.
+    const clip_base_meta: [clip_count]ClipMeta = blk: {
         var table: [clip_count]ClipMeta = undefined;
         for (clip_fields, 0..) |f, i| {
             const clip_data = @field(zon.clips, f.name);
@@ -98,11 +133,47 @@ pub fn AnimationDef(comptime zon: anytype) type {
         break :blk table;
     };
 
-    // Find max frames across all clips
+    // Per-variant ClipMeta (#666): start from the base, then patch each
+    // variant's `.overrides` block. Overrides change clip CONTENT (frames/
+    // speed/mode/folder) only — never structure — so the single Clip/
+    // Variant enum pair still drives every skin (Unity Sprite Library
+    // Variant's structural-consistency rule). Comptime-validated: override
+    // keys must be existing clips; only the four content fields may appear.
+    const clip_meta_2d: [clip_count][variant_count]ClipMeta = blk: {
+        var table: [clip_count][variant_count]ClipMeta = undefined;
+        for (0..clip_count) |ci| {
+            for (0..variant_count) |vi| table[ci][vi] = clip_base_meta[ci];
+        }
+        inline for (variant_list, 0..) |velem, vi| {
+            const vinfo = @typeInfo(@TypeOf(velem));
+            if (vinfo == .@"struct" and @hasField(@TypeOf(velem), "overrides")) {
+                const ov = velem.overrides;
+                inline for (@typeInfo(@TypeOf(ov)).@"struct".fields) |of| {
+                    const cidx = clipIdxByName(clip_fields, of.name) orelse
+                        @compileError("variant '" ++ variantNameOf(velem) ++
+                        "' overrides unknown clip '" ++ of.name ++ "'");
+                    const override = @field(ov, of.name);
+                    validateOverrideFields(@TypeOf(override), of.name, variantNameOf(velem));
+                    var m = clip_base_meta[cidx];
+                    if (@hasField(@TypeOf(override), "frames")) m.frame_count = override.frames;
+                    if (@hasField(@TypeOf(override), "speed")) m.speed = override.speed;
+                    if (@hasField(@TypeOf(override), "mode")) m.mode = override.mode;
+                    if (@hasField(@TypeOf(override), "folder")) m.folder = override.folder;
+                    table[cidx][vi] = m;
+                }
+            }
+        }
+        break :blk table;
+    };
+
+    // Max frames across base AND overridden counts — the sprite-name
+    // table depth must fit the largest per-variant frame count.
     const max_frames: usize = blk: {
         var mx: usize = 1;
-        for (&clip_meta_table) |meta| {
-            if (meta.frame_count > mx) mx = meta.frame_count;
+        for (0..clip_count) |ci| {
+            for (0..variant_count) |vi| {
+                if (clip_meta_2d[ci][vi].frame_count > mx) mx = clip_meta_2d[ci][vi].frame_count;
+            }
         }
         break :blk mx;
     };
@@ -118,10 +189,11 @@ pub fn AnimationDef(comptime zon: anytype) type {
         @setEvalBranchQuota(clip_count * variant_count * max_frames * 2000);
         var table: SpriteNameTable = undefined;
         for (0..clip_count) |ci| {
-            const folder = clip_meta_table[ci].folder;
-            const fc = clip_meta_table[ci].frame_count;
             for (0..variant_count) |vi| {
-                const vname: []const u8 = variant_list[vi];
+                // Per-variant folder + frame count (honors overrides).
+                const folder = clip_meta_2d[ci][vi].folder;
+                const fc = clip_meta_2d[ci][vi].frame_count;
+                const vname: []const u8 = VariantNames.names[vi];
                 for (0..max_frames) |fi| {
                     if (fi < fc) {
                         const frame_1 = fi + 1;
@@ -142,9 +214,23 @@ pub fn AnimationDef(comptime zon: anytype) type {
         pub const variant_count_val = variant_count;
         pub const max_frames_val = max_frames;
 
-        /// Get metadata for a clip (frame_count, speed, mode, folder).
+        /// Base (variant-independent) metadata for a clip.
+        ///
+        /// Deprecated for entities with per-variant overrides (#666): a
+        /// variant that overrides this clip plays a DIFFERENT frame count/
+        /// speed/folder, and reading the base row would drive the base
+        /// count into empty sprite-name slots. Use `clipMetaFor(clip,
+        /// variant)` in `transitionClip`-style call sites; `clipMeta` stays
+        /// for callers with no overrides (it equals `clipMetaFor(clip, v)`
+        /// for every non-overriding variant).
         pub fn clipMeta(clip: Clip) ClipMeta {
-            return clip_meta_table[@intFromEnum(clip)];
+            return clip_base_meta[@intFromEnum(clip)];
+        }
+
+        /// Metadata for a clip AS SEEN BY a specific variant (#666) —
+        /// the base patched by that variant's `.overrides`, if any.
+        pub fn clipMetaFor(clip: Clip, variant: Variant) ClipMeta {
+            return clip_meta_2d[@intFromEnum(clip)][@intFromEnum(variant)];
         }
 
         /// Look up the precomputed sprite name for a clip/variant/frame combination.

--- a/test/animation_def_test.zig
+++ b/test/animation_def_test.zig
@@ -67,6 +67,22 @@ test "AnimationDef: variantFromIndex with valid and out-of-range" {
     try testing.expectEqual(TestAnim.variants.w_india, TestAnim.variantFromIndex(99));
 }
 
+test "AnimationDef: variantFromName hit, miss, round-trip (#665)" {
+    const V = TestAnim.variants;
+    // Hit — resolves each name to its variant regardless of position.
+    try testing.expectEqual(@as(?V, V.m_bald), TestAnim.variantFromName("m_bald"));
+    try testing.expectEqual(@as(?V, V.m_beard), TestAnim.variantFromName("m_beard"));
+    try testing.expectEqual(@as(?V, V.w_india), TestAnim.variantFromName("w_india"));
+    // Miss — a renamed/deleted variant resolves to null (caller falls back).
+    try testing.expectEqual(@as(?V, null), TestAnim.variantFromName("does_not_exist"));
+    try testing.expectEqual(@as(?V, null), TestAnim.variantFromName(""));
+    // Round-trip: name → variant → name is the identity for every variant.
+    inline for (.{ "m_bald", "m_beard", "w_india" }) |nm| {
+        const v = TestAnim.variantFromName(nm).?;
+        try testing.expectEqualStrings(nm, TestAnim.variantName(v));
+    }
+}
+
 test "AnimationDef: clipName and variantName" {
     try testing.expectEqualStrings("walk", TestAnim.clipName(.walk));
     try testing.expectEqualStrings("m_beard", TestAnim.variantName(.m_beard));

--- a/test/animation_def_test.zig
+++ b/test/animation_def_test.zig
@@ -156,3 +156,65 @@ test "AnimationState: advance in distance mode uses timer directly" {
     // mod(2.5, 4.0) = 2.5, frame = min(2, 3) = 2
     try testing.expectEqual(@as(u8, 2), state.frame);
 }
+
+// ── Per-variant clip overrides (#666) ─────────────────────
+
+const override_zon = .{
+    .variants = .{
+        "m_bald",
+        "m_beard",
+        .{ .name = "w_ginger", .overrides = .{
+            .drink = .{ .frames = 8, .speed = 4.0 }, // fewer frames, slower
+            .carry = .{ .folder = "take_ginger" }, // different sprite folder
+        } },
+    },
+    .clips = .{
+        .idle = .{ .frames = 1, .mode = .static },
+        .drink = .{ .frames = 10, .mode = .time, .speed = 5.0 },
+        .carry = .{ .frames = 4, .mode = .distance, .speed = 15.0, .folder = "take" },
+    },
+};
+const OverrideAnim = AnimationDef(override_zon);
+
+test "AnimationDef: mixed string/struct variants keep enum order and names (#666)" {
+    try testing.expectEqual(@as(u8, 0), @intFromEnum(OverrideAnim.variants.m_bald));
+    try testing.expectEqual(@as(u8, 1), @intFromEnum(OverrideAnim.variants.m_beard));
+    try testing.expectEqual(@as(u8, 2), @intFromEnum(OverrideAnim.variants.w_ginger));
+    try testing.expectEqualStrings("w_ginger", OverrideAnim.variantName(.w_ginger));
+    // #665 name resolution still works for a struct-declared variant.
+    const V = OverrideAnim.variants;
+    try testing.expectEqual(@as(?V, V.w_ginger), OverrideAnim.variantFromName("w_ginger"));
+}
+
+test "AnimationDef: clipMetaFor patches overridden variants, base for others (#666)" {
+    // Base row (what clipMeta and non-overriding variants see).
+    const base = OverrideAnim.clipMeta(.drink);
+    try testing.expectEqual(@as(u8, 10), base.frame_count);
+    try testing.expectEqual(@as(f32, 5.0), base.speed);
+    try testing.expectEqual(@as(u8, 10), OverrideAnim.clipMetaFor(.drink, .m_bald).frame_count);
+
+    // w_ginger overrides drink: 8 frames @ speed 4.
+    const ginger = OverrideAnim.clipMetaFor(.drink, .w_ginger);
+    try testing.expectEqual(@as(u8, 8), ginger.frame_count);
+    try testing.expectEqual(@as(f32, 4.0), ginger.speed);
+
+    // A clip w_ginger does NOT override inherits the base.
+    try testing.expectEqual(@as(u8, 1), OverrideAnim.clipMetaFor(.idle, .w_ginger).frame_count);
+}
+
+test "AnimationDef: spriteName honors overridden folder and frame count (#666)" {
+    // carry base folder is "take"; w_ginger overrides it to "take_ginger".
+    try testing.expectEqualStrings("take/m_bald_0001.png", OverrideAnim.spriteName(.carry, .m_bald, 0));
+    try testing.expectEqualStrings("take_ginger/w_ginger_0001.png", OverrideAnim.spriteName(.carry, .w_ginger, 0));
+
+    // drink base has 10 frames (m_bald frame 9 valid); w_ginger has 8.
+    try testing.expectEqualStrings("drink/m_bald_0010.png", OverrideAnim.spriteName(.drink, .m_bald, 9));
+    try testing.expectEqualStrings("drink/w_ginger_0008.png", OverrideAnim.spriteName(.drink, .w_ginger, 7));
+    // Beyond the override's frame count → empty (even though < base max).
+    try testing.expectEqualStrings("", OverrideAnim.spriteName(.drink, .w_ginger, 8));
+}
+
+// Comptime-error cases (verified by construction; the repo has no
+// compile-failure harness, so these stay documented rather than run):
+//   - override key naming a nonexistent clip → "overrides unknown clip '…'"
+//   - override field other than frames/speed/mode/folder → "unknown field '…'"


### PR DESCRIPTION
Closes #666. Phase 3 of the animation epic (#673).

> **Stacked on #675 (#665 variant-by-name)** — overrides require name-based variant identity (variants become structs), so this targets `feat/665-variant-by-name`. Merge #675 first, then this retargets to `main`. Overrides use the count `.frames = N` form (this branch is off #665, not #664); reconciling with #664's entry forms is a follow-up.

## What changed

A `.variants` element can now be a **struct with an optional per-clip `.overrides` block**, so one skin changes a clip's *content* (frames / speed / mode / folder) while inheriting everything else:

```zig
.variants = .{
    "m_bald",
    .{ .name = "w_ginger", .overrides = .{
        .drink = .{ .frames = 8, .speed = 4.0 },  // fewer frames, slower
        .carry = .{ .folder = "take_ginger" },    // different folder
    } },
},
```

Overrides never change clip **structure** — no adding/removing/renaming clips per variant — so the single Clip/Variant enum pair still drives every skin (Unity Sprite Library Variant's structural-consistency rule; clips keyed on names stay valid for all skins).

## Implementation (`src/animation_def.zig`, all comptime)
- Variant names resolve from a string element *or* its `.name`; enum order preserved (a plain string == an empty-override struct).
- The single `clip_meta_table` splits into `clip_base_meta[clip]` (variant-independent base) and `clip_meta_2d[clip][variant]` (base, then patched per override).
- `max_frames` now spans base **and** overridden counts; the sprite-name table generates each `[clip][variant]` row from `clip_meta_2d`, so an overridden folder/frame count resolves correctly and slots past a variant's (smaller) count read empty.
- New **`clipMetaFor(clip, variant)`**; `clipMeta(clip)` still returns the base row (a deprecation note steers override-aware call sites — e.g. game `transitionClip` — to `clipMetaFor`).
- Comptime `@compileError` for an override key not naming an existing clip, or a field other than frames/speed/mode/folder — each message names the bad key + variant.

## Tests (+3 in `animation_def_test`, 16 total, full suite green)
mixed string/struct variants keep enum order + names (and #665 `variantFromName` still resolves a struct variant) · `clipMetaFor` patches the overriding variant, base for others · `spriteName` honors an overridden folder + frame count, slots past the override's count empty. Comptime-error cases documented (no compile-failure harness in the repo).

## Acceptance mapping
- Override one clip's frame count/speed/folder without duplicating the def; non-overridden clips inherit → clipMetaFor test ✅
- `spriteName(clip, overridden_variant, frame)` built from the override's folder/frames → spriteName test ✅
- Structural violations (unknown clip key, bad field) are comptime errors with actionable messages → documented ✅
- All existing defs compile unchanged; `zig build test` passes ✅

## Deferred (per ticket)
The one behavioral trap — game-side `transitionClip` switching from `clipMeta` to `clipMetaFor` — lands with the game integration batch (grep both repos for `clipMeta(`). Cross-file inheritance stays a possible follow-up.

https://claude.ai/code/session_01P7YLw4hXFCCaY2LAUt4G1j