### PR TITLE
feat(animation): enum-tolerant beat/event APIs + duck-typed transition queue (#686)

### DIFF
--- a/src/animation_def.zig
+++ b/src/animation_def.zig
@@ -156,6 +156,14 @@ fn validateOverrideFields(comptime T: type, comptime clip_name: []const u8, comp
     }
 }
 
+/// Clip index of a duck-typed state: game wrappers carry a typed `Clip`
+/// enum where the engine component carries a `u8` — accept both (#686),
+/// so `advanceState`/`advanceStateEvents` drop into either.
+fn clipIndexOf(state: anytype) u8 {
+    const T = @TypeOf(state.clip);
+    return if (@typeInfo(T) == .@"enum") @intFromEnum(state.clip) else state.clip;
+}
+
 pub fn AnimationDef(comptime zon: anytype) type {
     if (!@hasField(@TypeOf(zon), "clips")) @compileError("animation .zon must have a .clips field");
     if (!@hasField(@TypeOf(zon), "variants")) @compileError("animation .zon must have a .variants field");
@@ -529,7 +537,7 @@ pub fn AnimationDef(comptime zon: anytype) type {
         /// can switch to it wholesale; only clips that declare runs
         /// *need* it. Full advance-dedup is #667.
         pub fn advanceState(state: anytype, dt: f32) void {
-            const ci = state.clip;
+            const ci = clipIndexOf(state);
             const meta = clip_meta_table[ci];
             switch (meta.mode) {
                 .time => {
@@ -593,7 +601,7 @@ pub fn AnimationDef(comptime zon: anytype) type {
         /// `advanceState` reads. The driver adds the entity and forwards
         /// `out` to `game.emit`.
         pub fn advanceStateEvents(state: anytype, dt: f32, out: *anim_events.PendingBuf) void {
-            const ci = state.clip;
+            const ci = clipIndexOf(state);
             const meta = clip_meta_table[ci];
             if (meta.mode == .static) {
                 state.frame = 0;

--- a/src/animation_state.zig
+++ b/src/animation_state.zig
@@ -85,17 +85,7 @@ pub const AnimationState = struct {
 
     /// Reset timer and frame for a new clip transition.
     pub fn transition(self: *AnimationState, clip: u8, frame_count: u8, speed: f32, mode: Mode) void {
-        self.clip = clip;
-        self.frame_count = frame_count;
-        self.speed = speed;
-        self.mode = mode;
-        self.frame = 0;
-        self.timer = 0;
-        self.pending_set = false; // a hard cut clears any queued switch
-        // Reset #670 event tracking — no marker catch-up across a cut clip.
-        self.event_pos = 0;
-        self.repetition = 0;
-        self.dirty = true;
+        transitionAny(self, clip, frame_count, speed, mode);
     }
 
     /// Transition using metadata from an AnimationDef.
@@ -108,60 +98,14 @@ pub const AnimationState = struct {
     /// switch for the current clip's next cycle boundary (a second
     /// `.at_end` overwrites the slot — last-wins).
     pub fn requestTransition(self: *AnimationState, clip: u8, meta: ClipMeta, switch_mode: SwitchMode) void {
-        switch (switch_mode) {
-            .immediate => self.transition(clip, meta.frame_count, meta.speed, meta.mode),
-            .sync => {
-                const old_clip = self.clip;
-                const old_fc = self.frame_count;
-                self.clip = clip;
-                self.frame_count = meta.frame_count;
-                self.speed = meta.speed;
-                self.mode = meta.mode;
-                if (clip != old_clip) {
-                    // Carry the normalized phase into the new timeline.
-                    if (old_fc <= 1) {
-                        self.timer = 0;
-                    } else {
-                        const new_fc: f32 = @floatFromInt(meta.frame_count);
-                        const of: f32 = @floatFromInt(old_fc);
-                        self.timer = self.timer * (new_fc / of);
-                    }
-                }
-                // Same clip → leave timer untouched (skin swap keeps phase).
-                self.pending_set = false;
-                self.dirty = true;
-            },
-            .at_end => {
-                if (self.mode == .static) {
-                    // No cycle exists to wait for → apply immediately.
-                    self.transition(clip, meta.frame_count, meta.speed, meta.mode);
-                    return;
-                }
-                self.pending_clip = clip;
-                self.pending_frame_count = meta.frame_count;
-                self.pending_speed = meta.speed;
-                self.pending_mode = meta.mode;
-                // Fire at the current clip's NEXT cycle boundary (linear
-                // timer units). Recomputed on every request → last-wins.
-                const fc: f32 = @floatFromInt(self.frame_count);
-                self.pending_at = if (fc > 0)
-                    (@floor(self.timer / fc) + 1.0) * fc
-                else
-                    self.timer;
-                self.pending_set = true;
-            },
-        }
+        requestTransitionAny(self, clip, meta, switch_mode);
     }
 
     /// Apply a queued `at_end` switch if the current clip has reached its
     /// cycle boundary. Call once per tick from the animation driver, after
     /// `advance`. Returns true when a pending switch was applied this tick.
     pub fn applyPending(self: *AnimationState) bool {
-        if (!self.pending_set) return false;
-        if (self.timer < self.pending_at) return false;
-        self.transition(self.pending_clip, self.pending_frame_count, self.pending_speed, self.pending_mode);
-        // `transition` already cleared `pending_set`.
-        return true;
+        return applyPendingAny(self);
     }
 };
 
@@ -187,4 +131,90 @@ pub fn advanceAny(state: anytype, dt: f32) void {
         const cycle = @mod(state.timer, fc);
         state.frame = @min(@as(u8, @intFromFloat(cycle)), state.frame_count - 1);
     }
+}
+
+
+/// Duck-typed hard-cut transition (#686): sets the core clip fields on
+/// any state-shaped struct — the wrapper's `clip` may be a typed enum
+/// (the engine component's is `u8`; both type-check at instantiation).
+/// The #670 event fields and the #671 queue are reset only when the
+/// struct HAS them, so minimal wrappers work unchanged.
+pub fn transitionAny(state: anytype, clip: anytype, frame_count: u8, speed: f32, mode: Mode) void {
+    const S = @TypeOf(state.*);
+    state.clip = clip;
+    state.frame_count = frame_count;
+    state.speed = speed;
+    state.mode = mode;
+    state.frame = 0;
+    state.timer = 0;
+    // A hard cut clears any queued switch.
+    if (@hasField(S, "pending_set")) state.pending_set = false;
+    // Reset #670 event tracking — no marker catch-up across a cut clip.
+    if (@hasField(S, "event_pos")) state.event_pos = 0;
+    if (@hasField(S, "repetition")) state.repetition = 0;
+    state.dirty = true;
+}
+
+/// Duck-typed `requestTransition` (#671 semantics, #686 wrapper drop-in).
+/// `.immediate`/`.sync` need only the core fields; `.at_end` additionally
+/// requires the queue fields (`pending_clip` of the same type as `clip`,
+/// `pending_frame_count`, `pending_speed`, `pending_mode`, `pending_at`,
+/// `pending_set`) — using it without them is a compile error, which is
+/// the correct failure mode.
+pub fn requestTransitionAny(state: anytype, clip: anytype, meta: ClipMeta, switch_mode: SwitchMode) void {
+    const S = @TypeOf(state.*);
+    switch (switch_mode) {
+        .immediate => transitionAny(state, clip, meta.frame_count, meta.speed, meta.mode),
+        .sync => {
+            const old_clip = state.clip;
+            const old_fc = state.frame_count;
+            state.clip = clip;
+            state.frame_count = meta.frame_count;
+            state.speed = meta.speed;
+            state.mode = meta.mode;
+            if (clip != old_clip) {
+                // Carry the normalized phase into the new timeline.
+                if (old_fc <= 1) {
+                    state.timer = 0;
+                } else {
+                    const new_fc: f32 = @floatFromInt(meta.frame_count);
+                    const of: f32 = @floatFromInt(old_fc);
+                    state.timer = state.timer * (new_fc / of);
+                }
+            }
+            // Same clip → leave timer untouched (skin swap keeps phase).
+            if (@hasField(S, "pending_set")) state.pending_set = false;
+            state.dirty = true;
+        },
+        .at_end => {
+            if (state.mode == .static) {
+                // No cycle exists to wait for → apply immediately.
+                transitionAny(state, clip, meta.frame_count, meta.speed, meta.mode);
+                return;
+            }
+            state.pending_clip = clip;
+            state.pending_frame_count = meta.frame_count;
+            state.pending_speed = meta.speed;
+            state.pending_mode = meta.mode;
+            // Fire at the current clip's NEXT cycle boundary (linear
+            // timer units). Recomputed on every request → last-wins.
+            const fc: f32 = @floatFromInt(state.frame_count);
+            state.pending_at = if (fc > 0)
+                (@floor(state.timer / fc) + 1.0) * fc
+            else
+                state.timer;
+            state.pending_set = true;
+        },
+    }
+}
+
+/// Duck-typed `applyPending` (#686): apply a queued `at_end` switch once
+/// the linear timer crosses the recorded boundary. Call once per tick
+/// after the advance. Returns true when the switch applied.
+pub fn applyPendingAny(state: anytype) bool {
+    if (!state.pending_set) return false;
+    if (state.timer < state.pending_at) return false;
+    transitionAny(state, state.pending_clip, state.pending_frame_count, state.pending_speed, state.pending_mode);
+    // `transitionAny` already cleared `pending_set`.
+    return true;
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -491,6 +491,11 @@ pub const BoundaryMode = anim_timing_mod.BoundaryMode;
 pub const AnimationDef = animation_def_mod.AnimationDef;
 pub const AnimationState = animation_state_mod.AnimationState;
 pub const advanceAny = animation_state_mod.advanceAny;
+// #686: duck-typed transition/queue — game wrappers with typed Clip
+// enums drop in without copying engine logic.
+pub const transitionAny = animation_state_mod.transitionAny;
+pub const requestTransitionAny = animation_state_mod.requestTransitionAny;
+pub const applyPendingAny = animation_state_mod.applyPendingAny;
 pub const AnimMode = animation_def_mod.Mode; // deprecated alias of AdvanceMode
 pub const AnimClipMeta = animation_def_mod.ClipMeta;
 // #671 transition semantics: explicit switch modes + data-driven via clips.

--- a/test/animation_state_transitions_test.zig
+++ b/test/animation_state_transitions_test.zig
@@ -142,3 +142,79 @@ test "AnimationDef without a .transitions block has an empty table (#671)" {
 //   - `.{ .to = "x", .via = "x" }`            → "via must differ from to"
 //   - `.{ .to = "nope", .via = "walk" }`      → "unknown clip: nope"
 //   - two rules with identical (from, to)     → "duplicate transition rule"
+
+// ── #686: game-wrapper drop-in (typed Clip enum, not u8) ──
+
+// Mirrors flying-platform's components/animation_state.zig: a wrapper
+// carrying typed enums plus the #670 event and #671 queue fields.
+const WClip = enum(u8) { idle, walk, enter_combat, idle_combat };
+const WrapperState = struct {
+    clip: WClip = .idle,
+    variant: u8 = 0,
+    frame_count: u8 = 1,
+    speed: f32 = 1.0,
+    mode: engine.AnimMode = .static,
+    frame: u8 = 0,
+    timer: f32 = 0,
+    event_pos: f32 = 0,
+    repetition: u16 = 0,
+    dirty: bool = true,
+    pending_clip: WClip = .idle,
+    pending_frame_count: u8 = 1,
+    pending_speed: f32 = 1.0,
+    pending_mode: engine.AnimMode = .static,
+    pending_at: f32 = 0,
+    pending_set: bool = false,
+};
+
+test "requestTransitionAny/applyPendingAny drive a typed-enum wrapper (#686)" {
+    var st = WrapperState{};
+    // enter combat: hard cut, then queue idle_combat for the cycle end.
+    engine.transitionAny(&st, WClip.enter_combat, 4, 1.0, .time);
+    engine.requestTransitionAny(&st, WClip.idle_combat, Def.clipMeta(.idle_combat), .at_end);
+    try testing.expectEqual(WClip.enter_combat, st.clip);
+    try testing.expect(st.pending_set);
+
+    st.timer = 3.9;
+    try testing.expect(!engine.applyPendingAny(&st));
+    st.timer = 4.0;
+    try testing.expect(engine.applyPendingAny(&st)); // boundary → cut
+    try testing.expectEqual(WClip.idle_combat, st.clip);
+    try testing.expectEqual(@as(u8, 2), st.frame_count); // idle_combat meta
+    try testing.expect(!st.pending_set);
+}
+
+test "advanceState/advanceStateEvents accept a typed-enum clip (#686)" {
+    // The marker def's punch clip is index 0 in its own enum — build a
+    // wrapper whose clip enum ORDINALS match the def's clip ordinals.
+    const MClip = enum(u8) { punch, idle };
+    var st = struct {
+        clip: MClip = .punch,
+        frame_count: u8 = 4,
+        speed: f32 = 1.0,
+        mode: engine.AnimMode = .time,
+        frame: u8 = 0,
+        timer: f32 = 0,
+        event_pos: f32 = 0,
+        repetition: u16 = 0,
+        dirty: bool = true,
+    }{};
+    const MDef = AnimationDef(.{
+        .variants = .{"h"},
+        .clips = .{
+            .punch = .{ .frames = .{ 1, 2, .{ .f = 3, .marker = "contact" }, 4 }, .mode = .time, .speed = 1.0 },
+            .idle = .{ .frames = 1, .mode = .static },
+        },
+    });
+    var buf = engine.AnimPendingBuf{};
+    MDef.advanceStateEvents(&st, 3.5, &buf); // crosses the marked beat
+    try testing.expectEqual(@as(u8, 3), st.frame);
+    try testing.expectEqual(@as(usize, 1), buf.len);
+    try testing.expectEqualStrings("contact", buf.slice()[0].marker);
+
+    // advanceState too (no events).
+    st.timer = 0;
+    st.frame = 0;
+    MDef.advanceState(&st, 1.5);
+    try testing.expectEqual(@as(u8, 1), st.frame);
+}


### PR DESCRIPTION
Closes #686. Unblocks the FP combat-cadence migration (deferred from Flying-Platform/flying-platform-labelle#596).

- `advanceState`/`advanceStateEvents` coerce the duck-typed state's clip (`clipIndexOf`: enum → `@intFromEnum`, int passes through) — a game wrapper's typed `Clip` enum now drops in.
- The #671 transition/queue logic extracts into free duck-typed fns `transitionAny`/`requestTransitionAny`/`applyPendingAny` (the `advanceAny` pattern); the `AnimationState` methods delegate. Wrapper enums flow through their own `pending_clip`; event/queue resets are `@hasField`-guarded so minimal wrappers stay valid; `.at_end` without queue fields is a compile error — the correct failure mode.

Behavior identical for the engine component (existing transition/event tests unchanged). **+2 tests**: typed-enum wrapper through `transitionAny → requestTransitionAny(.at_end) → applyPendingAny`, and `advanceState`/`advanceStateEvents` firing a marker on a typed-enum state. Full suite green.

https://claude.ai/code/session_01P7YLw4hXFCCaY2LAUt4G1j