### PR TITLE
fix(save-load): harden loadGameState vs malformed JSON (defensive tags + strict local_path) (#696)

### DIFF
--- a/src/game/save_load/load.zig
+++ b/src/game/save_load/load.zig
@@ -120,8 +120,25 @@ pub fn Mixin(comptime Game: type) type {
 
             var current: Entity = root;
             var rest = local_path;
+            // `first` distinguishes the leading segment (no separator) from
+            // subsequent ones (a single `.` separator is REQUIRED). This
+            // rejects malformed paths a hostile / corrupted save could carry:
+            //   * a leading `.` (`.children[0]`)
+            //   * missing separators between segments
+            //     (`children[0]children[1]`)
+            //   * doubled / stray separators (`children[0]..children[1]`)
+            // The old code stripped a `.` when present but never required
+            // one, so all of the above resolved as if well-formed — aliasing
+            // the wrong child's saved components onto the resolved entity.
+            var first = true;
             while (rest.len > 0) {
-                if (rest[0] == '.') rest = rest[1..];
+                if (first) {
+                    first = false;
+                } else {
+                    // Exactly one separator dot between segments.
+                    if (rest[0] != '.') return null;
+                    rest = rest[1..];
+                }
                 const prefix = "children[";
                 if (!std.mem.startsWith(u8, rest, prefix)) return null;
                 rest = rest[prefix.len..];
@@ -165,14 +182,34 @@ pub fn Mixin(comptime Game: type) type {
             const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json, .{});
             defer parsed.deinit();
 
+            // Defensive: the top-level JSON must be an object. A malformed
+            // save whose root is an array / scalar / null would otherwise
+            // panic on the `.object` tag-cast in debug, or read garbage in
+            // release. Saves are engine-written (trusted producer), so this
+            // never fires normally — the value is a clean error instead of a
+            // panic on a corrupted / hand-edited file.
+            if (parsed.value != .object) return error.MalformedSave;
             const root = parsed.value.object;
 
-            const version = (root.get("version") orelse return error.MissingField).integer;
+            // `version` must be a non-negative integer. Tag-check before the
+            // `.integer` access so a string / object / null version fails
+            // cleanly rather than panicking.
+            const version_val = root.get("version") orelse return error.MissingField;
+            const version: i64 = switch (version_val) {
+                .integer => |i| i,
+                else => return error.MalformedSave,
+            };
             if (version != SAVE_VERSION) {
                 return error.UnsupportedVersion;
             }
 
-            const entities_json = (root.get("entities") orelse return error.MissingField).array;
+            // `entities` must be an array. Tag-check before the `.array`
+            // access for the same reason.
+            const entities_val = root.get("entities") orelse return error.MissingField;
+            const entities_json = switch (entities_val) {
+                .array => |a| a,
+                else => return error.MalformedSave,
+            };
 
             // Optional saved scene name (engine#638). Saves written before
             // this field omit it — fall back to the current scene's
@@ -492,13 +529,16 @@ pub fn Mixin(comptime Game: type) type {
             const arena = self.active_world.nested_entity_arena.allocator();
 
             for (entities_json.items) |entry| {
-                const obj = entry.object;
-                const saved_id: u64 = @intCast((obj.get("id") orelse continue).integer);
+                // Defensive: skip entries whose shape is wrong (non-object
+                // entry, missing/negative/non-integer id) instead of
+                // panicking on the `.object` / `.integer` tag-casts. Mirrors
+                // the Phase 1/2 treatment via the shared `getSavedId` helper,
+                // which also avoids `@intCast` trapping on a negative id.
+                const saved_id = getSavedId(entry) orelse continue;
                 const current_id = id_map.get(saved_id) orelse continue;
                 const entity: Entity = @intCast(current_id);
 
-                if (obj.get("ref_arrays")) |ref_arrays_val| {
-                    const ref_obj = ref_arrays_val.object;
+                if (getObjectField(entry.object, "ref_arrays")) |ref_obj| {
                     inline for (names) |name| {
                         const T = Reg.getType(name);
                         if (comptime serde.hasRefArrayFields(T)) {
@@ -514,8 +554,9 @@ pub fn Mixin(comptime Game: type) type {
             const Sprite = Game.SpriteComp;
             const Shape = Game.ShapeComp;
             for (entities_json.items) |entry| {
-                const obj = entry.object;
-                const saved_id: u64 = @intCast((obj.get("id") orelse continue).integer);
+                // Defensive: same shape guard as Step 4 — skip malformed
+                // entries via `getSavedId` rather than tag-casting.
+                const saved_id = getSavedId(entry) orelse continue;
                 const current_id = id_map.get(saved_id) orelse continue;
                 const entity: Entity = @intCast(current_id);
                 self.addEntityToActiveScene(entity);

--- a/test/save_load_two_phase_test.zig
+++ b/test/save_load_two_phase_test.zig
@@ -77,7 +77,8 @@ fn setupFixture(
     }
 
     var buf: [std.fs.max_path_bytes]u8 = undefined;
-    const _len = try tmp_dir.dir.realPath(std.testing.io, &buf); const dir_path = buf[0.._len];
+    const _len = try tmp_dir.dir.realPath(std.testing.io, &buf);
+    const dir_path = buf[0.._len];
     const prefab_dir = try std.fmt.allocPrint(testing.allocator, "{s}/prefabs", .{dir_path});
     errdefer testing.allocator.free(prefab_dir);
 
@@ -270,7 +271,8 @@ test "two-phase load: scene-loaded prefab with children round-trips end-to-end" 
     });
 
     var buf: [std.fs.max_path_bytes]u8 = undefined;
-    const _len = try tmp_dir.dir.realPath(std.testing.io, &buf); const dir_path = buf[0.._len];
+    const _len = try tmp_dir.dir.realPath(std.testing.io, &buf);
+    const dir_path = buf[0.._len];
     const prefab_dir = try std.fmt.allocPrint(testing.allocator, "{s}/prefabs", .{dir_path});
     defer testing.allocator.free(prefab_dir);
 
@@ -434,7 +436,8 @@ test "two-phase load: nested prefab doesn't duplicate into a ghost root" {
     });
 
     var buf: [std.fs.max_path_bytes]u8 = undefined;
-    const _len = try tmp_dir.dir.realPath(std.testing.io, &buf); const dir_path = buf[0.._len];
+    const _len = try tmp_dir.dir.realPath(std.testing.io, &buf);
+    const dir_path = buf[0.._len];
     const prefab_dir = try std.fmt.allocPrint(testing.allocator, "{s}/prefabs", .{dir_path});
     defer testing.allocator.free(prefab_dir);
 
@@ -479,7 +482,6 @@ test "two-phase load: nested prefab doesn't duplicate into a ghost root" {
     while (h_view.next()) |_| total += 1;
     try testing.expectEqual(@as(usize, 2), total);
 }
-
 
 test "save: entities with only PrefabInstance are collected (no game-owned saveable)" {
     // Regression guard for the "pure visual prefab" gap flagged in
@@ -549,4 +551,139 @@ test "save: entities with only PrefabInstance are collected (no game-owned savea
     // is purely "did the entity survive the collection step at
     // all").
     _ = fixture.game.getPosition(restored_entity);
+}
+
+// ── #696: malformed / hostile save hardening ────────────────────────
+//
+// Saves are engine-written (trusted producer), so none of these fire in
+// normal operation. The contract is a CLEAN failure — a returned error or
+// a gracefully-skipped entry — instead of a `.integer`/`.object` tag-cast
+// panic (debug) or memory corruption (release) on a corrupted / hand-edited
+// file. These tests feed loadGameState hand-crafted bad JSON and assert it
+// neither crashes nor misparses.
+
+/// Write raw bytes to a save file under cwd and attempt to load them into a
+/// bare TestGame. Returns whatever `loadGameState` returns (error or void).
+fn tryLoadRaw(save_path: []const u8, bytes: []const u8) !void {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = save_path, .data = bytes });
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, save_path) catch {};
+    return game.loadGameState(save_path);
+}
+
+test "malformed save: non-object root → error.MalformedSave (no panic)" {
+    // A save whose top-level value is an array would panic on the
+    // `parsed.value.object` tag-cast before the fix.
+    try testing.expectError(
+        error.MalformedSave,
+        tryLoadRaw("test_bad_root.json", "[]"),
+    );
+}
+
+test "malformed save: wrong-typed version → error.MalformedSave (no panic)" {
+    // `version` as a string would panic on `.integer` before the fix.
+    try testing.expectError(
+        error.MalformedSave,
+        tryLoadRaw("test_bad_version.json",
+            \\{ "version": "2", "entities": [] }
+        ),
+    );
+}
+
+test "malformed save: wrong-typed entities → error.MalformedSave (no panic)" {
+    // `entities` as an object would panic on `.array` before the fix.
+    try testing.expectError(
+        error.MalformedSave,
+        tryLoadRaw("test_bad_entities.json",
+            \\{ "version": 2, "entities": {} }
+        ),
+    );
+}
+
+test "malformed save: non-integer entry id is skipped, not tag-cast (Step 4/5)" {
+    // Steps 4 and 5 previously did `(obj.get("id").?).integer` directly —
+    // a string `id` would panic there. With the shared `getSavedId` guard
+    // the entry is skipped and the load completes with no entities.
+    try tryLoadRaw("test_bad_id.json",
+        \\{ "version": 2, "entities": [ { "id": "not-a-number", "components": {} } ] }
+    );
+}
+
+test "malformed save: wrong-typed ref_arrays is skipped, not tag-cast (Step 4)" {
+    // Step 4 previously did `ref_arrays_val.object` directly — a scalar
+    // `ref_arrays` would panic. `getObjectField` skips it instead. The
+    // entry has a valid integer id so it survives to Step 4.
+    try tryLoadRaw("test_bad_refarrays.json",
+        \\{ "version": 2, "entities": [ { "id": 0, "components": {}, "ref_arrays": 42 } ] }
+    );
+}
+
+test "findChildByLocalPath: leading-dot separator is rejected (no misparse)" {
+    // `PrefabChild.local_path` is emitted as `children[0]` (no leading
+    // dot, single `.` between segments). A corrupted save carrying a
+    // LEADING dot (`.children[0]`) used to resolve anyway — the old code
+    // stripped the dot but never required its absence at the start. The
+    // hardened walk rejects it, so Phase 1b can't map the child onto the
+    // spawned prefab child; Phase 1c falls back to a fresh orphan entity.
+    // The load must still complete cleanly (no crash), and the malformed
+    // child override must NOT land on the prefab-spawned child.
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    var fixture = try setupFixture(&tmp_dir, .{
+        .unit =
+        \\{
+        \\  "components": { "Health": { "current": 50, "max": 50 } },
+        \\  "children": [
+        \\    { "components": { "Health": { "current": 10, "max": 10 } } }
+        \\  ]
+        \\}
+        ,
+    });
+    defer fixture.deinit();
+
+    const root = fixture.game.spawnFromPrefab("unit", .{ .x = 0, .y = 0 }).?;
+    // Mutate the child so a correct mapping would apply Health 7 to the
+    // spawned child; a rejected path leaves it at the prefab default (10).
+    const child = fixture.game.getChildren(root)[0];
+    fixture.game.active_world.ecs_backend.getComponent(child, Health).?.current = 7;
+
+    const save_path = "test_bad_localpath.json";
+    try fixture.game.saveGameState(save_path);
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, save_path) catch {};
+
+    // Inject the malformed separator into the saved local_path.
+    const contents = try std.Io.Dir.cwd().readFileAlloc(std.testing.io, save_path, testing.allocator, .limited(1024 * 1024));
+    defer testing.allocator.free(contents);
+    try testing.expect(std.mem.indexOf(u8, contents, "\"children[0]\"") != null);
+    const rewritten = try std.mem.replaceOwned(u8, testing.allocator, contents, "\"children[0]\"", "\".children[0]\"");
+    defer testing.allocator.free(rewritten);
+    try std.Io.Dir.cwd().writeFile(std.testing.io, .{ .sub_path = save_path, .data = rewritten });
+
+    // Load must not crash / error.
+    fixture.game.resetEcsBackend();
+    try fixture.game.loadGameState(save_path);
+
+    // The prefab-spawned child kept the prefab default (10) — the saved
+    // override (7) was diverted to a fresh orphan, proving the malformed
+    // path was rejected rather than silently resolved.
+    const loaded_root = blk: {
+        var view = fixture.game.active_world.ecs_backend.view(.{PrefabInstance}, .{});
+        defer view.deinit();
+        break :blk view.next().?;
+    };
+    const loaded_child = fixture.game.getChildren(loaded_root)[0];
+    try testing.expectApproxEqAbs(
+        @as(f32, 10),
+        fixture.game.active_world.ecs_backend.getComponent(loaded_child, Health).?.current,
+        0.01,
+    );
+
+    // 3 Health entities: root + spawned child (default) + orphan (override).
+    var total: usize = 0;
+    var view = fixture.game.active_world.ecs_backend.view(.{Health}, .{});
+    defer view.deinit();
+    while (view.next()) |_| total += 1;
+    try testing.expectEqual(@as(usize, 3), total);
 }


### PR DESCRIPTION
Fixes #696.

Follow-up from the #695 review (applies to the merged #694 split layout). Saves are engine-written (trusted producer), so none of these fire in normal operation — the value is graceful `error.MalformedSave` / skipped-entry failure instead of a `.integer`/`.object` tag-cast panic (debug) or memory corruption (release) on a corrupted / hand-edited file.

## Changes (`src/game/save_load/load.zig`)

1. **Header parse** — tag-check the top-level object, `version` (`.integer`), and `entities` (`.array`) before access; return `error.MalformedSave` on mismatch.
2. **Steps 4/5** (ref-array + scene-register loops) — replaced the raw `entry.object` / `(obj.get("id").?).integer` / `ref_arrays_val.object` tag-casts with the shared `getSavedId` / `getObjectField` helpers. A non-object entry, missing/negative/non-integer id, or wrong-typed `ref_arrays` is now skipped instead of panicking (also avoids `@intCast` trapping on a negative saved id).
3. **`findChildByLocalPath`** — require exactly one `.` separator between segments and reject a leading dot. The old walk stripped a dot when present but never required one, so `.children[0]` and `children[0]children[1]` resolved as if well-formed, aliasing the wrong child's components.

Valid-save round-trip behaviour is unchanged (existing `save_load_mixin_test.zig` / `save_load_two_phase_test.zig` stay green).

## Tests
Added regression tests in `test/save_load_two_phase_test.zig`:
- non-object root → `error.MalformedSave`
- wrong-typed `version` / `entities` → `error.MalformedSave`
- non-integer entry id → skipped, no tag-cast panic (Step 4/5)
- wrong-typed `ref_arrays` → skipped, no tag-cast panic (Step 4)
- leading-dot `local_path` → rejected (override diverted to a fresh orphan, spawned child keeps prefab default), load stays graceful

## Verification
`zig build`, `zig build test` (725 tests), `zig build spec` (28 specs), `zig fmt --check` all green.

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw