### PR TITLE
feat(prefab): bounded live-instance refresh on hot-swap — editor_reload_prefab v1.4 (#691)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -190,6 +190,11 @@ pub fn build(b: *std.Build) void {
         // runtime-sourced state names (loader meta.initial_state +
         // editor_set_state share the PR #599 UAF-safe ordering).
         "test/set_state_owned_test.zig",
+        // editor_reload_prefab v1.4 (#691) — bounded live-instance
+        // refresh: declared-transient diff on roots + local_path-matched
+        // children, runtime-attached survival, entity-ref preservation,
+        // reference-mode override re-merge, length-gated structural edits.
+        "test/prefab_refresh_test.zig",
     };
 
     for (test_files) |test_file| {

--- a/src/editor_api.zig
+++ b/src/editor_api.zig
@@ -231,7 +231,7 @@ pub export fn editor_load_animation_def(name: [*]const u8, nlen: usize, src: [*]
     return vt.load_animation_def(name[0..nlen], src[0..slen]);
 }
 
-/// Push a prefab JSONC SOURCE into the running game (contract v1.3,
+/// Push a prefab JSONC SOURCE into the running game (contract v1.4,
 /// labelle-studio issue #24 — the prefab half). `name` is the prefab's
 /// registry name (`"condenser"` for `prefabs/condenser.jsonc`,
 /// `"<pack>__<stem>"` for pack prefabs); `src` is the full JSONC
@@ -244,19 +244,25 @@ pub export fn editor_load_animation_def(name: [*]const u8, nlen: usize, src: [*]
 /// placed instances from the new data), and save/load Phase 1
 /// re-spawns.
 ///
-/// Already-spawned instances keep their current components — the studio
-/// UI says "applies to new spawns" — and the replaced definition's
-/// memory is retired, never freed, so their borrowed slices stay valid
-/// even while the sim is paused. In-place live refresh is a documented
-/// follow-up (see `game/prefab_runtime_mixin.zig` for why it is not
-/// boundable today).
+/// v1.4 (engine#691): already-spawned instances additionally get the
+/// prefab's `.transient`-policy components re-applied in place — the
+/// exact set save/load already rebuilds from prefab data on every
+/// load. Runtime-attached transients, `.saveable` state, entity
+/// identity, `Position`/`Sprite`/`Shape`, and structural child edits
+/// stay untouched; see `jsonc/scene_loader/prefab_refresh.zig` for the
+/// scope contract. The change is visible on the next TICKED frame
+/// (under `editor_pause` that is the next `editor_step`/resume — same
+/// latency as `editor_load_animation_def`). The replaced definition's
+/// memory is retired, never freed, so components still borrowing
+/// slices from it stay valid even while the sim is paused.
 ///
 /// Returns 0 = ok; -1 = not bound / empty name; -2 = parse/shape
 /// failure (unparseable, non-object top level, RFC #560 §B2 violation);
 /// -3 = out of memory. On ANY nonzero return the registry is untouched
 /// — the previous definition stays live, so a half-saved file never
-/// corrupts the preview. The buffers are copied; the caller may free
-/// them right after the call.
+/// corrupts the preview. The rc values are unchanged from v1.3 — a
+/// v1.3-era studio keeps working, it just under-promises. The buffers
+/// are copied; the caller may free them right after the call.
 pub export fn editor_reload_prefab(name: [*]const u8, nlen: usize, src: [*]const u8, slen: usize) i32 {
     const vt = vtable orelse return -1;
     return vt.reload_prefab(name[0..nlen], src[0..slen]);

--- a/src/game.zig
+++ b/src/game.zig
@@ -55,6 +55,8 @@ const misc_mixin = @import("game/misc_mixin.zig");
 const animation_runtime_mixin = @import("game/animation_runtime_mixin.zig");
 const animation_def_runtime = @import("animation_def_runtime.zig");
 const prefab_runtime_mixin = @import("game/prefab_runtime_mixin.zig");
+const roster_mod = @import("game/roster.zig");
+const game_init_mod = @import("game/game_init.zig");
 
 /// Full game configuration — the assembler fills ALL comptime slots.
 /// RenderImpl is a renderer plugin (e.g. gfx.GfxRenderer) satisfying RenderInterface.
@@ -169,36 +171,11 @@ pub fn GameConfigWithYAxis(
         pub const EntityType = Entity;
 
         // ── Roster cache (#653, Packs Phase 2 / #657) ─────────────
-        // `entitiesWith(Tag)` hands back a slice borrowed from one of
-        // these slots — engine-owned, valid only until the next
-        // structural mutation (component add/remove, entity
-        // create/destroy, world switch). A monotonic
-        // `roster_generation` is bumped on every such mutation; a slot
-        // whose stored `gen` no longer matches is stale and gets
-        // re-queried lazily on the next read.
-        //
-        // Slots live in a hash map (`roster_cache`) keyed by a comptime
-        // hash of the tag-set's (alphabetically sorted) component type
-        // names (`rosterKey`). Because every key is a comptime constant
-        // — there is no runtime-constructed key — the key space is
-        // *statically bounded* by the distinct `entitiesWith` tag-sets
-        // in the compiled game. That bound is what lets the map cache
-        // every tag-set with **zero eviction**: a slot's buffer is only
-        // ever rewritten for the SAME tag-set after a generation bump,
-        // so a borrowed slice can never be silently clobbered by a read
-        // of a *different* tag-set (#657). The prior v1 design used a
-        // fixed 8-slot array with round-robin eviction, which mutated a
-        // still-borrowed buffer during an unrelated read once more than
-        // 8 tag-sets were live — a lifetime-contract violation this
-        // follow-up removes.
-        const RosterSlot = struct {
-            /// `roster_generation` value at which `list` was filled.
-            gen: u64 = 0,
-            /// False until first filled (or after an OOM during refill).
-            valid: bool = false,
-            /// Borrowed-out collection; owned by `Game`, freed in `deinit`.
-            list: std.ArrayList(Entity) = .empty,
-        };
+        // The full design + borrowed-slice lifetime contract live in
+        // `game/roster.zig` (facade split). Game owns the two state
+        // fields (`roster_generation`, `roster_cache`); the mixin owns
+        // the logic.
+        const RosterSlot = roster_mod.Slot(Entity);
 
         /// Runtime timer wheel for flow `Delay` nodes (#25 Stage 2). Keyed
         /// on the engine `Entity` type; fires pause-aware callbacks against
@@ -310,6 +287,10 @@ pub fn GameConfigWithYAxis(
         const MiscMixin = misc_mixin.Mixin(Self);
         const AnimationRuntimeMixin = animation_runtime_mixin.Mixin(Self);
         const PrefabRuntimeMixin = prefab_runtime_mixin.Mixin(Self);
+        const RosterMixin = roster_mod.Mixin(Self);
+        // VideoImpl/AudioImpl are `GameConfig` fn params (not `Self`
+        // decls), so the construction mixin takes them explicitly.
+        const InitMixin = game_init_mod.Mixin(Self, VideoImpl, AudioImpl);
 
         /// Scene lifecycle hooks
         pub const SceneHooks = struct {
@@ -583,6 +564,15 @@ pub fn GameConfigWithYAxis(
         prefab_dir: ?[]const u8 = null,
         spawn_prefab_fn: ?*const fn (*Self, []const u8, Position) ?Entity = null,
         prefab_cache_ptr: ?*anyopaque = null,
+        /// Live-instance transient refresh after a prefab hot-swap
+        /// (#691) — set by the scene bridge next to `spawn_prefab_fn`
+        /// because the refresh needs the BRIDGE's `Components`
+        /// registry (which may differ from `ComponentRegistry`).
+        /// Args: installed registry key + the retired generation as an
+        /// opaque `*const jsonc.Value` (opaque for the same reason
+        /// `prefab_cache_ptr` is — this file stays jsonc-free), null
+        /// when the push inserted a brand-new prefab.
+        refresh_prefab_fn: ?*const fn (*Self, []const u8, ?*const anyopaque) void = null,
 
         // Logging
         log: Log = .{},
@@ -737,77 +727,11 @@ pub fn GameConfigWithYAxis(
         tombstone_cursor: if (is_debug) usize else void =
             if (is_debug) 0 else {},
 
-        // ── Scheduler trampolines (#25 Stage 2) ──────────────────
-        // Type-erased shims so `Scheduler` reads the gameplay clock and
-        // checks entity liveness without importing `*Self` (which would be
-        // a circular comptime dependency). `game_ctx` is `@ptrCast(self)`,
-        // re-cast back to `*Self` here.
-
-        fn schedulerNow(game_ctx: *anyopaque) f64 {
-            const self: *Self = @ptrCast(@alignCast(game_ctx));
-            return self.elapsedSeconds();
-        }
-
-        fn schedulerIsAlive(game_ctx: *anyopaque, entity: Entity) bool {
-            const self: *Self = @ptrCast(@alignCast(game_ctx));
-            return self.ecs_backend.entityExists(entity);
-        }
-
-        /// Point the scheduler's type-erased `game_ctx` at this game's stable
-        /// address. `Game.init` returns by value, so `game_ctx` can only be
-        /// fixed once the game lands at its final location. Idempotent — safe
-        /// to call from `setHooks` and at the top of every `tick`, and the
-        /// codegen-generated main can call it explicitly after `init`.
-        pub fn bindScheduler(self: *Self) void {
-            self.scheduler.game_ctx = @ptrCast(self);
-        }
-
-        pub fn init(allocator: std.mem.Allocator) Self {
-            const world = allocator.create(World) catch @panic("failed to allocate default world");
-            world.* = World.init(allocator);
-            // One-time setup for the per-OS gamepad hotplug source on the
-            // fallback path (core#18). No-op when a backend polls natively
-            // or no flow listens (`uses_os_gamepad_source` folds it away),
-            // and the source's own `init` is `@hasDecl`-guarded per platform.
-            if (comptime uses_os_gamepad_source) core.gamepad_source.init();
-            // Wire the audio backend into a video backend that supports it (e.g.
-            // the bgfx VideoBackend), so opened videos play their audio track in
-            // A/V sync — the player's master clock is the audio position
-            // (#549/#306). Comptime-gated: stub video, or an audio backend
-            // without the mixer API, folds this away. The VideoBackend can't
-            // import the audio module (one mixer), so the engine — which holds
-            // both impls — injects the raw audio fns as function pointers.
-            if (comptime @hasDecl(VideoImpl, "setAudioBackend") and @hasDecl(AudioImpl, "loadMusicFromPcm")) {
-                VideoImpl.setAudioBackend(.{
-                    .loadPcm = &AudioImpl.loadMusicFromPcm,
-                    .play = &AudioImpl.playMusic,
-                    .update = &AudioImpl.updateMusic,
-                    .stop = &AudioImpl.stopMusic,
-                    .clock = &AudioImpl.musicPositionSeconds,
-                    .unload = &AudioImpl.unloadMusic,
-                });
-            }
-            return .{
-                .allocator = allocator,
-                .active_world = world,
-                .ecs_backend = &world.ecs_backend,
-                .renderer = &world.renderer,
-                .worlds = std.StringHashMap(*World).init(allocator),
-                .roster_cache = std.AutoHashMap(u64, RosterSlot).init(allocator),
-                .atlas_manager = atlas_mod.TextureManager.init(allocator),
-                .assets = assets_mod.AssetCatalog.init(allocator),
-                .scenes = std.StringHashMap(SceneEntry).init(allocator),
-                .jsonc_scenes = std.StringHashMap(JsoncSceneInfo).init(allocator),
-                .embedded_scene_sources = std.StringHashMap([]const u8).init(allocator),
-                .scene_source_overrides = std.StringHashMap([]const u8).init(allocator),
-                .runtime_anim_defs = animation_def_runtime.RuntimeAnimDefs.init(allocator),
-                .gizmo_state = gizmo_draws_mod.GizmoState(Entity).init(allocator),
-                // `game_ctx` is a placeholder here (the not-yet-stable world
-                // pointer); `bindScheduler` fixes it once `self` is stable.
-                // The trampolines are address-stable comptime fn pointers.
-                .scheduler = SchedulerType.init(allocator, world, schedulerNow, schedulerIsAlive),
-            };
-        }
+        // ── Construction + scheduler glue — `game/game_init.zig` ──
+        // (`deinit` stays with the lifecycle mixin, which owns the
+        // shutdown ordering contract.)
+        pub const init = InitMixin.init;
+        pub const bindScheduler = InitMixin.bindScheduler;
 
         pub const deinit = LifecycleMixin.deinit;
 
@@ -904,123 +828,11 @@ pub fn GameConfigWithYAxis(
         pub const setZIndex = Visuals.setZIndex;
         pub const setSpriteFlip = Visuals.setSpriteFlip;
 
-        // ── Roster cache (#653, #657) ─────────────────────────────
-        //
-        // `entitiesWith(includes)` returns a slice **borrowed from an
-        // engine-owned cache**. The slice is valid only until the next
-        // structural mutation (component add/remove, entity
-        // create/destroy, world switch / ECS reset) — callers must NOT
-        // free it, and must **copy** it if they need to retain it past
-        // such a mutation. Repeated reads of the same tag-set within a
-        // mutation-free window return the cached slice without
-        // re-scanning the ECS; the first read after a mutation lazily
-        // re-queries.
-        //
-        // Slots live in a hash map keyed by the comptime tag-set hash
-        // (`rosterKey`). The key space is statically bounded (every key
-        // is a comptime constant), so the map **never evicts**: a
-        // slot's buffer is only ever rewritten for the SAME tag-set
-        // after a generation bump. That is precisely what makes the
-        // borrowed-slice contract sound — within a mutation-free window
-        // the slice is stable **no matter how many other tag-sets are
-        // queried** (the #657 fix; the old fixed-slot design could evict
-        // and clobber a still-borrowed buffer during an unrelated read).
-        //
-        // On OOM the read logs and returns a truncated roster, leaving
-        // the entry `valid = false` so the next read retries the full
-        // query rather than treating the partial result as fresh.
-        //
-        // This backs the Packs query-surface caching (e.g.
-        // `citizens.idleWorkers()` borrows from here) and the
-        // "borrowed-slice" lifetime contract for list-returning
-        // queries — they hand back this cached slice rather than a
-        // caller-owned `collectEntities` allocation.
-        //
-        // `includes` mirrors the include tuple of `collectEntities`
-        // (e.g. `.{Health}` or `.{Health, Velocity}`); the exclude set
-        // is always empty for rosters. See `RosterSlot`.
-        pub fn entitiesWith(self: *Self, comptime includes: anytype) []const Entity {
-            const key = comptime rosterKey(includes);
-            // A rehash while inserting a new key moves `RosterSlot`
-            // *values*, but borrowed slices point at each list's heap
-            // buffer, not the slot struct — so never hold `value_ptr`
-            // across another `roster_cache` operation (this fn doesn't).
-            const gop = self.roster_cache.getOrPut(key) catch |err| {
-                // OOM growing the map itself: there is no slot to fill,
-                // so hand back a static empty roster (not borrowed).
-                self.log.err("[Game] entitiesWith: roster cache OOM for key {d}: {s}", .{ key, @errorName(err) });
-                return &[_]Entity{};
-            };
-            if (!gop.found_existing) gop.value_ptr.* = .{};
-            const slot = gop.value_ptr;
-            // Cache hit: this tag-set's slot, filled at the current epoch.
-            if (slot.valid and slot.gen == self.roster_generation) {
-                return slot.list.items;
-            }
-            // Stale or never filled — re-query. This slot belongs to
-            // `key` forever, so its buffer is never rewritten on behalf
-            // of a different tag-set.
-            slot.list.clearRetainingCapacity();
-            slot.valid = false;
-            var view = self.ecs_backend.view(includes, .{});
-            defer view.deinit();
-            while (view.next()) |ent| {
-                slot.list.append(self.allocator, ent) catch |err| {
-                    // OOM mid-fill: leave the slot invalid so the next
-                    // read retries the full query rather than handing
-                    // back a truncated roster as if it were fresh. Log
-                    // it — the truncated slice we hand back this frame
-                    // is otherwise indistinguishable from a genuinely
-                    // small roster, so a silent miss would be very hard
-                    // to diagnose.
-                    self.log.err("[Game] entitiesWith: roster refill OOM for key {d}: {s}", .{ key, @errorName(err) });
-                    return slot.list.items;
-                };
-            }
-            slot.gen = self.roster_generation;
-            slot.valid = true;
-            return slot.list.items;
-        }
-
-        /// Comptime hash identifying a tag-set by the concatenation of
-        /// its component type names. The names are sorted alphabetically
-        /// before hashing, so `entitiesWith(.{A, B})` and
-        /// `entitiesWith(.{B, A})` produce the same key and share a
-        /// single cache slot instead of thrashing two.
-        fn rosterKey(comptime includes: anytype) u64 {
-            comptime {
-                var names: [includes.len][]const u8 = undefined;
-                for (includes, 0..) |T, i| {
-                    names[i] = @typeName(T);
-                }
-                // Insertion sort — tag-sets are tiny (a handful of
-                // components), and this runs entirely at comptime.
-                for (1..names.len) |i| {
-                    var j = i;
-                    while (j > 0 and std.mem.order(u8, names[j - 1], names[j]) == .gt) : (j -= 1) {
-                        const tmp = names[j - 1];
-                        names[j - 1] = names[j];
-                        names[j] = tmp;
-                    }
-                }
-                var h = std.hash.Wyhash.init(0);
-                for (names) |name| {
-                    h.update(name);
-                    h.update("\x00");
-                }
-                return h.final();
-            }
-        }
-
-        /// Invalidate every cached roster by advancing the epoch. Cheap
-        /// (one add); called from every structural-mutation path (here
-        /// and across the entity / component / world / visual mixins) so
-        /// the next `entitiesWith` read re-queries. Capacity in each
-        /// slot's list is retained for reuse. `pub` because the mixin
-        /// files call it on `*Game` across file boundaries.
-        pub inline fn bumpRoster(self: *Self) void {
-            self.roster_generation +%= 1;
-        }
+        // ── Roster cache (#653, #657) — `game/roster.zig` ─────────
+        // Borrowed-slice lifetime contract + design rationale live in
+        // the module header there.
+        pub const entitiesWith = RosterMixin.entitiesWith;
+        pub const bumpRoster = RosterMixin.bumpRoster;
 
         // ── Position & Hierarchy ──────────────────────────────────
 

--- a/src/game/game_init.zig
+++ b/src/game/game_init.zig
@@ -1,0 +1,99 @@
+//! Game construction — `init` + the scheduler's type-erased glue,
+//! extracted from `game.zig` (facade split; same Mixin idiom as the
+//! sibling files, with the two backend impls threaded as explicit
+//! comptime params because they are `GameConfig` function parameters,
+//! not `Game` decls).
+//!
+//! `deinit` intentionally does NOT live here — teardown belongs to
+//! the lifecycle mixin (`game/lifecycle_mixin.zig`), which owns the
+//! shutdown ordering contract.
+
+const std = @import("std");
+const core = @import("labelle-core");
+const atlas_mod = @import("../atlas.zig");
+const assets_mod = @import("../assets/mod.zig");
+const animation_def_runtime = @import("../animation_def_runtime.zig");
+const gizmo_draws_mod = @import("gizmo_draws.zig");
+const roster_mod = @import("roster.zig");
+
+/// Returns the construction mixin for a given Game type.
+/// `VideoImpl`/`AudioImpl` are the raw backend impls (`Game.Video` /
+/// `Game.Audio` are their INTERFACE wrappers, which is why they must
+/// be passed alongside `Game` rather than read off it).
+pub fn Mixin(comptime Game: type, comptime VideoImpl: type, comptime AudioImpl: type) type {
+    const Entity = Game.EntityType;
+
+    return struct {
+        // ── Scheduler trampolines (#25 Stage 2) ──────────────────
+        // Type-erased shims so `Scheduler` reads the gameplay clock and
+        // checks entity liveness without importing `*Game` (which would be
+        // a circular comptime dependency). `game_ctx` is `@ptrCast(self)`,
+        // re-cast back to `*Game` here.
+
+        fn schedulerNow(game_ctx: *anyopaque) f64 {
+            const self: *Game = @ptrCast(@alignCast(game_ctx));
+            return self.elapsedSeconds();
+        }
+
+        fn schedulerIsAlive(game_ctx: *anyopaque, entity: Entity) bool {
+            const self: *Game = @ptrCast(@alignCast(game_ctx));
+            return self.ecs_backend.entityExists(entity);
+        }
+
+        /// Point the scheduler's type-erased `game_ctx` at this game's stable
+        /// address. `Game.init` returns by value, so `game_ctx` can only be
+        /// fixed once the game lands at its final location. Idempotent — safe
+        /// to call from `setHooks` and at the top of every `tick`, and the
+        /// codegen-generated main can call it explicitly after `init`.
+        pub fn bindScheduler(self: *Game) void {
+            self.scheduler.game_ctx = @ptrCast(self);
+        }
+
+        pub fn init(allocator: std.mem.Allocator) Game {
+            const world = allocator.create(Game.World) catch @panic("failed to allocate default world");
+            world.* = Game.World.init(allocator);
+            // One-time setup for the per-OS gamepad hotplug source on the
+            // fallback path (core#18). No-op when a backend polls natively
+            // or no flow listens (`uses_os_gamepad_source` folds it away),
+            // and the source's own `init` is `@hasDecl`-guarded per platform.
+            if (comptime Game.uses_os_gamepad_source) core.gamepad_source.init();
+            // Wire the audio backend into a video backend that supports it (e.g.
+            // the bgfx VideoBackend), so opened videos play their audio track in
+            // A/V sync — the player's master clock is the audio position
+            // (#549/#306). Comptime-gated: stub video, or an audio backend
+            // without the mixer API, folds this away. The VideoBackend can't
+            // import the audio module (one mixer), so the engine — which holds
+            // both impls — injects the raw audio fns as function pointers.
+            if (comptime @hasDecl(VideoImpl, "setAudioBackend") and @hasDecl(AudioImpl, "loadMusicFromPcm")) {
+                VideoImpl.setAudioBackend(.{
+                    .loadPcm = &AudioImpl.loadMusicFromPcm,
+                    .play = &AudioImpl.playMusic,
+                    .update = &AudioImpl.updateMusic,
+                    .stop = &AudioImpl.stopMusic,
+                    .clock = &AudioImpl.musicPositionSeconds,
+                    .unload = &AudioImpl.unloadMusic,
+                });
+            }
+            return .{
+                .allocator = allocator,
+                .active_world = world,
+                .ecs_backend = &world.ecs_backend,
+                .renderer = &world.renderer,
+                .worlds = std.StringHashMap(*Game.World).init(allocator),
+                .roster_cache = std.AutoHashMap(u64, roster_mod.Slot(Entity)).init(allocator),
+                .atlas_manager = atlas_mod.TextureManager.init(allocator),
+                .assets = assets_mod.AssetCatalog.init(allocator),
+                .scenes = std.StringHashMap(Game.SceneEntry).init(allocator),
+                .jsonc_scenes = std.StringHashMap(Game.JsoncSceneInfo).init(allocator),
+                .embedded_scene_sources = std.StringHashMap([]const u8).init(allocator),
+                .scene_source_overrides = std.StringHashMap([]const u8).init(allocator),
+                .runtime_anim_defs = animation_def_runtime.RuntimeAnimDefs.init(allocator),
+                .gizmo_state = gizmo_draws_mod.GizmoState(Entity).init(allocator),
+                // `game_ctx` is a placeholder here (the not-yet-stable world
+                // pointer); `bindScheduler` fixes it once `self` is stable.
+                // The trampolines are address-stable comptime fn pointers.
+                .scheduler = Game.SchedulerType.init(allocator, world, schedulerNow, schedulerIsAlive),
+            };
+        }
+    };
+}

--- a/src/game/prefab_runtime_mixin.zig
+++ b/src/game/prefab_runtime_mixin.zig
@@ -11,11 +11,21 @@
 //! the current scene), and save/load Phase 1 re-spawns all resolve
 //! through the same registry.
 //!
-//! ## What this deliberately does NOT do
+//! ## Live instances: the bounded refresh (#691)
 //!
-//! Already-spawned instances keep the components they were built with.
-//! Re-instantiating them in place is not a registry concern and is not
-//! cleanly boundable today:
+//! After a successful swap, already-spawned instances get their
+//! **`.transient`-policy components** re-applied in place through
+//! `game.refresh_prefab_fn` (installed by the scene bridge next to
+//! `spawn_prefab_fn` — the refresh needs the bridge's `Components`
+//! registry). That is the exact component set save/load already
+//! resets from prefab data on every `loadGameState`, so the refresh
+//! adds no new state contract. See
+//! `jsonc/scene_loader/prefab_refresh.zig` for the full scope
+//! contract (declared-key diffing, child `local_path` resolution,
+//! entity-ref preservation, what deliberately stays untouched).
+//!
+//! Full re-instantiation stays out of scope, for the reasons that
+//! shaped the bounded design:
 //!
 //!   * destroy + respawn loses runtime component state unless the
 //!     save/load Phase 2 override pass is replayed, and dangles every
@@ -28,14 +38,9 @@
 //!     overrides could not be re-applied;
 //!   * destroy/spawn fire lifecycle hooks and engine events into a sim
 //!     the editor may have paused.
-//!
-//! The engine-side design for a bounded live refresh (re-applying
-//! `.transient`-policy components — the ones save/load already resets
-//! from prefab data by contract) is tracked in its own issue; hosts can
-//! see new data live today by re-spawning (or scene-reloading) affected
-//! entities.
 const prefab_cache_mod = @import("../jsonc/prefab_cache.zig");
 const PrefabCache = prefab_cache_mod.PrefabCache;
+const Value = @import("jsonc").Value;
 
 /// Returns the prefab-runtime mixin for a given Game type.
 pub fn Mixin(comptime Game: type) type {
@@ -60,7 +65,21 @@ pub fn Mixin(comptime Game: type) type {
             else
                 prefab_cache_mod.initPersistentCache(self, self.prefab_dir orelse "prefabs") catch
                     return error.OutOfMemory;
-            try cache.replaceFromSource(self.log, name, source);
+            const result = try cache.replaceFromSource(self.log, name, source);
+
+            // Bounded live refresh (#691): re-apply `.transient`
+            // components on already-spawned instances. Only when a
+            // bridge installed the hook (a pre-scene push has no
+            // instances to refresh) and a previous generation existed
+            // (an INSERT can't have live instances either). The swap
+            // above already succeeded — the refresh is best-effort by
+            // design and never fails the push.
+            if (self.refresh_prefab_fn) |refresh| {
+                if (result.retired) |retired| {
+                    const old: Value = retired;
+                    refresh(self, result.key, @ptrCast(&old));
+                }
+            }
         }
     };
 }

--- a/src/game/roster.zig
+++ b/src/game/roster.zig
@@ -1,0 +1,144 @@
+//! Roster cache (#653, Packs Phase 2 / #657) — the engine-owned,
+//! generation-invalidated `entitiesWith` cache, extracted from
+//! `game.zig` (facade split; same Mixin(Game) idiom as its siblings).
+//!
+//! `entitiesWith(includes)` returns a slice **borrowed from an
+//! engine-owned cache**. The slice is valid only until the next
+//! structural mutation (component add/remove, entity create/destroy,
+//! world switch / ECS reset) — callers must NOT free it, and must
+//! **copy** it if they need to retain it past such a mutation.
+//! Repeated reads of the same tag-set within a mutation-free window
+//! return the cached slice without re-scanning the ECS; the first
+//! read after a mutation lazily re-queries.
+//!
+//! Slots live in a hash map keyed by the comptime tag-set hash
+//! (`rosterKey`). The key space is statically bounded (every key is a
+//! comptime constant), so the map **never evicts**: a slot's buffer
+//! is only ever rewritten for the SAME tag-set after a generation
+//! bump. That is precisely what makes the borrowed-slice contract
+//! sound — within a mutation-free window the slice is stable **no
+//! matter how many other tag-sets are queried** (the #657 fix; the
+//! old fixed-slot design used a fixed 8-slot array with round-robin
+//! eviction, which mutated a still-borrowed buffer during an
+//! unrelated read once more than 8 tag-sets were live — a
+//! lifetime-contract violation the map design removes).
+//!
+//! On OOM the read logs and returns a truncated roster, leaving the
+//! entry `valid = false` so the next read retries the full query
+//! rather than treating the partial result as fresh.
+//!
+//! This backs the Packs query-surface caching (e.g.
+//! `citizens.idleWorkers()` borrows from here) and the
+//! "borrowed-slice" lifetime contract for list-returning queries —
+//! they hand back this cached slice rather than a caller-owned
+//! `collectEntities` allocation.
+
+const std = @import("std");
+
+/// One cached roster. `Game` owns two pieces of state for the cache:
+/// `roster_generation` (the epoch) and `roster_cache`
+/// (`AutoHashMap(u64, Slot(Entity))`) — both declared as fields in
+/// `game.zig`, freed in the lifecycle mixin's `deinit`.
+pub fn Slot(comptime Entity: type) type {
+    return struct {
+        /// `roster_generation` value at which `list` was filled.
+        gen: u64 = 0,
+        /// False until first filled (or after an OOM during refill).
+        valid: bool = false,
+        /// Borrowed-out collection; owned by `Game`, freed in `deinit`.
+        list: std.ArrayList(Entity) = .empty,
+    };
+}
+
+/// Returns the roster mixin for a given Game type.
+pub fn Mixin(comptime Game: type) type {
+    const Entity = Game.EntityType;
+
+    return struct {
+        /// `includes` mirrors the include tuple of `collectEntities`
+        /// (e.g. `.{Health}` or `.{Health, Velocity}`); the exclude
+        /// set is always empty for rosters. See the module header for
+        /// the borrowed-slice lifetime contract.
+        pub fn entitiesWith(self: *Game, comptime includes: anytype) []const Entity {
+            const key = comptime rosterKey(includes);
+            // A rehash while inserting a new key moves slot *values*,
+            // but borrowed slices point at each list's heap buffer,
+            // not the slot struct — so never hold `value_ptr` across
+            // another `roster_cache` operation (this fn doesn't).
+            const gop = self.roster_cache.getOrPut(key) catch |err| {
+                // OOM growing the map itself: there is no slot to fill,
+                // so hand back a static empty roster (not borrowed).
+                self.log.err("[Game] entitiesWith: roster cache OOM for key {d}: {s}", .{ key, @errorName(err) });
+                return &[_]Entity{};
+            };
+            if (!gop.found_existing) gop.value_ptr.* = .{};
+            const slot = gop.value_ptr;
+            // Cache hit: this tag-set's slot, filled at the current epoch.
+            if (slot.valid and slot.gen == self.roster_generation) {
+                return slot.list.items;
+            }
+            // Stale or never filled — re-query. This slot belongs to
+            // `key` forever, so its buffer is never rewritten on behalf
+            // of a different tag-set.
+            slot.list.clearRetainingCapacity();
+            slot.valid = false;
+            var view = self.ecs_backend.view(includes, .{});
+            defer view.deinit();
+            while (view.next()) |ent| {
+                slot.list.append(self.allocator, ent) catch |err| {
+                    // OOM mid-fill: leave the slot invalid so the next
+                    // read retries the full query rather than handing
+                    // back a truncated roster as if it were fresh. Log
+                    // it — the truncated slice we hand back this frame
+                    // is otherwise indistinguishable from a genuinely
+                    // small roster, so a silent miss would be very hard
+                    // to diagnose.
+                    self.log.err("[Game] entitiesWith: roster refill OOM for key {d}: {s}", .{ key, @errorName(err) });
+                    return slot.list.items;
+                };
+            }
+            slot.gen = self.roster_generation;
+            slot.valid = true;
+            return slot.list.items;
+        }
+
+        /// Comptime hash identifying a tag-set by the concatenation of
+        /// its component type names. The names are sorted alphabetically
+        /// before hashing, so `entitiesWith(.{A, B})` and
+        /// `entitiesWith(.{B, A})` produce the same key and share a
+        /// single cache slot instead of thrashing two.
+        fn rosterKey(comptime includes: anytype) u64 {
+            comptime {
+                var names: [includes.len][]const u8 = undefined;
+                for (includes, 0..) |T, i| {
+                    names[i] = @typeName(T);
+                }
+                // Insertion sort — tag-sets are tiny (a handful of
+                // components), and this runs entirely at comptime.
+                for (1..names.len) |i| {
+                    var j = i;
+                    while (j > 0 and std.mem.order(u8, names[j - 1], names[j]) == .gt) : (j -= 1) {
+                        const tmp = names[j - 1];
+                        names[j - 1] = names[j];
+                        names[j] = tmp;
+                    }
+                }
+                var h = std.hash.Wyhash.init(0);
+                for (names) |name| {
+                    h.update(name);
+                    h.update("\x00");
+                }
+                return h.final();
+            }
+        }
+
+        /// Invalidate every cached roster by advancing the epoch. Cheap
+        /// (one add); called from every structural-mutation path (the
+        /// entity / component / world / visual mixins) so the next
+        /// `entitiesWith` read re-queries. Capacity in each slot's
+        /// list is retained for reuse.
+        pub inline fn bumpRoster(self: *Game) void {
+            self.roster_generation +%= 1;
+        }
+    };
+}

--- a/src/jsonc/prefab_cache.zig
+++ b/src/jsonc/prefab_cache.zig
@@ -148,12 +148,20 @@ pub const PrefabCache = struct {
     /// key as a collision). Unreachable from the studio — its wasm games
     /// never run the filesystem scan and always boot a scene (scan done)
     /// before any push.
+    ///
+    /// Returns what the live-refresh pass (#691) needs to diff
+    /// generations: the key the source landed under, and the RETIRED
+    /// value on a replace (`null` on an insert — nothing can be live).
+    /// `retired` stays valid forever (retire-don't-free, above);
+    /// `key` aliases either the new tree's `"name"` string or the
+    /// caller's `name` buffer, so it is only guaranteed for the
+    /// duration of the caller's frame — consume it immediately.
     pub fn replaceFromSource(
         self: *PrefabCache,
         log: anytype,
         name: []const u8,
         source: []const u8,
-    ) error{ OutOfMemory, InvalidFormat }!void {
+    ) error{ OutOfMemory, InvalidFormat }!ReplaceResult {
         const src = try self.persistent.dupe(u8, source);
         var parser = JsoncParser.init(self.persistent, src);
         const val = parser.parse() catch |err| switch (err) {
@@ -178,13 +186,32 @@ pub const PrefabCache = struct {
         if (self.prefabs.getPtr(key)) |existing| {
             // Replace in place — the map keeps its own key allocation;
             // the old Value tree is retired (never freed, see above).
+            const retired = existing.*;
             existing.* = val;
+            return .{ .key = key, .retired = retired };
         } else {
             // Insert. `key` may alias the caller's `name` buffer (freed
             // right after the call), so the map needs its own copy.
             const duped_key = try self.persistent.dupe(u8, key);
             try self.prefabs.put(duped_key, val);
+            return .{ .key = key, .retired = null };
         }
+    }
+
+    pub const ReplaceResult = struct {
+        /// Effective name the source was installed under.
+        key: []const u8,
+        /// The generation this push replaced (never freed), or null
+        /// when the push inserted a brand-new entry.
+        retired: ?Value,
+    };
+
+    /// Registry-map lookup ONLY — no disk fallback, no insertion, no
+    /// collision side effects. The live-refresh pass (#691) resolves
+    /// `PrefabInstance.path` through this so matching instances can
+    /// never trigger `get`'s desktop disk re-read of an aliased name.
+    pub fn getInstalled(self: *PrefabCache, name: []const u8) ?Value {
+        return self.prefabs.get(name);
     }
 };
 

--- a/src/jsonc/scene_loader.zig
+++ b/src/jsonc/scene_loader.zig
@@ -36,6 +36,7 @@ const scene_process_mod = @import("scene_loader/scene_process.zig");
 const entity_walker_mod = @import("scene_loader/entity_walker.zig");
 const nested_spawn_mod = @import("scene_loader/nested_spawn.zig");
 const prefab_spawn_mod = @import("scene_loader/prefab_spawn.zig");
+const prefab_refresh_mod = @import("scene_loader/prefab_refresh.zig");
 
 pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
     return struct {
@@ -52,6 +53,7 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
         const Walker = entity_walker_mod.EntityWalker(GameType, Components, Self);
         const Nested = nested_spawn_mod.NestedSpawn(GameType, Components, Self);
         const Prefab = prefab_spawn_mod.PrefabSpawn(GameType, Components, Self);
+        const Refresh = prefab_refresh_mod.PrefabRefresh(GameType, Components);
 
         // ── Cycle detection (RFC #569) ─────────────────────────
         pub const checkEntityTreeCycles = Cycle.checkEntityTreeCycles;
@@ -63,6 +65,9 @@ pub fn SceneLoader(comptime GameType: type, comptime Components: type) type {
 
         // ── Runtime prefab spawn ───────────────────────────────
         pub const spawnPrefabImpl = Prefab.spawnPrefabImpl;
+
+        // ── Live-instance prefab refresh (#691) ────────────────
+        pub const refreshPrefabInstancesImpl = Refresh.refreshPrefabInstancesImpl;
 
         // ── Entity-tree walker ─────────────────────────────────
         pub const loadEntityInternal = Walker.loadEntityInternal;

--- a/src/jsonc/scene_loader/prefab_refresh.zig
+++ b/src/jsonc/scene_loader/prefab_refresh.zig
@@ -1,0 +1,414 @@
+//! Bounded live-instance prefab refresh (#691).
+//!
+//! After `editor_reload_prefab` swaps a prefab's registry entry
+//! (contract v1.3, `PrefabCache.replaceFromSource`), this module
+//! re-applies the prefab's **`.transient`-policy components** onto the
+//! instances already spawned from it — the same component set the
+//! save/load contract already resets from prefab data on every
+//! `loadGameState` (Phase 1 respawns; `.transient` never rides the
+//! save file). Everything else keeps the live-refresh guarantees the
+//! full destroy+respawn design was rejected over: entity identity,
+//! runtime `.saveable` state, and every reference other entities hold
+//! stay untouched.
+//!
+//! ## Scope contract (what refreshes, what deliberately does not)
+//!
+//!   * Only registry components whose `getSavePolicy(T) == .transient`.
+//!     `Position` / `Sprite` / `Shape` are structural/renderer-owned
+//!     (special-cased by name in `component_apply.zig` before the
+//!     registry loop) and are never touched — visual-definition edits
+//!     to those still need a respawn or scene reload.
+//!   * Declared-key diffing, not entity diffing: a transient component
+//!     the GAME attached at runtime (FP's condenser gate toggling
+//!     `SpriteAnimation`, `Selection`, …) is invisible to the diff —
+//!     only keys that appear in the OLD prefab JSON and vanished from
+//!     the NEW one are removed. This intentionally diverges from pure
+//!     load semantics (load destroys the entity, so runtime attachments
+//!     die with it; refresh preserves the live entity, so game-owned
+//!     attachments keep their meaning).
+//!   * Children are matched through their spawn-time
+//!     `PrefabChild.local_path` resolved against BOTH trees in
+//!     lockstep, gated on equal `children` array lengths at every
+//!     level: a structural edit (add/remove a child) skips the child
+//!     refresh rather than risk re-applying entry N's components onto
+//!     the entity spawned from old entry N±1. Same-length reorders
+//!     cannot be detected — reordering children mid-Play refreshes the
+//!     wrong sibling until a respawn/scene reload converges it.
+//!   * Reference-mode children (`{ "prefab": "x", "overrides": … }`)
+//!     refresh when the prefab that DECLARES them is pushed (their
+//!     effective set is `mergedOverride` over the referenced prefab's
+//!     current components). Pushing the REFERENCED prefab does not
+//!     walk containing instances — those children also carry their own
+//!     `PrefabInstance` tag, but the root pass skips `PrefabChild`
+//!     carriers precisely so a base-prefab push can never clobber
+//!     override-merged values. Future spawns pick the new base up
+//!     immediately; live ref-children converge on respawn.
+//!   * Entity-ref fields (`[]const u64` arrays and any field named in
+//!     the component's `entity_ref_fields`) are preserved from the old
+//!     component: the spawn path patches those AFTER apply
+//!     (`patchEntityIdField`), so re-deserializing from JSON would
+//!     zero live links to nested entities.
+//!   * `onReady`/`postLoad` fire per re-applied key — load-consistent
+//!     (Phase 1 respawn fires them on every `loadGameState` too).
+//!
+//! Visibility: the refresh only writes ECS components. The renderer
+//! picks the change up on the next TICKED frame (`renderer.sync` lives
+//! in `tick`'s always-run block) — under `editor_pause` that is the
+//! next `editor_step`/resume, exactly like `editor_load_animation_def`.
+//!
+//! Wired into `game.refresh_prefab_fn` by the scene loader's public
+//! entry points, right next to `spawn_prefab_fn` — the fn pointer (not
+//! a Game mixin) because the refresh needs the BRIDGE's `Components`
+//! registry: hosts may parameterize the bridge with a registry that is
+//! not `Game.ComponentRegistry`.
+
+const std = @import("std");
+const jsonc = @import("jsonc");
+const Value = jsonc.Value;
+const core = @import("labelle-core");
+const Position = core.Position;
+
+const prefab_cache_mod = @import("../prefab_cache.zig");
+const PrefabCache = prefab_cache_mod.PrefabCache;
+const uf = @import("../unified_format.zig");
+const component_apply_mod = @import("../component_apply.zig");
+const on_ready_mod = @import("../on_ready.zig");
+
+/// Follow at most this many `{ "prefab": … }` alias hops when
+/// resolving a node to its authored (component/children-bearing)
+/// form. Reference chains deeper than this are authoring errors the
+/// spawn path's cycle gate already rejects; the refresh just bails.
+const MAX_REF_HOPS = 4;
+
+pub fn PrefabRefresh(comptime GameType: type, comptime Components: type) type {
+    const Entity = GameType.EntityType;
+    const ApplyHelpers = component_apply_mod.ComponentApply(GameType, Components);
+    const OnReadyHelpers = on_ready_mod.OnReady(GameType, Components);
+
+    return struct {
+        /// One declared component: registry key + effective JSON value
+        /// (override-merged for reference-mode nodes).
+        const Declared = struct { key: []const u8, value: Value };
+
+        /// A `null` slice means the declaration set could not be
+        /// computed (arena OOM, unresolvable reference) — callers
+        /// treat it as "unknown": nothing is applied from an unknown
+        /// new set, nothing is removed against an unknown old set.
+        const DeclaredSet = ?[]const Declared;
+
+        /// Wired into `game.refresh_prefab_fn`. `key` is the registry
+        /// key the new source was installed under (its effective
+        /// name); `old_opaque` is a `*const jsonc.Value` of the
+        /// retired generation (opaque so `game.zig` stays jsonc-free —
+        /// same rationale as `prefab_cache_ptr`), or null when the
+        /// push INSERTED a brand-new prefab (nothing can be live).
+        pub fn refreshPrefabInstancesImpl(
+            game: *GameType,
+            key: []const u8,
+            old_opaque: ?*const anyopaque,
+        ) void {
+            const old_ptr: *const Value = @ptrCast(@alignCast(old_opaque orelse return));
+            const cache_ptr = game.prefab_cache_ptr orelse return;
+            const cache: *PrefabCache = @ptrCast(@alignCast(cache_ptr));
+            const new_val = cache.getInstalled(key) orelse return;
+            const new_obj = new_val.asObject() orelse return;
+            const old_obj = old_ptr.*.asObject() orelse return;
+            const new_root = uf.rootObject(new_obj);
+            const old_root = uf.rootObject(old_obj);
+
+            // Everything the diff synthesizes (flat-component views,
+            // merged overrides, matched-entity lists) lives here; leaf
+            // values are shared with the cache's trees (never freed),
+            // so nothing a component keeps can dangle.
+            var arena = std.heap.ArenaAllocator.init(game.allocator);
+            defer arena.deinit();
+            const a = arena.allocator();
+
+            const new_comps = rootDeclared(new_root, a, game.log);
+            const old_comps = rootDeclared(old_root, a, game.log);
+
+            // Collect matches FIRST, mutate after: add/removeComponent
+            // moves entities between archetypes on real backends,
+            // which invalidates live view iterators.
+            var roots: std.ArrayList(Entity) = .empty;
+            var children: std.ArrayList(Entity) = .empty;
+            {
+                var view = game.ecs_backend.view(.{GameType.PrefabInstanceComp}, .{});
+                defer view.deinit();
+                while (view.next()) |entity| {
+                    if (!instanceMatches(game, cache, entity, new_val)) continue;
+                    // Reference-mode children carry BOTH tags (walker
+                    // tags the reference, the outer root's tag walk
+                    // marks descent) — their effective set is the
+                    // override-merged one owned by the CONTAINING
+                    // declaration, so the root pass must not clobber
+                    // it with the base prefab's values.
+                    if (game.ecs_backend.getComponent(entity, GameType.PrefabChildComp) != null) continue;
+                    roots.append(a, entity) catch return;
+                }
+            }
+            {
+                var view = game.ecs_backend.view(.{GameType.PrefabChildComp}, .{});
+                defer view.deinit();
+                while (view.next()) |entity| {
+                    const pc = game.ecs_backend.getComponent(entity, GameType.PrefabChildComp) orelse continue;
+                    if (!instanceMatches(game, cache, pc.root, new_val)) continue;
+                    children.append(a, entity) catch return;
+                }
+            }
+
+            for (roots.items) |entity| {
+                refreshEntity(game, entity, old_comps, new_comps);
+            }
+            for (children.items) |entity| {
+                const pc = game.ecs_backend.getComponent(entity, GameType.PrefabChildComp) orelse continue;
+                const pair = resolveLocalPathPair(old_root, new_root, pc.local_path, cache) orelse continue;
+                const child_old = nodeDeclared(pair.old, cache, a, game.log);
+                const child_new = nodeDeclared(pair.new, cache, a, game.log);
+                refreshEntity(game, entity, child_old, child_new);
+            }
+        }
+
+        // ── Instance matching ──────────────────────────────────────
+
+        /// Does `entity`'s `PrefabInstance.path` resolve — through the
+        /// installed registry only, no disk fallback side effects — to
+        /// the tree that was just installed? Tree identity is entries
+        /// pointer identity: `replaceFromSource` installs exactly one
+        /// parsed tree per generation.
+        fn instanceMatches(game: *GameType, cache: *PrefabCache, entity: Entity, new_val: Value) bool {
+            const inst = game.ecs_backend.getComponent(entity, GameType.PrefabInstanceComp) orelse return false;
+            const resolved = cache.getInstalled(inst.path) orelse return false;
+            return sameTree(resolved, new_val);
+        }
+
+        fn sameTree(x: Value, y: Value) bool {
+            const xo = x.asObject() orelse return false;
+            const yo = y.asObject() orelse return false;
+            return xo.entries.ptr == yo.entries.ptr;
+        }
+
+        // ── Declared-component views ───────────────────────────────
+
+        /// Declared set of a prefab ROOT (always author-mode —
+        /// `replaceFromSource`'s §B2 gate rejects reference roots
+        /// carrying children, and pure alias roots have no components
+        /// to declare). `null` values are skipped: an inline `null`
+        /// carries no removal meaning (RFC #562 scopes removal to
+        /// reference `overrides`), so it is neither applied nor
+        /// treated as declared.
+        fn rootDeclared(root: Value.Object, a: std.mem.Allocator, log: anytype) DeclaredSet {
+            const comps = (uf.prefabComponents(root, a, log) catch return null) orelse
+                return &.{};
+            var list: std.ArrayList(Declared) = .empty;
+            for (comps.entries) |entry| {
+                if (entry.value == .null_value) continue;
+                list.append(a, .{ .key = entry.key, .value = entry.value }) catch return null;
+            }
+            return list.toOwnedSlice(a) catch null;
+        }
+
+        /// Declared set of a child NODE — inline entities use their
+        /// own `components` view; reference-mode entities merge their
+        /// `overrides` onto the referenced prefab's current components
+        /// (`null` override = removal, RFC #562: the key counts as NOT
+        /// declared, so a live component under it is removed like any
+        /// other dropped key).
+        fn nodeDeclared(node: Value.Object, cache: *PrefabCache, a: std.mem.Allocator, log: anytype) DeclaredSet {
+            const is_reference = node.getString("prefab") != null;
+            const patch = uf.entityPatch(node, a, log) catch return null;
+
+            if (!is_reference) {
+                const comps = patch orelse return &.{};
+                var list: std.ArrayList(Declared) = .empty;
+                for (comps.entries) |entry| {
+                    if (entry.value == .null_value) continue;
+                    list.append(a, .{ .key = entry.key, .value = entry.value }) catch return null;
+                }
+                return list.toOwnedSlice(a) catch null;
+            }
+
+            const resolved = resolveNode(node, cache) orelse return null;
+            const base = uf.prefabComponents(resolved, a, log) catch return null;
+
+            var handled = std.StringHashMap(void).init(a);
+            var list: std.ArrayList(Declared) = .empty;
+            if (patch) |p| {
+                for (p.entries) |entry| {
+                    handled.put(entry.key, {}) catch return null;
+                    if (entry.value == .null_value) continue; // removal
+                    const merged = uf.mergedOverride(base, entry.key, entry.value, a) catch return null;
+                    list.append(a, .{ .key = entry.key, .value = merged }) catch return null;
+                }
+            }
+            if (base) |b| {
+                for (b.entries) |entry| {
+                    if (handled.contains(entry.key)) continue;
+                    if (entry.value == .null_value) continue;
+                    list.append(a, .{ .key = entry.key, .value = entry.value }) catch return null;
+                }
+            }
+            return list.toOwnedSlice(a) catch null;
+        }
+
+        /// Follow `{ "prefab": … }` alias hops through the INSTALLED
+        /// registry until an author-mode node (bounded, no disk I/O).
+        fn resolveNode(node: Value.Object, cache: *PrefabCache) ?Value.Object {
+            var cur = node;
+            var hops: u8 = 0;
+            while (cur.getString("prefab")) |pname| {
+                hops += 1;
+                if (hops > MAX_REF_HOPS) return null;
+                const v = cache.getInstalled(pname) orelse return null;
+                const o = v.asObject() orelse return null;
+                cur = uf.rootObject(o);
+            }
+            return cur;
+        }
+
+        // ── local_path resolution (lockstep, length-gated) ─────────
+
+        const NodePair = struct { old: Value.Object, new: Value.Object };
+
+        /// Walk a spawn-time `children[i].children[j]…` path through
+        /// BOTH trees at once (format produced by
+        /// `tagAsPrefabInstance` and consumed by the save mixin's
+        /// `findChildByLocalPath`). Reference-mode nodes descend
+        /// through the referenced prefab's current children (§B2
+        /// guarantees a reference node authors none of its own). Any
+        /// level where the two arrays disagree in length is a
+        /// structural edit — return null and leave that child alone.
+        fn resolveLocalPathPair(
+            old_root: Value.Object,
+            new_root: Value.Object,
+            local_path: []const u8,
+            cache: *PrefabCache,
+        ) ?NodePair {
+            if (local_path.len == 0) return null;
+            var cur_old = old_root;
+            var cur_new = new_root;
+            var rest = local_path;
+            while (rest.len > 0) {
+                if (rest[0] == '.') rest = rest[1..];
+                const prefix = "children[";
+                if (!std.mem.startsWith(u8, rest, prefix)) return null;
+                rest = rest[prefix.len..];
+                const close = std.mem.indexOfScalar(u8, rest, ']') orelse return null;
+                const idx = std.fmt.parseInt(usize, rest[0..close], 10) catch return null;
+                rest = rest[close + 1 ..];
+
+                const old_res = resolveNode(cur_old, cache) orelse return null;
+                const new_res = resolveNode(cur_new, cache) orelse return null;
+                const old_children = old_res.getArray("children") orelse return null;
+                const new_children = new_res.getArray("children") orelse return null;
+                if (old_children.items.len != new_children.items.len) return null;
+                if (idx >= new_children.items.len) return null;
+                cur_old = old_children.items[idx].asObject() orelse return null;
+                cur_new = new_children.items[idx].asObject() orelse return null;
+            }
+            return .{ .old = cur_old, .new = cur_new };
+        }
+
+        // ── Per-entity diff + re-apply ─────────────────────────────
+
+        /// `Position`/`Sprite`/`Shape` are name-special-cased in
+        /// `applyComponent` BEFORE its registry loop — they must never
+        /// enter the transient path even if a host registers a
+        /// same-named registry type.
+        fn isReservedName(name: []const u8) bool {
+            return std.mem.eql(u8, name, "Position") or
+                std.mem.eql(u8, name, "Sprite") or
+                std.mem.eql(u8, name, "Shape");
+        }
+
+        fn containsKey(set: []const Declared, key: []const u8) bool {
+            for (set) |kv| {
+                if (std.mem.eql(u8, kv.key, key)) return true;
+            }
+            return false;
+        }
+
+        /// Re-apply every transient key declared in NEW; remove every
+        /// transient key declared in OLD that NEW dropped. Unknown
+        /// (`null`) sets fail safe: no applies from an unknown new, no
+        /// removals against an unknown old.
+        fn refreshEntity(game: *GameType, entity: Entity, old_set: DeclaredSet, new_set: DeclaredSet) void {
+            if (new_set) |ns| {
+                for (ns) |kv| {
+                    if (isReservedName(kv.key)) continue;
+                    applyTransient(game, entity, kv.key, kv.value);
+                }
+            }
+            if (old_set) |os| {
+                const ns = new_set orelse return;
+                for (os) |kv| {
+                    if (isReservedName(kv.key)) continue;
+                    if (containsKey(ns, kv.key)) continue;
+                    removeTransient(game, entity, kv.key);
+                }
+            }
+        }
+
+        /// Comptime-dispatch a single named component; only
+        /// `.transient`-policy registry types pass. The old
+        /// component's entity-ref fields survive the re-deserialize
+        /// (the spawn path patches those AFTER apply — see
+        /// `patchEntityIdField` — so the JSON never carries live
+        /// ids). `onReady`/`postLoad` fire exactly like a Phase 1
+        /// respawn would.
+        fn applyTransient(game: *GameType, entity: Entity, name: []const u8, value: Value) void {
+            const comp_names = comptime Components.names();
+            inline for (comp_names) |comp_name| {
+                if (std.mem.eql(u8, name, comp_name)) {
+                    const T = Components.getType(comp_name);
+                    if (comptime isTransient(T)) {
+                        const prev: ?T = if (game.ecs_backend.getComponent(entity, T)) |p| p.* else null;
+                        ApplyHelpers.applyComponent(game, entity, name, value, Position{});
+                        if (prev) |old_comp| preserveEntityRefs(T, game, entity, old_comp);
+                        OnReadyHelpers.fireOnReadyByName(game, entity, name);
+                    }
+                    return;
+                }
+            }
+        }
+
+        fn removeTransient(game: *GameType, entity: Entity, name: []const u8) void {
+            const comp_names = comptime Components.names();
+            inline for (comp_names) |comp_name| {
+                if (std.mem.eql(u8, name, comp_name)) {
+                    const T = Components.getType(comp_name);
+                    if (comptime isTransient(T)) {
+                        if (game.ecs_backend.getComponent(entity, T) != null) {
+                            game.removeComponent(entity, T);
+                        }
+                    }
+                    return;
+                }
+            }
+        }
+
+        fn isTransient(comptime T: type) bool {
+            if (@typeInfo(T) != .@"struct") return false;
+            return (core.getSavePolicy(T) orelse .saveable) == .transient;
+        }
+
+        /// Copy entity-ref fields (declared `entity_ref_fields` plus
+        /// every `[]const u64` field — the shape `patchEntityIdField`
+        /// writes) from the pre-refresh component into the freshly
+        /// applied one.
+        fn preserveEntityRefs(comptime T: type, game: *GameType, entity: Entity, prev: T) void {
+            const cur = game.ecs_backend.getComponent(entity, T) orelse return;
+            const ref_fields = comptime core.getEntityRefFields(T);
+            inline for (@typeInfo(T).@"struct".fields) |field| {
+                const is_ref = comptime blk: {
+                    if (field.type == []const u64) break :blk true;
+                    for (ref_fields) |rf| {
+                        if (std.mem.eql(u8, rf, field.name)) break :blk true;
+                    }
+                    break :blk false;
+                };
+                if (is_ref) @field(cur, field.name) = @field(prev, field.name);
+            }
+        }
+    };
+}

--- a/src/jsonc/scene_loader/prefab_refresh.zig
+++ b/src/jsonc/scene_loader/prefab_refresh.zig
@@ -354,8 +354,13 @@ pub fn PrefabRefresh(comptime GameType: type, comptime Components: type) type {
         /// component's entity-ref fields survive the re-deserialize
         /// (the spawn path patches those AFTER apply — see
         /// `patchEntityIdField` — so the JSON never carries live
-        /// ids). `onReady`/`postLoad` fire exactly like a Phase 1
-        /// respawn would.
+        /// ids). A component the new source INTRODUCES (no `prev`)
+        /// lands with empty ref fields by construction: the refresh
+        /// never spawns nested entities (scope contract), so there
+        /// are no ids to patch — a respawn/scene reload converges it,
+        /// same as every other structural addition.
+        /// `onReady`/`postLoad` fire exactly like a Phase 1 respawn
+        /// would.
         fn applyTransient(game: *GameType, entity: Entity, name: []const u8, value: Value) void {
             const comp_names = comptime Components.names();
             inline for (comp_names) |comp_name| {

--- a/src/jsonc/scene_loader/scene_process.zig
+++ b/src/jsonc/scene_loader/scene_process.zig
@@ -50,9 +50,12 @@ pub fn SceneProcess(comptime GameType: type, comptime Components: type, comptime
 
             try loadSceneFile(game, scene_path, prefab_cache, 0);
 
-            // Enable runtime prefab spawning.
+            // Enable runtime prefab spawning + hot-swap live refresh
+            // (#691) — the refresh must come from the bridge because it
+            // needs this bridge's `Components` registry.
             game.prefab_dir = prefab_dir;
             game.spawn_prefab_fn = &Self.spawnPrefabImpl;
+            game.refresh_prefab_fn = &Self.refreshPrefabInstancesImpl;
         }
 
         /// Load a scene from an in-memory JSONC source string (for
@@ -117,6 +120,7 @@ pub fn SceneProcess(comptime GameType: type, comptime Components: type, comptime
 
             game.prefab_dir = prefab_dir;
             game.spawn_prefab_fn = &Self.spawnPrefabImpl;
+            game.refresh_prefab_fn = &Self.refreshPrefabInstancesImpl;
         }
 
         /// Pre-load a prefab from in-memory JSONC source into the

--- a/test/prefab_refresh_test.zig
+++ b/test/prefab_refresh_test.zig
@@ -1,0 +1,339 @@
+//! Bounded live-instance prefab refresh (#691) —
+//! `jsonc/scene_loader/prefab_refresh.zig` through the public
+//! `reloadPrefabSource` seam (the same path `editor_reload_prefab`
+//! drives, minus the vtable plumbing `editor_api_test.zig` covers).
+//!
+//! The scope contract under test:
+//!   * `.transient` registry components declared by the prefab are
+//!     re-applied in place on live instances; `.saveable` runtime
+//!     state is never touched.
+//!   * Runtime-attached transients (keys the JSON never declared)
+//!     survive a push — the diff is declared-keys, not entity state.
+//!   * A declared transient key DROPPED by the new source is removed.
+//!   * Children resolve through `PrefabChild.local_path` against both
+//!     generations in lockstep; a child-count change skips the child
+//!     (structural edits need a respawn), the root still refreshes.
+//!   * Reference-mode children re-merge `overrides` onto the
+//!     referenced prefab's CURRENT definition when the DECLARING
+//!     prefab is pushed; pushing the referenced prefab leaves them
+//!     alone (documented gap — future spawns converge).
+//!   * Entity-ref fields (`[]const u64` + declared `entity_refs`)
+//!     survive the re-deserialize.
+//!   * `onReady` fires per re-applied key, exactly like a Phase 1
+//!     respawn.
+//!   * Instances of OTHER prefabs never refresh.
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+const core = @import("labelle-core");
+
+var ready_count: usize = 0;
+
+/// Transient visual-ish component — the SpriteAnimation stand-in. The
+/// string field pins tree lifetime: after a push it must read the NEW
+/// tree's bytes on refreshed instances.
+const Overlay = struct {
+    pub const save = core.Saveable(.transient, @This(), .{});
+    fps: f32 = 0,
+    text: []const u8 = "",
+
+    pub fn onReady(payload: anytype) void {
+        _ = payload;
+        ready_count += 1;
+    }
+};
+
+/// Saveable game state — refresh must never write it.
+const Keep = struct {
+    pub const save = core.Saveable(.saveable, @This(), .{});
+    hp: i32 = 0,
+};
+
+/// Transient toggled by "game code" at runtime (FP's condenser-gate
+/// shape) and also usable as a declared-then-dropped key.
+const Gate = struct {
+    pub const save = core.Saveable(.transient, @This(), .{});
+    n: i32 = 0,
+};
+
+/// Transient carrying entity refs — the fields the spawn path patches
+/// AFTER apply, which a naive re-deserialize would zero.
+const Links = struct {
+    pub const save = core.Saveable(.transient, @This(), .{ .entity_refs = &.{"owner"} });
+    fps: f32 = 0,
+    owner: u64 = 0,
+    links: []const u64 = &.{},
+};
+
+const Components = engine.ComponentRegistry(.{
+    .Overlay = Overlay,
+    .Keep = Keep,
+    .Gate = Gate,
+    .Links = Links,
+});
+
+const Bridge = engine.JsoncSceneBridge(engine.Game, Components);
+
+fn boot(game: *engine.Game, prefabs: []const struct { name: []const u8, src: []const u8 }) !void {
+    for (prefabs) |p| {
+        try Bridge.addEmbeddedPrefab(game, p.name, p.src, "prefabs");
+    }
+    try Bridge.loadSceneFromSource(game,
+        \\{ "entities": [] }
+    , "prefabs");
+}
+
+// ── Root instances ──────────────────────────────────────────────────
+
+test "root: declared transients re-apply in place; saveable runtime state and the retired tree's readers stay untouched" {
+    var game = engine.Game.init(testing.allocator);
+    defer game.deinit();
+    try boot(&game, &.{.{ .name = "condenser", .src =
+        \\{ "components": {
+        \\    "Overlay": { "fps": 6.0, "text": "v1" },
+        \\    "Keep": { "hp": 3 }
+        \\} }
+    }});
+
+    const e = game.spawnPrefab("condenser", .{ .x = 0, .y = 0 }).?;
+    // Runtime progression on the SAVEABLE component — must survive.
+    game.ecs_backend.getComponent(e, Keep).?.hp = 99;
+
+    try game.reloadPrefabSource("condenser",
+        \\{ "components": {
+        \\    "Overlay": { "fps": 24.0, "text": "v2" },
+        \\    "Keep": { "hp": 3 }
+        \\} }
+    );
+
+    const o = game.ecs_backend.getComponent(e, Overlay).?;
+    try testing.expectEqual(@as(f32, 24.0), o.fps);
+    try testing.expectEqualStrings("v2", o.text); // NEW tree's bytes
+    // `.saveable` is not in the refresh set — runtime state intact.
+    try testing.expectEqual(@as(i32, 99), game.ecs_backend.getComponent(e, Keep).?.hp);
+}
+
+test "root: runtime-attached transient (never declared) survives a push; dropped DECLARED key is removed" {
+    var game = engine.Game.init(testing.allocator);
+    defer game.deinit();
+    try boot(&game, &.{.{ .name = "condenser", .src =
+        \\{ "components": {
+        \\    "Overlay": { "fps": 6.0 },
+        \\    "Gate": { "n": 1 }
+        \\} }
+    }});
+
+    const e = game.spawnPrefab("condenser", .{ .x = 0, .y = 0 }).?;
+    // Game code attaches its own transient — the condenser-gate shape.
+    game.addComponent(e, Links{ .fps = 7.0 });
+
+    // v2 drops the DECLARED `Gate`; `Links` was never declared.
+    try game.reloadPrefabSource("condenser",
+        \\{ "components": { "Overlay": { "fps": 24.0 } } }
+    );
+
+    // Declared-and-dropped → removed (a fresh spawn wouldn't have it).
+    try testing.expect(game.ecs_backend.getComponent(e, Gate) == null);
+    // Runtime-attached → invisible to the declared-key diff.
+    try testing.expectEqual(@as(f32, 7.0), game.ecs_backend.getComponent(e, Links).?.fps);
+    try testing.expectEqual(@as(f32, 24.0), game.ecs_backend.getComponent(e, Overlay).?.fps);
+}
+
+test "root: instances of OTHER prefabs never refresh; a fresh spawn uses the new data" {
+    var game = engine.Game.init(testing.allocator);
+    defer game.deinit();
+    try boot(&game, &.{
+        .{ .name = "a", .src =
+        \\{ "components": { "Overlay": { "fps": 6.0 } } }
+        },
+        .{ .name = "b", .src =
+        \\{ "components": { "Overlay": { "fps": 6.0 } } }
+        },
+    });
+
+    const ea = game.spawnPrefab("a", .{ .x = 0, .y = 0 }).?;
+    const eb = game.spawnPrefab("b", .{ .x = 0, .y = 0 }).?;
+
+    try game.reloadPrefabSource("a",
+        \\{ "components": { "Overlay": { "fps": 24.0 } } }
+    );
+
+    try testing.expectEqual(@as(f32, 24.0), game.ecs_backend.getComponent(ea, Overlay).?.fps);
+    try testing.expectEqual(@as(f32, 6.0), game.ecs_backend.getComponent(eb, Overlay).?.fps);
+
+    const ea2 = game.spawnPrefab("a", .{ .x = 0, .y = 0 }).?;
+    try testing.expectEqual(@as(f32, 24.0), game.ecs_backend.getComponent(ea2, Overlay).?.fps);
+}
+
+test "root: entity-ref fields survive the re-deserialize; onReady fires per re-applied key" {
+    var game = engine.Game.init(testing.allocator);
+    defer game.deinit();
+    try boot(&game, &.{.{ .name = "holder", .src =
+        \\{ "components": {
+        \\    "Overlay": { "fps": 6.0 },
+        \\    "Links": { "fps": 6.0 }
+        \\} }
+    }});
+
+    const e = game.spawnPrefab("holder", .{ .x = 0, .y = 0 }).?;
+    // The spawn path patches refs AFTER apply (patchEntityIdField);
+    // simulate that post-spawn wiring.
+    const wired = [_]u64{ 11, 22 };
+    {
+        const l = game.ecs_backend.getComponent(e, Links).?;
+        l.owner = 5;
+        l.links = &wired;
+    }
+
+    ready_count = 0;
+    try game.reloadPrefabSource("holder",
+        \\{ "components": {
+        \\    "Overlay": { "fps": 24.0 },
+        \\    "Links": { "fps": 24.0 }
+        \\} }
+    );
+
+    const l = game.ecs_backend.getComponent(e, Links).?;
+    try testing.expectEqual(@as(f32, 24.0), l.fps); // value re-applied
+    try testing.expectEqual(@as(u64, 5), l.owner); // declared entity_ref
+    try testing.expectEqualSlices(u64, &wired, l.links); // []const u64
+    // Overlay is the only registered type with onReady — one re-apply,
+    // one fire (load-consistent: Phase 1 respawn fires it too).
+    try testing.expectEqual(@as(usize, 1), ready_count);
+}
+
+// ── Children ────────────────────────────────────────────────────────
+
+test "child: inline child transients re-apply through local_path; a child-count change skips the child but not the root" {
+    var game = engine.Game.init(testing.allocator);
+    defer game.deinit();
+    try boot(&game, &.{.{ .name = "station", .src =
+        \\{
+        \\  "components": { "Overlay": { "fps": 6.0 } },
+        \\  "children": [
+        \\    { "components": { "Overlay": { "fps": 6.0, "text": "plant-v1" } } }
+        \\  ]
+        \\}
+    }});
+
+    const root = game.spawnPrefab("station", .{ .x = 0, .y = 0 }).?;
+    const child = game.getChildren(root)[0];
+
+    // Same shape → child refreshes.
+    try game.reloadPrefabSource("station",
+        \\{
+        \\  "components": { "Overlay": { "fps": 12.0 } },
+        \\  "children": [
+        \\    { "components": { "Overlay": { "fps": 30.0, "text": "plant-v2" } } }
+        \\  ]
+        \\}
+    );
+    try testing.expectEqual(@as(f32, 30.0), game.ecs_backend.getComponent(child, Overlay).?.fps);
+    try testing.expectEqualStrings("plant-v2", game.ecs_backend.getComponent(child, Overlay).?.text);
+
+    // Child count changed (structural edit) → the length gate skips
+    // the child; the ROOT still refreshes; no phantom child spawns.
+    try game.reloadPrefabSource("station",
+        \\{
+        \\  "components": { "Overlay": { "fps": 48.0 } },
+        \\  "children": [
+        \\    { "components": { "Overlay": { "fps": 60.0 } } },
+        \\    { "components": { "Overlay": { "fps": 60.0 } } }
+        \\  ]
+        \\}
+    );
+    try testing.expectEqual(@as(f32, 48.0), game.ecs_backend.getComponent(root, Overlay).?.fps);
+    try testing.expectEqual(@as(f32, 30.0), game.ecs_backend.getComponent(child, Overlay).?.fps);
+    try testing.expectEqual(@as(usize, 1), game.getChildren(root).len);
+}
+
+test "child: reference-mode child re-merges overrides onto the referenced prefab when the DECLARING prefab is pushed; pushing the referenced prefab leaves it alone" {
+    var game = engine.Game.init(testing.allocator);
+    defer game.deinit();
+    try boot(&game, &.{
+        .{ .name = "leaf", .src =
+        \\{ "components": { "Overlay": { "fps": 6.0, "text": "leaf" } } }
+        },
+        .{ .name = "wrap", .src =
+        \\{
+        \\  "components": { "Keep": { "hp": 1 } },
+        \\  "children": [
+        \\    { "prefab": "leaf", "overrides": { "Overlay": { "fps": 99.0 } } }
+        \\  ]
+        \\}
+        },
+    });
+
+    const root = game.spawnPrefab("wrap", .{ .x = 0, .y = 0 }).?;
+    const child = game.getChildren(root)[0];
+    try testing.expectEqual(@as(f32, 99.0), game.ecs_backend.getComponent(child, Overlay).?.fps);
+
+    // Push the DECLARING prefab: override deep-merges onto leaf's
+    // current components — patched field updates, base field stays.
+    try game.reloadPrefabSource("wrap",
+        \\{
+        \\  "components": { "Keep": { "hp": 1 } },
+        \\  "children": [
+        \\    { "prefab": "leaf", "overrides": { "Overlay": { "fps": 77.0 } } }
+        \\  ]
+        \\}
+    );
+    {
+        const o = game.ecs_backend.getComponent(child, Overlay).?;
+        try testing.expectEqual(@as(f32, 77.0), o.fps);
+        try testing.expectEqualStrings("leaf", o.text);
+    }
+
+    // Push the REFERENCED prefab: the child also carries its own
+    // `PrefabInstance("leaf")` tag, but the root pass must skip
+    // `PrefabChild` carriers — otherwise leaf's base values would
+    // clobber the override merge. Documented gap: it doesn't refresh.
+    try game.reloadPrefabSource("leaf",
+        \\{ "components": { "Overlay": { "fps": 1.0, "text": "leaf-v2" } } }
+    );
+    {
+        const o = game.ecs_backend.getComponent(child, Overlay).?;
+        try testing.expectEqual(@as(f32, 77.0), o.fps);
+        try testing.expectEqualStrings("leaf", o.text);
+    }
+}
+
+// ── Keying / lifecycle edges ────────────────────────────────────────
+
+test "effective-name alias: a push whose source names an installed key refreshes that key's instances" {
+    var game = engine.Game.init(testing.allocator);
+    defer game.deinit();
+    try boot(&game, &.{.{ .name = "vent", .src =
+        \\{ "components": { "Overlay": { "fps": 6.0 } } }
+    }});
+
+    const e = game.spawnPrefab("vent", .{ .x = 0, .y = 0 }).?;
+
+    // Studio pushes under the file stem, the source's `"name"` field
+    // targets the installed key (RFC #561 effective naming).
+    try game.reloadPrefabSource("whatever",
+        \\{ "name": "vent", "components": { "Overlay": { "fps": 24.0 } } }
+    );
+    try testing.expectEqual(@as(f32, 24.0), game.ecs_backend.getComponent(e, Overlay).?.fps);
+}
+
+test "insert (no previous generation) and invalid pushes touch nothing" {
+    var game = engine.Game.init(testing.allocator);
+    defer game.deinit();
+    try boot(&game, &.{.{ .name = "condenser", .src =
+        \\{ "components": { "Overlay": { "fps": 6.0 } } }
+    }});
+
+    const e = game.spawnPrefab("condenser", .{ .x = 0, .y = 0 }).?;
+
+    // Brand-new prefab: insert path, no instances, no refresh, no crash.
+    try game.reloadPrefabSource("brand_new",
+        \\{ "components": { "Overlay": { "fps": 1.0 } } }
+    );
+    try testing.expectEqual(@as(f32, 6.0), game.ecs_backend.getComponent(e, Overlay).?.fps);
+
+    // Malformed source: transactional — registry AND instances stay.
+    try testing.expectError(error.InvalidFormat, game.reloadPrefabSource("condenser", "{ \"components\": "));
+    try testing.expectEqual(@as(f32, 6.0), game.ecs_backend.getComponent(e, Overlay).?.fps);
+}


### PR DESCRIPTION
Implements #691: after `editor_reload_prefab` swaps a prefab's registry entry, already-spawned instances get the prefab's **`.transient`-policy components** re-applied in place — the exact component set save/load already rebuilds from prefab data on every `loadGameState`, so the refresh adds no new state contract. Entity identity, `.saveable` runtime state, and every reference other entities hold stay untouched (the reasons full destroy+respawn was rejected).

## Design (from the deep investigation)

**Declared-key diffing, not entity diffing.** The issue's own acceptance example (condenser overlay `SpriteAnimation`) turned out to be *runtime-attached* by `condenser_gate.zig`, not declared in JSON — so "remove anything absent from new JSON" would strip game-owned components on every push. Instead, only keys declared in the OLD generation that vanished from the NEW one are removed. `PrefabCache.replaceFromSource` now returns the installed key + the retired generation (retire-don't-free makes the old tree permanently valid to diff against).

**Bridge-installed fn pointer, as the issue sketched.** `game.refresh_prefab_fn` is set by the scene loader's entry points next to `spawn_prefab_fn` — the refresh needs the *bridge's* `Components` registry, which may differ from `Game.ComponentRegistry` (our own `editor_api_test` builds such a game).

**Children** resolve through spawn-time `PrefabChild.local_path` against BOTH trees in lockstep, gated on equal `children`-array lengths at every level (structural edits skip the child; the root still refreshes). Reference-mode children re-merge `overrides` onto the referenced prefab's *current* definition when the **declaring** prefab is pushed; pushing the *referenced* prefab leaves them alone — the root pass skips `PrefabChild` carriers so a base push can never clobber override-merged values (they're double-tagged: `entity_walker.zig:272`).

**Hazards closed:**
- Entity-ref fields (`[]const u64` + declared `entity_refs`) are copied from the old component — the spawn path patches those AFTER apply (`patchEntityIdField`), so a naive re-deserialize would zero live links.
- Instance matching resolves `PrefabInstance.path` through the new side-effect-free `getInstalled()` (map-only), never `get()`'s desktop disk fallback.
- Matches are collected before mutating (add/remove moves archetypes → live view iterators invalidate).
- `onReady` fires per re-applied key — load-consistent (Phase 1 respawn fires it on every load too).
- `Position`/`Sprite`/`Shape` never enter the transient path even if a host registers a same-named registry type.

**Visibility:** the refresh writes ECS components only; the renderer picks it up on the next **ticked** frame (`renderer.sync` lives in `tick`) — under `editor_pause` that's the next step/resume, same latency as `editor_load_animation_def`. rc values unchanged from v1.3, so current studio builds keep working and just under-promise; no studio changes required (its post-push `refreshDigest()` already anticipated this).

## >1000-line refactor (session rule)

`game.zig` (1466 → **1256**): the roster-cache subsystem moved to `game/roster.zig` and construction + scheduler glue to `game/game_init.zig`, both on the existing `Mixin(Game)` idiom, docs preserved. The remainder is irreducible declaration surface — fields, explicit `pub const` delegations, and `GameConfig`-param-bound aliases that must live inside the one comptime struct now that Zig 0.16 removed `usingnamespace`. (Pre-existing offender not in this change's blast radius: `save_load_mixin.zig` at 1156 — proposed follow-up split: save-writer / restore.)

## Tests

`test/prefab_refresh_test.zig` (8 cases): root re-apply + saveable untouched + new-tree slices; runtime-attached survival; dropped-key removal; other-prefab isolation; entity-ref preservation + onReady count; inline-child refresh + length-gate skip; reference-child override re-merge + referenced-push no-op; effective-name alias; insert/invalid no-ops. Full suite: **144/144 steps, 719/719 tests.**

Closes #691

https://claude.ai/code/session_01P7YLw4hXFCCaY2LAUt4G1j