### PR TITLE
fix: applyFileMetaDirectives guard survives a re-entrant setState from a state hook (#600)

### DIFF
--- a/src/game/state_mixin.zig
+++ b/src/game/state_mixin.zig
@@ -49,9 +49,18 @@ pub fn Mixin(comptime Game: type) type {
         ///      slot (still live at this point) or a default literal —
         ///      safe either way.
         ///   4. If `setState` short-circuited (state name unchanged),
-        ///      `game.game_state` may still alias the about-to-be-freed
-        ///      previous slot. Detect via pointer identity and re-point
-        ///      to `new_owned`. No state-change hooks re-fire — the
+        ///      `game.game_state` still aliases the about-to-be-freed
+        ///      previous owned slot. Re-point to `new_owned` — but ONLY
+        ///      when `game_state` is actually pointing at that slot. A
+        ///      broad `ptr != new_owned` check over-reaches (#600): a
+        ///      `state_after_change` hook fired by the inner `setState`
+        ///      may legitimately call `setState`/`setStateOwned` again
+        ///      and re-point `game_state` at a DIFFERENT state; the
+        ///      guard must leave that hook-installed value untouched
+        ///      rather than silently clobber it back to `new_owned`.
+        ///      Gate on `game_state.ptr == old_owned.ptr` so we only
+        ///      refresh the pointer when we're about to free the very
+        ///      slot it aliases. No state-change hooks re-fire — the
         ///      visible value is unchanged, only the backing moves.
         ///   5. Free the previous owned slot (no-op if null).
         pub fn setStateOwned(self: *Game, state_name: []const u8) error{OutOfMemory}!void {
@@ -59,8 +68,14 @@ pub fn Mixin(comptime Game: type) type {
             const old_owned = self.owned_initial_state;
             self.owned_initial_state = new_owned;
             self.setState(new_owned);
-            if (self.game_state.ptr != new_owned.ptr) {
-                self.game_state = new_owned;
+            // Only reclaim the pointer if it still aliases the slot we're
+            // about to free (setState short-circuited on eql). If a
+            // `state_after_change` hook re-pointed `game_state` elsewhere,
+            // leave its choice intact (#600).
+            if (old_owned) |old_slot| {
+                if (self.game_state.ptr == old_slot.ptr) {
+                    self.game_state = new_owned;
+                }
             }
             if (old_owned) |s| self.allocator.free(s);
         }

--- a/test/set_state_owned_test.zig
+++ b/test/set_state_owned_test.zig
@@ -10,6 +10,41 @@ const testing = std.testing;
 const engine = @import("engine");
 
 const Game = engine.Game;
+const game_mod = engine.game_mod;
+
+// ── Re-entrant setState guard (#600) ────────────────────────────────
+//
+// A `state_after_change` hook that re-calls `setState` during a
+// `setStateOwned` (the exact shape of loader `meta.initial_state` firing
+// a game hook that transitions again) must have its chosen state
+// preserved. The old `ptr != new_owned` refresh guard over-reached and
+// clobbered the hook's state back to `new_owned`; the fix gates the
+// refresh on `game_state` still aliasing the slot about to be freed.
+
+const Redirector = struct {
+    // Type-erased to break the comptime cycle: `TestGame` is
+    // `GameWith(*Redirector)`, so a `*TestGame` field here would make
+    // Redirector's layout depend on TestGame and vice-versa. The method
+    // body may reference `TestGame` (lazy), the field may not.
+    game: *anyopaque = undefined,
+    armed: bool = false,
+    redirect_to: []const u8 = "hooked",
+    redirects: usize = 0,
+
+    // One-shot: on the armed transition, redirect to another state.
+    // Disarms first so the nested setState's own state_after_change
+    // doesn't recurse.
+    pub fn state_after_change(self: *Redirector, info: anytype) void {
+        _ = info;
+        if (!self.armed) return;
+        self.armed = false;
+        const game: *TestGame = @ptrCast(@alignCast(self.game));
+        game.setState(self.redirect_to);
+        self.redirects += 1;
+    }
+};
+
+const TestGame = game_mod.GameWith(*Redirector);
 
 test "setStateOwned: copies the name — caller may free its buffer immediately" {
     var game = Game.init(testing.allocator);
@@ -67,4 +102,39 @@ test "setStateOwned: fires the same state transition as setState" {
     const count_before = game.state_change_count;
     try game.setStateOwned("menu");
     try testing.expectEqual(count_before + 1, game.state_change_count);
+}
+
+test "setStateOwned: a re-entrant setState from a state hook is not clobbered (#600)" {
+    var redir = Redirector{};
+
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+    redir.game = @ptrCast(&game);
+    game.setHooks(&redir);
+
+    // Seed an owned state first so `owned_initial_state` is non-null and
+    // gets freed by the next call — this is the very slot the refresh
+    // guard must not misattribute after the hook re-points `game_state`.
+    try game.setStateOwned("loading");
+
+    // Arm the hook, then simulate `applyFileMetaDirectives` handing a
+    // transient buffer. The inner setState fires state_after_change,
+    // whose handler transitions to "hooked".
+    redir.armed = true;
+    const buf = try testing.allocator.dupe(u8, "loaded");
+    try game.setStateOwned(buf);
+    testing.allocator.free(buf);
+
+    // The hook fired and redirected exactly once.
+    try testing.expectEqual(@as(usize, 1), redir.redirects);
+
+    // With the old `ptr != new_owned` guard, setStateOwned would have
+    // silently overwritten the hook's "hooked" back to "loaded". The
+    // fixed guard leaves the hook-installed state intact.
+    try testing.expectEqualStrings("hooked", game.getState());
+
+    // No dangling: the previously owned "loading" backing was freed, but
+    // `game_state` points at the static "hooked" literal — reading it is
+    // safe, and testing.allocator's leak/double-free check is the oracle
+    // for the freed owned slots.
 }


### PR DESCRIPTION
Fixes #600.

## Root cause
`applyFileMetaDirectives` (scene_process.zig) applies `meta.initial_state` via `game.setStateOwned(...)`. The UAF-safe ownership dance in `setStateOwned` (state_mixin.zig) ended with:

```zig
self.setState(new_owned);
if (self.game_state.ptr != new_owned.ptr) {
    self.game_state = new_owned; // refresh if setState short-circuited
}
if (old_owned) |s| self.allocator.free(s);
```

The refresh guard assumed the ONLY reason `game_state.ptr != new_owned.ptr` post-`setState` is that `setState` short-circuited on its eql-check. But `setState` fires `state_after_change` hooks after assigning `game_state`. If a handler calls `setState("other")`, it legitimately re-points `game_state` — and the broad guard then silently overwrote the hook's change with `new_owned`, dropping the transition (and its `state_change_count` / hook side effects). Same lifetime class as the setState-by-reference UAFs that produced `setStateOwned` in #599.

## Fix
Narrow the guard to only reclaim the pointer when it still aliases the slot about to be freed:

```zig
if (old_owned) |old_slot| {
    if (self.game_state.ptr == old_slot.ptr) {
        self.game_state = new_owned;
    }
}
```

This is exactly the shape proposed in #600. A hook-installed state is left untouched; the pointer is only refreshed in the eql short-circuit case where `game_state` still points at the previous owned slot.

## Test
Adds a regression test to `test/set_state_owned_test.zig`: a `state_after_change` hook that re-transitions (`setState("hooked")`) during a `setStateOwned` call. It asserts the hook's state survives. Verified it FAILS on the old guard (`expected "hooked", got "loaded"`) and PASSES on the fix. `testing.allocator`'s leak/double-free detection is the oracle for the freed owned slots (this is a semantic-clobber class, not a fresh UAF).

## Verification
- `zig build` — pass
- `zig build test` — pass (28/28 in this file's binary; full suite green)
- `zig build spec` — pass
- `zig fmt --check` — clean

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw