### PR TITLE
feat(editor_api): editor_load_animation_def — hot-push runtime animation defs (contract v1.2)

### DIFF
--- a/src/animation_def_runtime.zig
+++ b/src/animation_def_runtime.zig
@@ -359,14 +359,24 @@ pub const AnimDefSource = union(enum) {
 /// re-resolves. `state` is duck-typed (reads/writes `.clip/.variant/
 /// .frame/.frame_count/.speed/.mode/.dirty`) to dodge the
 /// animation_state ↔ animation_def import cycle.
+///
+/// `.clip`/`.variant` may be plain `u8` (the engine `AnimationState`) OR
+/// enums (game-typed wrappers like FP's, whose `Clip`/`Variant` come from
+/// the comptime `AnimationDef`). Enum writes only ever happen on a
+/// SHRINKING clamp — the new value `count - 1` is strictly below the old
+/// (in-range) value, so `@enumFromInt` can never manufacture a tag the
+/// enum doesn't have, even when the runtime def has MORE entries than the
+/// comptime enum (a grown def leaves the fields untouched).
 pub fn refreshState(state: anytype, def: *const RuntimeAnimationDef) void {
     const clip_count = def.clip_meta.len;
     if (clip_count == 0) return;
-    if (state.clip >= clip_count) state.clip = @intCast(clip_count - 1);
-    if (def.variant_names.len > 0 and state.variant >= def.variant_names.len) {
-        state.variant = @intCast(def.variant_names.len - 1);
+    if (rawIndex(state.clip) >= clip_count) {
+        setIndex(&state.clip, @intCast(clip_count - 1));
     }
-    const meta = def.clip_meta[state.clip];
+    if (def.variant_names.len > 0 and rawIndex(state.variant) >= def.variant_names.len) {
+        setIndex(&state.variant, @intCast(def.variant_names.len - 1));
+    }
+    const meta = def.clip_meta[rawIndex(state.clip)];
     state.frame_count = meta.frame_count;
     state.speed = meta.speed;
     state.mode = meta.mode;
@@ -374,6 +384,29 @@ pub fn refreshState(state: anytype, def: *const RuntimeAnimationDef) void {
         state.frame = meta.frame_count - 1;
     }
     state.dirty = true;
+}
+
+/// Read a clip/variant index field as its raw `u8` regardless of whether
+/// the game types it as an int or an enum.
+fn rawIndex(v: anytype) u8 {
+    return switch (@typeInfo(@TypeOf(v))) {
+        .int => @intCast(v),
+        .@"enum" => @intCast(@intFromEnum(v)),
+        else => @compileError("animation clip/variant fields must be u8 or enum, got " ++
+            @typeName(@TypeOf(v))),
+    };
+}
+
+/// Write a clamped index back into an int- or enum-typed field. Callers
+/// guarantee `idx` is below the field's current (valid) value — see
+/// `refreshState`'s shrink-only invariant.
+fn setIndex(ptr: anytype, idx: u8) void {
+    const T = @typeInfo(@TypeOf(ptr)).pointer.child;
+    ptr.* = switch (@typeInfo(T)) {
+        .int => idx,
+        .@"enum" => @enumFromInt(idx),
+        else => unreachable, // rawIndex already rejected other types
+    };
 }
 
 /// Owns the live def plus at most one prior generation, and tracks the
@@ -444,5 +477,94 @@ pub const ReloadWatcher = struct {
         if (self.previous) |*p| p.deinit();
         self.current.deinit();
         self.* = undefined;
+    }
+};
+
+// ── Named runtime-def store (editor hot-reload) ───────────────
+
+/// Runtime animation-def store for a running game — the map behind
+/// `Game.loadAnimationDefSource` / `editor_api.editor_load_animation_def`.
+/// Keys are def NAMES (the `.zon` stem, `"worker"` for
+/// `animations/worker.zon`); values are the latest parsed generation.
+///
+/// **Replaced generations are RETIRED, not freed.** A def's sprite-name
+/// slices may be held by live `Sprite.sprite_name` fields, and game code
+/// may hold `get()` borrows across frames; unlike `ReloadWatcher`'s
+/// host-loop protocol there is no "everyone re-resolved by end-of-frame"
+/// guarantee here — the editor can push while the sim is PAUSED
+/// (`editor_pause`), when no tick will re-resolve anything for an
+/// arbitrary number of rendered frames. Retired generations go to a
+/// graveyard freed only in `deinit`: each is a few KB of name strings and
+/// the count is bounded by editor saves per session, which buys zero
+/// use-after-free risk for a negligible ceiling. Release builds never
+/// construct one of these (the surface is only reached via `editor_api`
+/// / explicit host calls), so shipped games pay nothing.
+pub const RuntimeAnimDefs = struct {
+    allocator: std.mem.Allocator,
+    /// name → live generation. Keys are owned dupes; values are
+    /// heap-boxed so `get()` borrows stay pointer-stable across `put`s
+    /// of OTHER names (StringHashMap moves values on rehash).
+    map: std.StringHashMap(*RuntimeAnimationDef),
+    /// Retired generations, kept alive until `deinit` (see above).
+    graveyard: std.ArrayList(*RuntimeAnimationDef) = .empty,
+
+    pub fn init(allocator: std.mem.Allocator) RuntimeAnimDefs {
+        return .{
+            .allocator = allocator,
+            .map = std.StringHashMap(*RuntimeAnimationDef).init(allocator),
+        };
+    }
+
+    pub fn deinit(self: *RuntimeAnimDefs) void {
+        var it = self.map.iterator();
+        while (it.next()) |entry| {
+            self.allocator.free(entry.key_ptr.*);
+            entry.value_ptr.*.deinit();
+            self.allocator.destroy(entry.value_ptr.*);
+        }
+        self.map.deinit();
+        for (self.graveyard.items) |old| {
+            old.deinit();
+            self.allocator.destroy(old);
+        }
+        self.graveyard.deinit(self.allocator);
+        self.* = undefined;
+    }
+
+    /// Install `def` as the live generation for `name`, retiring any
+    /// previous one to the graveyard. Takes ownership of `def` on
+    /// success; on error (OOM) ownership stays with the caller and the
+    /// store is unchanged.
+    pub fn put(self: *RuntimeAnimDefs, name: []const u8, def: RuntimeAnimationDef) !void {
+        // Reserve the graveyard slot BEFORE any mutation so a failed
+        // append can never strand the outgoing generation.
+        try self.graveyard.ensureUnusedCapacity(self.allocator, 1);
+        const boxed = try self.allocator.create(RuntimeAnimationDef);
+        errdefer self.allocator.destroy(boxed);
+        const gop = try self.map.getOrPut(name);
+        if (gop.found_existing) {
+            self.graveyard.appendAssumeCapacity(gop.value_ptr.*);
+        } else {
+            gop.key_ptr.* = self.allocator.dupe(u8, name) catch |err| {
+                // Undo the half-inserted entry (its key is still the
+                // caller's transient slice) before propagating.
+                self.map.removeByPtr(gop.key_ptr);
+                return err;
+            };
+        }
+        boxed.* = def;
+        gop.value_ptr.* = boxed;
+    }
+
+    /// The live generation for `name`, or null when nothing was pushed.
+    /// The borrow stays valid for the store's lifetime (generations are
+    /// never freed before `deinit` — see the graveyard note).
+    pub fn get(self: *const RuntimeAnimDefs, name: []const u8) ?*const RuntimeAnimationDef {
+        return self.map.get(name);
+    }
+
+    /// Number of def names currently overridden.
+    pub fn count(self: *const RuntimeAnimDefs) usize {
+        return self.map.count();
     }
 };

--- a/src/editor_api.zig
+++ b/src/editor_api.zig
@@ -69,6 +69,7 @@ const VTable = struct {
     set_scene: *const fn (name: []const u8) i32,
     load_scene: *const fn (name: []const u8, src: []const u8) i32,
     set_state: *const fn (name: []const u8) i32,
+    load_animation_def: *const fn (name: []const u8, src: []const u8) i32,
     set_entity_position: *const fn (id: u64, x: f32, y: f32) void,
     scene_digest: *const fn (out: []u8) usize,
     apply_camera: *const fn (x: f32, y: f32, zoom: f32) void,
@@ -209,6 +210,26 @@ pub export fn editor_set_state(name: [*]const u8, len: usize) i32 {
     return vt.set_state(name[0..len]);
 }
 
+/// Push a `.zon` animation-def SOURCE into the running game (contract
+/// v1.2, labelle-studio issue #24 — the animation analog of
+/// `editor_load_scene`). `name` is the def's stem (`"worker"` for
+/// `animations/worker.zon`); `src` is the full ZON source. On success
+/// the def is parsed (`RuntimeAnimationDef.load`), installed as the
+/// runtime override consulted by `Game.runtimeAnimDef`, and every live
+/// component that opted in via `anim_def_name` is `refreshState`-ed
+/// (stale speed/frame-count copies re-read, indices clamped, `dirty`
+/// set) — see `game/animation_runtime_mixin.zig`.
+///
+/// Returns 0 = ok; -1 = not bound / empty name; -2 = parse/validation
+/// failure; -3 = out of memory. On ANY nonzero return the running game
+/// is untouched — the previous override (or the comptime table) stays
+/// live, so a half-saved file never corrupts the preview. The buffers
+/// are copied; the caller may free them right after the call.
+pub export fn editor_load_animation_def(name: [*]const u8, nlen: usize, src: [*]const u8, slen: usize) i32 {
+    const vt = vtable orelse return -1;
+    return vt.load_animation_def(name[0..nlen], src[0..slen]);
+}
+
 /// Move entity `id` to world coordinates (x, y). Marks the position
 /// dirty so the render pipeline re-syncs. Unknown/positionless ids are
 /// ignored.
@@ -292,6 +313,7 @@ fn Holder(comptime GP: type, comptime RP: type) type {
             .set_scene = &setSceneImpl,
             .load_scene = &loadSceneImpl,
             .set_state = &setStateImpl,
+            .load_animation_def = &loadAnimationDefImpl,
             .set_entity_position = &setEntityPositionImpl,
             .scene_digest = &sceneDigestImpl,
             .apply_camera = &applyCameraImpl,
@@ -374,6 +396,20 @@ fn Holder(comptime GP: type, comptime RP: type) type {
             // worse off than before this rollback existed.
             _ = setSceneImpl(name);
             return -1;
+        }
+
+        fn loadAnimationDefImpl(name: []const u8, src: []const u8) i32 {
+            // Empty name: never meaningful, most likely a host-side
+            // length bug (mirrors setStateImpl).
+            if (name.len == 0) return -1;
+            // `loadAnimationDefSource` is transactional by construction:
+            // parse failures error out BEFORE the registry or any live
+            // component is touched, so unlike loadSceneImpl there is no
+            // rollback dance here.
+            game.loadAnimationDefSource(name, src) catch |err| {
+                return if (err == error.OutOfMemory) -3 else -2;
+            };
+            return 0;
         }
 
         fn setEntityPositionImpl(id: u64, x: f32, y: f32) void {

--- a/src/game.zig
+++ b/src/game.zig
@@ -52,6 +52,8 @@ const input_events_mixin = @import("game/input_events_mixin.zig");
 const events_mixin = @import("game/events_mixin.zig");
 const loop_mixin = @import("game/loop_mixin.zig");
 const misc_mixin = @import("game/misc_mixin.zig");
+const animation_runtime_mixin = @import("game/animation_runtime_mixin.zig");
+const animation_def_runtime = @import("animation_def_runtime.zig");
 
 /// Full game configuration — the assembler fills ALL comptime slots.
 /// RenderImpl is a renderer plugin (e.g. gfx.GfxRenderer) satisfying RenderInterface.
@@ -305,6 +307,7 @@ pub fn GameConfigWithYAxis(
         const EventsMixin = events_mixin.Mixin(Self);
         const LoopMixin = loop_mixin.Mixin(Self);
         const MiscMixin = misc_mixin.Mixin(Self);
+        const AnimationRuntimeMixin = animation_runtime_mixin.Mixin(Self);
 
         /// Scene lifecycle hooks
         pub const SceneHooks = struct {
@@ -432,6 +435,14 @@ pub fn GameConfigWithYAxis(
         /// replacing an entry frees the previous source. See
         /// `setSceneSourceOverride` / `sceneSourceOverride`.
         scene_source_overrides: std.StringHashMap([]const u8),
+        /// Runtime animation-def overrides (labelle-studio Play mode /
+        /// `editor_api.editor_load_animation_def`, engine#672). Keyed by
+        /// def name (the `.zon` stem, `"worker"`); game code consults
+        /// `runtimeAnimDef` before its comptime table. See
+        /// `game/animation_runtime_mixin.zig` for the refresh convention
+        /// and `RuntimeAnimDefs` for the retire-don't-free ownership
+        /// story. Empty (and cost-free) outside editor-preview hosts.
+        runtime_anim_defs: animation_def_runtime.RuntimeAnimDefs,
         /// Name of the scene whose registered `loader_fn` is currently
         /// executing. Set by `setScene` / `setSceneAtomic` / the
         /// hot-reload path around the loader call ONLY — a borrow of the
@@ -787,6 +798,7 @@ pub fn GameConfigWithYAxis(
                 .jsonc_scenes = std.StringHashMap(JsoncSceneInfo).init(allocator),
                 .embedded_scene_sources = std.StringHashMap([]const u8).init(allocator),
                 .scene_source_overrides = std.StringHashMap([]const u8).init(allocator),
+                .runtime_anim_defs = animation_def_runtime.RuntimeAnimDefs.init(allocator),
                 .gizmo_state = gizmo_draws_mod.GizmoState(Entity).init(allocator),
                 // `game_ctx` is a placeholder here (the not-yet-stable world
                 // pointer); `bindScheduler` fixes it once `self` is stable.
@@ -1165,6 +1177,14 @@ pub fn GameConfigWithYAxis(
         pub const setSceneSourceOverride = MiscMixin.setSceneSourceOverride;
         pub const removeSceneSourceOverride = MiscMixin.removeSceneSourceOverride;
         pub const sceneSourceOverride = MiscMixin.sceneSourceOverride;
+
+        /// Runtime animation-def overrides (labelle-studio Play mode /
+        /// `editor_api.editor_load_animation_def`) — see
+        /// `game/animation_runtime_mixin.zig` for the `anim_def_name`
+        /// refresh convention and the fallback contract.
+        pub const loadAnimationDefSource = AnimationRuntimeMixin.loadAnimationDefSource;
+        pub const runtimeAnimDef = AnimationRuntimeMixin.runtimeAnimDef;
+        pub const refreshAnimationStates = AnimationRuntimeMixin.refreshAnimationStates;
         pub const setSceneAssets = SceneMixin.setSceneAssets;
         pub const setSceneInitialState = SceneMixin.setSceneInitialState;
         pub const setScene = SceneMixin.setScene;

--- a/src/game/animation_runtime_mixin.zig
+++ b/src/game/animation_runtime_mixin.zig
@@ -1,0 +1,104 @@
+/// Animation-runtime mixin — runtime `AnimationDef` overrides on a live
+/// game (labelle-engine#672 driver seam, labelle-studio Play mode).
+///
+/// The comptime `AnimationDef` path bakes clip tables into the binary;
+/// this mixin lets a host push a re-parsed `.zon` def into the RUNNING
+/// game and have live animation components pick the new numbers up. It is
+/// the engine half of the studio's `_editor_load_animation_def` hot-push
+/// (`editor_api.zig` dispatches here); a desktop host loop watching file
+/// mtimes (`ReloadWatcher`) can call the same `loadAnimationDefSource`.
+///
+/// ## How live entities are found — the `anim_def_name` convention
+///
+/// The engine can't know which game component mirrors which def (the
+/// binding is a comptime `@import` in game code). A game component opts
+/// in by declaring the def it was generated from:
+///
+/// ```zig
+/// pub const AnimationState = struct {
+///     pub const anim_def_name = "worker"; // animations/worker.zon
+///     clip: Clip = .idle,   // u8 or enum — both refresh
+///     ...
+/// };
+/// ```
+///
+/// On every successful `loadAnimationDefSource("worker", src)`, all
+/// registered components whose `anim_def_name` matches are walked and
+/// `refreshState`-ed (stale `frame_count`/`speed`/`mode` copies re-read,
+/// out-of-range `clip`/`variant`/`frame` clamped, `dirty` set). Declaring
+/// `anim_def_name` opts the component into `refreshState`'s duck-type
+/// contract (`.clip/.variant/.frame/.frame_count/.speed/.mode/.dirty`).
+/// Components without the decl are never touched, and a game with no
+/// opted-in components compiles this walk away entirely.
+///
+/// ## What the game must still do itself
+///
+/// The refresh updates STATE; sprite-name resolution and transition
+/// metadata still come from wherever the game reads them. For reloaded
+/// numbers to survive the next `transition`, game code consults
+/// `runtimeAnimDef(name)` (falling back to its comptime table) — the
+/// `AnimDefSource` seam. Games that don't are still refreshed in place,
+/// but revert to comptime numbers on their next clip switch.
+const std = @import("std");
+const animation_def_runtime = @import("../animation_def_runtime.zig");
+
+/// Returns the animation-runtime mixin for a given Game type.
+pub fn Mixin(comptime Game: type) type {
+    return struct {
+        /// Parse a `.zon` animation-def source and install it as the
+        /// runtime override for `name` (the def's stem, `"worker"` for
+        /// `animations/worker.zon`), then refresh every live component
+        /// that declares `anim_def_name == name`. On a parse/validation
+        /// error NOTHING changes — the previous override (or the
+        /// comptime table) stays live, so a half-saved file never
+        /// corrupts a running preview. `name` and `source` are copied;
+        /// the caller may free both immediately.
+        pub fn loadAnimationDefSource(self: *Game, name: []const u8, source: []const u8) !void {
+            var def = try animation_def_runtime.RuntimeAnimationDef.load(self.allocator, source);
+            errdefer def.deinit();
+            try self.runtime_anim_defs.put(name, def);
+            refreshAnimationStates(self, name);
+        }
+
+        /// The live runtime override for `name`, or null when nothing
+        /// was pushed. Game code resolving sprite names / transition
+        /// metadata should prefer this over its comptime table when
+        /// present (the `AnimDefSource` seam). The borrow stays valid
+        /// until `deinit` — see `RuntimeAnimDefs`' graveyard note.
+        pub fn runtimeAnimDef(self: *const Game, name: []const u8) ?*const animation_def_runtime.RuntimeAnimationDef {
+            return self.runtime_anim_defs.get(name);
+        }
+
+        /// Re-sync every live component whose `anim_def_name` decl
+        /// matches `name` against the current runtime override (no-op
+        /// when none is installed). Called by `loadAnimationDefSource`;
+        /// public so hosts with their own reload plumbing can re-run it.
+        pub fn refreshAnimationStates(self: *Game, name: []const u8) void {
+            const def = self.runtime_anim_defs.get(name) orelse return;
+            const Registry = Game.ComponentRegistry;
+            if (comptime !@hasDecl(Registry, "names")) return;
+            inline for (comptime Registry.names()) |cname| {
+                const C = Registry.getType(cname);
+                if (comptime animDefNameOf(C)) |def_name| {
+                    if (std.mem.eql(u8, def_name, name)) {
+                        var view = self.ecs_backend.view(.{C}, .{});
+                        defer view.deinit();
+                        while (view.next()) |entity| {
+                            if (self.ecs_backend.getComponent(entity, C)) |state| {
+                                animation_def_runtime.refreshState(state, def);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /// The def name a component opted into via `pub const
+        /// anim_def_name`, or null (= never refreshed).
+        fn animDefNameOf(comptime C: type) ?[]const u8 {
+            if (@typeInfo(C) != .@"struct") return null;
+            if (!@hasDecl(C, "anim_def_name")) return null;
+            return C.anim_def_name;
+        }
+    };
+}

--- a/src/game/lifecycle_mixin.zig
+++ b/src/game/lifecycle_mixin.zig
@@ -107,6 +107,9 @@ pub fn Mixin(comptime Game: type) type {
                 self.allocator.free(entry.value_ptr.*);
             }
             self.scene_source_overrides.deinit();
+            // Runtime animation-def overrides: frees live generations,
+            // owned keys, AND the retired-generation graveyard.
+            self.runtime_anim_defs.deinit();
             self.atlas_manager.deinit();
             // Free the borrowed-slice roster cache (#653, #657). The map
             // owns every slot's list buffer (managed map `deinit()` takes

--- a/src/root.zig
+++ b/src/root.zig
@@ -505,6 +505,9 @@ pub const RuntimeAnimationDef = animation_def_runtime_mod.RuntimeAnimationDef;
 pub const AnimDefSource = animation_def_runtime_mod.AnimDefSource;
 pub const refreshState = animation_def_runtime_mod.refreshState;
 pub const ReloadWatcher = animation_def_runtime_mod.ReloadWatcher;
+// Named runtime-def store behind `Game.loadAnimationDefSource` /
+// `editor_api.editor_load_animation_def` (studio Play-mode hot reload).
+pub const RuntimeAnimDefs = animation_def_runtime_mod.RuntimeAnimDefs;
 pub const AnimFrameEntry = animation_def_mod.FrameEntry;
 // Per-frame animation events (#670): marker/clip-end/loop-end payloads +
 // the entity-less `PendingBuf` the pure advance methods append to.

--- a/test/animation_def_runtime_test.zig
+++ b/test/animation_def_runtime_test.zig
@@ -203,3 +203,120 @@ test "ReloadWatcher: holds exactly one previous generation, frees on swap (#672)
     try testing.expectEqualStrings("c/v_0002.png", w.def().spriteName(0, 0, 1));
     // w.deinit() frees gen2. testing.allocator asserts no leak / no double-free.
 }
+
+// ── refreshState over game-typed (enum) components (#24 hot reload) ──
+
+/// FP-shaped AnimationState: `clip`/`variant` are ENUMS generated from
+/// the comptime def, not raw u8s. `refreshState` must read them via
+/// `@intFromEnum` and clamp-write via `@enumFromInt`.
+const TypedState = struct {
+    const Clip = enum(u8) { idle, walk, eat };
+    const Variant = enum(u8) { a, b };
+
+    clip: Clip = .idle,
+    variant: Variant = .a,
+    frame_count: u8 = 1,
+    speed: f32 = 1.0,
+    mode: engine.AnimMode = .static,
+    frame: u8 = 0,
+    dirty: bool = false,
+};
+
+test "refreshState: enum-typed clip/variant — meta re-copy without a clamp write" {
+    // Def still has all three clips: the enum fields must be left
+    // untouched (no @enumFromInt write happens on the grow/steady path).
+    var state = TypedState{ .clip = .eat, .variant = .b, .frame_count = 8, .speed = 4.0, .mode = .time };
+    const src =
+        \\.{
+        \\    .variants = .{ "a", "b" },
+        \\    .clips = .{
+        \\        .idle = .{ .frames = 1 },
+        \\        .walk = .{ .frames = 4, .mode = .distance, .speed = 15.0 },
+        \\        .eat = .{ .frames = 6, .mode = .time, .speed = 3.0 },
+        \\    },
+        \\}
+    ;
+    var def = try RuntimeAnimationDef.load(testing.allocator, src);
+    defer def.deinit();
+
+    refreshState(&state, &def);
+    try testing.expectEqual(TypedState.Clip.eat, state.clip);
+    try testing.expectEqual(TypedState.Variant.b, state.variant);
+    try testing.expectEqual(@as(u8, 6), state.frame_count); // .eat's new count
+    try testing.expectEqual(@as(f32, 3.0), state.speed);
+    try testing.expectEqual(engine.AnimMode.time, state.mode);
+    try testing.expect(state.dirty);
+}
+
+test "refreshState: enum-typed clip/variant — shrink clamps stay inside the enum" {
+    // Def shrank to one clip / one variant: .eat (2) and .b (1) are out
+    // of range and must clamp to the last entry — indices 0 and 0, both
+    // valid enum tags (the clamp target is always below the old value).
+    var state = TypedState{ .clip = .eat, .variant = .b, .frame = 5, .frame_count = 6 };
+    const src =
+        \\.{
+        \\    .variants = .{ "a" },
+        \\    .clips = .{ .idle = .{ .frames = 2 } },
+        \\}
+    ;
+    var def = try RuntimeAnimationDef.load(testing.allocator, src);
+    defer def.deinit();
+
+    refreshState(&state, &def);
+    try testing.expectEqual(TypedState.Clip.idle, state.clip); // 2 → 0
+    try testing.expectEqual(TypedState.Variant.a, state.variant); // 1 → 0
+    try testing.expectEqual(@as(u8, 2), state.frame_count);
+    try testing.expectEqual(@as(u8, 1), state.frame); // 5 → count-1
+}
+
+// ── RuntimeAnimDefs: named store + retire-don't-free (#24 hot reload) ──
+
+test "RuntimeAnimDefs: put/get round-trip and count" {
+    var store = engine.RuntimeAnimDefs.init(testing.allocator);
+    defer store.deinit();
+
+    try testing.expectEqual(@as(usize, 0), store.count());
+    try testing.expect(store.get("worker") == null);
+
+    try store.put("worker", try RuntimeAnimationDef.load(testing.allocator,
+        \\.{ .variants = .{ "v" }, .clips = .{ .c = .{ .frames = 2 } } }
+    ));
+    try testing.expectEqual(@as(usize, 1), store.count());
+    const def = store.get("worker").?;
+    try testing.expectEqual(@as(usize, 1), def.clip_names.len);
+    try testing.expectEqualStrings("c/v_0001.png", def.spriteName(0, 0, 0));
+
+    // The key was duped — the caller's buffer can die.
+    const transient = try testing.allocator.dupe(u8, "bandit");
+    try store.put(transient, try RuntimeAnimationDef.load(testing.allocator,
+        \\.{ .variants = .{ "v" }, .clips = .{ .c = .{ .frames = 1 } } }
+    ));
+    testing.allocator.free(transient);
+    try testing.expectEqual(@as(usize, 2), store.count());
+    try testing.expect(store.get("bandit") != null);
+}
+
+test "RuntimeAnimDefs: replacing a def retires the old generation alive (no UAF)" {
+    var store = engine.RuntimeAnimDefs.init(testing.allocator);
+    defer store.deinit();
+
+    try store.put("worker", try RuntimeAnimationDef.load(testing.allocator,
+        \\.{ .variants = .{ "v" }, .clips = .{ .c = .{ .frames = 2, .speed = 1.0 } } }
+    ));
+    // Simulate a Sprite holding a name slice + game code holding a borrow
+    // across the swap (paused sim: nothing will re-resolve them).
+    const gen0 = store.get("worker").?;
+    const held_name = gen0.spriteName(0, 0, 1);
+
+    try store.put("worker", try RuntimeAnimationDef.load(testing.allocator,
+        \\.{ .variants = .{ "v" }, .clips = .{ .c = .{ .frames = 3, .speed = 9.0 } } }
+    ));
+    // New generation is live…
+    try testing.expectEqual(@as(usize, 1), store.count());
+    try testing.expectEqual(@as(f32, 9.0), store.get("worker").?.clipMeta(0).speed);
+    // …and the retired one is still readable (graveyard keeps it alive
+    // until deinit — testing.allocator would flag a UAF here otherwise).
+    try testing.expectEqualStrings("c/v_0002.png", held_name);
+    try testing.expectEqual(@as(f32, 1.0), gen0.clipMeta(0).speed);
+    // store.deinit() frees both generations; testing.allocator asserts no leak.
+}

--- a/test/editor_api_test.zig
+++ b/test/editor_api_test.zig
@@ -71,10 +71,11 @@ test "pre-bind: every export is a safe no-op" {
     editor_api.unbind();
     defer editor_api.unbind();
 
-    // Scene/state ops report failure (no game to act on).
+    // Scene/state/animation ops report failure (no game to act on).
     try testing.expectEqual(@as(i32, -1), editor_api.editor_set_scene("main", 4));
     try testing.expectEqual(@as(i32, -1), editor_api.editor_load_scene("main", 4, "{}", 2));
     try testing.expectEqual(@as(i32, -1), editor_api.editor_set_state("playing", 7));
+    try testing.expectEqual(@as(i32, -1), editor_api.editor_load_animation_def("worker", 6, ".{}", 3));
 
     // Void setters silently ignore.
     editor_api.editor_set_entity_position(42, 1.0, 2.0);
@@ -466,4 +467,170 @@ test "camera override: comptime no-op for camera-less games (StubRender)" {
     editor_api.editor_set_camera(1, 2, 3);
     editor_api.frame(&game);
     editor_api.editor_release_camera();
+}
+
+// ── editor_load_animation_def (contract v1.2, studio issue #24) ─────
+
+/// FP-shaped, ENUM-typed animation component opted into hot reload via
+/// the `anim_def_name` decl (see `game/animation_runtime_mixin.zig`).
+const TypedAnimState = struct {
+    pub const anim_def_name = "worker";
+
+    const Clip = enum(u8) { idle, walk };
+    const Variant = enum(u8) { a, b };
+
+    clip: Clip = .idle,
+    variant: Variant = .a,
+    frame_count: u8 = 1,
+    speed: f32 = 1.0,
+    mode: engine.AnimMode = .static,
+    frame: u8 = 0,
+    dirty: bool = false,
+};
+
+/// Engine-shaped (raw u8) component bound to the SAME def — both must
+/// refresh from one push.
+const RawAnimState = struct {
+    pub const anim_def_name = "worker";
+
+    clip: u8 = 0,
+    variant: u8 = 0,
+    frame_count: u8 = 1,
+    speed: f32 = 1.0,
+    mode: engine.AnimMode = .static,
+    frame: u8 = 0,
+    dirty: bool = false,
+};
+
+/// Bound to a DIFFERENT def — a "worker" push must never touch it.
+const OtherAnimState = struct {
+    pub const anim_def_name = "bandit";
+
+    clip: u8 = 0,
+    variant: u8 = 0,
+    frame_count: u8 = 4,
+    speed: f32 = 8.0,
+    mode: engine.AnimMode = .time,
+    frame: u8 = 2,
+    dirty: bool = false,
+};
+
+const AnimComponents = engine.ComponentRegistry(.{
+    .TypedAnimState = TypedAnimState,
+    .RawAnimState = RawAnimState,
+    .OtherAnimState = OtherAnimState,
+});
+
+const AnimMockEcs = core.MockEcsBackend(u32);
+const AnimGame = engine.game_mod.GameConfig(
+    core.StubRender(AnimMockEcs.Entity),
+    AnimMockEcs,
+    engine.input_mod.StubInput,
+    engine.audio_mod.StubAudio,
+    engine.StubVideo,
+    engine.gui_mod.StubGui,
+    void,
+    core.StubLogSink,
+    AnimComponents,
+    &.{},
+    void,
+);
+
+const WORKER_V2 =
+    \\.{
+    \\    .variants = .{ "a", "b" },
+    \\    .clips = .{
+    \\        .idle = .{ .frames = 1 },
+    \\        .walk = .{ .frames = 2, .mode = .distance, .speed = 30.0 },
+    \\    },
+    \\}
+;
+
+test "editor_load_animation_def: parses, installs, and refreshes opted-in components" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = AnimGame.init(testing.allocator);
+    defer game.deinit();
+
+    // Live entities mid-walk holding the STALE comptime numbers
+    // (4 frames @ 15.0), the shape of FP workers when a studio save
+    // lands: frame 3 will be out of range after the reload shrinks
+    // walk to 2 frames.
+    const typed_ent = game.createEntity();
+    game.active_world.ecs_backend.addComponent(typed_ent, TypedAnimState{
+        .clip = .walk,
+        .variant = .b,
+        .frame = 3,
+        .frame_count = 4,
+        .speed = 15.0,
+        .mode = .distance,
+    });
+    const raw_ent = game.createEntity();
+    game.active_world.ecs_backend.addComponent(raw_ent, RawAnimState{
+        .clip = 1,
+        .frame = 3,
+        .frame_count = 4,
+        .speed = 15.0,
+        .mode = .distance,
+    });
+    const other_ent = game.createEntity();
+    game.active_world.ecs_backend.addComponent(other_ent, OtherAnimState{});
+
+    var runner = DummyRunner{};
+    editor_api.bind(&game, &runner);
+
+    try testing.expectEqual(@as(i32, 0), editor_api.editor_load_animation_def("worker", 6, WORKER_V2, WORKER_V2.len));
+
+    // Installed and queryable through the game API (the AnimDefSource
+    // seam game code resolves through).
+    const def = game.runtimeAnimDef("worker").?;
+    try testing.expectEqualStrings("walk", def.clip_names[1]);
+    try testing.expectEqual(@as(f32, 30.0), def.clipMeta(1).speed);
+
+    // Enum-typed component: meta re-copied, frame clamped, dirty set.
+    const t = game.active_world.ecs_backend.getComponent(typed_ent, TypedAnimState).?;
+    try testing.expectEqual(TypedAnimState.Clip.walk, t.clip);
+    try testing.expectEqual(TypedAnimState.Variant.b, t.variant);
+    try testing.expectEqual(@as(f32, 30.0), t.speed);
+    try testing.expectEqual(@as(u8, 2), t.frame_count);
+    try testing.expectEqual(@as(u8, 1), t.frame); // 3 clamped to count-1
+    try testing.expect(t.dirty);
+
+    // Raw-u8 component refreshed from the same push.
+    const r = game.active_world.ecs_backend.getComponent(raw_ent, RawAnimState).?;
+    try testing.expectEqual(@as(f32, 30.0), r.speed);
+    try testing.expectEqual(@as(u8, 2), r.frame_count);
+    try testing.expect(r.dirty);
+
+    // Component bound to another def: byte-for-byte untouched.
+    const o = game.active_world.ecs_backend.getComponent(other_ent, OtherAnimState).?;
+    try testing.expectEqual(@as(f32, 8.0), o.speed);
+    try testing.expectEqual(@as(u8, 4), o.frame_count);
+    try testing.expect(!o.dirty);
+}
+
+test "editor_load_animation_def: malformed source is rejected and the old def stays live" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = AnimGame.init(testing.allocator);
+    defer game.deinit();
+    var runner = DummyRunner{};
+    editor_api.bind(&game, &runner);
+
+    try testing.expectEqual(@as(i32, 0), editor_api.editor_load_animation_def("worker", 6, WORKER_V2, WORKER_V2.len));
+
+    // Half-saved file mid-edit: parse failure → -2, nothing changes.
+    const garbage = ".{ .variants = .{ \"a\" }, .clips = ";
+    try testing.expectEqual(@as(i32, -2), editor_api.editor_load_animation_def("worker", 6, garbage, garbage.len));
+    // Structurally valid ZON that fails def validation → also -2.
+    const no_clips = ".{ .variants = .{ \"a\" } }";
+    try testing.expectEqual(@as(i32, -2), editor_api.editor_load_animation_def("worker", 6, no_clips, no_clips.len));
+
+    // The previous generation is still the live one.
+    try testing.expectEqual(@as(f32, 30.0), game.runtimeAnimDef("worker").?.clipMeta(1).speed);
+
+    // Empty name: host-side length bug — rejected without touching the game.
+    try testing.expectEqual(@as(i32, -1), editor_api.editor_load_animation_def("x", 0, WORKER_V2, WORKER_V2.len));
 }


### PR DESCRIPTION
## What

The engine half of **labelle-studio#24** (hot-reload animation edits into Play mode), building on the #672 primitives whose driver wiring was deliberately deferred to the host. For the studio's wasm Play mode there are no file mtimes to poll — the studio watches `animations/*.zon` saves and **pushes** the source into the running game. This PR gives that push a landing site.

### editor_api (contract v1.2)

- New export `editor_load_animation_def(name, nlen, src, slen) -> i32`, dispatched through the existing type-erased vtable (bind pattern unchanged; no generated-main changes needed).
- Return codes: `0` ok · `-1` unbound / empty name · `-2` parse/validation failure · `-3` OOM. **On any nonzero return the running game is untouched** — the previous override (or the comptime table) stays live, so a half-saved file never corrupts the preview.

### Game surface

- `Game.loadAnimationDefSource(name, src)` — parse via `RuntimeAnimationDef.load`, install as the runtime override, refresh live components (new `game/animation_runtime_mixin.zig`).
- `Game.runtimeAnimDef(name)` — the `AnimDefSource` seam: game code resolving sprite names / transition metadata consults this before its comptime table.
- `Game.refreshAnimationStates(name)` — public for hosts with their own reload plumbing (e.g. a future desktop mtime loop using `ReloadWatcher`).

### The `anim_def_name` convention (how live entities are found)

The engine can't know which game component mirrors which def (that binding is a comptime `@import` in game code). A component opts in by declaring `pub const anim_def_name = "worker";` — every registered component whose decl matches the pushed name is walked and `refreshState`-ed (stale `frame_count`/`speed`/`mode` copies re-read, out-of-range indices clamped, `dirty` set). Games with no opted-in components compile the walk away entirely.

### Supporting changes

- `refreshState` now tolerates **enum-typed** `clip`/`variant` fields (FP-style wrappers typed off the comptime def). Clamp writes are shrink-only, so `@enumFromInt` can never manufacture an invalid tag even when the runtime def has more entries than the comptime enum.
- New `RuntimeAnimDefs` named store. Replaced generations are **retired to a graveyard freed at deinit**, not freed on swap: the editor can push while the sim is paused (`editor_pause`), when no tick will re-resolve `Sprite.sprite_name` slices for an arbitrary number of rendered frames — `ReloadWatcher`'s end-of-frame release protocol doesn't hold on this path, and a few KB per editor save buys zero UAF risk. Release builds never construct one.

## What this does NOT do (by design)

- **No wasm keep-alive**: `-sEXPORTED_FUNCTIONS` lives in labelle-bgfx — companion PR appends the symbol there (labelle-bgfx#34-ish; emcc hard-errors on listed-but-missing symbols, so that bgfx release will require an engine with this export for editor-preview builds).
- **No game-side adoption**: FP's `AnimationState` still snapshots comptime meta on `transition` and resolves sprites from the comptime table. Pushes already refresh its live states in place (speed/frame-count/mode) once it declares `anim_def_name`; routing `transitionClip`/`spriteName` through `runtimeAnimDef` is the FP follow-up that makes reloads stick across clip switches.

## Tests

`zig build test` — all green (700 tests across 70 test binaries). New coverage:
- `editor_api_test.zig`: full push → registry → live-refresh flow against a custom Game with enum-typed, raw-u8, and other-def components (the other-def one must stay byte-untouched); malformed/structurally-invalid source → `-2` with the old def intact; empty name → `-1`; pre-bind → `-1`.
- `animation_def_runtime_test.zig`: enum-typed `refreshState` (steady-state no-write + shrink clamps staying inside the enum); `RuntimeAnimDefs` put/get/replace with the retired generation provably still readable (testing.allocator would flag the UAF otherwise).

## Verification

```
zig build test --summary all   # 19+ test binaries, all pass, no leaks
```

Part of labelle-studio#24 · builds on #672 · companion PRs: labelle-bgfx (export list), labelle-studio (watch + push).

https://claude.ai/code/session_01P7YLw4hXFCCaY2LAUt4G1j
