### PR TITLE
feat(editor_api): editor_reload_prefab — hot-swap prefab definitions (contract v1.3)

### DIFF
--- a/src/editor_api.zig
+++ b/src/editor_api.zig
@@ -70,6 +70,7 @@ const VTable = struct {
     load_scene: *const fn (name: []const u8, src: []const u8) i32,
     set_state: *const fn (name: []const u8) i32,
     load_animation_def: *const fn (name: []const u8, src: []const u8) i32,
+    reload_prefab: *const fn (name: []const u8, src: []const u8) i32,
     set_entity_position: *const fn (id: u64, x: f32, y: f32) void,
     scene_digest: *const fn (out: []u8) usize,
     apply_camera: *const fn (x: f32, y: f32, zoom: f32) void,
@@ -230,6 +231,37 @@ pub export fn editor_load_animation_def(name: [*]const u8, nlen: usize, src: [*]
     return vt.load_animation_def(name[0..nlen], src[0..slen]);
 }
 
+/// Push a prefab JSONC SOURCE into the running game (contract v1.3,
+/// labelle-studio issue #24 — the prefab half). `name` is the prefab's
+/// registry name (`"condenser"` for `prefabs/condenser.jsonc`,
+/// `"<pack>__<stem>"` for pack prefabs); `src` is the full JSONC
+/// source. On success the source is parsed, shape-checked, and
+/// installed in the prefab registry under its effective name
+/// (replace-or-insert — see `PrefabCache.replaceFromSource`), so every
+/// FUTURE spawn resolves the new definition: runtime `spawnPrefab`
+/// calls, scene loads referencing the prefab (including an
+/// `editor_load_scene` reload of the current scene, which re-spawns its
+/// placed instances from the new data), and save/load Phase 1
+/// re-spawns.
+///
+/// Already-spawned instances keep their current components — the studio
+/// UI says "applies to new spawns" — and the replaced definition's
+/// memory is retired, never freed, so their borrowed slices stay valid
+/// even while the sim is paused. In-place live refresh is a documented
+/// follow-up (see `game/prefab_runtime_mixin.zig` for why it is not
+/// boundable today).
+///
+/// Returns 0 = ok; -1 = not bound / empty name; -2 = parse/shape
+/// failure (unparseable, non-object top level, RFC #560 §B2 violation);
+/// -3 = out of memory. On ANY nonzero return the registry is untouched
+/// — the previous definition stays live, so a half-saved file never
+/// corrupts the preview. The buffers are copied; the caller may free
+/// them right after the call.
+pub export fn editor_reload_prefab(name: [*]const u8, nlen: usize, src: [*]const u8, slen: usize) i32 {
+    const vt = vtable orelse return -1;
+    return vt.reload_prefab(name[0..nlen], src[0..slen]);
+}
+
 /// Move entity `id` to world coordinates (x, y). Marks the position
 /// dirty so the render pipeline re-syncs. Unknown/positionless ids are
 /// ignored.
@@ -314,6 +346,7 @@ fn Holder(comptime GP: type, comptime RP: type) type {
             .load_scene = &loadSceneImpl,
             .set_state = &setStateImpl,
             .load_animation_def = &loadAnimationDefImpl,
+            .reload_prefab = &reloadPrefabImpl,
             .set_entity_position = &setEntityPositionImpl,
             .scene_digest = &sceneDigestImpl,
             .apply_camera = &applyCameraImpl,
@@ -407,6 +440,19 @@ fn Holder(comptime GP: type, comptime RP: type) type {
             // component is touched, so unlike loadSceneImpl there is no
             // rollback dance here.
             game.loadAnimationDefSource(name, src) catch |err| {
+                return if (err == error.OutOfMemory) -3 else -2;
+            };
+            return 0;
+        }
+
+        fn reloadPrefabImpl(name: []const u8, src: []const u8) i32 {
+            // Empty name: never meaningful, most likely a host-side
+            // length bug (mirrors setStateImpl / loadAnimationDefImpl).
+            if (name.len == 0) return -1;
+            // `reloadPrefabSource` is transactional by construction:
+            // parse/shape failures error out BEFORE the registry is
+            // touched, so there is no rollback dance here either.
+            game.reloadPrefabSource(name, src) catch |err| {
                 return if (err == error.OutOfMemory) -3 else -2;
             };
             return 0;

--- a/src/game.zig
+++ b/src/game.zig
@@ -54,6 +54,7 @@ const loop_mixin = @import("game/loop_mixin.zig");
 const misc_mixin = @import("game/misc_mixin.zig");
 const animation_runtime_mixin = @import("game/animation_runtime_mixin.zig");
 const animation_def_runtime = @import("animation_def_runtime.zig");
+const prefab_runtime_mixin = @import("game/prefab_runtime_mixin.zig");
 
 /// Full game configuration — the assembler fills ALL comptime slots.
 /// RenderImpl is a renderer plugin (e.g. gfx.GfxRenderer) satisfying RenderInterface.
@@ -308,6 +309,7 @@ pub fn GameConfigWithYAxis(
         const LoopMixin = loop_mixin.Mixin(Self);
         const MiscMixin = misc_mixin.Mixin(Self);
         const AnimationRuntimeMixin = animation_runtime_mixin.Mixin(Self);
+        const PrefabRuntimeMixin = prefab_runtime_mixin.Mixin(Self);
 
         /// Scene lifecycle hooks
         pub const SceneHooks = struct {
@@ -1185,6 +1187,13 @@ pub fn GameConfigWithYAxis(
         pub const loadAnimationDefSource = AnimationRuntimeMixin.loadAnimationDefSource;
         pub const runtimeAnimDef = AnimationRuntimeMixin.runtimeAnimDef;
         pub const refreshAnimationStates = AnimationRuntimeMixin.refreshAnimationStates;
+
+        /// Runtime prefab-definition hot-swap (labelle-studio Play mode /
+        /// `editor_api.editor_reload_prefab`) — replace-or-insert the
+        /// prefab registry entry so FUTURE spawns use the new source;
+        /// existing instances keep their data. See
+        /// `game/prefab_runtime_mixin.zig` for the scope contract.
+        pub const reloadPrefabSource = PrefabRuntimeMixin.reloadPrefabSource;
         pub const setSceneAssets = SceneMixin.setSceneAssets;
         pub const setSceneInitialState = SceneMixin.setSceneInitialState;
         pub const setScene = SceneMixin.setScene;

--- a/src/game/prefab_runtime_mixin.zig
+++ b/src/game/prefab_runtime_mixin.zig
@@ -1,0 +1,66 @@
+//! Prefab-runtime mixin — hot-swap prefab definitions on a live game
+//! (labelle-studio Play mode, studio issue #24; the prefab analog of
+//! `game/animation_runtime_mixin.zig`).
+//!
+//! Prefab JSONC is consumed at `spawnPrefab` time: `spawnPrefabImpl`
+//! (`jsonc/scene_loader/prefab_spawn.zig`) looks the definition up in
+//! the game's `PrefabCache` on EVERY spawn. Replacing the cache entry is
+//! therefore all it takes for every *future* instantiation to use the
+//! new data — runtime `spawnPrefab`/`spawnFromPrefab` calls, scene loads
+//! that reference the prefab (including an `editor_load_scene` reload of
+//! the current scene), and save/load Phase 1 re-spawns all resolve
+//! through the same registry.
+//!
+//! ## What this deliberately does NOT do
+//!
+//! Already-spawned instances keep the components they were built with.
+//! Re-instantiating them in place is not a registry concern and is not
+//! cleanly boundable today:
+//!
+//!   * destroy + respawn loses runtime component state unless the
+//!     save/load Phase 2 override pass is replayed, and dangles every
+//!     entity reference OTHER entities hold into the old tree —
+//!     `loadGameState` only survives this because it rebuilds the whole
+//!     world under one global `id_map` remap;
+//!   * `PrefabInstance.overrides` is still the `""` stub (the structured
+//!     overrides pipeline is an acknowledged follow-up — see
+//!     `entity_mixin.tagAsPrefabInstance`), so scene-level per-instance
+//!     overrides could not be re-applied;
+//!   * destroy/spawn fire lifecycle hooks and engine events into a sim
+//!     the editor may have paused.
+//!
+//! The engine-side design for a bounded live refresh (re-applying
+//! `.transient`-policy components — the ones save/load already resets
+//! from prefab data by contract) is tracked in its own issue; hosts can
+//! see new data live today by re-spawning (or scene-reloading) affected
+//! entities.
+const prefab_cache_mod = @import("../jsonc/prefab_cache.zig");
+const PrefabCache = prefab_cache_mod.PrefabCache;
+
+/// Returns the prefab-runtime mixin for a given Game type.
+pub fn Mixin(comptime Game: type) type {
+    return struct {
+        /// Parse a prefab JSONC source and install it in the prefab
+        /// registry under its effective name (replace-or-insert) so all
+        /// future spawns use it. On any error NOTHING changes — the
+        /// previous definition stays live, so a half-saved file never
+        /// corrupts a running preview. `name` and `source` are copied;
+        /// the caller may free both immediately.
+        ///
+        /// Uses the game's attached `PrefabCache` when one exists (the
+        /// normal case — the assembler registers embedded prefabs and
+        /// loads a scene before any editor push); otherwise creates the
+        /// persistent cache, which the next scene load then reuses via
+        /// `getOrCreatePrefabCache`'s reuse contract. The existing
+        /// cache's `prefab_dir` is deliberately left untouched (only
+        /// scene loads may retarget the desktop disk-fallback dir).
+        pub fn reloadPrefabSource(self: *Game, name: []const u8, source: []const u8) error{ OutOfMemory, InvalidFormat }!void {
+            const cache: *PrefabCache = if (self.prefab_cache_ptr) |ptr|
+                @ptrCast(@alignCast(ptr))
+            else
+                prefab_cache_mod.initPersistentCache(self, self.prefab_dir orelse "prefabs") catch
+                    return error.OutOfMemory;
+            try cache.replaceFromSource(self.log, name, source);
+        }
+    };
+}

--- a/src/jsonc/prefab_cache.zig
+++ b/src/jsonc/prefab_cache.zig
@@ -104,6 +104,88 @@ pub const PrefabCache = struct {
         self.prefabs.put(duped_key, val) catch return null;
         return val;
     }
+
+    /// Replace — or insert — the registry entry for a prefab from an
+    /// in-memory JSONC source: the labelle-studio Play-mode hot-reload
+    /// path (`editor_api.editor_reload_prefab`, studio issue #24).
+    ///
+    /// Transactional: the source is parsed and shape-checked BEFORE the
+    /// registry is touched, so a malformed/half-saved file returns an
+    /// error and every future spawn keeps using the previous definition.
+    /// Rejected (validated at push time so the editor gets an error
+    /// instead of silent future spawn failures):
+    ///   * unparseable JSONC,
+    ///   * a non-object top level (a prefab must be a single entity
+    ///     object — array "bundles" are a scene-file shape),
+    ///   * an RFC #560 §B2 violation (`prefab` reference + `children`).
+    /// Deeper semantic problems (unknown components, cycles introduced
+    /// through OTHER prefabs) surface at spawn time through the loader's
+    /// existing gates, which log and return a null spawn without
+    /// corrupting the world.
+    ///
+    /// Keying matches `addEmbeddedPrefab` / `scanDir`: the entry lands
+    /// under the source's *effective name* (its `"name"` field when
+    /// present, else `name`). Corollary: pushing a source whose `"name"`
+    /// diverges from the old one REGISTERS the new name and leaves the
+    /// previous entry (old name → old data) in place until restart —
+    /// a rename, not an in-place edit.
+    ///
+    /// Ownership/graveyard: `source` is duped into `self.persistent`
+    /// (the caller may free its buffer immediately), and a REPLACED
+    /// `Value` tree is never freed — it stays allocated for the game's
+    /// lifetime. That is load-bearing, not sloppiness: components on
+    /// already-spawned entities hold `[]const u8` slices into the old
+    /// tree (see the module header), and the editor can push while the
+    /// sim is paused, when no tick will ever re-read them — the same
+    /// retire-don't-free reasoning as `RuntimeAnimDefs`, obtained here
+    /// for free because the cache's persistent allocator never frees.
+    /// On the error paths the partial parse leaks into `persistent` the
+    /// same harmless way `scanDir`'s error path documents.
+    ///
+    /// Desktop caveat: an entry pushed for a file living in a directory
+    /// `scanDir` has NOT yet walked will make that later first-time scan
+    /// fail with `error.DuplicatePrefabName` (the scan treats the pushed
+    /// key as a collision). Unreachable from the studio — its wasm games
+    /// never run the filesystem scan and always boot a scene (scan done)
+    /// before any push.
+    pub fn replaceFromSource(
+        self: *PrefabCache,
+        log: anytype,
+        name: []const u8,
+        source: []const u8,
+    ) error{ OutOfMemory, InvalidFormat }!void {
+        const src = try self.persistent.dupe(u8, source);
+        var parser = JsoncParser.init(self.persistent, src);
+        const val = parser.parse() catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => {
+                log.err("[prefab-reload] '{s}': source does not parse ({s}) — keeping the previous definition", .{ name, @errorName(err) });
+                return error.InvalidFormat;
+            },
+        };
+        const obj = val.asObject() orelse {
+            log.err("[prefab-reload] '{s}': top level must be an object (a prefab is a single entity) — keeping the previous definition", .{name});
+            return error.InvalidFormat;
+        };
+        // RFC #560 §B2 at push time — mirrors the gate every use site
+        // re-checks (`spawnPrefabImpl`), but failing HERE keeps the old
+        // definition live instead of installing one that can never spawn.
+        uf.rejectB2Violation(uf.rootObject(obj), log, "hot-reloaded prefab root") catch {
+            return error.InvalidFormat;
+        };
+
+        const key = uf.effectiveName(obj, name);
+        if (self.prefabs.getPtr(key)) |existing| {
+            // Replace in place — the map keeps its own key allocation;
+            // the old Value tree is retired (never freed, see above).
+            existing.* = val;
+        } else {
+            // Insert. `key` may alias the caller's `name` buffer (freed
+            // right after the call), so the map needs its own copy.
+            const duped_key = try self.persistent.dupe(u8, key);
+            try self.prefabs.put(duped_key, val);
+        }
+    }
 };
 
 /// Allocate a persistent `PrefabCache` and store it on the game's

--- a/test/editor_api_test.zig
+++ b/test/editor_api_test.zig
@@ -71,11 +71,12 @@ test "pre-bind: every export is a safe no-op" {
     editor_api.unbind();
     defer editor_api.unbind();
 
-    // Scene/state/animation ops report failure (no game to act on).
+    // Scene/state/animation/prefab ops report failure (no game to act on).
     try testing.expectEqual(@as(i32, -1), editor_api.editor_set_scene("main", 4));
     try testing.expectEqual(@as(i32, -1), editor_api.editor_load_scene("main", 4, "{}", 2));
     try testing.expectEqual(@as(i32, -1), editor_api.editor_set_state("playing", 7));
     try testing.expectEqual(@as(i32, -1), editor_api.editor_load_animation_def("worker", 6, ".{}", 3));
+    try testing.expectEqual(@as(i32, -1), editor_api.editor_reload_prefab("condenser", 9, "{}", 2));
 
     // Void setters silently ignore.
     editor_api.editor_set_entity_position(42, 1.0, 2.0);
@@ -633,4 +634,169 @@ test "editor_load_animation_def: malformed source is rejected and the old def st
 
     // Empty name: host-side length bug — rejected without touching the game.
     try testing.expectEqual(@as(i32, -1), editor_api.editor_load_animation_def("x", 0, WORKER_V2, WORKER_V2.len));
+}
+
+// ── editor_reload_prefab (contract v1.3, studio issue #24) ──────────
+//
+// The prefab half of #24: replace-or-insert the prefab REGISTRY entry
+// so future spawns use the new source. Existing instances keep their
+// components — including `[]const u8` fields aliasing the replaced
+// (retired, never freed) parse tree, which the tests read back after
+// the swap to pin the graveyard contract.
+
+/// Carries a string field on purpose: deserialized `text` is a slice
+/// into the prefab's parsed source tree, so an instance spawned from v1
+/// still reading "v1-overlay" after a v2 push proves the old tree
+/// survives the registry swap.
+const PipeOverlay = struct {
+    text: []const u8 = "",
+    fps: f32 = 0,
+};
+
+const PrefabComponents = engine.ComponentRegistry(.{
+    .PipeOverlay = PipeOverlay,
+});
+
+const PrefabBridge = engine.JsoncSceneBridge(engine.Game, PrefabComponents);
+
+const CONDENSER_V1 =
+    \\{ "components": { "PipeOverlay": { "text": "v1-overlay", "fps": 6.0 } } }
+;
+const CONDENSER_V2 =
+    \\{ "components": { "PipeOverlay": { "text": "v2-overlay", "fps": 24.0 } } }
+;
+
+/// Boot the assembler's wasm sequence: embedded prefab registration,
+/// then a scene load (which attaches the prefab cache to the game and
+/// enables `spawnPrefab`).
+fn bootPrefabGame(game: *engine.Game) !void {
+    try PrefabBridge.addEmbeddedPrefab(game, "condenser", CONDENSER_V1, "prefabs");
+    try PrefabBridge.loadSceneFromSource(game,
+        \\{ "entities": [] }
+    , "prefabs");
+}
+
+test "editor_reload_prefab: future spawns use the pushed source; existing instances keep the retired data" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = engine.Game.init(testing.allocator);
+    defer game.deinit();
+    try bootPrefabGame(&game);
+
+    // A live instance spawned from v1 — the shape of a condenser
+    // overlay already in the world when a studio save lands.
+    const before = game.spawnPrefab("condenser", .{ .x = 10, .y = 20 }).?;
+    {
+        const c = game.ecs_backend.getComponent(before, PipeOverlay).?;
+        try testing.expectEqualStrings("v1-overlay", c.text);
+        try testing.expectEqual(@as(f32, 6.0), c.fps);
+    }
+
+    var runner = DummyRunner{};
+    editor_api.bind(&game, &runner);
+
+    // Push v2 from a TRANSIENT buffer (the studio frees its wasm buffer
+    // right after the call — the engine must have copied what it keeps).
+    const src = try testing.allocator.dupe(u8, CONDENSER_V2);
+    try testing.expectEqual(@as(i32, 0), editor_api.editor_reload_prefab("condenser", 9, src.ptr, src.len));
+    testing.allocator.free(src);
+
+    // Future spawn: the new definition.
+    const after = game.spawnPrefab("condenser", .{ .x = 30, .y = 40 }).?;
+    const c2 = game.ecs_backend.getComponent(after, PipeOverlay).?;
+    try testing.expectEqualStrings("v2-overlay", c2.text);
+    try testing.expectEqual(@as(f32, 24.0), c2.fps);
+
+    // Existing instance: untouched, and its string still reads the OLD
+    // tree byte-for-byte — the replaced generation was retired, not
+    // freed (the sim may be paused; nothing will re-resolve the slice).
+    const c1 = game.ecs_backend.getComponent(before, PipeOverlay).?;
+    try testing.expectEqualStrings("v1-overlay", c1.text);
+    try testing.expectEqual(@as(f32, 6.0), c1.fps);
+}
+
+test "editor_reload_prefab: malformed/invalid sources are rejected and the old definition stays live" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = engine.Game.init(testing.allocator);
+    defer game.deinit();
+    try bootPrefabGame(&game);
+
+    var runner = DummyRunner{};
+    editor_api.bind(&game, &runner);
+
+    // Half-saved file mid-edit: parse failure → -2.
+    const garbage = "{ \"components\": { \"PipeOverlay\": ";
+    try testing.expectEqual(@as(i32, -2), editor_api.editor_reload_prefab("condenser", 9, garbage, garbage.len));
+
+    // Parses, but a prefab must be a single entity OBJECT (an array top
+    // level is a scene-bundle shape) → -2.
+    const bundle = "[ { \"components\": {} } ]";
+    try testing.expectEqual(@as(i32, -2), editor_api.editor_reload_prefab("condenser", 9, bundle, bundle.len));
+
+    // RFC #560 §B2: a prefab REFERENCE root cannot also author
+    // children → -2 at push time (spawn would only fail later).
+    const b2 = "{ \"prefab\": \"other\", \"children\": [] }";
+    try testing.expectEqual(@as(i32, -2), editor_api.editor_reload_prefab("condenser", 9, b2, b2.len));
+
+    // Empty name: host-side length bug — rejected up front.
+    try testing.expectEqual(@as(i32, -1), editor_api.editor_reload_prefab("x", 0, CONDENSER_V2, CONDENSER_V2.len));
+
+    // After every rejection the registry still serves v1.
+    const e = game.spawnPrefab("condenser", .{ .x = 0, .y = 0 }).?;
+    const c = game.ecs_backend.getComponent(e, PipeOverlay).?;
+    try testing.expectEqualStrings("v1-overlay", c.text);
+    try testing.expectEqual(@as(f32, 6.0), c.fps);
+}
+
+test "editor_reload_prefab: inserts brand-new prefabs, keyed by the source's effective name" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = engine.Game.init(testing.allocator);
+    defer game.deinit();
+    try bootPrefabGame(&game);
+
+    var runner = DummyRunner{};
+    editor_api.bind(&game, &runner);
+
+    // A prefab file created while Play mode runs: no previous entry —
+    // the push INSERTS and the name becomes spawnable immediately.
+    const vent =
+        \\{ "components": { "PipeOverlay": { "text": "vent", "fps": 12.0 } } }
+    ;
+    try testing.expectEqual(@as(i32, 0), editor_api.editor_reload_prefab("steam_vent", 10, vent, vent.len));
+    const e = game.spawnPrefab("steam_vent", .{ .x = 0, .y = 0 }).?;
+    try testing.expectEqualStrings("vent", game.ecs_backend.getComponent(e, PipeOverlay).?.text);
+
+    // Keying matches addEmbeddedPrefab/scanDir: an explicit `"name"`
+    // field outranks the pushed name (RFC #561 flat registry) — the
+    // entry registers under the EFFECTIVE name.
+    const named =
+        \\{ "name": "renamed_vent", "components": { "PipeOverlay": { "text": "renamed" } } }
+    ;
+    try testing.expectEqual(@as(i32, 0), editor_api.editor_reload_prefab("whatever", 8, named, named.len));
+    const r = game.spawnPrefab("renamed_vent", .{ .x = 0, .y = 0 }).?;
+    try testing.expectEqualStrings("renamed", game.ecs_backend.getComponent(r, PipeOverlay).?.text);
+}
+
+test "reloadPrefabSource: a push BEFORE any scene load creates the cache the boot then reuses" {
+    var game = engine.Game.init(testing.allocator);
+    defer game.deinit();
+
+    // No scene, no cache yet — the push must not require one (the
+    // studio parks pushes until boot, but the ENGINE side stays safe
+    // regardless of host ordering).
+    try game.reloadPrefabSource("early_bird", CONDENSER_V2);
+
+    // The boot sequence reuses the already-attached cache
+    // (`getOrCreatePrefabCache` contract), so both the pre-push prefab
+    // and the embedded one resolve.
+    try bootPrefabGame(&game);
+    const e = game.spawnPrefab("early_bird", .{ .x = 0, .y = 0 }).?;
+    try testing.expectEqualStrings("v2-overlay", game.ecs_backend.getComponent(e, PipeOverlay).?.text);
+    const c = game.spawnPrefab("condenser", .{ .x = 0, .y = 0 }).?;
+    try testing.expectEqualStrings("v1-overlay", game.ecs_backend.getComponent(c, PipeOverlay).?.text);
 }


### PR DESCRIPTION
## What

The prefab half of **labelle-studio#24** (the animation half landed as #688). New export `editor_reload_prefab(name, nlen, src, slen) -> i32` (contract v1.3): the studio pushes a saved `prefabs/**.jsonc` source into the running wasm game and every FUTURE spawn uses it.

### Why a registry swap is the whole engine story for future spawns

Prefab JSONC is consumed at `spawnPrefab` time: `spawnPrefabImpl` (`src/jsonc/scene_loader/prefab_spawn.zig`) looks the definition up in the game's `PrefabCache` on EVERY spawn. Replacing the cache entry therefore covers, with zero extra machinery:

- runtime `spawnPrefab` / `spawnFromPrefab` calls,
- scene loads that reference the prefab — **including an `editor_load_scene` reload of the current scene**, which re-spawns its placed instances from the new data (a nice studio interaction: push a prefab, then hot-reload the scene to see placed instances update),
- save/load Phase 1 re-spawns (`loadGameState` → `spawnFromPrefab`).

### Pieces

- **`PrefabCache.replaceFromSource`** (`src/jsonc/prefab_cache.zig`): dupe the source into the cache's persistent allocator (the caller's buffer is a studio-owned wasm allocation freed right after the call), parse, shape-check, then replace-or-insert under the **effective name** (RFC #561 — same keying as `addEmbeddedPrefab` / `scanDir`). Transactional: any failure leaves the registry untouched.
- **`Game.reloadPrefabSource`** (new `src/game/prefab_runtime_mixin.zig`, wired like `animation_runtime_mixin`): uses the attached cache, or creates the persistent cache a later boot then reuses (`getOrCreatePrefabCache` reuse contract). Never clobbers an existing cache's `prefab_dir`.
- **`editor_api`**: vtable entry + export, dispatched through the existing bind pattern (no generated-main changes). Return codes: `0` ok · `-1` unbound / empty name · `-2` parse/shape failure · `-3` OOM. **On any nonzero return the registry is untouched** — a half-saved file never corrupts the preview.

### Push-time validation (fail at the editor, not at some later spawn)

Rejected with `-2`: unparseable JSONC; a non-object top level (array "bundles" are a scene-file shape); an RFC #560 §B2 violation (`prefab` reference + `children`). Deeper semantic problems (unknown components, cycles introduced through OTHER prefabs) still surface at spawn time through the loader's existing gates — logged, null spawn, world intact.

### The graveyard, for free

A REPLACED `Value` tree is never freed. That is load-bearing: components on already-spawned entities hold `[]const u8` slices into the old tree (the documented `PrefabCache` ownership contract), and the editor can push while the sim is paused (`editor_pause`) when nothing will ever re-read them — the same retire-don't-free reasoning as #688's `RuntimeAnimDefs`, obtained here for free because the cache's persistent allocator (page/c_allocator, game-lifetime) never frees. The test suite reads a v1-spawned instance's string back after a v2 push to pin this.

## What this does NOT do (by design — scoped honestly)

**Already-spawned instances keep their components** (the studio UI copy says "applies to new spawns"). In-place re-instantiation is not cleanly boundable today:

- destroy + respawn dangles every entity reference OTHER entities hold into the old tree — `loadGameState` only survives that because it rebuilds the whole world under one global `id_map` remap (save_load_mixin Phase 1a/1b/2), which a scoped per-prefab respawn cannot replay;
- runtime component state would be lost without an in-memory replay of Phase 2's saved-override pass;
- `PrefabInstance.overrides` is still the `""` stub (structured-overrides pipeline is an acknowledged follow-up in `entity_mixin.tagAsPrefabInstance`), so scene-level per-instance overrides could not be re-applied;
- destroy/spawn fire lifecycle hooks and engine events into a sim the editor may have paused.

The bounded middle slice — re-applying only `.transient`-policy components (SpriteAnimation/SpriteByField), the ones save/load already resets from prefab data by contract — is written up in follow-up issue #691 rather than half-shipped here.

- **No wasm keep-alive**: `-sEXPORTED_FUNCTIONS` lives in labelle-bgfx — companion PR appends `_editor_reload_prefab` there. ⚠ Merge order: this PR first → **engine release** (> 1.71.0) → bgfx keep-alive (emcc hard-errors on listed-but-missing symbols, so that bgfx release requires an engine with this export for editor-preview builds) → studio wiring (optional-export detection, safe on any build).

## Tests

`zig build test` — all green. New coverage in `test/editor_api_test.zig` (execution probe-verified):
- push → registry swap → future spawn uses new data, while a pre-push instance keeps the old data **byte-for-byte through its aliased string** (the graveyard contract), pushed from a transient buffer freed right after the call;
- malformed / non-object / §B2-violating sources → `-2` with the old definition still spawning; empty name → `-1`; pre-bind → `-1`;
- insert-new prefab (created while playing) becomes spawnable; effective-name keying (`"name"` field outranks the pushed name);
- `reloadPrefabSource` before any scene load creates the cache the boot then reuses.

Part of labelle-studio#24 · companion PRs: labelle-bgfx (export list), labelle-studio (watch + push).

https://claude.ai/code/session_01P7YLw4hXFCCaY2LAUt4G1j
