### PR TITLE
tilemap: engine Tilemap component + .tmx loader + post-sprite render pass (T2 Phase 2)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -87,6 +87,9 @@ pub fn build(b: *std.Build) void {
         "test/save_load_mixin_test.zig",
         "test/jsonc/bridge_leak_test.zig",
         "test/jsonc/nested_lifecycle_test.zig",
+        // C2 — a project-registered component named `Tilemap` must win over
+        // the engine built-in in the scene loader (no silent shadowing).
+        "test/jsonc/tilemap_precedence_test.zig",
         "test/scene_ref_test.zig",
         "test/asset_catalog_test.zig",
         "test/audio_loader_test.zig",

--- a/build.zig
+++ b/build.zig
@@ -294,6 +294,38 @@ pub fn build(b: *std.Build) void {
     const assets_single_threaded = b.addTest(.{ .root_module = assets_single_threaded_module });
     test_step.dependOn(&assets_single_threaded.step);
 
+    // T2 tilemap test — proves the engine `Tilemap` component + `.tmx`
+    // decode + post-sprite render pass against the ACTUALLY-shipped gfx
+    // 1.21.0 API. The engine module takes no gfx dependency; this test
+    // reaches gfx's std-only `tilemap` sub-package (the `TileMap` decoder
+    // + `TileMapRendererWith`) through the lazy `labelle_gfx` pin and
+    // drives it over `core.mock_backend.MockBackend`. `lazyDependency`
+    // returns null on the first uncached run and Zig re-invokes after
+    // fetching, so downstream engine-module consumers never pull gfx.
+    if (b.lazyDependency("labelle_gfx", .{ .target = target, .optimize = optimize })) |gfx_dep| {
+        // gfx pins its `tilemap` sub-package in-tree (`.path = "tilemap"`);
+        // reach that module through gfx's own builder. The sub-package is
+        // std-only (no labelle-core), so there is no core-diamond to unify.
+        const tilemap_module = gfx_dep.builder.dependency("tilemap", .{
+            .target = target,
+            .optimize = optimize,
+        }).module("tilemap");
+        const tilemap_test = b.addTest(.{
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("test/tilemap_test.zig"),
+                .target = target,
+                .optimize = optimize,
+                .imports = &.{
+                    .{ .name = "labelle-core", .module = core_module },
+                    .{ .name = "engine", .module = engine_module },
+                    .{ .name = "scene", .module = scene_module },
+                    .{ .name = "tilemap", .module = tilemap_module },
+                },
+            }),
+        });
+        test_step.dependOn(&b.addRunArtifact(tilemap_test).step);
+    }
+
     // zspec BDD specs — mirrors the `spec` step in labelle-pathfinding.
     // Uses zspec's own test runner; the spec files declare
     // `describe`-style nested structs rather than flat `test` blocks.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -47,6 +47,22 @@
             .hash = "zspec-0.9.1-jaKLbXgMBACFwbNjflhbMyP113leoYjboxn-1UOP-FGw",
             .lazy = true,
         },
+        // TEST-ONLY, lazy. The engine module itself takes NO labelle-gfx
+        // dependency — it reaches tilemap types through the renderer plugin
+        // (`RenderImpl.TileMapRendererType`), exactly as it reaches
+        // Sprite/Shape/`drawMesh`. This pin exists solely so the T2 tilemap
+        // test (`test/tilemap_test.zig`) can decode a real `.tmx` through
+        // gfx's std-only `tilemap` sub-package + drive gfx's
+        // `TileMapRendererWith(MockBackend)` post-sprite, proving the whole
+        // path against the actually-shipped gfx 1.21.0 API rather than a
+        // hand-rolled stand-in. `lazy` so downstream consumers of the engine
+        // module never fetch it — it is reached only by the `test` step via
+        // `b.lazyDependency`, mirroring `zspec`.
+        .labelle_gfx = .{
+            .url = "https://github.com/labelle-toolkit/labelle-gfx/archive/refs/tags/v1.21.0.tar.gz",
+            .hash = "labelle_gfx-1.21.0-nMpCPCWWBADjXOGmLAPU849pmoxipfIbvwefjhTVPzNn",
+            .lazy = true,
+        },
     },
     .paths = .{
         "build.zig",

--- a/src/editor_api.zig
+++ b/src/editor_api.zig
@@ -543,6 +543,14 @@ fn Holder(comptime GP: type, comptime RP: type) type {
                     try appendJsonString(buf, cur, sp.sprite_name);
                 }
             }
+            // Tilemap presence (T2 Phase 2) — publishes the referenced
+            // `.tmx` asset name; no per-tile data (tilemaps are immutable).
+            if (comptime @hasDecl(G, "TilemapComp") and @hasField(G.TilemapComp, "asset_name")) {
+                if (game.getComponent(ent, G.TilemapComp)) |tm| {
+                    try appendLit(buf, cur, ",\"tilemap\":");
+                    try appendJsonString(buf, cur, tm.asset_name);
+                }
+            }
             // WORLD coordinates, not the raw (parent-relative) Position
             // component — `editor_set_entity_position` consumes world
             // coords, so the digest must publish the same space or the

--- a/src/game.zig
+++ b/src/game.zig
@@ -57,6 +57,9 @@ const animation_def_runtime = @import("animation_def_runtime.zig");
 const prefab_runtime_mixin = @import("game/prefab_runtime_mixin.zig");
 const roster_mod = @import("game/roster.zig");
 const game_init_mod = @import("game/game_init.zig");
+const tilemap_mod = @import("tilemap.zig");
+const tilemap_runtime = @import("tilemap_runtime.zig");
+const tilemap_mixin = @import("game/tilemap_mixin.zig");
 
 /// Full game configuration — the assembler fills ALL comptime slots.
 /// RenderImpl is a renderer plugin (e.g. gfx.GfxRenderer) satisfying RenderInterface.
