### PR TITLE
release: labelle-engine 1.75.0 — Tilemap component (T2 Phase 2)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xe8a81a8dc7f48c87,
     .name = .engine,
-    .version = "1.68.0",
+    .version = "1.75.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         // Requires labelle-core >= v1.20.0 — font_types aliases core's


### PR DESCRIPTION
Version bump for the T2 tilemap Phase 2 landing (#703). Pins labelle-gfx v1.21.0.

Ships: engine `Tilemap` component (asset_name, Saveable, immutable), `.tmx` embedded-asset loader (decodes via gfx `loadFromMemoryWithBasePath`), `addTilemap`/`removeTilemap` mixin, scene-loader `{"Tilemap": {"asset_name": ...}}` parse, post-sprite render pass (y-axis-aligned with sprites via `core.toScreenY`, GPU-texture-leak-free teardown), editor digest presence. Renderer-agnostic (RenderImpl seam; engine never imports gfx). Registered `Tilemap` components take precedence over the built-in.

Enables T2 Phase 4 (assembler .tmx embedding) + Phase 5 (pack-colony-demo migration) to pin a stable engine. Per-world tilemap scoping tracked in #704.

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw