### PR TITLE
fix(entity): destroyEntity unlinks from the parent's Children — stale-id/alias hole (#701)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -195,6 +195,11 @@ pub fn build(b: *std.Build) void {
         // children, runtime-attached survival, entity-ref preservation,
         // reference-mode override re-merge, length-gated structural edits.
         "test/prefab_refresh_test.zig",
+        // #701 — destroyEntity/destroyEntityOnly unlink the destroyed
+        // entity from its parent's `Children` list (stale-id/alias hole).
+        // The cascade iterates a snapshot so the per-child unlink can't
+        // invalidate the walk.
+        "test/destroy_unlink_test.zig",
     };
 
     for (test_files) |test_file| {

--- a/src/game.zig
+++ b/src/game.zig
@@ -843,6 +843,7 @@ pub fn GameConfigWithYAxis(
         pub const setParentKeepTransform = ComponentsMixin.setParentKeepTransform;
         pub const removeParent = ComponentsMixin.removeParent;
         pub const removeParentKeepTransform = ComponentsMixin.removeParentKeepTransform;
+        pub const detachFromParent = ComponentsMixin.detachFromParent;
         pub const getParent = ComponentsMixin.getParent;
         pub const getChildren = ComponentsMixin.getChildren;
         pub const hasChildren = ComponentsMixin.hasChildren;

--- a/src/game/components_mixin.zig
+++ b/src/game/components_mixin.zig
@@ -129,7 +129,31 @@ pub fn Mixin(comptime Game: type) type {
 
         pub fn removeParent(self: *Game, child: Entity) void {
             self.assertEntityAlive(child, "removeParent");
-            if (self.ecs_backend.getComponent(child, Parent)) |parent_comp| {
+            detachFromParent(self, child);
+            self.renderer.updateHierarchyFlag(child, false);
+            self.renderer.markPositionDirty(child);
+        }
+
+        /// List-unlink half of `removeParent` (#701): remove `child` from
+        /// its parent's `Children` list and drop the `Parent` component —
+        /// without the renderer hierarchy-flag / dirty-position pokes
+        /// `removeParent` adds for entities that keep living. Shared by
+        /// `removeParent` and the destroy paths (`destroyEntity` /
+        /// `destroyEntityOnly`), where transform bookkeeping for the dying
+        /// entity would be wasted work (the renderer untracks it right
+        /// after). No-op when `child` has no `Parent`.
+        ///
+        /// The `entityExists` guard on the parent matters on the destroy
+        /// paths: teardown order is arbitrary (the scene drain pops
+        /// tracked entities in reverse order; a cascade destroys children
+        /// while the parent is mid-destroy), so the recorded parent may
+        /// already be gone. Sparse-set lookups on the zig-ecs backend are
+        /// index-only, so a `getComponent` through a dead id can alias a
+        /// recycled entity — a `removeChild` write through that alias
+        /// would corrupt an unrelated live entity's list.
+        pub fn detachFromParent(self: *Game, child: Entity) void {
+            const parent_comp = self.ecs_backend.getComponent(child, Parent) orelse return;
+            if (self.ecs_backend.entityExists(parent_comp.entity)) {
                 if (self.ecs_backend.getComponent(parent_comp.entity, Children)) |children_comp| {
                     children_comp.removeChild(child);
                 }
@@ -138,8 +162,6 @@ pub fn Mixin(comptime Game: type) type {
             // Parent membership changed via the ecs_backend directly, so
             // invalidate rosters (#653).
             self.bumpRoster();
-            self.renderer.updateHierarchyFlag(child, false);
-            self.renderer.markPositionDirty(child);
         }
 
         pub fn removeParentKeepTransform(self: *Game, child: Entity) void {

--- a/src/game/entity_mixin.zig
+++ b/src/game/entity_mixin.zig
@@ -6,8 +6,8 @@
 /// helpers (`tagPrefabChildren`, `untrackSceneEntity`, `recordTombstone`)
 /// are called via lexical sibling-function syntax so they resolve inside
 /// this struct. Cross-cluster calls (`emitHook`, `emitEngineEvent`,
-/// `getChildren`, `hasChildren`, `tagAsPrefabInstance`, `destroyEntity`)
-/// route through the `Game` re-exports.
+/// `getChildren`, `hasChildren`, `tagAsPrefabInstance`, `destroyEntity`,
+/// `detachFromParent`) route through the `Game` re-exports.
 const std = @import("std");
 const builtin = @import("builtin");
 const core = @import("labelle-core");
@@ -229,7 +229,18 @@ pub fn Mixin(comptime Game: type) type {
 
         pub fn destroyEntity(self: *Game, entity: Entity) void {
             if (self.ecs_backend.getComponent(entity, Children)) |children_comp| {
-                for (children_comp.getChildren()) |child| {
+                // Cascade over a by-value snapshot of the children list.
+                // Each child's destroy unlinks it from THIS live list via
+                // `detachFromParent` (a swap-remove), so iterating the
+                // live slice would shrink and reorder it under the loop —
+                // skipping children and double-destroying swap remnants.
+                // The snapshot (a 16-slot inline array, cheap stack copy)
+                // also shields the walk from `entity_destroyed` hooks
+                // re-parenting into this list mid-cascade, and from the
+                // component pool reshuffling under the held pointer while
+                // descendants' own `Children` components are removed.
+                const children_snapshot = children_comp.*;
+                for (children_snapshot.getChildren()) |child| {
                     destroyEntity(self, child);
                 }
             }
@@ -237,6 +248,14 @@ pub fn Mixin(comptime Game: type) type {
             // editor-side consumer can still introspect the entity from
             // a `getComponent` style API while reacting to the frame.
             if (self.preview) |*p| p.emitEntityDestroyed(@intCast(entity)) catch {};
+            // #701 — unlink from the parent's `Children` before the
+            // backend destroy (after it, the `Parent` component is
+            // unreachable). A destroy-while-parented used to leave a
+            // permanently stale id in the parent's list; with index-only
+            // sparse-set lookups a recycled index later aliases that id
+            // onto an unrelated entity. List-unlink only: no renderer
+            // transform pokes for the dying entity.
+            self.detachFromParent(entity);
             untrackSceneEntity(self, entity);
             self.active_world.sprite_cache.invalidate(@intCast(entity));
             self.renderer.untrackEntity(entity);
@@ -250,6 +269,14 @@ pub fn Mixin(comptime Game: type) type {
 
         pub fn destroyEntityOnly(self: *Game, entity: Entity) void {
             if (self.preview) |*p| p.emitEntityDestroyed(@intCast(entity)) catch {};
+            // #701 — same parent-unlink as `destroyEntity`. This variant
+            // deliberately leaves the entity's own children alive (its
+            // contract — the scene drain destroys every tracked entity
+            // itself), but the destroyed entity must still vanish from
+            // its parent's `Children` list. During a drain the parent may
+            // already be destroyed — `detachFromParent` guards with
+            // `entityExists` before touching the parent's list.
+            self.detachFromParent(entity);
             untrackSceneEntity(self, entity);
             self.active_world.sprite_cache.invalidate(@intCast(entity));
             self.renderer.untrackEntity(entity);

--- a/test/destroy_unlink_test.zig
+++ b/test/destroy_unlink_test.zig
@@ -1,0 +1,240 @@
+/// #701 — `destroyEntity` / `destroyEntityOnly` must unlink the destroyed
+/// entity from its parent's `Children` list.
+///
+/// Before the fix, a destroy-while-parented left a permanently stale id in
+/// the parent's list: recycled indices later aliased it onto unrelated
+/// entities (debug panics / silent cross-entity corruption on the zig-ecs
+/// backend), a parent destroy recursed into the dead id, and every leaked
+/// id permanently consumed one of the 16 `Children` slots. Observed in the
+/// wild as Flying-Platform/flying-platform-labelle#603.
+///
+/// The regression trap covered here: the cascade in `destroyEntity` used
+/// to iterate the live `getChildren()` slice — now that each child's
+/// destroy swap-removes itself from that same list, the cascade iterates a
+/// by-value snapshot instead. These tests assert the cascade stays
+/// coherent (no skipped children, no double destroys, no bystander
+/// corruption).
+const std = @import("std");
+const testing = std.testing;
+
+const engine = @import("engine");
+const Game = engine.Game;
+const Entity = Game.EntityType;
+
+fn childrenContain(game: *Game, parent: Entity, child: Entity) bool {
+    for (game.getChildren(parent)) |c| {
+        if (c == child) return true;
+    }
+    return false;
+}
+
+test "#701: destroying a child unlinks it from the parent's Children" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const parent = game.createEntity();
+    const child = game.createEntity();
+    game.setParent(child, parent, .{});
+    try testing.expect(childrenContain(&game, parent, child));
+
+    game.destroyEntity(child);
+
+    // The id is gone from the parent's list…
+    try testing.expect(!childrenContain(&game, parent, child));
+    try testing.expectEqual(@as(usize, 0), game.getChildren(parent).len);
+    // …and the parent survives, untouched.
+    try testing.expect(game.ecs_backend.entityExists(parent));
+    try testing.expect(!game.ecs_backend.entityExists(child));
+
+    // The parent stays fully destroyable: before the fix its cascade
+    // recursed into the stale child id and the backend destroy trapped
+    // (#701 consequence 4).
+    game.destroyEntity(parent);
+    try testing.expectEqual(@as(usize, 0), game.entityCount());
+}
+
+test "#701: destroying the middle child leaves the siblings listed" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const parent = game.createEntity();
+    var kids: [5]Entity = undefined;
+    for (&kids) |*k| {
+        k.* = game.createEntity();
+        game.setParent(k.*, parent, .{});
+    }
+
+    game.destroyEntity(kids[2]);
+
+    // Membership (not order) is the list's contract — removeChild is a
+    // swap-remove.
+    try testing.expectEqual(@as(usize, 4), game.getChildren(parent).len);
+    for (kids, 0..) |k, i| {
+        if (i == 2) {
+            try testing.expect(!childrenContain(&game, parent, k));
+            try testing.expect(!game.ecs_backend.entityExists(k));
+        } else {
+            try testing.expect(childrenContain(&game, parent, k));
+            try testing.expect(game.ecs_backend.entityExists(k));
+        }
+    }
+}
+
+test "#701: cascade destroy with several children survives the per-child unlink" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const parent = game.createEntity();
+    var kids: [5]Entity = undefined;
+    for (&kids) |*k| {
+        k.* = game.createEntity();
+        game.setParent(k.*, parent, .{});
+    }
+    // A bystander tree the cascade must not touch.
+    const bystander = game.createEntity();
+    const bystander_child = game.createEntity();
+    game.setParent(bystander_child, bystander, .{});
+
+    // Each child's destroy swap-removes it from the dying parent's live
+    // list; the cascade must iterate a snapshot or it skips children /
+    // double-destroys swap remnants.
+    game.destroyEntity(parent);
+
+    try testing.expect(!game.ecs_backend.entityExists(parent));
+    for (kids) |k| {
+        try testing.expect(!game.ecs_backend.entityExists(k));
+    }
+    // Bystanders intact.
+    try testing.expect(game.ecs_backend.entityExists(bystander));
+    try testing.expect(game.ecs_backend.entityExists(bystander_child));
+    try testing.expect(childrenContain(&game, bystander, bystander_child));
+    try testing.expectEqual(@as(usize, 2), game.entityCount());
+}
+
+test "#701: destroying the middle of a grandparent chain cascades down and updates the grandparent" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const grandparent = game.createEntity();
+    const middle = game.createEntity();
+    const leaf = game.createEntity();
+    game.setParent(middle, grandparent, .{});
+    game.setParent(leaf, middle, .{});
+
+    game.destroyEntity(middle);
+
+    try testing.expect(!game.ecs_backend.entityExists(middle));
+    try testing.expect(!game.ecs_backend.entityExists(leaf)); // cascaded
+    try testing.expect(game.ecs_backend.entityExists(grandparent));
+    try testing.expectEqual(@as(usize, 0), game.getChildren(grandparent).len);
+
+    // Grandparent still healthy after the unlink.
+    game.destroyEntity(grandparent);
+    try testing.expectEqual(@as(usize, 0), game.entityCount());
+}
+
+test "#701: three-level cascade destroys the whole tree" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    // G → M → C. Destroying G runs M's unlink while G is mid-destroy —
+    // the parent-side list mutation must not corrupt G's ongoing cascade.
+    const grandparent = game.createEntity();
+    const middle = game.createEntity();
+    const leaf_a = game.createEntity();
+    const leaf_b = game.createEntity();
+    game.setParent(middle, grandparent, .{});
+    game.setParent(leaf_a, middle, .{});
+    game.setParent(leaf_b, middle, .{});
+
+    game.destroyEntity(grandparent);
+
+    try testing.expect(!game.ecs_backend.entityExists(grandparent));
+    try testing.expect(!game.ecs_backend.entityExists(middle));
+    try testing.expect(!game.ecs_backend.entityExists(leaf_a));
+    try testing.expect(!game.ecs_backend.entityExists(leaf_b));
+    try testing.expectEqual(@as(usize, 0), game.entityCount());
+}
+
+test "#701: destroyEntityOnly unlinks from the parent but leaves its own children alive" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const parent = game.createEntity();
+    const entity = game.createEntity();
+    const child_of_entity = game.createEntity();
+    game.setParent(entity, parent, .{});
+    game.setParent(child_of_entity, entity, .{});
+
+    game.destroyEntityOnly(entity);
+
+    try testing.expect(!game.ecs_backend.entityExists(entity));
+    // Unlinked from the surviving parent.
+    try testing.expectEqual(@as(usize, 0), game.getChildren(parent).len);
+    // Contract preserved: no cascade — the scene drain that uses this
+    // variant destroys every tracked entity itself.
+    try testing.expect(game.ecs_backend.entityExists(child_of_entity));
+    try testing.expect(game.ecs_backend.entityExists(parent));
+}
+
+test "#701: destroyEntityOnly tolerates a parent destroyed earlier in the drain" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const parent = game.createEntity();
+    const child = game.createEntity();
+    game.setParent(child, parent, .{});
+
+    // The scene drain pops tracked entities in arbitrary (reverse) order,
+    // so the parent can die first. The child's unlink must skip the dead
+    // parent (entityExists guard) instead of writing through a stale id.
+    game.destroyEntityOnly(parent);
+    game.destroyEntityOnly(child);
+
+    try testing.expectEqual(@as(usize, 0), game.entityCount());
+}
+
+test "#701: re-parent then destroy touches only the current parent's list" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const p1 = game.createEntity();
+    const p2 = game.createEntity();
+    const sibling = game.createEntity();
+    const e = game.createEntity();
+    game.setParent(sibling, p1, .{});
+    game.setParent(e, p1, .{});
+    game.setParent(e, p2, .{}); // move p1 → p2 (setParent unlinks from p1)
+    try testing.expect(!childrenContain(&game, p1, e));
+    try testing.expect(childrenContain(&game, p2, e));
+
+    game.destroyEntity(e);
+
+    try testing.expectEqual(@as(usize, 1), game.getChildren(p1).len);
+    try testing.expect(childrenContain(&game, p1, sibling));
+    try testing.expectEqual(@as(usize, 0), game.getChildren(p2).len);
+    try testing.expect(game.ecs_backend.entityExists(p1));
+    try testing.expect(game.ecs_backend.entityExists(p2));
+}
+
+test "#701: repeated child destroys don't leak Children slots" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    // Consequence 3 of the bug: MAX_CHILDREN slots with silent drop in
+    // addChild — every leaked stale id permanently consumed a slot, so
+    // after enough destroys new children silently failed to register.
+    const parent = game.createEntity();
+    const max = Game.ChildrenComp.MAX_CHILDREN;
+    var i: usize = 0;
+    while (i < max + 4) : (i += 1) {
+        const child = game.createEntity();
+        game.setParent(child, parent, .{});
+        game.destroyEntity(child);
+    }
+
+    const last = game.createEntity();
+    game.setParent(last, parent, .{});
+    try testing.expectEqual(@as(usize, 1), game.getChildren(parent).len);
+    try testing.expect(childrenContain(&game, parent, last));
+}


### PR DESCRIPTION
Closes #701.

## The invariant

`destroyEntity` cascaded DOWN into the destroyed entity's own `Children` but never removed the entity from its **parent's** `Children` list — only `removeParent` did that cleanup. A destroy-while-parented left a permanently stale id in the parent's list; with zig-ecs's index-only sparse-set lookups a recycled index later aliases that id onto an unrelated entity: debug `assertValid` panics, silent cross-entity corruption in release, permanent `Children` slot exhaustion (`MAX_CHILDREN = 16`, silent drop in `addChild`), and a debug trap when the parent is later cascade-destroyed through the dead id — the Flying-Platform/flying-platform-labelle#603 chain.

The invariant **"a `Children` list only holds live ids"** now lives in the engine, on both destroy paths.

## What changed

- **`components_mixin.zig`** — extracted `detachFromParent`: the list-unlink half of `removeParent` (remove from the parent's `Children` + drop `Parent` + `bumpRoster`) **without** the renderer hierarchy-flag / dirty-position pokes, which are wasted work on a dying entity (the renderer untracks it immediately after; no world-position recomputation is triggered). `removeParent` now routes through it — one unlink pathway, no duplicated list surgery. The helper guards the parent lookup with `entityExists`: on destroy paths the recorded parent may already be dead (scene-drain order is arbitrary), and an index-only `getComponent` through a dead id can alias a recycled entity — a `removeChild` write through that alias would corrupt a live entity's list.
- **`entity_mixin.zig`** — `destroyEntity` and `destroyEntityOnly` call `self.detachFromParent(entity)` right before the teardown block (it must precede the backend destroy — after it the `Parent` component is unreachable). Ordering: after the preview-telemetry emit, so editor-side consumers can still introspect the fully-intact entity; and after the children cascade in the cascading variant.
- **`game.zig`** — `detachFromParent` re-exported on `Game` (cross-mixin calls route through the `Game` re-exports, per the file convention).

## Cascade-iteration handling (the regression trap)

Each child's destroy now **swap-removes** it from the dying parent's *live* `Children` list — iterating `getChildren()` in place would shrink and reorder the slice under the loop (skipped children, double-destroys of swap remnants). Chosen option: **iterate a by-value snapshot** of the `Children` component (`const children_snapshot = children_comp.*` — a 16-slot inline-array stack copy). Least invasive correct option; it needs no is-being-destroyed state threading, keeps the unlink logic uniform for every child, and as a bonus shields the walk from `entity_destroyed` hooks re-parenting into the list mid-cascade and from component-pool reshuffling under the held pointer while descendants' own `Children` components are removed (a latent hazard of the old in-place iteration).

`destroyEntityOnly` keeps its no-cascade contract: its own children stay alive (the `unloadCurrentScene` drain destroys every tracked entity itself, in arbitrary pop order — which is exactly why the unlink tolerates a parent drained first). The drain stays O(N): the added unlink is O(1) lookups + an O(16) `removeChild`.

## Tests

New `test/destroy_unlink_test.zig` (9 tests, wired into `build.zig`'s `test_files`):

1. Destroy the child → parent's `Children` no longer contains it; parent alive and still destroyable afterwards (the old code trapped here).
2. Destroy the middle of 5 children → siblings all still listed (membership contract; `removeChild` is a swap-remove so order isn't asserted).
3. Cascade-destroy a parent with 5 children + a bystander tree → all children gone, bystander hierarchy untouched (the snapshot-iteration regression trap).
4. Grandparent chain, destroy the middle → leaf cascaded, grandparent's list updated, grandparent still healthy.
5. 3-level full cascade (G→M→2 leaves) → whole tree destroyed, no corruption from mid-cascade unlinks.
6. `destroyEntityOnly` → unlinked from the surviving parent, its own children left alive per contract.
7. `destroyEntityOnly` drain-order tolerance → parent destroyed first, child's unlink skips the dead parent via the `entityExists` guard.
8. Re-parent (P1→P2) then destroy → only the current parent's list touched; P1's other child untouched.
9. Slot-exhaustion regression → `MAX_CHILDREN + 4` destroy/re-add cycles leak no slots.

## Suite

`zig build test`: **146/146 steps, 740/740 tests pass** (main baseline 144 steps / 731 tests — the delta is exactly this PR's new test binary). `zig build spec` green. `zig fmt` clean on touched files.

## Notes

- Sweep of other internal `destroyEntity`/`destroyEntityOnly` callers: `unloadCurrentScene` drain (covered above), `spawnFromPrefab` failure teardown and `entity_walker`'s `errdefer` (both now correctly unlink a partially-built child from its parent — strict improvement), `resetEcsBackend` (wholesale ECS wipe, doesn't route through destroy — unaffected). `save_load`'s `getChildren` walks are read-only.
- FP's call-site workaround (Flying-Platform/flying-platform-labelle#606 — `removeParent` before destroy + `entityExists` guards on child walks) becomes redundant-but-harmless once this lands.

https://claude.ai/code/session_01P7YLw4hXFCCaY2LAUt4G1j