@@ -218,6 +221,24 @@ pub fn GameConfigWithYAxis(
         pub const ChildrenComp = Children;
         pub const PrefabInstanceComp = PrefabInstance;
         pub const PrefabChildComp = PrefabChildT;
+
+        // ── Tilemap (T2 Phase 2) ─────────────────────────────────
+        /// Engine built-in `Tilemap` component (references a `.tmx` asset
+        /// by name). Handled by dedicated built-in channels (scene loader,
+        /// save/load, digest) — NOT a `ComponentRegistry` component.
+        pub const TilemapComp = tilemap_mod.Tilemap;
+        /// True when the renderer plugin exposes gfx's tilemap seam
+        /// (`RenderImpl.TileMapRendererType` + the shared texture path).
+        /// Gates the decoded-map runtime + post-sprite pass; when false the
+        /// component still attaches but renders nothing (stub renderers).
+        pub const tilemap_supported = tilemap_runtime.supported(RenderImpl);
+        /// Per-entity decoded-map + draw-pass renderer (heap-owned by the
+        /// side table). `void` on renderers without the tilemap seam.
+        pub const TilemapRuntimeType = if (tilemap_supported)
+            tilemap_runtime.Runtime(RenderImpl)
+        else
+            void;
+
         pub const Input = @import("input.zig").InputInterface(InputImpl);
 
         /// True when the active input backend itself declares
@@ -288,6 +309,7 @@ pub fn GameConfigWithYAxis(
         const AnimationRuntimeMixin = animation_runtime_mixin.Mixin(Self);
         const PrefabRuntimeMixin = prefab_runtime_mixin.Mixin(Self);
         const RosterMixin = roster_mod.Mixin(Self);
+        const TilemapMixin = tilemap_mixin.Mixin(Self);
         // VideoImpl/AudioImpl are `GameConfig` fn params (not `Self`
         // decls), so the construction mixin takes them explicitly.
         const InitMixin = game_init_mod.Mixin(Self, VideoImpl, AudioImpl);
@@ -406,6 +428,18 @@ pub fn GameConfigWithYAxis(
         /// program-lifetime borrows of `@embedFile` slices and are NOT
         /// freed by the map.
         embedded_scene_sources: std.StringHashMap([]const u8),
+        /// Embedded tilemap-asset bytes (T2 Phase 2), keyed by asset name:
+        /// both the `.tmx` documents (looked up by `Tilemap.asset_name`)
+        /// and each tileset image (looked up by its `image_source`). Keys
+        /// are owned (dup'd); values are program-lifetime `@embedFile`
+        /// borrows, never freed by the map. The assembler emits registration
+        /// calls in `init()` (Phase 4); see `addEmbeddedTilemapAsset`.
+        embedded_tilemap_sources: std.StringHashMap([]const u8),
+        /// Per-entity decoded-map + draw-pass renderers (T2 Phase 2). Heap
+        /// pointers so the gfx tilemap renderer's `*const TileMap` into the
+        /// runtime stays stable. `void` on renderers without the tilemap
+        /// seam. Owned here; freed in `deinitTilemaps` / `releaseTilemap`.
+        tilemaps: if (tilemap_supported) std.AutoHashMap(Entity, *TilemapRuntimeType) else void,
         /// Runtime scene-source overrides (labelle-studio Play mode /
         /// `editor_api`). Keyed by scene NAME (e.g. `"main"`); the JSONC
         /// loader consults this map BEFORE the embedded/compiled source
@@ -826,6 +860,16 @@ pub fn GameConfigWithYAxis(
         pub const removeText = Visuals.removeText;
         pub const setZIndex = Visuals.setZIndex;
         pub const setSpriteFlip = Visuals.setSpriteFlip;
+
+        // ── Tilemap (mixin, T2 Phase 2) ──────────────────────────
+        pub const addTilemap = TilemapMixin.addTilemap;
+        pub const acquireTilemap = TilemapMixin.acquireTilemap;
+        pub const releaseTilemap = TilemapMixin.releaseTilemap;
+        pub const renderTilemaps = TilemapMixin.renderTilemaps;
+        pub const tilemapRuntime = TilemapMixin.tilemapRuntime;
+        pub const addEmbeddedTilemapAsset = TilemapMixin.addEmbeddedTilemapAsset;
+        pub const clearTilemaps = TilemapMixin.clearTilemaps;
+        pub const deinitTilemaps = TilemapMixin.deinitTilemaps;
 
         // ── Roster cache (#653, #657) — `game/roster.zig` ─────────
         // Borrowed-slice lifetime contract + design rationale live in

--- a/src/game.zig
+++ b/src/game.zig
@@ -439,6 +439,17 @@ pub fn GameConfigWithYAxis(
         /// pointers so the gfx tilemap renderer's `*const TileMap` into the
         /// runtime stays stable. `void` on renderers without the tilemap
         /// seam. Owned here; freed in `deinitTilemaps` / `releaseTilemap`.
+        ///
+        /// **Single-world scope (T2 limitation, F2 / #704).** This table is
+        /// keyed on the Game and is NOT swapped with `active_world`, so its
+        /// entity ids belong to whichever world was active when
+        /// `addTilemap` ran. `resetEcsBackend` (scene swap / `loadGameState`)
+        /// clears it via `clearTilemaps`, so the common single-world path is
+        /// safe. A raw world *swap* (multiple live worlds) could leave a
+        /// shelved world's ids here; `renderTilemaps` guards against drawing
+        /// them by reaping any id that isn't `Tilemap`-bearing in the
+        /// CURRENTLY active ECS. Proper per-world scoping (own the table on
+        /// `World`, clean it in `destroyWorld`) is tracked in #704.
         tilemaps: if (tilemap_supported) std.AutoHashMap(Entity, *TilemapRuntimeType) else void,
         /// Runtime scene-source overrides (labelle-studio Play mode /
         /// `editor_api`). Keyed by scene NAME (e.g. `"main"`); the JSONC
@@ -865,6 +876,7 @@ pub fn GameConfigWithYAxis(
         pub const addTilemap = TilemapMixin.addTilemap;
         pub const acquireTilemap = TilemapMixin.acquireTilemap;
         pub const releaseTilemap = TilemapMixin.releaseTilemap;
+        pub const removeTilemap = TilemapMixin.removeTilemap;
         pub const renderTilemaps = TilemapMixin.renderTilemaps;
         pub const tilemapRuntime = TilemapMixin.tilemapRuntime;
         pub const addEmbeddedTilemapAsset = TilemapMixin.addEmbeddedTilemapAsset;

--- a/src/game/entity_mixin.zig
+++ b/src/game/entity_mixin.zig
@@ -259,6 +259,7 @@ pub fn Mixin(comptime Game: type) type {
             untrackSceneEntity(self, entity);
             self.active_world.sprite_cache.invalidate(@intCast(entity));
             self.renderer.untrackEntity(entity);
+            self.releaseTilemap(entity);
             self.ecs_backend.destroyEntity(entity);
             self.bumpRoster();
             recordTombstone(self, entity);
@@ -280,6 +281,7 @@ pub fn Mixin(comptime Game: type) type {
             untrackSceneEntity(self, entity);
             self.active_world.sprite_cache.invalidate(@intCast(entity));
             self.renderer.untrackEntity(entity);
+            self.releaseTilemap(entity);
             self.ecs_backend.destroyEntity(entity);
             self.bumpRoster();
             recordTombstone(self, entity);

--- a/src/game/game_init.zig
+++ b/src/game/game_init.zig
@@ -86,6 +86,10 @@ pub fn Mixin(comptime Game: type, comptime VideoImpl: type, comptime AudioImpl: 
                 .scenes = std.StringHashMap(Game.SceneEntry).init(allocator),
                 .jsonc_scenes = std.StringHashMap(Game.JsoncSceneInfo).init(allocator),
                 .embedded_scene_sources = std.StringHashMap([]const u8).init(allocator),
+                .embedded_tilemap_sources = std.StringHashMap([]const u8).init(allocator),
+                .tilemaps = if (Game.tilemap_supported)
+                    std.AutoHashMap(Entity, *Game.TilemapRuntimeType).init(allocator)
+                else {},
                 .scene_source_overrides = std.StringHashMap([]const u8).init(allocator),
                 .runtime_anim_defs = animation_def_runtime.RuntimeAnimDefs.init(allocator),
                 .gizmo_state = gizmo_draws_mod.GizmoState(Entity).init(allocator),

--- a/src/game/lifecycle_mixin.zig
+++ b/src/game/lifecycle_mixin.zig
@@ -7,7 +7,6 @@
 /// just reads or writes a `Game` field — the actual platform effects
 /// (window fullscreen, animation advance) happen elsewhere, driven off
 /// these flags.
-
 const std = @import("std");
 const core = @import("labelle-core");
 
@@ -99,6 +98,13 @@ pub fn Mixin(comptime Game: type) type {
             var emb_iter = self.embedded_scene_sources.iterator();
             while (emb_iter.next()) |entry| self.allocator.free(entry.key_ptr.*);
             self.embedded_scene_sources.deinit();
+            // Tilemap runtimes (T2 Phase 2): free every decoded map +
+            // draw-pass renderer, then the embedded-source registry's
+            // owned keys (values are @embedFile borrows).
+            self.deinitTilemaps();
+            var tm_iter = self.embedded_tilemap_sources.iterator();
+            while (tm_iter.next()) |entry| self.allocator.free(entry.key_ptr.*);
+            self.embedded_tilemap_sources.deinit();
             // Scene-source overrides own BOTH keys and values (runtime
             // copies from `setSceneSourceOverride`) — free them all.
             var ovr_iter = self.scene_source_overrides.iterator();

--- a/src/game/lifecycle_mixin.zig
+++ b/src/game/lifecycle_mixin.zig
@@ -87,6 +87,12 @@ pub fn Mixin(comptime Game: type) type {
             if (self.active_world_name) |name| {
                 self.allocator.free(name);
             }
+            // Tilemap runtimes (T2 Phase 2) — MUST run before the active
+            // world's renderer is torn down: each runtime unloads the
+            // tileset textures it uploaded through `renderer.unloadTexture`
+            // (F1), so the renderer has to still be alive.
+            self.deinitTilemaps();
+
             // Clean up active world
             self.active_world.deinit();
             self.allocator.destroy(self.active_world);
@@ -98,10 +104,10 @@ pub fn Mixin(comptime Game: type) type {
             var emb_iter = self.embedded_scene_sources.iterator();
             while (emb_iter.next()) |entry| self.allocator.free(entry.key_ptr.*);
             self.embedded_scene_sources.deinit();
-            // Tilemap runtimes (T2 Phase 2): free every decoded map +
-            // draw-pass renderer, then the embedded-source registry's
-            // owned keys (values are @embedFile borrows).
-            self.deinitTilemaps();
+            // Tilemap embedded-source registry (T2 Phase 2): free the owned
+            // keys (values are program-lifetime @embedFile borrows). The
+            // runtimes themselves were already freed above, before the
+            // renderer teardown.
             var tm_iter = self.embedded_tilemap_sources.iterator();
             while (tm_iter.next()) |entry| self.allocator.free(entry.key_ptr.*);
             self.embedded_tilemap_sources.deinit();

--- a/src/game/loop_mixin.zig
+++ b/src/game/loop_mixin.zig
@@ -224,6 +224,13 @@ pub fn Mixin(comptime Game: type) type {
             // takes. The common path (no gate armed) is unchanged.
             if (self.post_load_render_gate == null) {
                 self.renderer.render();
+                // Tilemap POST-SPRITE pass (T2 Phase 2): the engine owns
+                // pass ordering — entities first, tilemaps after. No-op
+                // when no Tilemap entities exist / renderer lacks the seam.
+                // Gated by the same post-load render gate as the world
+                // draw so restored tilemaps don't flash before their
+                // tileset textures re-bind.
+                self.renderTilemaps();
             }
             self.renderGizmos();
             self.clearGizmos();

--- a/src/game/save_load/load.zig
+++ b/src/game/save_load/load.zig
@@ -523,6 +523,29 @@ pub fn Mixin(comptime Game: type) type {
                         });
                     }
                 }
+
+                // Restore Tilemap (built-in, T2 Phase 2) — counterpart to
+                // the save block. `addTilemap` re-attaches the component AND
+                // rebuilds the decoded-map runtime from the (still-embedded)
+                // `.tmx` asset; runtime state itself is never saved.
+                // `asset_name` is duped into the world arena to outlive the
+                // parsed JSON deinit.
+                const TilemapT_load = Game.TilemapComp;
+                if (comptime !Common.isRegistered(TilemapT_load)) {
+                    if (components.get("Tilemap")) |tm_val| blk: {
+                        const tm_obj = switch (tm_val) {
+                            .object => |o| o,
+                            else => break :blk,
+                        };
+                        const name_str = switch (tm_obj.get("asset_name") orelse break :blk) {
+                            .string => |s| s,
+                            else => break :blk,
+                        };
+                        const tm_arena = self.active_world.nested_entity_arena.allocator();
+                        const name_dup = try tm_arena.dupe(u8, name_str);
+                        self.addTilemap(entity, .{ .asset_name = name_dup });
+                    }
+                }
             }
 
             // Step 4: Restore ref arrays ([]const u64 slices)

--- a/src/game/save_load/save.zig
+++ b/src/game/save_load/save.zig
@@ -124,6 +124,24 @@ pub fn Mixin(comptime Game: type) type {
                 }
             }
 
+            // Auto-collect Tilemap entities (T2 Phase 2). Same rationale as
+            // the prefab-tag sweep above: the built-in `Tilemap` carries no
+            // registry component, so a tilemap-only entity would otherwise
+            // be missed by the registry-driven sweep and silently dropped
+            // from the save. Skipped when a game registers `Tilemap` in its
+            // own `ComponentRegistry` (then the registry sweep collected it).
+            if (comptime !Common.isRegistered(Game.TilemapComp)) {
+                var tm_view = self.active_world.ecs_backend.view(.{Game.TilemapComp}, .{});
+                defer tm_view.deinit();
+                while (tm_view.next()) |entity| {
+                    const id = Common.entityToU64(entity);
+                    if (!entity_set.contains(id)) {
+                        try entity_set.put(id, {});
+                        try entity_list.append(allocator, id);
+                    }
+                }
+            }
+
             var alloc_writer: std.Io.Writer.Allocating = .init(allocator);
             defer alloc_writer.deinit();
             const writer = &alloc_writer.writer;
@@ -244,6 +262,23 @@ pub fn Mixin(comptime Game: type) type {
                         try writer.print("{d}", .{Common.entityToU64(pc.root)});
                         try writer.writeAll(", \"local_path\": ");
                         try writeJsonString(writer, pc.local_path);
+                        try writer.writeAll("}");
+                        first_comp = false;
+                    }
+                }
+
+                // Save Tilemap (built-in, T2 Phase 2). `asset_name` is a
+                // `[]const u8` (serde can't round-trip it — same reason
+                // PrefabInstance lives here), and T2 tilemaps are immutable
+                // (deterministic from the asset), so ONLY the asset
+                // reference persists — the decoded map is never saved.
+                // Same registry-identity guard as the other built-ins.
+                const TilemapT = Game.TilemapComp;
+                if (comptime !Common.isRegistered(TilemapT)) {
+                    if (self.active_world.ecs_backend.getComponent(entity, TilemapT)) |tm| {
+                        if (!first_comp) try writer.writeAll(",");
+                        try writer.writeAll("\n        \"Tilemap\": {\"asset_name\": ");
+                        try writeJsonString(writer, tm.asset_name);
                         try writer.writeAll("}");
                         first_comp = false;
                     }

--- a/src/game/tilemap_mixin.zig
+++ b/src/game/tilemap_mixin.zig
@@ -9,6 +9,7 @@
 //! no-op — keeping the feature purely additive for stub renderers.
 
 const std = @import("std");
+const core = @import("labelle-core");
 const tilemap_runtime = @import("../tilemap_runtime.zig");
 
 pub fn Mixin(comptime Game: type) type {
@@ -92,23 +93,94 @@ pub fn Mixin(comptime Game: type) type {
             }
         }
 
+        /// Detach a `Tilemap` component AND free its decoded-map runtime —
+        /// the counterpart to `addTilemap` (F4). Prefer this over the
+        /// generic `removeComponent(entity, Tilemap)`, which would strip the
+        /// component but leave the side-table runtime alive; `renderTilemaps`
+        /// reaps such orphans defensively, but going through `removeTilemap`
+        /// frees the runtime immediately.
+        pub fn removeTilemap(self: *Game, entity: Entity) void {
+            releaseTilemap(self, entity);
+            self.removeComponent(entity, Tilemap);
+        }
+
         /// The post-sprite tilemap pass: after the entity render pass, draw
         /// every `Tilemap` entity's decoded map at its world `Position`.
         /// The engine owns pass ordering here (entities first, tilemaps
         /// after); gfx's `RetainedEngine` is untouched.
         ///
-        /// T2 runs the pass in screen space (`camera_* = 0`): tiles draw at
-        /// `world_pos - 0`. Aligning with a moving camera transform and
-        /// Z-interleaving with sprite layers are deferred to T3 — the gfx
-        /// `drawAllLayers` seam already accepts the camera offset for when
-        /// that lands.
+        /// **Y-axis (F3).** The map's world offset is flipped through the
+        /// SAME `core.toScreenY` transform sprites use, so a tilemap and a
+        /// sprite at the same `Position.y` align under `.up` (and are the
+        /// identity under `.down`). Since the map draws downward from its
+        /// top-left, under `.up` — where `Position.y` is the map's *bottom*
+        /// edge — the flipped screen offset is additionally raised by the
+        /// map's pixel height so the bottom edge lands at
+        /// `toScreenY(.up, pos.y, H)`.
+        ///
+        /// **Ghost guard (F4/F2).** Entities whose `Tilemap` component was
+        /// stripped via the generic `removeComponent` — or stale ids left
+        /// over from a world swap (F2) — are reaped from the side table and
+        /// never drawn: the table is keyed on the Game, not swapped with
+        /// `active_world`, so it's guarded against the CURRENTLY active ECS.
+        ///
+        /// T2 runs the pass in screen space (`camera_* = 0`). Camera-transform
+        /// alignment + Z-interleaving with sprite layers are deferred to T3.
         pub fn renderTilemaps(self: *Game) void {
             if (comptime !supported) return;
+
+            reapGhostTilemaps(self);
+
+            const y_axis = Game.y_axis;
+            const screen_h = tilemapScreenHeight(self);
             var it = self.tilemaps.iterator();
             while (it.next()) |e| {
-                const pos = self.getWorldPosition(e.key_ptr.*);
-                e.value_ptr.*.draw(0, 0, pos.x, pos.y, null, null);
+                const entity = e.key_ptr.*;
+                const rt = e.value_ptr.*;
+                const pos = self.getWorldPosition(entity);
+                const off_x = pos.x;
+                // Flip the map's world Y into screen space exactly as the
+                // renderer flips sprite Y, then (under `.up`) raise by the
+                // map height so the map's bottom edge sits at the flipped
+                // Position.y — identity under `.down`.
+                const off_y = core.toScreenY(y_axis, pos.y, screen_h) -
+                    switch (y_axis) {
+                        .up => rt.pixelHeight(),
+                        .down => @as(f32, 0),
+                    };
+                rt.draw(0, 0, off_x, off_y, null, null);
             }
+        }
+
+        /// Free + drop side-table runtimes whose entity no longer carries a
+        /// `Tilemap` in the active ECS (generic `removeComponent`, or a
+        /// stale id from another world). Restart-on-remove keeps it
+        /// iterator-safe and alloc-free; ghosts are rare so this stays ~O(n).
+        fn reapGhostTilemaps(self: *Game) void {
+            reap: while (true) {
+                var it = self.tilemaps.iterator();
+                while (it.next()) |e| {
+                    if (!self.ecs_backend.hasComponent(e.key_ptr.*, Tilemap)) {
+                        const rt = e.value_ptr.*;
+                        _ = self.tilemaps.remove(e.key_ptr.*);
+                        rt.deinit();
+                        self.allocator.destroy(rt);
+                        continue :reap;
+                    }
+                }
+                break;
+            }
+        }
+
+        /// The renderer's LOGICAL screen height — the same value sprites are
+        /// flipped against (`GfxRendererWith.screen_height`, set via
+        /// `setScreenHeight`). Only consulted for the `.up` flip; `.down` is
+        /// the identity so the value is unused there.
+        fn tilemapScreenHeight(self: *Game) f32 {
+            if (comptime @hasField(@TypeOf(self.renderer.*), "screen_height")) {
+                return self.renderer.screen_height;
+            }
+            return 0;
         }
 
         /// Test/introspection accessor: the decoded-map runtime for an

--- a/src/game/tilemap_mixin.zig
+++ b/src/game/tilemap_mixin.zig
@@ -153,9 +153,20 @@ pub fn Mixin(comptime Game: type) type {
         }
 
         /// Free + drop side-table runtimes whose entity no longer carries a
-        /// `Tilemap` in the active ECS (generic `removeComponent`, or a
-        /// stale id from another world). Restart-on-remove keeps it
-        /// iterator-safe and alloc-free; ghosts are rare so this stays ~O(n).
+        /// `Tilemap` in the active ECS (generic `removeComponent`).
+        /// Restart-on-remove keeps it iterator-safe and alloc-free; ghosts
+        /// are rare so this stays ~O(n).
+        ///
+        /// **Assumes a single active world (C1 / #704).** The table is
+        /// Game-global, so "not `Tilemap`-bearing in the active ECS" cannot
+        /// distinguish "component was removed" (correctly reaped) from
+        /// "entity belongs to a *shelved* world" (must be preserved). Under a
+        /// raw world swap this reap would DESTRUCT a shelved world's runtime,
+        /// and switching back would leave a `Tilemap` component with no
+        /// runtime (draws nothing). That aliasing is inherent to the
+        /// single-table design and the core motivation for per-world scoping;
+        /// it is safe for minimal-T2 (single world; `resetEcsBackend` clears
+        /// the table on scene swap / load). Tracked in #704.
         fn reapGhostTilemaps(self: *Game) void {
             reap: while (true) {
                 var it = self.tilemaps.iterator();

--- a/src/game/tilemap_mixin.zig
+++ b/src/game/tilemap_mixin.zig
@@ -1,0 +1,143 @@
+//! Tilemap mixin (T2 Phase 2) — the `Game`-side lifecycle for the
+//! `Tilemap` component: registration, `.tmx` decode behind the embedded
+//! asset registry, the post-sprite render pass, and teardown.
+//!
+//! All heavy machinery is gated on `Game.tilemap_supported` (whether the
+//! renderer plugin exposes gfx's tilemap seam). When unsupported,
+//! `addTilemap` still attaches the component (so scene-load / save / digest
+//! behave), but no decoded-map runtime is built and the render pass is a
+//! no-op — keeping the feature purely additive for stub renderers.
+
+const std = @import("std");
+const tilemap_runtime = @import("../tilemap_runtime.zig");
+
+pub fn Mixin(comptime Game: type) type {
+    const Entity = Game.EntityType;
+    const Tilemap = Game.TilemapComp;
+    const supported = Game.tilemap_supported;
+    const Runtime = Game.TilemapRuntimeType;
+
+    return struct {
+        /// Register raw bytes for a tilemap-related embedded asset — the
+        /// `.tmx` document itself AND each tileset image it references,
+        /// both keyed by their asset name (the `.tmx` file name and each
+        /// tileset's `image_source`). The assembler emits these calls in
+        /// `init()` for embedded builds (Phase 4); tests register fixtures
+        /// directly. `name` is owned (dup'd); `bytes` is a program-lifetime
+        /// borrow (`@embedFile`), stored by reference and never freed.
+        pub fn addEmbeddedTilemapAsset(self: *Game, name: []const u8, bytes: []const u8) !void {
+            const gop = try self.embedded_tilemap_sources.getOrPut(name);
+            if (!gop.found_existing) {
+                gop.key_ptr.* = try self.allocator.dupe(u8, name);
+            }
+            gop.value_ptr.* = bytes;
+        }
+
+        /// Bytes provider trampoline backing `tilemap_runtime.ImageProvider`.
+        fn provideImage(context: ?*anyopaque, name: []const u8) ?[]const u8 {
+            const game: *Game = @ptrCast(@alignCast(context.?));
+            return game.embedded_tilemap_sources.get(name);
+        }
+
+        /// Attach a `Tilemap` component and (when supported) decode its
+        /// `.tmx` asset + bind a draw-pass renderer. Mirrors the
+        /// `addSprite`/`addShape` shape, minus renderer entity-tracking —
+        /// a tilemap is not a per-entity retained visual; it renders as a
+        /// dedicated post-sprite pass.
+        pub fn addTilemap(self: *Game, entity: Entity, tilemap: Tilemap) void {
+            self.ecs_backend.addComponent(entity, tilemap);
+            self.bumpRoster(); // membership changed (#653)
+            if (comptime !supported) return;
+            acquireTilemap(self, entity, tilemap.asset_name);
+        }
+
+        /// (Re)build the decoded-map runtime for an entity from its asset.
+        /// Idempotent: a prior runtime for `entity` is freed first, so a
+        /// save/load rehydrate or a scene reload can't leak or double-bind.
+        /// A missing asset / decode failure leaves the component attached
+        /// with no runtime (the entity simply renders nothing) rather than
+        /// failing the load.
+        pub fn acquireTilemap(self: *Game, entity: Entity, asset_name: []const u8) void {
+            if (comptime !supported) return;
+            releaseTilemap(self, entity);
+
+            const tmx = self.embedded_tilemap_sources.get(asset_name) orelse {
+                self.log.warn("tilemap asset '{s}' not registered — nothing to decode", .{asset_name});
+                return;
+            };
+
+            const rt = self.allocator.create(Runtime) catch return;
+            const provider = tilemap_runtime.ImageProvider{
+                .context = self,
+                .getFn = provideImage,
+            };
+            rt.initInPlace(self.allocator, self.renderer, tmx, provider) catch |err| {
+                self.log.warn("tilemap '{s}' decode failed: {s}", .{ asset_name, @errorName(err) });
+                self.allocator.destroy(rt);
+                return;
+            };
+            self.tilemaps.put(entity, rt) catch {
+                rt.deinit();
+                self.allocator.destroy(rt);
+            };
+        }
+
+        /// Drop and free an entity's tilemap runtime, if any. Called from
+        /// the entity destroy paths and before a re-acquire.
+        pub fn releaseTilemap(self: *Game, entity: Entity) void {
+            if (comptime !supported) return;
+            if (self.tilemaps.fetchRemove(entity)) |kv| {
+                kv.value.deinit();
+                self.allocator.destroy(kv.value);
+            }
+        }
+
+        /// The post-sprite tilemap pass: after the entity render pass, draw
+        /// every `Tilemap` entity's decoded map at its world `Position`.
+        /// The engine owns pass ordering here (entities first, tilemaps
+        /// after); gfx's `RetainedEngine` is untouched.
+        ///
+        /// T2 runs the pass in screen space (`camera_* = 0`): tiles draw at
+        /// `world_pos - 0`. Aligning with a moving camera transform and
+        /// Z-interleaving with sprite layers are deferred to T3 — the gfx
+        /// `drawAllLayers` seam already accepts the camera offset for when
+        /// that lands.
+        pub fn renderTilemaps(self: *Game) void {
+            if (comptime !supported) return;
+            var it = self.tilemaps.iterator();
+            while (it.next()) |e| {
+                const pos = self.getWorldPosition(e.key_ptr.*);
+                e.value_ptr.*.draw(0, 0, pos.x, pos.y, null, null);
+            }
+        }
+
+        /// Test/introspection accessor: the decoded-map runtime for an
+        /// entity, or null. Returns `void`-typed `null` on stub renderers.
+        pub fn tilemapRuntime(self: *Game, entity: Entity) ?*Runtime {
+            if (comptime !supported) return null;
+            return self.tilemaps.get(entity);
+        }
+
+        /// Free every tilemap runtime but keep the (empty) side table
+        /// usable. Called on ECS reset (scene swap / `loadGameState`),
+        /// where every tilemap entity id is invalidated but the map itself
+        /// is reused for the incoming entities.
+        pub fn clearTilemaps(self: *Game) void {
+            if (comptime !supported) return;
+            var it = self.tilemaps.iterator();
+            while (it.next()) |e| {
+                e.value_ptr.*.deinit();
+                self.allocator.destroy(e.value_ptr.*);
+            }
+            self.tilemaps.clearRetainingCapacity();
+        }
+
+        /// Free every tilemap runtime + the side table. Called from the
+        /// lifecycle mixin's `deinit`.
+        pub fn deinitTilemaps(self: *Game) void {
+            if (comptime !supported) return;
+            clearTilemaps(self);
+            self.tilemaps.deinit();
+        }
+    };
+}

--- a/src/game/world_mixin.zig
+++ b/src/game/world_mixin.zig
@@ -115,6 +115,10 @@ pub fn Mixin(comptime Game: type) type {
             // Clear renderer entity tracking but keep GPU textures loaded.
             // Textures are expensive to reload (embedded atlas data parsed at startup).
             self.active_world.renderer.clear();
+            // Free per-entity tilemap runtimes — the ECS is about to be
+            // wiped, so every tilemap entity id becomes a dangling handle
+            // (T2 Phase 2). Rehydrated by the incoming scene / load path.
+            self.clearTilemaps();
             self.active_world.ecs_backend.deinit();
             _ = self.active_world.nested_entity_arena.reset(.retain_capacity);
 

--- a/src/jsonc/component_apply.zig
+++ b/src/jsonc/component_apply.zig
@@ -112,6 +112,15 @@ pub fn ComponentApply(comptime GameType: type, comptime Components: type) type {
                 return;
             }
 
+            // Tilemap (T2 Phase 2) — built-in, uses addTilemap so the
+            // `.tmx` asset decodes + binds a draw-pass renderer at load.
+            if (std.mem.eql(u8, name, "Tilemap")) {
+                if (deserializer.deserialize(GameType.TilemapComp, value, comp_alloc)) |tilemap| {
+                    game.addTilemap(entity, tilemap);
+                }
+                return;
+            }
+
             // All other components — comptime dispatch via
             // Components registry.
             const filtered = stripEntityArrayFields(value, game.allocator);

--- a/src/jsonc/component_apply.zig
+++ b/src/jsonc/component_apply.zig
@@ -114,11 +114,22 @@ pub fn ComponentApply(comptime GameType: type, comptime Components: type) type {
 
             // Tilemap (T2 Phase 2) — built-in, uses addTilemap so the
             // `.tmx` asset decodes + binds a draw-pass renderer at load.
-            if (std.mem.eql(u8, name, "Tilemap")) {
-                if (deserializer.deserialize(GameType.TilemapComp, value, comp_alloc)) |tilemap| {
-                    game.addTilemap(entity, tilemap);
+            //
+            // A project-registered component named `Tilemap` WINS: the
+            // built-in branch is compiled out when the registry defines the
+            // name, so the generic `Components.names()` dispatch below routes
+            // it to the registered type. Without this guard the built-in
+            // would silently shadow the registered component (and because
+            // `TilemapComp.asset_name` defaults to `""`, even custom JSON
+            // lacking `asset_name` would deserialize as an empty engine
+            // tilemap) — silent scene-data loss (C2).
+            if (comptime !Components.has("Tilemap")) {
+                if (std.mem.eql(u8, name, "Tilemap")) {
+                    if (deserializer.deserialize(GameType.TilemapComp, value, comp_alloc)) |tilemap| {
+                        game.addTilemap(entity, tilemap);
+                    }
+                    return;
                 }
-                return;
             }
 
             // All other components — comptime dispatch via

--- a/src/root.zig
+++ b/src/root.zig
@@ -58,6 +58,12 @@ pub const StderrLogSink = core.StderrLogSink;
 pub const GameWith = game_mod.GameWith;
 pub const Game = game_mod.Game;
 
+// ── Tilemap (T2 Phase 2) ──
+/// Engine built-in `Tilemap` component — references an embedded `.tmx`
+/// asset by name. Reachable on a configured game as `Game.TilemapComp`.
+/// See `src/tilemap.zig` / `src/tilemap_runtime.zig`.
+pub const Tilemap = @import("tilemap.zig").Tilemap;
+
 // ── Input ──
 pub const InputInterface = input_mod.InputInterface;
 pub const StubInput = input_mod.StubInput;
@@ -678,4 +684,3 @@ pub const GizmoInterface = core.GizmoInterface;
 pub const StubGizmos = core.StubGizmos;
 pub const PhysicsInterface = core.PhysicsInterface;
 pub const StubPhysics = core.StubPhysics;
-

--- a/src/tilemap.zig
+++ b/src/tilemap.zig
@@ -1,0 +1,31 @@
+//! Tilemap component (T2 Phase 2, labelle-engine tilemap epic).
+//!
+//! A `Tilemap` entity references an embedded `.tmx` asset by name. The
+//! component itself is a tiny POD holding only that reference — the
+//! decoded map + its per-entity draw-pass renderer live engine-side in a
+//! side table on `Game` (see `game/tilemap_mixin.zig`), keyed by entity.
+//!
+//! **Immutable at runtime (T2).** A tilemap is fully deterministic from
+//! its `.tmx` asset: there are no runtime tile mutations and no dirty
+//! tracking. Consequently the save/load contract persists ONLY
+//! `asset_name` (via the engine's built-in save channel, alongside
+//! `Position`/`PrefabInstance` — see `game/save_load/`), and load
+//! rehydrates the decoded map by re-decoding the asset. The decoded map
+//! is never serialized.
+//!
+//! **Engine built-in, NOT a `ComponentRegistry` component.** Like
+//! `Position` and `PrefabInstance`, `Tilemap` is handled by dedicated
+//! built-in channels in the scene loader, save/load, and digest — its
+//! `asset_name` is a `[]const u8`, which the registry-driven `serde`
+//! path cannot round-trip. Do not register it in a game's
+//! `ComponentRegistry`.
+
+/// The `Tilemap` component. Reachable on a configured game as
+/// `Game.TilemapComp`.
+pub const Tilemap = struct {
+    /// Name of the embedded `.tmx` asset this entity renders. Resolved
+    /// through `Game.addEmbeddedTilemapAsset` (the `.tmx` bytes) + the
+    /// same registry for each tileset's image bytes. The ONLY field that
+    /// persists across save/load — the decoded map is rebuilt from it.
+    asset_name: []const u8 = "",
+};

--- a/src/tilemap_runtime.zig
+++ b/src/tilemap_runtime.zig
@@ -1,0 +1,187 @@
+//! Per-entity tilemap draw-pass runtime (T2 Phase 2).
+//!
+//! The engine is renderer-agnostic — it never imports labelle-gfx. It
+//! reaches gfx's tilemap types the same way it reaches `Sprite`/`Shape`
+//! and the `drawMesh` seam: through the renderer plugin (`RenderImpl`).
+//! This module centralises ALL the reflection needed to name gfx's
+//! `TileMap` decoder + `TileMapRenderer` (`RenderImpl.TileMapRendererType`,
+//! shipped by gfx 1.21.0), so the rest of the engine stays gfx-free.
+//!
+//! `supported(RenderImpl)` gates the whole feature: a renderer that does
+//! not expose the tilemap seam (e.g. a bare test stub) compiles to a void
+//! side table and no-op mixin methods — purely additive, zero cost.
+//!
+//! Ownership: the decoded `TileMap` and the `TileMapRenderer` live inside
+//! `Runtime`, which `Game` heap-allocates (stable address — the renderer
+//! keeps a `*const TileMap` into `Runtime.map`). Tileset textures are
+//! uploaded through `RenderImpl.loadTextureFromMemory` (the SAME backend
+//! texture path sprites use) and are therefore owned by the renderer's
+//! shared texture registry, NOT by the tilemap renderer — the resolver
+//! seam hands them over as unowned. They are freed when the renderer is
+//! deinited (scene teardown / shutdown), so `Runtime.deinit` does not
+//! unload them (see `TileMapRenderer.TextureEntry.owned`).
+
+const std = @import("std");
+
+/// True when `RenderImpl` exposes the gfx 1.21.0 tilemap seam: the
+/// per-backend `TileMapRenderer` type plus the shared texture path the
+/// resolver bridges through. `GfxRendererWith` satisfies all three.
+pub fn supported(comptime RenderImpl: type) bool {
+    return @hasDecl(RenderImpl, "TileMapRendererType") and
+        @hasDecl(RenderImpl, "loadTextureFromMemory") and
+        @hasDecl(RenderImpl, "getTextureInfo");
+}
+
+/// Supplies raw image bytes for a tileset's `image_source` name. The
+/// engine backs this with `Game`'s embedded tilemap-asset registry so the
+/// runtime stays decoupled from `Game`.
+pub const ImageProvider = struct {
+    context: ?*anyopaque = null,
+    getFn: *const fn (context: ?*anyopaque, name: []const u8) ?[]const u8,
+
+    fn get(self: ImageProvider, name: []const u8) ?[]const u8 {
+        return self.getFn(self.context, name);
+    }
+};
+
+/// The per-entity tilemap runtime for a given renderer plugin. Only
+/// instantiate when `supported(RenderImpl)` is true.
+pub fn Runtime(comptime RenderImpl: type) type {
+    const TmRenderer = RenderImpl.TileMapRendererType;
+
+    // `TileMapRenderer.map` is `*const TileMap` — derive the gfx `TileMap`
+    // decoder type without naming gfx directly.
+    const TileMapPtr = @FieldType(TmRenderer, "map");
+    const TileMap = @typeInfo(TileMapPtr).pointer.child;
+
+    // `Tileset` = element of `TileMap.tilesets` (a `[]Tileset`).
+    const TilesetsField = @FieldType(TileMap, "tilesets");
+    const Tileset = @typeInfo(TilesetsField).pointer.child;
+
+    // Texture-id handle returned by `loadTextureFromMemory` (threaded back
+    // into `getTextureInfo` — the engine never needs to name it).
+    const LoadRet = @typeInfo(@TypeOf(RenderImpl.loadTextureFromMemory)).@"fn".return_type.?;
+    const TextureId = @typeInfo(LoadRet).error_union.payload;
+
+    // Backend texture type the resolver must hand to the tilemap renderer.
+    const GetInfoRet = @typeInfo(@TypeOf(RenderImpl.getTextureInfo)).@"fn".return_type.?;
+    const TextureInfo = @typeInfo(GetInfoRet).optional.child;
+    const Texture = @FieldType(TextureInfo, "backend_texture");
+
+    const Resolver = TmRenderer.TextureResolver;
+
+    return struct {
+        const Self = @This();
+
+        pub const MapType = TileMap;
+
+        allocator: std.mem.Allocator,
+        renderer: *RenderImpl,
+        /// Decoded map — MUST stay at a stable address; `tm` holds a
+        /// `*const TileMap` into it. `Game` heap-allocates the `Runtime`.
+        map: TileMap,
+        /// The gfx tilemap draw-pass renderer, bound to this backend.
+        tm: TmRenderer,
+        /// Per-tileset catalog texture id (null = image unresolved →
+        /// that tileset draws nothing). Read by the resolver trampoline.
+        tileset_ids: []?TextureId,
+
+        const ResolverCtx = struct {
+            renderer: *RenderImpl,
+            ids: []const ?TextureId,
+        };
+
+        fn resolveTexture(context: ?*anyopaque, index: usize, tileset: *const Tileset) ?Texture {
+            _ = tileset;
+            const ctx: *const ResolverCtx = @ptrCast(@alignCast(context.?));
+            if (index >= ctx.ids.len) return null;
+            const id = ctx.ids[index] orelse return null;
+            const info = ctx.renderer.getTextureInfo(id) orelse return null;
+            return info.backend_texture;
+        }
+
+        /// Decode `tmx_bytes`, upload each tileset image through the
+        /// shared texture path, and bind the draw-pass renderer. `self`
+        /// MUST already sit at its final (heap-stable) address.
+        pub fn initInPlace(
+            self: *Self,
+            allocator: std.mem.Allocator,
+            renderer: *RenderImpl,
+            tmx_bytes: []const u8,
+            images: ImageProvider,
+        ) !void {
+            // base_path "" — embedded env: the resolver supplies textures,
+            // and the filesystem fallback is disabled below.
+            var map = try TileMap.loadFromMemoryWithBasePath(allocator, tmx_bytes, "");
+            errdefer map.deinit();
+
+            const ids = try allocator.alloc(?TextureId, map.tilesets.len);
+            errdefer allocator.free(ids);
+            for (ids) |*slot| slot.* = null;
+
+            for (map.tilesets, 0..) |*tileset, i| {
+                if (tileset.image_source.len == 0) continue;
+                const bytes = images.get(tileset.image_source) orelse continue;
+                const ft = try fileTypeZ(allocator, tileset.image_source);
+                defer allocator.free(ft);
+                // A missing/undecodable tileset image degrades to "this
+                // tileset draws nothing" rather than failing the whole map.
+                ids[i] = renderer.loadTextureFromMemory(ft, bytes) catch null;
+            }
+
+            self.* = .{
+                .allocator = allocator,
+                .renderer = renderer,
+                .map = map,
+                .tm = undefined,
+                .tileset_ids = ids,
+            };
+
+            var ctx = ResolverCtx{ .renderer = renderer, .ids = self.tileset_ids };
+            self.tm = try TmRenderer.initWithOptions(allocator, &self.map, .{
+                .resolver = Resolver{ .context = &ctx, .resolveFn = resolveTexture },
+                // Embedded env: never touch the filesystem for unresolved
+                // tilesets — the resolver is the only texture source.
+                .load_unresolved_from_filesystem = false,
+            });
+        }
+
+        pub fn deinit(self: *Self) void {
+            self.tm.deinit();
+            self.map.deinit();
+            self.allocator.free(self.tileset_ids);
+        }
+
+        /// The post-sprite draw pass for this entity. `offset_x/offset_y`
+        /// is the entity's world `Position`; `camera_x/camera_y` are the
+        /// world coords of the view's top-left (0,0 when the caller runs
+        /// the pass in screen space, T2's default). Draws every visible
+        /// tile layer in document order.
+        pub fn draw(
+            self: *Self,
+            camera_x: f32,
+            camera_y: f32,
+            offset_x: f32,
+            offset_y: f32,
+            view_width: ?f32,
+            view_height: ?f32,
+        ) void {
+            self.tm.drawAllLayers(camera_x, camera_y, .{
+                .offset_x = offset_x,
+                .offset_y = offset_y,
+                .view_width = view_width,
+                .view_height = view_height,
+            });
+        }
+    };
+}
+
+/// Allocator-owned, null-terminated lowercase-ish file-type token derived
+/// from an `image_source` extension (e.g. `"tiles.png"` → `"png"`).
+/// Defaults to `"png"` when there is no extension. Caller frees.
+fn fileTypeZ(allocator: std.mem.Allocator, image_source: []const u8) ![:0]const u8 {
+    const dot = std.mem.lastIndexOfScalar(u8, image_source, '.');
+    const ext = if (dot) |d| image_source[d + 1 ..] else "";
+    const chosen = if (ext.len == 0) "png" else ext;
+    return allocator.dupeZ(u8, chosen);
+}

--- a/src/tilemap_runtime.zig
+++ b/src/tilemap_runtime.zig
@@ -85,6 +85,13 @@ pub fn Runtime(comptime RenderImpl: type) type {
         /// Per-tileset catalog texture id (null = image unresolved →
         /// that tileset draws nothing). Read by the resolver trampoline.
         tileset_ids: []?TextureId,
+        /// Resolver context, stored inline so its address is heap-stable
+        /// (matches the `Game`-heap-allocated `Runtime`). gfx resolves
+        /// textures eagerly inside `initWithOptions` today — but keeping
+        /// the context alongside the renderer keeps the code correct even
+        /// if gfx ever moves to lazy (draw-time) resolution, instead of
+        /// silently depending on that timing across the repo boundary.
+        resolver_ctx: ResolverCtx,
 
         const ResolverCtx = struct {
             renderer: *RenderImpl,
@@ -135,11 +142,14 @@ pub fn Runtime(comptime RenderImpl: type) type {
                 .map = map,
                 .tm = undefined,
                 .tileset_ids = ids,
+                .resolver_ctx = undefined,
             };
 
-            var ctx = ResolverCtx{ .renderer = renderer, .ids = self.tileset_ids };
+            // Point the resolver at the heap-stable field (not a stack local),
+            // so the context outlives `initInPlace` for any resolution timing.
+            self.resolver_ctx = .{ .renderer = renderer, .ids = self.tileset_ids };
             self.tm = try TmRenderer.initWithOptions(allocator, &self.map, .{
-                .resolver = Resolver{ .context = &ctx, .resolveFn = resolveTexture },
+                .resolver = Resolver{ .context = &self.resolver_ctx, .resolveFn = resolveTexture },
                 // Embedded env: never touch the filesystem for unresolved
                 // tilesets — the resolver is the only texture source.
                 .load_unresolved_from_filesystem = false,
@@ -183,5 +193,9 @@ fn fileTypeZ(allocator: std.mem.Allocator, image_source: []const u8) ![:0]const 
     const dot = std.mem.lastIndexOfScalar(u8, image_source, '.');
     const ext = if (dot) |d| image_source[d + 1 ..] else "";
     const chosen = if (ext.len == 0) "png" else ext;
-    return allocator.dupeZ(u8, chosen);
+    const out = try allocator.dupeZ(u8, chosen);
+    // Normalise to lowercase so a `.PNG` tileset resolves the same decoder
+    // as `.png` (the image loaders dispatch on a lowercase file type).
+    for (out) |*c| c.* = std.ascii.toLower(c.*);
+    return out;
 }

--- a/src/tilemap_runtime.zig
+++ b/src/tilemap_runtime.zig
@@ -29,7 +29,12 @@ const std = @import("std");
 pub fn supported(comptime RenderImpl: type) bool {
     return @hasDecl(RenderImpl, "TileMapRendererType") and
         @hasDecl(RenderImpl, "loadTextureFromMemory") and
-        @hasDecl(RenderImpl, "getTextureInfo");
+        @hasDecl(RenderImpl, "getTextureInfo") and
+        // `unloadTexture` is the counterpart to `loadTextureFromMemory` —
+        // the runtime OWNS the tileset textures it uploads (gfx receives
+        // them as unowned via the resolver) and must release them on
+        // teardown (F1). `GfxRendererWith` declares all four.
+        @hasDecl(RenderImpl, "unloadTexture");
 }
 
 /// Supplies raw image bytes for a tileset's `image_source` name. The
@@ -158,8 +163,34 @@ pub fn Runtime(comptime RenderImpl: type) type {
 
         pub fn deinit(self: *Self) void {
             self.tm.deinit();
+            // Release the tileset textures this runtime uploaded (F1). gfx
+            // received them through the resolver as UNOWNED, so `tm.deinit`
+            // does NOT free them — the runtime that uploaded them owns them.
+            // Dedup so a tileset id that (in a future engine that dedups
+            // uploads by content) backs two tilesets is never double-unloaded.
+            for (self.tileset_ids, 0..) |maybe_id, i| {
+                const id = maybe_id orelse continue;
+                var already = false;
+                for (self.tileset_ids[0..i]) |prev| {
+                    if (prev) |p| {
+                        if (p == id) {
+                            already = true;
+                            break;
+                        }
+                    }
+                }
+                if (!already) self.renderer.unloadTexture(id);
+            }
             self.map.deinit();
             self.allocator.free(self.tileset_ids);
+        }
+
+        /// The map's height in pixels (`tile_height * rows`). Used by the
+        /// engine's render pass to apply the project Y-axis flip to the
+        /// map's world offset so a tilemap and a sprite at the same
+        /// `Position.y` align (F3).
+        pub fn pixelHeight(self: *const Self) f32 {
+            return @floatFromInt(self.map.getPixelHeight());
         }
 
         /// The post-sprite draw pass for this entity. `offset_x/offset_y`

--- a/test/jsonc/tilemap_precedence_test.zig
+++ b/test/jsonc/tilemap_precedence_test.zig
@@ -1,0 +1,67 @@
+//! C2 regression — a project-registered component named `Tilemap` must
+//! WIN over the engine built-in `Tilemap` in the scene loader.
+//!
+//! Before the fix, the built-in `Tilemap` branch in `component_apply` ran
+//! before the registry dispatch and returned unconditionally, so a
+//! registered `Tilemap` was silently shadowed: its scene JSON deserialized
+//! as an empty engine tilemap (because `TilemapComp.asset_name` defaults to
+//! `""`) and the registered component never loaded — silent data loss.
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+const core = @import("labelle-core");
+
+/// A project component that happens to be named `Tilemap` (distinct shape
+/// from the engine built-in, which only has `asset_name`).
+const Tilemap = struct {
+    pub const save = core.Saveable(.saveable, @This(), .{});
+    rows: i32 = 0,
+    cols: i32 = 0,
+};
+
+const TestComponents = engine.ComponentRegistry(.{
+    .Tilemap = Tilemap,
+});
+
+const MockEcs = core.MockEcsBackend(u32);
+const TestGame = engine.game_mod.GameConfig(
+    core.StubRender(MockEcs.Entity),
+    MockEcs,
+    engine.input_mod.StubInput,
+    engine.audio_mod.StubAudio,
+    engine.StubVideo,
+    engine.gui_mod.StubGui,
+    void,
+    core.StubLogSink,
+    TestComponents,
+    &.{},
+    void,
+);
+
+const Bridge = engine.JsoncSceneBridge(TestGame, TestComponents);
+
+test "a registered component named Tilemap wins over the engine built-in" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    try Bridge.loadSceneFromSource(&game,
+        \\{ "entities": [
+        \\  { "components": { "Tilemap": { "rows": 4, "cols": 7 } } }
+        \\] }
+    , "/tmp/labelle-nonexistent");
+
+    var view = game.ecs_backend.view(.{Tilemap}, .{});
+    defer view.deinit();
+    const ent = view.next().?;
+
+    // The REGISTERED component loaded with its real field values — not the
+    // engine built-in (which would have swallowed the block as an empty
+    // `asset_name` tilemap and left this component absent).
+    const tm = game.ecs_backend.getComponent(ent, Tilemap).?;
+    try testing.expectEqual(@as(i32, 4), tm.rows);
+    try testing.expectEqual(@as(i32, 7), tm.cols);
+
+    // And the engine built-in tilemap was NOT attached to the entity.
+    try testing.expect(game.getComponent(ent, TestGame.TilemapComp) == null);
+}

--- a/test/tilemap_test.zig
+++ b/test/tilemap_test.zig
@@ -1,0 +1,320 @@
+//! T2 Phase 2 — engine `Tilemap` component end-to-end.
+//!
+//! Proves the whole path against the ACTUALLY-shipped gfx 1.21.0 tilemap
+//! API (the engine module itself takes no gfx dependency — see
+//! `src/tilemap_runtime.zig`):
+//!   1. `addTilemap` decodes an embedded `.tmx` through gfx's
+//!      `TileMap.loadFromMemoryWithBasePath` into a per-entity runtime.
+//!   2. The tilemap draws as a POST-SPRITE pass at the entity's world
+//!      `Position` offset — asserted through gfx's real
+//!      `TileMapRendererWith(MockBackend)` recording draw calls, and
+//!      ordered strictly after the entity (sprite) render pass.
+//!   3. Save persists ONLY `asset_name`; load rehydrates the runtime.
+//!   4. The editor scene digest reports the tilemap entity.
+//!
+//! The renderer here is a hand-rolled mock satisfying `core.RenderInterface`
+//! that additionally exposes the gfx tilemap seam (`TileMapRendererType`
+//! bound to `core.MockBackend`, plus `loadTextureFromMemory`/`getTextureInfo`
+//! standing in for the shared sprite texture path). This mirrors how the
+//! production `GfxRendererWith` exposes those exact decls.
+
+const std = @import("std");
+const testing = std.testing;
+
+const engine = @import("engine");
+const core = @import("labelle-core");
+const tilemap = @import("tilemap");
+
+const GameConfig = engine.GameConfig;
+const MockEcsBackend = engine.MockEcsBackend;
+const StubInput = engine.StubInput;
+const StubAudio = engine.StubAudio;
+const StubVideo = engine.StubVideo;
+const StubGui = engine.StubGui;
+const StubLogSink = engine.StubLogSink;
+const editor_api = engine.editor_api;
+
+const MockBackend = core.mock_backend.MockBackend;
+
+// A minimal, valid Tiled map: 3×2 tiles of 16px, one embedded tileset
+// (`tiles.png`), one fully-populated CSV tile layer (6 non-zero gids).
+const minimal_tmx =
+    \\<?xml version="1.0" encoding="UTF-8"?>
+    \\<map version="1.10" orientation="orthogonal" width="3" height="2" tilewidth="16" tileheight="16">
+    \\ <tileset firstgid="1" name="test_tiles" tilewidth="16" tileheight="16" columns="4" tilecount="8">
+    \\  <image source="tiles.png" width="64" height="32"/>
+    \\ </tileset>
+    \\ <layer name="ground" width="3" height="2">
+    \\  <data encoding="csv">
+    \\1,2,3,
+    \\4,5,6,
+    \\</data>
+    \\ </layer>
+    \\</map>
+;
+
+// Stand-in tileset image bytes. The mock renderer's `loadTextureFromMemory`
+// never decodes them — it just mints a handle — so any non-empty blob works.
+const fake_png = "\x89PNG\r\n\x1a\n fake tileset pixels";
+
+/// The sprite pass emits one draw with this sentinel texture id, so the
+/// test can prove tilemap tiles are drawn strictly AFTER it (post-sprite).
+const sprite_sentinel_id: u32 = 90001;
+
+/// Renderer mock: satisfies `core.RenderInterface` and exposes the gfx
+/// 1.21.0 tilemap seam. `render()` emits a sentinel sprite-pass draw.
+const MockRender = struct {
+    const Self = @This();
+
+    pub const Sprite = struct {
+        sprite_name: []const u8 = "",
+        visible: bool = true,
+        z_index: i16 = 0,
+        layer: enum { default } = .default,
+    };
+    pub const Shape = struct {
+        shape: union(enum) {
+            rectangle: struct { width: f32 = 10, height: f32 = 10 },
+            circle: struct { radius: f32 = 10 },
+        } = .{ .rectangle = .{} },
+        color: struct { r: u8 = 255, g: u8 = 255, b: u8 = 255, a: u8 = 255 } = .{},
+        visible: bool = true,
+        z_index: i16 = 0,
+        layer: enum { default } = .default,
+    };
+
+    // ── gfx 1.21.0 tilemap seam (as GfxRendererWith exposes it) ──
+    pub const TileMapRendererType = tilemap.TileMapRendererWith(MockBackend);
+    pub const TextureInfo = struct { backend_texture: MockBackend.Texture };
+
+    alloc: std.mem.Allocator = undefined,
+    textures: std.AutoHashMapUnmanaged(u32, MockBackend.Texture) = .empty,
+    next_id: u32 = 1,
+    render_count: usize = 0,
+
+    pub fn init(allocator: std.mem.Allocator) Self {
+        return .{ .alloc = allocator };
+    }
+    pub fn deinit(self: *Self) void {
+        self.textures.deinit(self.alloc);
+    }
+
+    // Upload path shared with sprites — mints a backend texture + handle.
+    pub fn loadTextureFromMemory(self: *Self, file_type: [:0]const u8, data: []const u8) !u32 {
+        _ = file_type;
+        _ = data;
+        const id = self.next_id;
+        self.next_id += 1;
+        try self.textures.put(self.alloc, id, .{ .id = id, .width = 64, .height = 32 });
+        return id;
+    }
+    pub fn getTextureInfo(self: *const Self, id: u32) ?TextureInfo {
+        const tex = self.textures.get(id) orelse return null;
+        return .{ .backend_texture = tex };
+    }
+
+    // ── core.RenderInterface no-ops (mirror StubRender) ──
+    pub fn trackEntity(_: *Self, _: u32, _: core.render.VisualType) void {}
+    pub fn untrackEntity(_: *Self, _: u32) void {}
+    pub fn markPositionDirty(_: *Self, _: u32) void {}
+    pub fn markPositionDirtyWithChildren(_: *Self, comptime _: type, _: anytype, _: u32) void {}
+    pub fn updateHierarchyFlag(_: *Self, _: u32, _: bool) void {}
+    pub fn markVisualDirty(_: *Self, _: u32) void {}
+    pub fn sync(_: *Self, comptime _: type, _: anytype) void {}
+    pub fn setScreenHeight(_: *Self, _: f32) void {}
+    pub fn renderGizmoDraws(_: *Self, _: []const core.gizmos.GizmoDraw) void {}
+    pub fn hasEntity(_: *const Self, _: u32) bool {
+        return false;
+    }
+    pub fn clear(self: *Self) void {
+        self.render_count = 0;
+    }
+
+    /// The entity (sprite) pass. Emits one sentinel draw so a following
+    /// tilemap pass is provably post-sprite.
+    pub fn render(self: *Self) void {
+        self.render_count += 1;
+        MockBackend.drawTexturePro(
+            .{ .id = sprite_sentinel_id, .width = 1, .height = 1 },
+            .{ .x = 0, .y = 0, .width = 1, .height = 1 },
+            .{ .x = 0, .y = 0, .width = 1, .height = 1 },
+            .{ .x = 0, .y = 0 },
+            0,
+            .{ .r = 255, .g = 255, .b = 255, .a = 255 },
+        );
+    }
+};
+
+const EmptyComponents = struct {
+    pub fn has(comptime _: []const u8) bool {
+        return false;
+    }
+    pub fn getType(comptime _: []const u8) type {
+        return void;
+    }
+    pub fn names() []const []const u8 {
+        return &.{};
+    }
+};
+
+fn TilemapGame() type {
+    return GameConfig(
+        MockRender,
+        MockEcsBackend(u32),
+        StubInput,
+        StubAudio,
+        StubVideo,
+        StubGui,
+        void, // Hooks
+        StubLogSink,
+        EmptyComponents,
+        &.{}, // gizmo categories
+        void, // game events
+    );
+}
+
+fn registerFixture(game: anytype) !void {
+    try game.addEmbeddedTilemapAsset("level.tmx", minimal_tmx);
+    try game.addEmbeddedTilemapAsset("tiles.png", fake_png);
+}
+
+test "the renderer plugin exposes the gfx tilemap seam" {
+    try testing.expect(TilemapGame().tilemap_supported);
+}
+
+test "addTilemap decodes the .tmx into a per-entity runtime" {
+    const G = TilemapGame();
+    var game = G.init(testing.allocator);
+    defer game.deinit();
+    try registerFixture(&game);
+
+    const e = game.createEntity();
+    game.addTilemap(e, .{ .asset_name = "level.tmx" });
+
+    // The component itself carries only the asset reference.
+    const comp = game.getComponent(e, G.TilemapComp).?;
+    try testing.expectEqualStrings("level.tmx", comp.asset_name);
+
+    // The decoded map is reachable off the engine-side runtime.
+    const rt = game.tilemapRuntime(e).?;
+    try testing.expectEqual(@as(u32, 3), rt.map.width);
+    try testing.expectEqual(@as(u32, 2), rt.map.height);
+    try testing.expectEqual(@as(u32, 16), rt.map.tile_width);
+    try testing.expectEqual(@as(usize, 1), rt.map.tile_layers.len);
+    try testing.expectEqual(@as(usize, 1), rt.map.tilesets.len);
+    try testing.expectEqualStrings("tiles.png", rt.map.tilesets[0].image_source);
+}
+
+test "tilemap renders as a POST-SPRITE pass at the entity's world offset" {
+    const G = TilemapGame();
+    var game = G.init(testing.allocator);
+    defer game.deinit();
+    try registerFixture(&game);
+
+    const e = game.createEntity();
+    game.setPosition(e, .{ .x = 100, .y = 50 });
+    game.addTilemap(e, .{ .asset_name = "level.tmx" });
+
+    const tileset_handle: u32 = 1; // first texture minted by the mock
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+
+    game.render(); // sprite pass (sentinel) THEN tilemap pass
+
+    const calls = MockBackend.getDrawCalls();
+    // Sprite pass first, tiles after — proves post-sprite ordering.
+    try testing.expect(calls.len >= 7);
+    try testing.expectEqual(sprite_sentinel_id, calls[0].texture_id);
+
+    var tile_draws: usize = 0;
+    var min_x: f32 = std.math.floatMax(f32);
+    var min_y: f32 = std.math.floatMax(f32);
+    for (calls[1..]) |c| {
+        try testing.expectEqual(tileset_handle, c.texture_id);
+        tile_draws += 1;
+        if (c.dest.x < min_x) min_x = c.dest.x;
+        if (c.dest.y < min_y) min_y = c.dest.y;
+    }
+    // 3×2 fully-populated layer → 6 tile draws.
+    try testing.expectEqual(@as(usize, 6), tile_draws);
+    // Top-left tile (0,0): dest = tile*16 + offset - camera, centred (+8).
+    // offset = entity Position (100,50), camera 0 → 108 / 58.
+    try testing.expectEqual(@as(f32, 108), min_x);
+    try testing.expectEqual(@as(f32, 58), min_y);
+}
+
+test "save persists only asset_name; load rehydrates the runtime" {
+    const G = TilemapGame();
+    const filename = "test_tilemap_save.json";
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, filename) catch {};
+
+    // Save a game with one tilemap entity.
+    {
+        var game = G.init(testing.allocator);
+        defer game.deinit();
+        try registerFixture(&game);
+        const e = game.createEntity();
+        game.setPosition(e, .{ .x = 32, .y = 64 });
+        game.addTilemap(e, .{ .asset_name = "level.tmx" });
+        try game.saveGameState(filename);
+    }
+
+    // The save carries the asset reference, not per-tile data.
+    {
+        const json = try std.Io.Dir.cwd().readFileAlloc(
+            std.testing.io,
+            filename,
+            testing.allocator,
+            .limited(1 << 20),
+        );
+        defer testing.allocator.free(json);
+        try testing.expect(std.mem.indexOf(u8, json, "\"Tilemap\"") != null);
+        try testing.expect(std.mem.indexOf(u8, json, "level.tmx") != null);
+        // No raw tile grid / gid CSV leaked into the save.
+        try testing.expect(std.mem.indexOf(u8, json, "tile_layers") == null);
+    }
+
+    // Load into a fresh game: the component AND the decoded-map runtime
+    // come back (runtime rebuilt from the still-embedded asset).
+    {
+        var game = G.init(testing.allocator);
+        defer game.deinit();
+        try registerFixture(&game);
+        try game.loadGameState(filename);
+
+        var found = false;
+        var v = game.ecs_backend.view(.{core.Position}, .{});
+        defer v.deinit();
+        while (v.next()) |ent| {
+            if (game.getComponent(ent, G.TilemapComp)) |tm| {
+                try testing.expectEqualStrings("level.tmx", tm.asset_name);
+                const rt = game.tilemapRuntime(ent).?;
+                try testing.expectEqual(@as(u32, 3), rt.map.width);
+                found = true;
+            }
+        }
+        try testing.expect(found);
+    }
+}
+
+test "scene digest reports the tilemap entity" {
+    const G = TilemapGame();
+    var game = G.init(testing.allocator);
+    defer game.deinit();
+    try registerFixture(&game);
+
+    const e = game.createEntity();
+    game.setPosition(e, .{ .x = 10, .y = 20 });
+    game.addTilemap(e, .{ .asset_name = "level.tmx" });
+
+    var runner = struct { ticks: u32 = 0 }{};
+    editor_api.bind(&game, &runner);
+    defer editor_api.unbind();
+
+    var buf: [4096]u8 = undefined;
+    const n = editor_api.editor_scene_digest(&buf, buf.len);
+    const digest = buf[0..n];
+
+    try testing.expect(std.mem.indexOf(u8, digest, "\"tilemap\":\"level.tmx\"") != null);
+}

--- a/test/tilemap_test.zig
+++ b/test/tilemap_test.zig
@@ -91,6 +91,9 @@ const MockRender = struct {
     textures: std.AutoHashMapUnmanaged(u32, MockBackend.Texture) = .empty,
     next_id: u32 = 1,
     render_count: usize = 0,
+    /// Logical screen height sprites (and the tilemap y-flip) flip against —
+    /// mirrors `GfxRendererWith.screen_height` (set via `setScreenHeight`).
+    screen_height: f32 = 600,
 
     pub fn init(allocator: std.mem.Allocator) Self {
         return .{ .alloc = allocator };
@@ -112,6 +115,11 @@ const MockRender = struct {
         const tex = self.textures.get(id) orelse return null;
         return .{ .backend_texture = tex };
     }
+    /// Release counterpart — the runtime unloads the tileset textures it
+    /// uploaded (F1). Idempotent: a stale id is a safe no-op.
+    pub fn unloadTexture(self: *Self, id: u32) void {
+        _ = self.textures.remove(id);
+    }
 
     // ── core.RenderInterface no-ops (mirror StubRender) ──
     pub fn trackEntity(_: *Self, _: u32, _: core.render.VisualType) void {}
@@ -121,7 +129,9 @@ const MockRender = struct {
     pub fn updateHierarchyFlag(_: *Self, _: u32, _: bool) void {}
     pub fn markVisualDirty(_: *Self, _: u32) void {}
     pub fn sync(_: *Self, comptime _: type, _: anytype) void {}
-    pub fn setScreenHeight(_: *Self, _: f32) void {}
+    pub fn setScreenHeight(self: *Self, h: f32) void {
+        self.screen_height = h;
+    }
     pub fn renderGizmoDraws(_: *Self, _: []const core.gizmos.GizmoDraw) void {}
     pub fn hasEntity(_: *const Self, _: u32) bool {
         return false;
@@ -238,10 +248,12 @@ test "tilemap renders as a POST-SPRITE pass at the entity's world offset" {
     }
     // 3×2 fully-populated layer → 6 tile draws.
     try testing.expectEqual(@as(usize, 6), tile_draws);
-    // Top-left tile (0,0): dest = tile*16 + offset - camera, centred (+8).
-    // offset = entity Position (100,50), camera 0 → 108 / 58.
+    // X is not flipped: tile (0,0) dest.x = 0*16 + offset_x(100) + 8 = 108.
     try testing.expectEqual(@as(f32, 108), min_x);
-    try testing.expectEqual(@as(f32, 58), min_y);
+    // Y IS flipped for the default `.up` project (F3): the map's top-left
+    // screen offset = toScreenY(.up, 50, 600) - pixelHeight(32) = 518, so the
+    // top row draws at 518 + 8 (centre) = 526.
+    try testing.expectEqual(@as(f32, 526), min_y);
 }
 
 test "save persists only asset_name; load rehydrates the runtime" {
@@ -317,4 +329,138 @@ test "scene digest reports the tilemap entity" {
     const digest = buf[0..n];
 
     try testing.expect(std.mem.indexOf(u8, digest, "\"tilemap\":\"level.tmx\"") != null);
+}
+
+// A `.down` (screen-native) project — the tilemap y-flip is the identity.
+fn TilemapGameDown() type {
+    return engine.GameConfigWithYAxis(
+        MockRender,
+        MockEcsBackend(u32),
+        StubInput,
+        StubAudio,
+        StubVideo,
+        StubGui,
+        void,
+        StubLogSink,
+        EmptyComponents,
+        &.{},
+        void,
+        .down,
+    );
+}
+
+test "F3: tilemap y-offset matches the sprite y-axis transform (.up)" {
+    const G = TilemapGame(); // default `.up`
+    var game = G.init(testing.allocator);
+    defer game.deinit();
+    try registerFixture(&game);
+
+    const pos_y: f32 = 50;
+    const e = game.createEntity();
+    game.setPosition(e, .{ .x = 0, .y = pos_y });
+    game.addTilemap(e, .{ .asset_name = "level.tmx" });
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+    game.render();
+
+    // Tiles are recorded with a CENTRED dest (gfx anchors at the tile
+    // centre), so the map's bottom edge = max centre-y + half a tile.
+    const half_tile: f32 = 8;
+    var max_center_y: f32 = -std.math.floatMax(f32);
+    for (MockBackend.getDrawCalls()[1..]) |c| {
+        if (c.dest.y > max_center_y) max_center_y = c.dest.y;
+    }
+    const map_bottom_edge = max_center_y + half_tile;
+
+    // The tilemap's bottom edge must land exactly where the renderer's own
+    // y-flip (the SAME path sprites use) places `Position.y`.
+    const sprite_screen_y = core.toScreenY(.up, pos_y, game.renderer.screen_height);
+    try testing.expectEqual(sprite_screen_y, map_bottom_edge);
+}
+
+test "F3: tilemap y-offset is the identity under .down" {
+    const G = TilemapGameDown();
+    var game = G.init(testing.allocator);
+    defer game.deinit();
+    try registerFixture(&game);
+
+    const e = game.createEntity();
+    game.setPosition(e, .{ .x = 0, .y = 50 });
+    game.addTilemap(e, .{ .asset_name = "level.tmx" });
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+    game.render();
+
+    // `.down`: offset_y = Position.y (identity, no height adjust). Top-left
+    // tile (0,0) centre = 0*16 + 50 + 8 = 58.
+    var min_y: f32 = std.math.floatMax(f32);
+    for (MockBackend.getDrawCalls()[1..]) |c| {
+        if (c.dest.y < min_y) min_y = c.dest.y;
+    }
+    try testing.expectEqual(@as(f32, 58), min_y);
+}
+
+test "F1: tileset textures are released on teardown (no GPU-texture leak)" {
+    const G = TilemapGame();
+    var game = G.init(testing.allocator);
+    defer game.deinit();
+    try registerFixture(&game);
+
+    const e = game.createEntity();
+    game.addTilemap(e, .{ .asset_name = "level.tmx" });
+    // One tileset image uploaded → one live backend texture.
+    try testing.expectEqual(@as(usize, 1), game.renderer.textures.count());
+
+    // Re-acquire must not grow the texture registry (old released first).
+    game.acquireTilemap(e, "level.tmx");
+    try testing.expectEqual(@as(usize, 1), game.renderer.textures.count());
+
+    // Release unloads the uploaded texture — no leak.
+    game.releaseTilemap(e);
+    try testing.expectEqual(@as(usize, 0), game.renderer.textures.count());
+}
+
+test "F4: removeTilemap frees the runtime and detaches the component" {
+    const G = TilemapGame();
+    var game = G.init(testing.allocator);
+    defer game.deinit();
+    try registerFixture(&game);
+
+    const e = game.createEntity();
+    game.addTilemap(e, .{ .asset_name = "level.tmx" });
+    try testing.expect(game.tilemapRuntime(e) != null);
+
+    game.removeTilemap(e);
+    try testing.expect(game.tilemapRuntime(e) == null);
+    try testing.expect(game.getComponent(e, G.TilemapComp) == null);
+    try testing.expectEqual(@as(usize, 0), game.renderer.textures.count());
+}
+
+test "F4: generic removeComponent leaves no drawing ghost (render reaps it)" {
+    const G = TilemapGame();
+    var game = G.init(testing.allocator);
+    defer game.deinit();
+    try registerFixture(&game);
+
+    const e = game.createEntity();
+    game.setPosition(e, .{ .x = 0, .y = 0 });
+    game.addTilemap(e, .{ .asset_name = "level.tmx" });
+    try testing.expect(game.tilemapRuntime(e) != null);
+
+    // Strip the component the "wrong" way (generic removeComponent) — the
+    // side-table runtime is now an orphan.
+    game.removeComponent(e, G.TilemapComp);
+
+    MockBackend.initMock(testing.allocator);
+    defer MockBackend.deinitMock();
+    game.render(); // reaps the ghost, draws only the sprite sentinel
+
+    // No tile draws — the ghost never rendered.
+    try testing.expectEqual(@as(usize, 1), MockBackend.getDrawCallCount());
+    try testing.expectEqual(sprite_sentinel_id, MockBackend.getDrawCalls()[0].texture_id);
+    // And the orphan runtime + its texture were reaped/freed.
+    try testing.expect(game.tilemapRuntime(e) == null);
+    try testing.expectEqual(@as(usize, 0), game.renderer.textures.count());
 }


### PR DESCRIPTION
## What

Phase 2 of the minimal T2 tilemap epic: a real, immutable `Tilemap` component that references an embedded `.tmx` asset by name, decodes it through the **gfx 1.21.0** tilemap API, and renders it as a **POST-SPRITE pass**. The engine owns pass ordering (entities first, tilemaps after); gfx's `RetainedEngine` is untouched.

## Load-bearing design decision (the render-orchestration unknown)

**The engine module takes NO labelle-gfx dependency** — the existing invariant (`game.zig`: "The engine does NOT depend on labelle-gfx — it accesses component types through RenderImpl"). The design brief assumed a direct `gfx.TileMap` / gfx pin on the module; grounding against `origin/main` showed that would break the invariant and the "purely additive" bar.

Instead, the engine reaches gfx's `TileMap` decoder + `TileMapRenderer` **through the renderer plugin** — `RenderImpl.TileMapRendererType`, `loadTextureFromMemory`, `getTextureInfo` — exactly as it reaches `Sprite`/`Shape` and the `drawMesh` seam. All the type reflection (naming `TileMap`, `Tileset`, the backend `Texture`, the resolver) is centralised in `src/tilemap_runtime.zig`. The whole feature is comptime-gated on `tilemap_supported`, so stub renderers get a `void` side table + no-op methods — zero cost, no behaviour change for existing consumers.

**Texture crux:** the engine catalog stores `u32` texture ids, but the gfx resolver seam needs a `Backend.Texture`. Bridged via the SAME path sprites use — `RenderImpl.loadTextureFromMemory` (upload) → `getTextureInfo(id).backend_texture` (resolve) — so tileset images share the sprite texture registry and are unowned by the tilemap renderer (`load_unresolved_from_filesystem = false`).

**Asset lifecycle:** a `LoaderKind.tilemap` catalog variant would touch ~13 files / ~86 exhaustive switch sites AND can't hold a gfx `TileMap` in the gfx-agnostic `DecodedPayload` union — that fails "minimal/additive". Used a dedicated embedded-source registry (`embedded_tilemap_sources` + `addEmbeddedTilemapAsset`), same idiom as `embedded_scene_sources`.

**Save:** `Tilemap.asset_name` is `[]const u8`, which the registry-driven serde can't round-trip — so it lives in the **built-in save channel** alongside `Position`/`PrefabInstance`, persisting only `asset_name`. Load rehydrates the runtime by re-decoding. Tilemap-only entities are swept into the save set; ECS reset frees stale runtimes.

The gfx pin (`build.zig.zon`) is **lazy + test-only**: consumed solely by the tilemap test to drive the real shipped gfx 1.21.0 tilemap sub-package headless.

## Files
- New: `src/tilemap.zig`, `src/tilemap_runtime.zig`, `src/game/tilemap_mixin.zig`, `test/tilemap_test.zig`
- Wiring: `game.zig`, `game_init.zig`, `lifecycle_mixin.zig`, `world_mixin.zig`, `entity_mixin.zig`, `loop_mixin.zig`, `jsonc/component_apply.zig`, `editor_api.zig`, `save_load/{save,load}.zig`, `root.zig`, `build.zig`, `build.zig.zon`

## Tests
`745/745` engine tests pass (`zig build test`), incl. 5 new: seam detection, `.tmx` decode, post-sprite ordering + world offset, save→load round-trip of `asset_name`, digest presence. `zig fmt` clean; ReleaseSafe build clean.

## Not in scope (deferred)
- Camera-transform alignment (T2 runs the pass in screen space, `camera_* = 0`) + Z-interleaving with sprite layers → T3.
- Assembler-side `.tmx` + tileset-image embedding → Phase 4.

Do **not** merge — no engine release/version bump (release choreography is handled post-review).

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw