### PR TITLE
chore: zig fmt game.zig (fix pre-existing fmt drift)

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -557,7 +557,6 @@ pub fn GameConfigWithYAxis(
         active_scene_add_entity_fn: ?*const fn (*anyopaque, Entity) void = null,
         active_scene_clear_entities_fn: ?*const fn (*anyopaque) void = null,
 
-
         gizmo_reconcile_fn: ?*const fn (*Self) void = null,
 
         // Prefab spawning — set by JSONC scene bridge during loadScene.
@@ -1234,8 +1233,12 @@ pub fn GameConfigWithYAxis(
 /// Convenience: Game with custom hooks, StubRender + mock ECS
 pub fn GameWith(comptime Hooks: type) type {
     const EmptyComponents = struct {
-        pub fn has(comptime _: []const u8) bool { return false; }
-        pub fn names() []const []const u8 { return &.{}; }
+        pub fn has(comptime _: []const u8) bool {
+            return false;
+        }
+        pub fn names() []const []const u8 {
+            return &.{};
+        }
     };
     return GameConfig(
         core.StubRender(MockEcsBackend(u32).Entity),


### PR DESCRIPTION
Pure `zig fmt` on `src/game.zig` — removes a stray blank line (~L558) and expands two single-line fn bodies in `GameWith`'s `EmptyComponents` so `zig fmt --check src/game.zig` passes. No behavior change.

Context: `zig fmt --check` drift is actually **repo-wide** on `main` (~20+ files) — meaning fmt-check isn't enforced in CI. This PR deliberately scopes to `game.zig` (the file called out during the large-file-split review). A full repo-wide reformat + adding a `zig fmt --check` CI gate to prevent recurrence is a separate, bigger decision — flagging it, not bundling it here.

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw