### PR TITLE
AnimationDef: per-variant frame-entry overrides + runtime entry-list parsing (#684, #685)

### DIFF
--- a/src/animation_def.zig
+++ b/src/animation_def.zig
@@ -20,6 +20,12 @@
 /// `speed` is beats/unit (seconds for `.time`, distance units for `.distance`);
 /// a slot showing for `run` beats. The count form has run 1 everywhere, so
 /// `beat_count == slot_count` and playback is bit-identical to pre-#664.
+///
+/// Entry lists are PER-VARIANT (#684): a variant's `.overrides` may replace
+/// a clip's `.frames` with any of the three forms, so every derived table
+/// (beat→slot, marker→beat, sprite names) is keyed `[clip][variant]`. A
+/// variant with no `.frames` override shares the base clip's entry list,
+/// so defs without overrides generate exactly the tables they always did.
 
 const std = @import("std");
 const anim_timing = @import("anim_timing.zig");
@@ -164,6 +170,14 @@ fn clipIndexOf(state: anytype) u8 {
     return if (@typeInfo(T) == .@"enum") @intFromEnum(state.clip) else state.clip;
 }
 
+/// Variant index of a duck-typed state — same enum-or-u8 coercion as
+/// `clipIndexOf`. Entry lists are per-variant (#684), so the advance
+/// paths need the state's variant to pick the right beat/marker row.
+fn variantIndexOf(state: anytype) u8 {
+    const T = @TypeOf(state.variant);
+    return if (@typeInfo(T) == .@"enum") @intFromEnum(state.variant) else state.variant;
+}
+
 pub fn AnimationDef(comptime zon: anytype) type {
     if (!@hasField(@TypeOf(zon), "clips")) @compileError("animation .zon must have a .clips field");
     if (!@hasField(@TypeOf(zon), "variants")) @compileError("animation .zon must have a .variants field");
@@ -204,12 +218,42 @@ pub fn AnimationDef(comptime zon: anytype) type {
 
     const Variant = @Enum(u8, .exhaustive, &VariantNames.names, &VariantNames.values);
 
-    // Per-clip normalized slot lists — the single source the meta table,
-    // name table, and beat table all derive from.
+    // Per-clip normalized slot lists (the BASE rows — what every variant
+    // without a `.frames` override plays).
     const clip_entries: [clip_count][]const FrameEntry = blk: {
         var arr: [clip_count][]const FrameEntry = undefined;
         for (clip_fields, 0..) |f, i| {
             arr[i] = normalizeFrames(@field(zon.clips, f.name).frames);
+        }
+        break :blk arr;
+    };
+
+    // Per-variant slot lists (#684) — the single source the meta, name,
+    // beat, and marker tables all derive from. Row [ci][vi] is the base
+    // list unless variant vi overrides that clip's `.frames` (any of the
+    // three #664 forms, through the same `normalizeFrames`). Non-
+    // overriding rows alias the base slice, so defs without overrides
+    // derive tables identical to the pre-#684 per-clip ones.
+    const clip_entries_2d: [clip_count][variant_count][]const FrameEntry = blk: {
+        @setEvalBranchQuota(clip_count * variant_count * 40 + 4000);
+        var arr: [clip_count][variant_count][]const FrameEntry = undefined;
+        for (0..clip_count) |ci| {
+            for (0..variant_count) |vi| arr[ci][vi] = clip_entries[ci];
+        }
+        inline for (variant_list, 0..) |velem, vi| {
+            const vinfo = @typeInfo(@TypeOf(velem));
+            if (vinfo == .@"struct" and @hasField(@TypeOf(velem), "overrides")) {
+                inline for (@typeInfo(@TypeOf(velem.overrides)).@"struct".fields) |of| {
+                    // Unknown clip names are reported by clip_meta_2d's
+                    // validation below — skip here to keep one error site.
+                    if (clipIdxByName(clip_fields, of.name)) |cidx| {
+                        const override = @field(velem.overrides, of.name);
+                        if (@hasField(@TypeOf(override), "frames")) {
+                            arr[cidx][vi] = normalizeFrames(override.frames);
+                        }
+                    }
+                }
+            }
         }
         break :blk arr;
     };
@@ -259,14 +303,12 @@ pub fn AnimationDef(comptime zon: anytype) type {
     // Variant enum pair still drives every skin (Unity Sprite Library
     // Variant's structural-consistency rule).
     //
-    // #664 reconciliation: a `.frames` override accepts the COUNT form
-    // only (an entry-list override would need per-variant beat/marker
-    // tables — a follow-up), and is rejected when the BASE clip declares
-    // per-slot holds or markers (the base beat table would no longer
-    // describe the overridden variant). Overridden variants play through
-    // the state-carried path: `transitionFromMeta(clip, clipMetaFor(clip,
-    // variant))` snapshots the right counts into AnimationState.
+    // A `.frames` override accepts any of the three #664 forms (#684):
+    // its counts are derived from the variant's own entry row in
+    // `clip_entries_2d`, and the beat/marker tables below are keyed
+    // `[clip][variant]` so holds/markers/reordering resolve per-variant.
     const clip_meta_2d: [clip_count][variant_count]ClipMeta = blk: {
+        @setEvalBranchQuota(clip_count * variant_count * 40 + 4000);
         var table: [clip_count][variant_count]ClipMeta = undefined;
         for (0..clip_count) |ci| {
             for (0..variant_count) |vi| table[ci][vi] = clip_meta_table[ci];
@@ -286,24 +328,26 @@ pub fn AnimationDef(comptime zon: anytype) type {
                     validateOverrideFields(@TypeOf(override), of.name, variantNameOf(velem));
                     var m = clip_meta_table[cidx];
                     if (@hasField(@TypeOf(override), "frames")) {
-                        const finfo = @typeInfo(@TypeOf(override.frames));
-                        if (!(finfo == .comptime_int or finfo == .int))
-                            @compileError("variant '" ++ variantNameOf(velem) ++ "' override for clip '" ++
-                                of.name ++ "': `.frames` must be a count — per-variant frame-entry overrides are a follow-up (#664 × #666)");
-                        for (clip_entries[cidx], 0..) |e, ei| {
-                            if (e.run != 1 or e.marker != null or e.f != ei + 1)
-                                @compileError("variant '" ++ variantNameOf(velem) ++ "' cannot override `.frames` of clip '" ++
-                                    of.name ++ "': the base clip declares holds/markers/reordering, which are per-clip (#664 × #666 follow-up)");
-                        }
-                        if (override.frames < 1 or override.frames > 255)
-                            @compileError("override .frames must be 1..255");
-                        m.frame_count = override.frames;
-                        m.entry_count = override.frames;
-                        m.beat_count = override.frames; // count form: 1 beat per slot
+                        const ventries = clip_entries_2d[cidx][vi];
+                        var beats: u16 = 0;
+                        for (ventries) |e| beats += e.run;
+                        m.frame_count = @intCast(ventries.len);
+                        m.entry_count = @intCast(ventries.len);
+                        m.beat_count = beats;
                     }
                     if (@hasField(@TypeOf(override), "speed")) m.speed = override.speed;
                     if (@hasField(@TypeOf(override), "mode")) m.mode = override.mode;
                     if (@hasField(@TypeOf(override), "folder")) m.folder = override.folder;
+                    // Same rule as the base table: a clip that is .static
+                    // FOR THIS VARIANT (inherited or overridden) only ever
+                    // shows slot 0, so holds in its effective entry list
+                    // are meaningless — reject the combination.
+                    if (m.mode == .static) {
+                        for (clip_entries_2d[cidx][vi]) |e| {
+                            if (e.run != 1) @compileError("variant '" ++ variantNameOf(velem) ++ "' makes clip '" ++
+                                of.name ++ "' .static with per-slot holds — holds are meaningless when frame is always slot 0");
+                        }
+                    }
                     table[cidx][vi] = m;
                 }
             }
@@ -311,9 +355,10 @@ pub fn AnimationDef(comptime zon: anytype) type {
         break :blk table;
     };
 
-    // Max slots (name-table depth; spans base AND overridden counts) and
-    // max beats (beat-table depth; base only — see clip_meta_2d note).
+    // Max slots (name-table depth) and max beats (beat-table depth) —
+    // both span every variant's rows, base and overridden (#684).
     const max_slots: usize = blk: {
+        @setEvalBranchQuota(clip_count * variant_count * 10 + 1000);
         var mx: usize = 1;
         for (0..clip_count) |ci| {
             for (0..variant_count) |vi| {
@@ -323,39 +368,33 @@ pub fn AnimationDef(comptime zon: anytype) type {
         break :blk mx;
     };
     const max_beats: usize = blk: {
+        @setEvalBranchQuota(clip_count * variant_count * 10 + 1000);
         var mx: usize = 1;
-        for (&clip_meta_table) |meta| {
-            if (meta.beat_count > mx) mx = meta.beat_count;
+        for (0..clip_count) |ci| {
+            for (0..variant_count) |vi| {
+                if (clip_meta_2d[ci][vi].beat_count > mx) mx = clip_meta_2d[ci][vi].beat_count;
+            }
         }
         break :blk mx;
     };
 
     // Precomputed sprite name table, keyed by SLOT. The name for slot i
     // uses `entries[i].f` (not i+1), so reordered/reused frames resolve
-    // to the right file. Format: "{folder}/{variant}_{f:04}.png".
+    // to the right file. Format: "{folder}/{variant}_{f:04}.png". Rows
+    // read the PER-VARIANT entry list (#684), so a `.frames` override in
+    // any form names exactly the files its own entries declare.
     const SpriteNameTable = [clip_count][variant_count][max_slots][]const u8;
     const sprite_names: SpriteNameTable = blk: {
         @setEvalBranchQuota(clip_count * variant_count * max_slots * 2000);
         var table: SpriteNameTable = undefined;
         for (0..clip_count) |ci| {
-            const entries = clip_entries[ci];
             for (0..variant_count) |vi| {
-                // Per-variant folder + slot count (honors overrides). A
-                // frames-overridden variant uses count-form files 1..N
-                // (guarded above: only legal when the base has no
-                // reorders/holds to preserve).
-                const meta_v = clip_meta_2d[ci][vi];
-                const folder = meta_v.folder;
-                const overridden = meta_v.entry_count != clip_meta_table[ci].entry_count;
-                const slot_count: usize = meta_v.entry_count;
+                const entries = clip_entries_2d[ci][vi];
+                const folder = clip_meta_2d[ci][vi].folder;
                 const vname: []const u8 = VariantNames.names[vi];
                 for (0..max_slots) |si| {
-                    if (si < slot_count) {
-                        const file_idx: u16 = if (overridden or si >= entries.len)
-                            @intCast(si + 1)
-                        else
-                            entries[si].f;
-                        table[ci][vi][si] = std.fmt.comptimePrint("{s}/{s}_{d:0>4}.png", .{ folder, vname, file_idx });
+                    if (si < entries.len) {
+                        table[ci][vi][si] = std.fmt.comptimePrint("{s}/{s}_{d:0>4}.png", .{ folder, vname, entries[si].f });
                     } else {
                         table[ci][vi][si] = "";
                     }
@@ -366,22 +405,27 @@ pub fn AnimationDef(comptime zon: anytype) type {
     };
 
     // Beat → slot table: slot j repeated `run_j` times, so a runtime
-    // `slot = beat_to_slot[clip][beat]` lookup is O(1) with no per-tick
-    // summation. Padded to `max_beats`; entries past a clip's beat_count
-    // are 0 (never read — `advanceState` mods by beat_count first).
-    const beat_to_slot: [clip_count][max_beats]u8 = blk: {
-        var table: [clip_count][max_beats]u8 = undefined;
+    // `slot = beat_to_slot[clip][variant][beat]` lookup is O(1) with no
+    // per-tick summation. Keyed per-variant (#684) because a `.frames`
+    // override changes the run structure. Padded to `max_beats`; entries
+    // past a row's beat_count are 0 (never read — `advanceState` mods by
+    // beat_count first).
+    const beat_to_slot: [clip_count][variant_count][max_beats]u8 = blk: {
+        @setEvalBranchQuota(clip_count * variant_count * (max_beats + 8) * 20 + 2000);
+        var table: [clip_count][variant_count][max_beats]u8 = undefined;
         for (0..clip_count) |ci| {
-            const entries = clip_entries[ci];
-            var b: usize = 0;
-            for (entries, 0..) |e, si| {
-                var r: usize = 0;
-                while (r < e.run) : (r += 1) {
-                    table[ci][b] = @intCast(si);
-                    b += 1;
+            for (0..variant_count) |vi| {
+                const entries = clip_entries_2d[ci][vi];
+                var b: usize = 0;
+                for (entries, 0..) |e, si| {
+                    var r: usize = 0;
+                    while (r < e.run) : (r += 1) {
+                        table[ci][vi][b] = @intCast(si);
+                        b += 1;
+                    }
                 }
+                while (b < max_beats) : (b += 1) table[ci][vi][b] = 0;
             }
-            while (b < max_beats) : (b += 1) table[ci][b] = 0;
         }
         break :blk table;
     };
@@ -427,16 +471,21 @@ pub fn AnimationDef(comptime zon: anytype) type {
 
     // Marker → beat table (#670): the marker name at each beat that is a
     // slot's FIRST beat and carries a marker, else "". A held slot (run>1)
-    // fires its marker once, at entry. Padded to `max_beats` with "".
-    const marker_beats: [clip_count][max_beats][]const u8 = blk: {
-        var table: [clip_count][max_beats][]const u8 = undefined;
+    // fires its marker once, at entry. Keyed per-variant (#684) — an
+    // overriding variant carries its own markers (or none). Padded to
+    // `max_beats` with "".
+    const marker_beats: [clip_count][variant_count][max_beats][]const u8 = blk: {
+        @setEvalBranchQuota(clip_count * variant_count * (max_beats + 8) * 20 + 2000);
+        var table: [clip_count][variant_count][max_beats][]const u8 = undefined;
         for (0..clip_count) |ci| {
-            for (0..max_beats) |bi| table[ci][bi] = "";
-            const entries = clip_entries[ci];
-            var b: usize = 0;
-            for (entries) |e| {
-                if (e.marker) |name| table[ci][b] = name;
-                b += e.run;
+            for (0..variant_count) |vi| {
+                for (0..max_beats) |bi| table[ci][vi][bi] = "";
+                const entries = clip_entries_2d[ci][vi];
+                var b: usize = 0;
+                for (entries) |e| {
+                    if (e.marker) |name| table[ci][vi][b] = name;
+                    b += e.run;
+                }
             }
         }
         break :blk table;
@@ -480,14 +529,16 @@ pub fn AnimationDef(comptime zon: anytype) type {
             return sprite_names[@intFromEnum(clip)][@intFromEnum(variant)][frame];
         }
 
-        /// The slot shown at a given beat of a clip (0-based beat). Beats
-        /// past the clip's `beat_count` wrap via the caller's mod; this
+        /// The slot shown at a given beat of a clip AS SEEN BY a variant
+        /// (0-based beat) — entry lists are per-variant (#684). Beats past
+        /// that variant's `beat_count` wrap via the caller's mod; this
         /// clamps defensively.
-        pub fn slotForBeat(clip: Clip, beat: u16) u8 {
+        pub fn slotForBeat(clip: Clip, variant: Variant, beat: u16) u8 {
             const ci = @intFromEnum(clip);
-            const bc = clip_meta_table[ci].beat_count;
+            const vi = @intFromEnum(variant);
+            const bc = clip_meta_2d[ci][vi].beat_count;
             if (bc == 0) return 0;
-            return beat_to_slot[ci][beat % bc];
+            return beat_to_slot[ci][vi][beat % bc];
         }
 
         /// Get variant name string.
@@ -529,8 +580,11 @@ pub fn AnimationDef(comptime zon: anytype) type {
         /// `AnimationState.advance` but cycles over BEATS (sum of runs)
         /// and maps the current beat to a slot via the comptime beat
         /// table, writing the slot into `state.frame`. `state` is
-        /// duck-typed (`.clip/.mode/.speed/.timer/.frame`) to avoid a
-        /// circular import with `animation_state.zig`.
+        /// duck-typed (`.clip/.variant/.mode/.speed/.timer/.frame`) to
+        /// avoid a circular import with `animation_state.zig`; `.clip`
+        /// and `.variant` may each be a `u8` or a typed enum (#686), and
+        /// the variant picks the entry row a `.frames` override installed
+        /// for it (#684).
         ///
         /// For count-shorthand clips (every run 1) `beat_count ==
         /// entry_count` and this is identical to `advance`, so a game
@@ -538,21 +592,22 @@ pub fn AnimationDef(comptime zon: anytype) type {
         /// *need* it. Full advance-dedup is #667.
         pub fn advanceState(state: anytype, dt: f32) void {
             const ci = clipIndexOf(state);
-            const meta = clip_meta_table[ci];
+            const vi = variantIndexOf(state);
+            const meta = clip_meta_2d[ci][vi];
             switch (meta.mode) {
                 .time => {
                     state.timer += dt * state.speed;
                     if (meta.beat_count > 0) {
                         const bc: f32 = @floatFromInt(meta.beat_count);
                         const beat: u16 = @intFromFloat(@mod(state.timer, bc));
-                        state.frame = beat_to_slot[ci][beat % meta.beat_count];
+                        state.frame = beat_to_slot[ci][vi][beat % meta.beat_count];
                     }
                 },
                 .distance => {
                     if (meta.beat_count > 0) {
                         const bc: f32 = @floatFromInt(meta.beat_count);
                         const beat: u16 = @intFromFloat(@mod(state.timer, bc));
-                        state.frame = beat_to_slot[ci][beat % meta.beat_count];
+                        state.frame = beat_to_slot[ci][vi][beat % meta.beat_count];
                     }
                 },
                 .static => {
@@ -578,13 +633,15 @@ pub fn AnimationDef(comptime zon: anytype) type {
             return wildcard;
         }
 
-        /// The marker name at a beat of a clip, or "" if none (#670).
-        /// Markers fire at a slot's FIRST beat only.
-        pub fn markerAtBeat(clip: Clip, beat: u16) []const u8 {
+        /// The marker name at a beat of a clip as seen by a variant, or ""
+        /// if none (#670; per-variant since #684). Markers fire at a
+        /// slot's FIRST beat only.
+        pub fn markerAtBeat(clip: Clip, variant: Variant, beat: u16) []const u8 {
             const cci = @intFromEnum(clip);
-            const bc = clip_meta_table[cci].beat_count;
+            const vi = @intFromEnum(variant);
+            const bc = clip_meta_2d[cci][vi].beat_count;
             if (bc == 0) return "";
-            return marker_beats[cci][beat % bc];
+            return marker_beats[cci][vi][beat % bc];
         }
 
         /// Beat-aware advance that ALSO emits per-frame markers + loop-end
@@ -602,7 +659,8 @@ pub fn AnimationDef(comptime zon: anytype) type {
         /// `out` to `game.emit`.
         pub fn advanceStateEvents(state: anytype, dt: f32, out: *anim_events.PendingBuf) void {
             const ci = clipIndexOf(state);
-            const meta = clip_meta_table[ci];
+            const vi = variantIndexOf(state);
+            const meta = clip_meta_2d[ci][vi];
             if (meta.mode == .static) {
                 state.frame = 0;
                 state.event_pos = 0;
@@ -634,9 +692,9 @@ pub fn AnimationDef(comptime zon: anytype) type {
                 // its marker on the first cycle — only on wraps. Fire it
                 // here exactly once, on the first forward advance.
                 if (old_pos == 0 and old_lin == 0) {
-                    const entry_name = marker_beats[ci][0];
+                    const entry_name = marker_beats[ci][vi][0];
                     if (entry_name.len > 0) {
-                        _ = out.append(.{ .kind = .marker, .clip = ci, .frame = beat_to_slot[ci][0], .marker = entry_name, .repetition = base_rep });
+                        _ = out.append(.{ .kind = .marker, .clip = ci, .frame = beat_to_slot[ci][vi][0], .marker = entry_name, .repetition = base_rep });
                     }
                 }
 
@@ -653,9 +711,9 @@ pub fn AnimationDef(comptime zon: anytype) type {
                         rep = anim_events.satAddU16(rep, 1);
                         _ = out.append(.{ .kind = .loop_end, .clip = ci, .repetition = rep });
                     }
-                    const name = marker_beats[ci][in_cycle];
+                    const name = marker_beats[ci][vi][in_cycle];
                     if (name.len > 0) {
-                        _ = out.append(.{ .kind = .marker, .clip = ci, .frame = beat_to_slot[ci][in_cycle], .marker = name, .repetition = rep });
+                        _ = out.append(.{ .kind = .marker, .clip = ci, .frame = beat_to_slot[ci][vi][in_cycle], .marker = name, .repetition = rep });
                     }
                 }
                 const add: u16 = if (wraps_full > 0xFFFF) 0xFFFF else @intCast(@max(wraps_full, 0));
@@ -664,7 +722,7 @@ pub fn AnimationDef(comptime zon: anytype) type {
 
             state.event_pos = new_pos;
             const final_beat: u16 = @intCast(@mod(@as(i64, @intFromFloat(@floor(new_pos))), @as(i64, bc)));
-            state.frame = beat_to_slot[ci][final_beat];
+            state.frame = beat_to_slot[ci][vi][final_beat];
         }
     };
 }

--- a/src/animation_def_runtime.zig
+++ b/src/animation_def_runtime.zig
@@ -32,6 +32,7 @@ const animation_def = @import("animation_def.zig");
 
 pub const Mode = animation_def.Mode;
 pub const ClipMeta = animation_def.ClipMeta;
+pub const FrameEntry = animation_def.FrameEntry;
 
 const Zoir = std.zig.Zoir;
 
@@ -44,9 +45,14 @@ pub const RuntimeAnimationDef = struct {
     /// Per-clip metadata (same `ClipMeta` as the comptime path). `folder`
     /// is heap-owned here (freed in `deinit`).
     clip_meta: []ClipMeta,
-    /// Precomputed sprite-name strings, `[clip][variant][frame]`. Jagged:
+    /// Per-clip normalized slot lists (#664 × #672): the same `FrameEntry`
+    /// rows the comptime `normalizeFrames` produces — count form expands
+    /// to slots 1..N with run 1. Heap-owned (marker strings included).
+    clip_entries: [][]FrameEntry,
+    /// Precomputed sprite-name strings, `[clip][variant][slot]`. Jagged:
     /// row length is that clip's `frame_count`. Byte-equal to the comptime
-    /// table's `"{folder}/{variant}_{frame:04}.png"`.
+    /// table's `"{folder}/{variant}_{f:04}.png"` (slot i names file
+    /// `entries[i].f`, so reorders/reuse resolve identically).
     sprite_names: [][][][]const u8,
 
     /// Parse a `.zon` animation definition. On any malformed input (parse
@@ -119,6 +125,13 @@ pub const RuntimeAnimationDef = struct {
             allocator.free(clip_meta);
         }
 
+        const clip_entries = try allocator.alloc([]FrameEntry, ccount);
+        var ce_filled: usize = 0;
+        errdefer {
+            for (clip_entries[0..ce_filled]) |es| freeEntries(allocator, es);
+            allocator.free(clip_entries);
+        }
+
         {
             var i: u32 = 0;
             while (i < ccount) : (i += 1) {
@@ -127,11 +140,16 @@ pub const RuntimeAnimationDef = struct {
                 cn_filled += 1;
 
                 const cnode = cstruct.vals.at(i);
-                // frames — required, 1..255 (mirrors the comptime u8 frame_count).
+                // frames — required. A bare int N (fast path) expands to
+                // slots 1..N with run 1; an entry list parses each element
+                // (#664 × #672). Stored before any further `try` so the
+                // errdefer above owns it on failure.
                 const frames_node = findField(zoir, cnode, "frames") orelse return error.MissingFrames;
-                const frames_i = try getSmallInt(zoir, frames_node);
-                if (frames_i < 1 or frames_i > 255) return error.FramesOutOfRange;
-                const frame_count: u8 = @intCast(frames_i);
+                clip_entries[i] = try parseFrames(allocator, zoir, frames_node);
+                ce_filled += 1;
+                const entries = clip_entries[i];
+                var beats: u16 = 0;
+                for (entries) |e| beats += e.run;
                 // Defaults replicate animation_def.zig exactly: folder = clip
                 // name, speed = 1.0, mode = .static.
                 const mode: Mode = if (findField(zoir, cnode, "mode")) |mn|
@@ -142,19 +160,22 @@ pub const RuntimeAnimationDef = struct {
                     try getFloat(zoir, sn)
                 else
                     1.0;
+                // Comptime parity: a .static clip only ever shows slot 0,
+                // so per-slot holds are meaningless — reject them.
+                if (mode == .static) {
+                    for (entries) |e| {
+                        if (e.run != 1) return error.HoldOnStaticClip;
+                    }
+                }
                 const folder_src: []const u8 = if (findField(zoir, cnode, "folder")) |fnode|
                     try getString(zoir, fnode)
                 else
                     cname;
                 const folder_dup = try allocator.dupe(u8, folder_src);
-                // Runtime parser reads the count form only, so the #664
-                // beat vocabulary degenerates: entry_count == beat_count
-                // == frame_count (every slot runs one beat). Entry-list
-                // parsing at runtime is a follow-up (#664 × #672).
                 clip_meta[i] = .{
-                    .frame_count = frame_count,
-                    .entry_count = frame_count,
-                    .beat_count = frame_count,
+                    .frame_count = @intCast(entries.len),
+                    .entry_count = @intCast(entries.len),
+                    .beat_count = beats,
                     .speed = speed,
                     .mode = mode,
                     .folder = folder_dup,
@@ -163,7 +184,7 @@ pub const RuntimeAnimationDef = struct {
             }
         }
 
-        // ── sprite-name table [clip][variant][frame] ──────────
+        // ── sprite-name table [clip][variant][slot] ───────────
         const sprite_names = try allocator.alloc([][][]const u8, ccount);
         var sn_clips: usize = 0;
         errdefer {
@@ -200,7 +221,9 @@ pub const RuntimeAnimationDef = struct {
                     }
                     var fi: usize = 0;
                     while (fi < fc) : (fi += 1) {
-                        row[fi] = try std.fmt.allocPrint(allocator, "{s}/{s}_{d:0>4}.png", .{ folder, variant_names[vi], fi + 1 });
+                        // Slot fi names file `entries[fi].f` (not fi+1),
+                        // matching the comptime table for reorders/reuse.
+                        row[fi] = try std.fmt.allocPrint(allocator, "{s}/{s}_{d:0>4}.png", .{ folder, variant_names[vi], clip_entries[ci][fi].f });
                         row_f += 1;
                     }
                     block[vi] = row;
@@ -216,6 +239,7 @@ pub const RuntimeAnimationDef = struct {
             .clip_names = clip_names,
             .variant_names = variant_names,
             .clip_meta = clip_meta,
+            .clip_entries = clip_entries,
             .sprite_names = sprite_names,
         };
     }
@@ -230,6 +254,8 @@ pub const RuntimeAnimationDef = struct {
             a.free(blk);
         }
         a.free(self.sprite_names);
+        for (self.clip_entries) |es| freeEntries(a, es);
+        a.free(self.clip_entries);
         for (self.clip_meta) |m| a.free(m.folder);
         a.free(self.clip_meta);
         for (self.clip_names) |n| a.free(n);
@@ -271,9 +297,104 @@ pub const RuntimeAnimationDef = struct {
         if (variant >= self.variant_names.len) return "";
         return self.sprite_names[clip][variant][frame];
     }
+
+    /// The slot shown at a given beat of a clip — the runtime mirror of
+    /// the comptime `slotForBeat`, computed on the fly by walking the
+    /// entry runs (no baked beat table; the runtime path is preview-only,
+    /// so O(entries) per lookup is inside budget). Returns 0 for any
+    /// out-of-range clip; wraps `beat` past the clip's beat_count.
+    pub fn slotForBeat(self: *const RuntimeAnimationDef, clip: u8, beat: u16) u8 {
+        if (clip >= self.clip_entries.len) return 0;
+        const bc = self.clip_meta[clip].beat_count;
+        if (bc == 0) return 0;
+        var b = beat % bc;
+        for (self.clip_entries[clip], 0..) |e, si| {
+            if (b < e.run) return @intCast(si);
+            b -= e.run;
+        }
+        return 0;
+    }
 };
 
+/// Free one clip's owned entry list, marker strings included.
+fn freeEntries(allocator: std.mem.Allocator, entries: []FrameEntry) void {
+    for (entries) |e| {
+        if (e.marker) |mk| allocator.free(mk);
+    }
+    allocator.free(entries);
+}
+
 // ── ZON node helpers (walk the dynamic Zoir tree) ─────────────
+
+/// Parse a clip's `frames` node into an owned entry list. Mirrors the
+/// comptime `normalizeFrames` (#664) forms and validation:
+///   .frames = 4                               // count: slots 1..4, run 1
+///   .frames = .{ 1, 2, 3, 2 }                 // explicit indices, run 1
+///   .frames = .{ .{ .f = 1, .run = 2 }, 2 }   // per-slot holds/markers
+/// The returned slice and any `marker` strings are owned by the caller
+/// (free via `freeEntries`); on error nothing is leaked.
+fn parseFrames(allocator: std.mem.Allocator, zoir: Zoir, node: Zoir.Node.Index) ![]FrameEntry {
+    switch (node.get(zoir)) {
+        // Count fast-path — a bare int N.
+        .int_literal => {
+            const n = try getSmallInt(zoir, node);
+            if (n < 1 or n > 255) return error.FramesOutOfRange;
+            const entries = try allocator.alloc(FrameEntry, @intCast(n));
+            for (entries, 0..) |*e, i| e.* = .{ .f = @intCast(i + 1), .run = 1 };
+            return entries;
+        },
+        // Entry list — ints and/or `.{ .f, .run, .marker }` structs.
+        .array_literal => |range| {
+            if (range.len == 0) return error.EmptyFrames; // defensive; `.{}` is empty_literal
+            if (range.len > 255) return error.FramesOutOfRange;
+            const entries = try allocator.alloc(FrameEntry, range.len);
+            var filled: usize = 0;
+            errdefer {
+                // Free the FULL allocation; only `filled` markers exist yet.
+                for (entries[0..filled]) |e| {
+                    if (e.marker) |mk| allocator.free(mk);
+                }
+                allocator.free(entries);
+            }
+            var i: u32 = 0;
+            while (i < range.len) : (i += 1) {
+                entries[filled] = try parseFrameEntry(allocator, zoir, range.at(i));
+                filled += 1;
+            }
+            return entries;
+        },
+        // `.{}` lowers to empty_literal, not a zero-length array.
+        .empty_literal => return error.EmptyFrames,
+        else => return error.ExpectedInt,
+    }
+}
+
+/// One element of an entry-list `frames`: a bare int index (run 1) or a
+/// struct literal with `f` (required), `run` (default 1), and an
+/// optional `marker` string (duped onto the heap).
+fn parseFrameEntry(allocator: std.mem.Allocator, zoir: Zoir, node: Zoir.Node.Index) !FrameEntry {
+    switch (node.get(zoir)) {
+        .int_literal => {
+            const f = try getSmallInt(zoir, node);
+            if (f < 1 or f > 9999) return error.FrameIndexOutOfRange;
+            return .{ .f = @intCast(f), .run = 1 };
+        },
+        .struct_literal => {
+            const f_node = findField(zoir, node, "f") orelse return error.MissingFrameIndex;
+            const f = try getSmallInt(zoir, f_node);
+            if (f < 1 or f > 9999) return error.FrameIndexOutOfRange;
+            var run: i32 = 1;
+            if (findField(zoir, node, "run")) |rn| run = try getSmallInt(zoir, rn);
+            if (run < 1 or run > 255) return error.RunOutOfRange;
+            var marker: ?[]const u8 = null;
+            if (findField(zoir, node, "marker")) |mn| {
+                marker = try allocator.dupe(u8, try getString(zoir, mn));
+            }
+            return .{ .f = @intCast(f), .run = @intCast(run), .marker = marker };
+        },
+        else => return error.BadFrameEntry,
+    }
+}
 
 fn findField(zoir: Zoir, node: Zoir.Node.Index, name: []const u8) ?Zoir.Node.Index {
     switch (node.get(zoir)) {

--- a/test/animation_def_runtime_test.zig
+++ b/test/animation_def_runtime_test.zig
@@ -30,10 +30,12 @@ test "RuntimeAnimationDef: byte-equal sprite names + index compatibility (#672)"
         // Clip index must match the comptime ordinal — a live u8 means the
         // same clip on both paths.
         try testing.expectEqual(@as(?u8, ci), rt.clipIndex(cf.name));
-        // Metadata parity.
+        // Metadata parity — the #664 beat vocabulary included (#685).
         const cm = WorkerAnim.clipMeta(clip);
         const rm = rt.clipMeta(ci);
         try testing.expectEqual(cm.frame_count, rm.frame_count);
+        try testing.expectEqual(cm.entry_count, rm.entry_count);
+        try testing.expectEqual(cm.beat_count, rm.beat_count);
         try testing.expectEqual(cm.speed, rm.speed);
         try testing.expectEqual(cm.mode, rm.mode);
         try testing.expectEqualStrings(cm.folder, rm.folder);
@@ -42,12 +44,20 @@ test "RuntimeAnimationDef: byte-equal sprite names + index compatibility (#672)"
             const variant: WorkerAnim.variants = @enumFromInt(vf.value);
             const vi: u8 = vf.value;
             try testing.expectEqual(@as(?u8, vi), rt.variantIndex(vf.name));
-            // Byte-equal sprite names across every valid frame of the clip.
+            // Byte-equal sprite names across every valid slot of the clip.
             var f: u8 = 0;
             while (f < cm.frame_count) : (f += 1) {
                 try testing.expectEqualStrings(
                     WorkerAnim.spriteName(clip, variant, f),
                     rt.spriteName(ci, vi, f),
+                );
+            }
+            // Beat→slot parity across every beat (holds resolve alike).
+            var b: u16 = 0;
+            while (b < cm.beat_count) : (b += 1) {
+                try testing.expectEqual(
+                    WorkerAnim.slotForBeat(clip, variant, b),
+                    rt.slotForBeat(ci, b),
                 );
             }
         }
@@ -66,6 +76,32 @@ test "RuntimeAnimationDef: folder override + defaulting parity (#672)" {
     try testing.expectEqualStrings("idle", idle.folder);
     try testing.expectEqual(@as(f32, 1.0), idle.speed);
     try testing.expectEqual(engine.AnimMode.static, idle.mode);
+}
+
+test "RuntimeAnimationDef: entry-list frames parse holds/reuse/markers (#685)" {
+    var rt = try RuntimeAnimationDef.load(testing.allocator, worker_src);
+    defer rt.deinit();
+
+    // The fixture's swing clip: .{ 1, 2, .{ .f = 3, .run = 2, .marker = "contact" }, 2 }.
+    const ci = rt.clipIndex("swing").?;
+    const m = rt.clipMeta(ci);
+    try testing.expectEqual(@as(u8, 4), m.entry_count);
+    try testing.expectEqual(@as(u16, 5), m.beat_count); // 1+1+2+1
+
+    const entries = rt.clip_entries[ci];
+    try testing.expectEqual(@as(usize, 4), entries.len);
+    try testing.expectEqual(@as(u16, 3), entries[2].f);
+    try testing.expectEqual(@as(u8, 2), entries[2].run);
+    try testing.expectEqualStrings("contact", entries[2].marker.?);
+    try testing.expectEqual(@as(?[]const u8, null), entries[0].marker);
+    try testing.expectEqual(@as(u16, 2), entries[3].f); // file reuse
+
+    // Slot 3 renders file 2 again; the held slot spans beats 2 and 3.
+    try testing.expectEqualStrings("swing/m_bald_0002.png", rt.spriteName(ci, 0, 3));
+    try testing.expectEqual(@as(u8, 2), rt.slotForBeat(ci, 2));
+    try testing.expectEqual(@as(u8, 2), rt.slotForBeat(ci, 3));
+    try testing.expectEqual(@as(u8, 3), rt.slotForBeat(ci, 4));
+    try testing.expectEqual(@as(u8, 0), rt.slotForBeat(ci, 5)); // wraps
 }
 
 test "RuntimeAnimationDef: minimal clip gets the comptime defaults (#672)" {
@@ -145,6 +181,23 @@ test "RuntimeAnimationDef.load: malformed input errors cleanly (#672)" {
     try testing.expectError(error.FramesOutOfRange, RuntimeAnimationDef.load(a, ".{ .variants = .{\"a\"}, .clips = .{ .c = .{ .frames = 0 } } }"));
     // Unknown mode enum.
     try testing.expectError(error.UnknownMode, RuntimeAnimationDef.load(a, ".{ .variants = .{\"a\"}, .clips = .{ .c = .{ .frames = 1, .mode = .bogus } } }"));
+}
+
+test "RuntimeAnimationDef.load: malformed entry lists error cleanly (#685)" {
+    const a = testing.allocator;
+    // Every message mirrors a comptime normalizeFrames @compileError.
+    try testing.expectError(error.EmptyFrames, RuntimeAnimationDef.load(a, ".{ .variants = .{\"a\"}, .clips = .{ .c = .{ .frames = .{} } } }"));
+    try testing.expectError(error.FrameIndexOutOfRange, RuntimeAnimationDef.load(a, ".{ .variants = .{\"a\"}, .clips = .{ .c = .{ .frames = .{ 0 } } } }"));
+    try testing.expectError(error.FrameIndexOutOfRange, RuntimeAnimationDef.load(a, ".{ .variants = .{\"a\"}, .clips = .{ .c = .{ .frames = .{ .{ .f = 10000 } } } } }"));
+    try testing.expectError(error.MissingFrameIndex, RuntimeAnimationDef.load(a, ".{ .variants = .{\"a\"}, .clips = .{ .c = .{ .frames = .{ .{ .run = 2 } } } } }"));
+    try testing.expectError(error.RunOutOfRange, RuntimeAnimationDef.load(a, ".{ .variants = .{\"a\"}, .clips = .{ .c = .{ .frames = .{ .{ .f = 1, .run = 0 } } } } }"));
+    try testing.expectError(error.BadFrameEntry, RuntimeAnimationDef.load(a, ".{ .variants = .{\"a\"}, .clips = .{ .c = .{ .frames = .{ \"x\" } } } }"));
+    // A marker mid-list must not leak when a later entry fails.
+    try testing.expectError(error.RunOutOfRange, RuntimeAnimationDef.load(a,
+        ".{ .variants = .{\"a\"}, .clips = .{ .c = .{ .frames = .{ .{ .f = 1, .marker = \"hit\" }, .{ .f = 2, .run = 999 } } } } }"));
+    // Comptime parity: holds on a .static clip are rejected.
+    try testing.expectError(error.HoldOnStaticClip, RuntimeAnimationDef.load(a,
+        ".{ .variants = .{\"a\"}, .clips = .{ .c = .{ .frames = .{ .{ .f = 1, .run = 2 } } } } }"));
 }
 
 // ── AnimDefSource dispatch ──

--- a/test/animation_def_test.zig
+++ b/test/animation_def_test.zig
@@ -188,8 +188,8 @@ test "AnimationDef: count shorthand yields unit-run beats (#664)" {
     try testing.expectEqualStrings("plain/hero_0001.png", FramesAnim.spriteName(.plain, .hero, 0));
     try testing.expectEqualStrings("plain/hero_0004.png", FramesAnim.spriteName(.plain, .hero, 3));
     // Identity beat→slot mapping.
-    try testing.expectEqual(@as(u8, 0), FramesAnim.slotForBeat(.plain, 0));
-    try testing.expectEqual(@as(u8, 3), FramesAnim.slotForBeat(.plain, 3));
+    try testing.expectEqual(@as(u8, 0), FramesAnim.slotForBeat(.plain, .hero, 0));
+    try testing.expectEqual(@as(u8, 3), FramesAnim.slotForBeat(.plain, .hero, 3));
 }
 
 test "AnimationDef: explicit list reorders and reuses files (#664)" {
@@ -209,11 +209,11 @@ test "AnimationDef: per-slot runs expand the beat table (#664)" {
     try testing.expectEqual(@as(u8, 2), m.entry_count);
     try testing.expectEqual(@as(u16, 3), m.beat_count);
     // beat_to_slot == { 0, 0, 1 }: slot 0 held two beats, then slot 1.
-    try testing.expectEqual(@as(u8, 0), FramesAnim.slotForBeat(.hold, 0));
-    try testing.expectEqual(@as(u8, 0), FramesAnim.slotForBeat(.hold, 1));
-    try testing.expectEqual(@as(u8, 1), FramesAnim.slotForBeat(.hold, 2));
+    try testing.expectEqual(@as(u8, 0), FramesAnim.slotForBeat(.hold, .hero, 0));
+    try testing.expectEqual(@as(u8, 0), FramesAnim.slotForBeat(.hold, .hero, 1));
+    try testing.expectEqual(@as(u8, 1), FramesAnim.slotForBeat(.hold, .hero, 2));
     // slotForBeat wraps past beat_count.
-    try testing.expectEqual(@as(u8, 0), FramesAnim.slotForBeat(.hold, 3));
+    try testing.expectEqual(@as(u8, 0), FramesAnim.slotForBeat(.hold, .hero, 3));
     // The bare int 2 became slot 1 pointing at file 2.
     try testing.expectEqualStrings("hold/hero_0001.png", FramesAnim.spriteName(.hold, .hero, 0));
     try testing.expectEqualStrings("hold/hero_0002.png", FramesAnim.spriteName(.hold, .hero, 1));
@@ -293,7 +293,163 @@ test "AnimationDef: spriteName honors overridden folder and frame count (#666)" 
     try testing.expectEqualStrings("", OverrideAnim.spriteName(.drink, .w_ginger, 8));
 }
 
+// ── Per-variant frame-ENTRY overrides (#684) ──────────────
+
+const entry_override_zon = .{
+    .variants = .{
+        "base_gal",
+        // Entry-list override on a count-form base clip: hold + reorder
+        // + a marker the base doesn't have.
+        .{ .name = "heavy", .overrides = .{
+            .swing = .{ .frames = .{ .{ .f = 1, .run = 2 }, .{ .f = 3, .marker = "impact" }, 2 } },
+        } },
+        // Count-form override on an entry-list base clip (the "vice
+        // versa" direction): flattens holds/markers/reuse away.
+        .{ .name = "swift", .overrides = .{
+            .combo = .{ .frames = 2, .speed = 9.0 },
+        } },
+    },
+    .clips = .{
+        // Count-form base; `heavy` replaces it with an entry list.
+        .swing = .{ .frames = 4, .mode = .time, .speed = 1.0 },
+        // Entry-list base (hold + marker + file reuse); `swift` replaces
+        // it with a bare count.
+        .combo = .{ .frames = .{ .{ .f = 1, .run = 3, .marker = "windup" }, 2, .{ .f = 1 } }, .mode = .time, .speed = 1.0 },
+    },
+};
+const EntryOverrideAnim = AnimationDef(entry_override_zon);
+
+test "AnimationDef: entry-list override on a count-form base (#684)" {
+    // Base variant keeps the count-form identity row.
+    const base = EntryOverrideAnim.clipMetaFor(.swing, .base_gal);
+    try testing.expectEqual(@as(u8, 4), base.entry_count);
+    try testing.expectEqual(@as(u16, 4), base.beat_count);
+    try testing.expectEqual(@as(u8, 2), EntryOverrideAnim.slotForBeat(.swing, .base_gal, 2));
+    try testing.expectEqualStrings("", EntryOverrideAnim.markerAtBeat(.swing, .base_gal, 2));
+    try testing.expectEqualStrings("swing/base_gal_0003.png", EntryOverrideAnim.spriteName(.swing, .base_gal, 2));
+
+    // heavy's row: 3 slots over 4 beats (per-variant RUNS), marker on slot 1.
+    const heavy = EntryOverrideAnim.clipMetaFor(.swing, .heavy);
+    try testing.expectEqual(@as(u8, 3), heavy.entry_count);
+    try testing.expectEqual(@as(u8, 3), heavy.frame_count);
+    try testing.expectEqual(@as(u16, 4), heavy.beat_count);
+    // beat_to_slot row: { 0, 0, 1, 2 } — slot 0 held two beats.
+    try testing.expectEqual(@as(u8, 0), EntryOverrideAnim.slotForBeat(.swing, .heavy, 0));
+    try testing.expectEqual(@as(u8, 0), EntryOverrideAnim.slotForBeat(.swing, .heavy, 1));
+    try testing.expectEqual(@as(u8, 1), EntryOverrideAnim.slotForBeat(.swing, .heavy, 2));
+    try testing.expectEqual(@as(u8, 2), EntryOverrideAnim.slotForBeat(.swing, .heavy, 3));
+    // The marker sits on slot 1's first beat (beat 2) — heavy only.
+    try testing.expectEqualStrings("impact", EntryOverrideAnim.markerAtBeat(.swing, .heavy, 2));
+    try testing.expectEqualStrings("", EntryOverrideAnim.markerAtBeat(.swing, .heavy, 0));
+    // Names use the override's file indices (reorder: slot 2 → file 2).
+    try testing.expectEqualStrings("swing/heavy_0001.png", EntryOverrideAnim.spriteName(.swing, .heavy, 0));
+    try testing.expectEqualStrings("swing/heavy_0003.png", EntryOverrideAnim.spriteName(.swing, .heavy, 1));
+    try testing.expectEqualStrings("swing/heavy_0002.png", EntryOverrideAnim.spriteName(.swing, .heavy, 2));
+    // Past the override's slot count → empty (base still has a slot 3).
+    try testing.expectEqualStrings("", EntryOverrideAnim.spriteName(.swing, .heavy, 3));
+}
+
+test "AnimationDef: count-form override on an entry-list base (#684)" {
+    // Base variant keeps hold + marker + file reuse.
+    const base = EntryOverrideAnim.clipMetaFor(.combo, .base_gal);
+    try testing.expectEqual(@as(u8, 3), base.entry_count);
+    try testing.expectEqual(@as(u16, 5), base.beat_count);
+    try testing.expectEqualStrings("windup", EntryOverrideAnim.markerAtBeat(.combo, .base_gal, 0));
+    try testing.expectEqual(@as(u8, 0), EntryOverrideAnim.slotForBeat(.combo, .base_gal, 2)); // still held
+    try testing.expectEqualStrings("combo/base_gal_0001.png", EntryOverrideAnim.spriteName(.combo, .base_gal, 2)); // reused file 1
+
+    // swift's count row: 2 unit-run slots, no marker, own speed.
+    const swift = EntryOverrideAnim.clipMetaFor(.combo, .swift);
+    try testing.expectEqual(@as(u8, 2), swift.entry_count);
+    try testing.expectEqual(@as(u16, 2), swift.beat_count);
+    try testing.expectEqual(@as(f32, 9.0), swift.speed);
+    try testing.expectEqual(@as(u8, 1), EntryOverrideAnim.slotForBeat(.combo, .swift, 1));
+    try testing.expectEqualStrings("", EntryOverrideAnim.markerAtBeat(.combo, .swift, 0));
+    try testing.expectEqualStrings("combo/swift_0001.png", EntryOverrideAnim.spriteName(.combo, .swift, 0));
+    try testing.expectEqualStrings("combo/swift_0002.png", EntryOverrideAnim.spriteName(.combo, .swift, 1));
+    try testing.expectEqualStrings("", EntryOverrideAnim.spriteName(.combo, .swift, 2));
+}
+
+test "AnimationDef: advanceState follows the state's variant row (#684)" {
+    // heavy still holds slot 0 at beat 1 where base_gal has moved on.
+    var heavy_state = AnimationState{ .variant = @intFromEnum(EntryOverrideAnim.variants.heavy) };
+    heavy_state.transitionFromMeta(
+        @intFromEnum(EntryOverrideAnim.clips.swing),
+        EntryOverrideAnim.clipMetaFor(.swing, .heavy),
+    );
+    var base_state = AnimationState{ .variant = @intFromEnum(EntryOverrideAnim.variants.base_gal) };
+    base_state.transitionFromMeta(
+        @intFromEnum(EntryOverrideAnim.clips.swing),
+        EntryOverrideAnim.clipMetaFor(.swing, .base_gal),
+    );
+
+    EntryOverrideAnim.advanceState(&heavy_state, 1.5); // beat 1
+    EntryOverrideAnim.advanceState(&base_state, 1.5); // beat 1
+    try testing.expectEqual(@as(u8, 0), heavy_state.frame); // held
+    try testing.expectEqual(@as(u8, 1), base_state.frame); // identity
+
+    EntryOverrideAnim.advanceState(&heavy_state, 2.0); // timer 3.5 → beat 3
+    try testing.expectEqual(@as(u8, 2), heavy_state.frame);
+}
+
+test "AnimationDef: advanceStateEvents fires the variant's own markers (#684)" {
+    // `impact` exists only in heavy's override — base_gal's count-form
+    // row stays silent over the same beats.
+    var buf = engine.AnimPendingBuf{};
+    var heavy_state = AnimationState{ .variant = @intFromEnum(EntryOverrideAnim.variants.heavy) };
+    heavy_state.transitionFromMeta(
+        @intFromEnum(EntryOverrideAnim.clips.swing),
+        EntryOverrideAnim.clipMetaFor(.swing, .heavy),
+    );
+    EntryOverrideAnim.advanceStateEvents(&heavy_state, 3.5, &buf); // crosses beat 2
+    try testing.expectEqual(@as(usize, 1), buf.len);
+    try testing.expectEqualStrings("impact", buf.slice()[0].marker);
+    try testing.expectEqual(@as(u8, 1), buf.slice()[0].frame); // heavy's slot 1
+
+    buf.clear();
+    var base_state = AnimationState{ .variant = @intFromEnum(EntryOverrideAnim.variants.base_gal) };
+    base_state.transitionFromMeta(
+        @intFromEnum(EntryOverrideAnim.clips.swing),
+        EntryOverrideAnim.clipMetaFor(.swing, .base_gal),
+    );
+    EntryOverrideAnim.advanceStateEvents(&base_state, 3.5, &buf);
+    try testing.expectEqual(@as(usize, 0), buf.len);
+}
+
+test "AnimationDef: no-override defs keep base-identical per-variant rows (#684)" {
+    // Every per-variant row of a def WITHOUT overrides must equal the
+    // base row — meta, beat→slot, markers, and names all agree across
+    // variants (the #684 byte-identity guarantee, checked per lookup).
+    inline for (@typeInfo(TestAnim.clips).@"enum".fields) |cf| {
+        const clip: TestAnim.clips = @enumFromInt(cf.value);
+        const base = TestAnim.clipMeta(clip);
+        inline for (@typeInfo(TestAnim.variants).@"enum".fields) |vf| {
+            const variant: TestAnim.variants = @enumFromInt(vf.value);
+            const m = TestAnim.clipMetaFor(clip, variant);
+            try testing.expectEqual(base.frame_count, m.frame_count);
+            try testing.expectEqual(base.entry_count, m.entry_count);
+            try testing.expectEqual(base.beat_count, m.beat_count);
+            try testing.expectEqual(base.speed, m.speed);
+            try testing.expectEqual(base.mode, m.mode);
+            try testing.expectEqualStrings(base.folder, m.folder);
+            var b: u16 = 0;
+            while (b < base.beat_count) : (b += 1) {
+                try testing.expectEqual(
+                    TestAnim.slotForBeat(clip, @enumFromInt(0), b),
+                    TestAnim.slotForBeat(clip, variant, b),
+                );
+                try testing.expectEqualStrings(
+                    TestAnim.markerAtBeat(clip, @enumFromInt(0), b),
+                    TestAnim.markerAtBeat(clip, variant, b),
+                );
+            }
+        }
+    }
+}
+
 // Comptime-error cases (verified by construction; the repo has no
 // compile-failure harness, so these stay documented rather than run):
 //   - override key naming a nonexistent clip → "overrides unknown clip '…'"
 //   - override field other than frames/speed/mode/folder → "unknown field '…'"
+//   - a variant whose effective (mode, frames) pair is .static with a
+//     .run > 1 → "holds are meaningless when frame is always slot 0"

--- a/test/animation_events_test.zig
+++ b/test/animation_events_test.zig
@@ -36,12 +36,12 @@ fn countKind(buf: *const PendingBuf, kind: Kind) usize {
 // ── Marker table (comptime) ───────────────────────────────
 
 test "AnimationDef.markerAtBeat: marker sits on its slot's beat (#670)" {
-    try testing.expectEqualStrings("", Def.markerAtBeat(.punch, 0));
-    try testing.expectEqualStrings("", Def.markerAtBeat(.punch, 1));
-    try testing.expectEqualStrings("contact", Def.markerAtBeat(.punch, 2));
-    try testing.expectEqualStrings("", Def.markerAtBeat(.punch, 3));
+    try testing.expectEqualStrings("", Def.markerAtBeat(.punch, .hero, 0));
+    try testing.expectEqualStrings("", Def.markerAtBeat(.punch, .hero, 1));
+    try testing.expectEqualStrings("contact", Def.markerAtBeat(.punch, .hero, 2));
+    try testing.expectEqualStrings("", Def.markerAtBeat(.punch, .hero, 3));
     // Wraps past beat_count.
-    try testing.expectEqualStrings("contact", Def.markerAtBeat(.punch, 6));
+    try testing.expectEqualStrings("contact", Def.markerAtBeat(.punch, .hero, 6));
 }
 
 // ── AnimationState marker + loop-end dispatch ─────────────

--- a/test/animation_state_transitions_test.zig
+++ b/test/animation_state_transitions_test.zig
@@ -190,6 +190,7 @@ test "advanceState/advanceStateEvents accept a typed-enum clip (#686)" {
     const MClip = enum(u8) { punch, idle };
     var st = struct {
         clip: MClip = .punch,
+        variant: u8 = 0,
         frame_count: u8 = 4,
         speed: f32 = 1.0,
         mode: engine.AnimMode = .time,

--- a/test/fixtures/worker_anim.zon
+++ b/test/fixtures/worker_anim.zon
@@ -16,5 +16,9 @@
         .enter_combat = .{ .frames = 4, .mode = .time, .speed = 8.0 },
         .idle_combat = .{ .frames = 2, .mode = .time, .speed = 3.0 },
         .punch = .{ .frames = 6, .mode = .time, .speed = 12.0 },
+        // Entry-list clip (#664 forms): mixes a bare index, a struct with
+        // a hold + marker, and file reuse — exercises the runtime parser's
+        // array_literal path against the comptime normalizeFrames (#685).
+        .swing = .{ .frames = .{ 1, 2, .{ .f = 3, .run = 2, .marker = "contact" }, 2 }, .mode = .time, .speed = 12.0 },
     },
 }


### PR DESCRIPTION
Two interlocking pieces of the #664 beat-model follow-up, one logical commit each.

## Commit 1 — comptime per-variant entries (#684)

A variant's `.frames` override now accepts **any** of the three #664 forms (count, explicit index list, per-slot holds with markers), normalized through the same `normalizeFrames` as base clips:

- `clip_entries_2d[clip][variant]` — base entries unless the variant overrides `.frames`; non-overriding rows alias the base slice.
- `beat_to_slot` / `marker_beats` gain the variant dimension; `max_slots` / `max_beats` span all variants.
- `clip_meta_2d` derives an overriding variant's `frame_count`/`entry_count`/`beat_count` from its own entry row; the count-form-only guard and the base-holds/markers/reordering rejection are **lifted** (`validateOverrideFields` stays). The ".static clips cannot hold" rule now applies per-variant to the effective (mode, entries) pair.
- `advanceState`/`advanceStateEvents` consult `state.variant` (enum or u8, coerced like `clipIndexOf`); `slotForBeat`/`markerAtBeat` grow a `Variant` parameter (call sites updated).
- Sprite-name rows read the per-variant entries — the `overridden → count-form files` special case is gone.

**Byte-identity guarantee**: defs with no overrides (or count-form overrides) generate identical tables. Proven by a golden dump of every `clipMetaFor` row, sprite name, and per-beat slot/marker for the 12-clip/8-variant worker fixture **and** the count-form-override def, run against v1.71.0 code and this branch: 1600 output lines each, `diff` empty.

## Commit 2 — runtime entry-list parsing (#685)

- `parseFrames` mirrors `normalizeFrames`: int fast-path kept; an `array_literal` parses ints and `.{ .f, .run, .marker }` struct literals into heap-owned `[]FrameEntry` (markers duped; errdefer-safe, `load`'s never-corrupt-the-running-def contract preserved). Validation errors map 1:1 onto the comptime `@compileError`s, incl. `HoldOnStaticClip`.
- `RuntimeAnimationDef` gains `clip_entries` (freed in `deinit`); `entry_count`/`beat_count` derive from it; sprite-name rows use `entries[i].f`; on-the-fly `slotForBeat(clip, beat)` (preview-only budget, no baked table).
- Fixture gains an entry-list `swing` clip (appended — clip order is load-bearing); the parity test now locks `entry_count`/`beat_count` and per-beat slot equality between the comptime and runtime paths.
- `refreshState` and the `RuntimeAnimDefs`/`editor_load_animation_def` surface (#688) unchanged.

## Tests

700 → 707 (+5 in #684: entry-list-on-count-base, count-on-entry-list-base, variant-aware `advanceState`, variant-scoped markers in `advanceStateEvents`, no-override row identity; +2 in #685: holds/reuse/markers parse + leak-safe malformed-entry errors). Each new test probe-verified (assert broken → observed the failure → restored). `zig build test` green after each commit.

Closes #684
Closes #685

https://claude.ai/code/session_01P7YLw4hXFCCaY2LAUt4G1j