### PR TITLE
fix(tilemap): supported() rejects backends with a non-concrete texture seam — null/headless compiles (v1.75.1)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xe8a81a8dc7f48c87,
     .name = .engine,
-    .version = "1.75.0",
+    .version = "1.75.1",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         // Requires labelle-core >= v1.20.0 — font_types aliases core's

--- a/src/root.zig
+++ b/src/root.zig
@@ -63,6 +63,11 @@ pub const Game = game_mod.Game;
 /// asset by name. Reachable on a configured game as `Game.TilemapComp`.
 /// See `src/tilemap.zig` / `src/tilemap_runtime.zig`.
 pub const Tilemap = @import("tilemap.zig").Tilemap;
+/// True when a renderer plugin exposes a CONCRETELY reflectable gfx tilemap
+/// seam. Gates `Game.tilemap_supported` / `Game.TilemapRuntimeType`; exposed
+/// so consumers (and tests) can probe a renderer without configuring a whole
+/// `Game`. See `src/tilemap_runtime.zig`.
+pub const tilemapSupported = @import("tilemap_runtime.zig").supported;
 
 // ── Input ──
 pub const InputInterface = input_mod.InputInterface;

--- a/src/tilemap_runtime.zig
+++ b/src/tilemap_runtime.zig
@@ -87,7 +87,9 @@ fn hasReflectableSeam(comptime RenderImpl: type) bool {
 
     // The shared upload path must expose a concrete (non-generic) error-union
     // return so `Runtime` can name the texture-id handle it threads around.
-    const load_ret = @typeInfo(@TypeOf(RenderImpl.loadTextureFromMemory)).@"fn".return_type orelse return false;
+    const LoadInfo = @typeInfo(@TypeOf(RenderImpl.loadTextureFromMemory));
+    if (LoadInfo != .@"fn") return false;
+    const load_ret = LoadInfo.@"fn".return_type orelse return false;
     if (@typeInfo(load_ret) != .error_union) return false;
 
     return true;

--- a/src/tilemap_runtime.zig
+++ b/src/tilemap_runtime.zig
@@ -25,7 +25,25 @@ const std = @import("std");
 
 /// True when `RenderImpl` exposes the gfx 1.21.0 tilemap seam: the
 /// per-backend `TileMapRenderer` type plus the shared texture path the
-/// resolver bridges through. `GfxRendererWith` satisfies all three.
+/// resolver bridges through. `GfxRendererWith` satisfies all of it.
+///
+/// Two gates, both required:
+///   1. NAME presence — the four decls that spell the seam exist.
+///   2. CONCRETE reflectability — the exact shapes `Runtime` derives its
+///      types from are present AND non-generic (`hasReflectableSeam`).
+///
+/// Gate 2 exists because `@hasDecl` alone is a trap: gfx 1.21.0's
+/// `GfxRendererWith.getTextureInfo` returns `?@TypeOf(self.inner).TextureInfo`,
+/// whose dependence on the `self` PARAMETER makes the wrapper a GENERIC
+/// function — so `@typeInfo(...).@"fn".return_type` is `null`. A `@hasDecl`
+/// pass therefore let `Runtime` be instantiated even though reflecting that
+/// return type fails to COMPILE (`error: unable to unwrap null`), which broke
+/// every headless/null-backend consumer on gfx 1.21.0. `Runtime` no longer
+/// reflects that generic wrapper (it keys `Texture` off the concrete resolver
+/// seam instead), and `supported()` verifies the concrete seam up front so
+/// the two can never disagree. A renderer without a reflectable seam (a bare
+/// test stub, a malformed backend) reports `false` → the feature compiles to
+/// a `void` side-table no-op instead of failing the whole build.
 pub fn supported(comptime RenderImpl: type) bool {
     return @hasDecl(RenderImpl, "TileMapRendererType") and
         @hasDecl(RenderImpl, "loadTextureFromMemory") and
@@ -34,7 +52,45 @@ pub fn supported(comptime RenderImpl: type) bool {
         // the runtime OWNS the tileset textures it uploads (gfx receives
         // them as unowned via the resolver) and must release them on
         // teardown (F1). `GfxRendererWith` declares all four.
-        @hasDecl(RenderImpl, "unloadTexture");
+        @hasDecl(RenderImpl, "unloadTexture") and
+        hasReflectableSeam(RenderImpl);
+}
+
+/// True when every type `Runtime` derives from `RenderImpl` is present and
+/// CONCRETELY reflectable. Each step is guarded by a tag/field check before
+/// it reflects, so a malformed seam returns `false` rather than triggering a
+/// compile error here. Callers must have already confirmed the four seam
+/// decls exist (see `supported`).
+fn hasReflectableSeam(comptime RenderImpl: type) bool {
+    if (!@hasDecl(RenderImpl, "TileMapRendererType")) return false;
+    const TmRenderer = RenderImpl.TileMapRendererType;
+    if (@typeInfo(TmRenderer) != .@"struct") return false;
+
+    // `Runtime` derives `TileMap` (and `Tileset`) from these concrete fields.
+    if (!@hasField(TmRenderer, "map")) return false;
+    if (@typeInfo(@FieldType(TmRenderer, "map")) != .pointer) return false;
+    const TileMap = @typeInfo(@FieldType(TmRenderer, "map")).pointer.child;
+    if (@typeInfo(TileMap) != .@"struct" or !@hasField(TileMap, "tilesets")) return false;
+    if (@typeInfo(@FieldType(TileMap, "tilesets")) != .pointer) return false;
+
+    // The backend texture handed to the tilemap renderer — derived from the
+    // CONCRETE resolver fn-pointer, never the generic `getTextureInfo` wrapper.
+    if (!@hasDecl(TmRenderer, "TextureResolver")) return false;
+    const Resolver = TmRenderer.TextureResolver;
+    if (@typeInfo(Resolver) != .@"struct" or !@hasField(Resolver, "resolveFn")) return false;
+    const ResolveFnPtr = @FieldType(Resolver, "resolveFn");
+    if (@typeInfo(ResolveFnPtr) != .pointer) return false;
+    const ResolveFn = @typeInfo(ResolveFnPtr).pointer.child;
+    if (@typeInfo(ResolveFn) != .@"fn") return false;
+    const resolve_ret = @typeInfo(ResolveFn).@"fn".return_type orelse return false;
+    if (@typeInfo(resolve_ret) != .optional) return false;
+
+    // The shared upload path must expose a concrete (non-generic) error-union
+    // return so `Runtime` can name the texture-id handle it threads around.
+    const load_ret = @typeInfo(@TypeOf(RenderImpl.loadTextureFromMemory)).@"fn".return_type orelse return false;
+    if (@typeInfo(load_ret) != .error_union) return false;
+
+    return true;
 }
 
 /// Supplies raw image bytes for a tileset's `image_source` name. The
@@ -68,12 +124,21 @@ pub fn Runtime(comptime RenderImpl: type) type {
     const LoadRet = @typeInfo(@TypeOf(RenderImpl.loadTextureFromMemory)).@"fn".return_type.?;
     const TextureId = @typeInfo(LoadRet).error_union.payload;
 
-    // Backend texture type the resolver must hand to the tilemap renderer.
-    const GetInfoRet = @typeInfo(@TypeOf(RenderImpl.getTextureInfo)).@"fn".return_type.?;
-    const TextureInfo = @typeInfo(GetInfoRet).optional.child;
-    const Texture = @FieldType(TextureInfo, "backend_texture");
-
     const Resolver = TmRenderer.TextureResolver;
+
+    // Backend texture type the resolver must hand to the tilemap renderer.
+    // Derived from the CONCRETE `TextureResolver.resolveFn` signature
+    // (`fn (…) ?Texture`) — NOT from `RenderImpl.getTextureInfo`'s return
+    // type. gfx 1.21.0's `GfxRendererWith.getTextureInfo` returns
+    // `?@TypeOf(self.inner).TextureInfo`, whose dependence on the `self`
+    // parameter makes the wrapper a GENERIC function, so its `return_type`
+    // reflects as `null` and `.?` would fail to compile on every backend
+    // (headless/null-backend regression fixed in v1.75.1). The resolver
+    // carries the same `Texture` concretely; we call `getTextureInfo` only
+    // at RUNTIME below, where its generic return type resolves fine.
+    const ResolveFnPtr = @FieldType(Resolver, "resolveFn");
+    const ResolveRet = @typeInfo(@typeInfo(ResolveFnPtr).pointer.child).@"fn".return_type.?;
+    const Texture = @typeInfo(ResolveRet).optional.child;
 
     return struct {
         const Self = @This();

--- a/test/tilemap_test.zig
+++ b/test/tilemap_test.zig
@@ -16,7 +16,14 @@
 //! that additionally exposes the gfx tilemap seam (`TileMapRendererType`
 //! bound to `core.MockBackend`, plus `loadTextureFromMemory`/`getTextureInfo`
 //! standing in for the shared sprite texture path). This mirrors how the
-//! production `GfxRendererWith` exposes those exact decls.
+//! production `GfxRendererWith` exposes those exact decls — INCLUDING that
+//! `getTextureInfo`'s return type references the `self` parameter
+//! (`?@TypeOf(self.inner).TextureInfo`), which makes the wrapper a GENERIC
+//! function. That generic seam is exactly what regressed on gfx 1.21.0 +
+//! the null backend (engine v1.75.1): `supported()` must still report the
+//! backend as supported, and `Runtime` must still compile, by keying its
+//! `Texture` type off the CONCRETE resolver seam rather than reflecting the
+//! generic wrapper's return type.
 
 const std = @import("std");
 const testing = std.testing;
@@ -85,8 +92,14 @@ const MockRender = struct {
 
     // ── gfx 1.21.0 tilemap seam (as GfxRendererWith exposes it) ──
     pub const TileMapRendererType = tilemap.TileMapRendererWith(MockBackend);
-    pub const TextureInfo = struct { backend_texture: MockBackend.Texture };
+    /// Stand-in for `GfxRendererWith`'s wrapped `RetainedEngine` (`self.inner`).
+    /// `getTextureInfo` names its `TextureInfo` off THIS, exactly as the
+    /// production wrapper does — which is what makes the wrapper generic.
+    pub const Inner = struct {
+        pub const TextureInfo = struct { backend_texture: MockBackend.Texture };
+    };
 
+    inner: Inner = .{},
     alloc: std.mem.Allocator = undefined,
     textures: std.AutoHashMapUnmanaged(u32, MockBackend.Texture) = .empty,
     next_id: u32 = 1,
@@ -111,7 +124,10 @@ const MockRender = struct {
         try self.textures.put(self.alloc, id, .{ .id = id, .width = 64, .height = 32 });
         return id;
     }
-    pub fn getTextureInfo(self: *const Self, id: u32) ?TextureInfo {
+    // Return type references `self` (`?@TypeOf(self.inner).TextureInfo`) →
+    // GENERIC function, byte-for-byte the shape of gfx `GfxRendererWith`. Its
+    // `@"fn".return_type` reflects as `null`; the fix must NOT reflect it.
+    pub fn getTextureInfo(self: *const Self, id: u32) ?@TypeOf(self.inner).TextureInfo {
         const tex = self.textures.get(id) orelse return null;
         return .{ .backend_texture = tex };
     }
@@ -190,6 +206,48 @@ fn registerFixture(game: anytype) !void {
 
 test "the renderer plugin exposes the gfx tilemap seam" {
     try testing.expect(TilemapGame().tilemap_supported);
+}
+
+test "regression: a GENERIC getTextureInfo seam is still supported (null-backend / gfx 1.21.0)" {
+    // Guard the reproduction itself: `MockRender.getTextureInfo` MUST be
+    // generic (return type references `self`), exactly like the production
+    // `GfxRendererWith.getTextureInfo`. If someone "simplifies" it back to a
+    // concrete return type this assertion fails and we'd stop covering the
+    // regression at all.
+    comptime {
+        const ret = @typeInfo(@TypeOf(MockRender.getTextureInfo)).@"fn".return_type;
+        std.debug.assert(ret == null); // null == generic == the broken shape
+    }
+    // Before v1.75.1 the whole `Game` type failed to COMPILE for this seam
+    // (`tilemap_runtime.zig` reflected the generic wrapper's return type →
+    // `error: unable to unwrap null`). It must now be supported so the null /
+    // headless / real gfx backends all build with tilemaps functional.
+    try testing.expect(engine.tilemapSupported(MockRender));
+    try testing.expect(TilemapGame().TilemapRuntimeType != void);
+}
+
+/// A renderer that SPELLS all four seam decls but whose `TileMapRendererType`
+/// carries no reflectable resolver/map — a bare or experimental backend.
+/// `supported()` must reject it so the feature degrades to a compile-time
+/// `void` no-op instead of failing inside `Runtime`.
+const NonReflectableRender = struct {
+    const Self = @This();
+    pub const TileMapRendererType = struct {}; // no `map`, no `TextureResolver`
+    pub fn loadTextureFromMemory(_: *Self, _: [:0]const u8, _: []const u8) !u32 {
+        return 0;
+    }
+    pub fn getTextureInfo(_: *const Self, _: u32) ?u32 {
+        return null;
+    }
+    pub fn unloadTexture(_: *Self, _: u32) void {}
+};
+
+test "supported() rejects a backend whose texture seam is not concretely reflectable" {
+    // All four decls present, so the old `@hasDecl`-only gate would have said
+    // true — but the seam can't be reflected into `Runtime`'s types.
+    try testing.expect(!engine.tilemapSupported(NonReflectableRender));
+    // A bare stub with none of the decls is likewise unsupported.
+    try testing.expect(!engine.tilemapSupported(struct {}));
 }
 
 test "addTilemap decodes the .tmx into a per-entity runtime" {


### PR DESCRIPTION
## The regression

engine v1.75.0 + gfx 1.21.0 fails to **compile** the T2 tilemap runtime for any backend built on `GfxRendererWith` — first surfaced by the **null backend** in labelle-assembler's Examples integration test (asset-streaming-smoke), blocking any headless/null consumer:

```
src/tilemap_runtime.zig:72:87: error: unable to unwrap null
  const GetInfoRet = @typeInfo(@TypeOf(RenderImpl.getTextureInfo)).@"fn".return_type.?;
src/game.zig:238:36: note: called at comptime here
  tilemap_runtime.Runtime(RenderImpl)
```

## Root cause

`supported()` gated the feature on decl **name** presence (`@hasDecl`) only. When true, `game.zig` instantiates `Runtime(RenderImpl)`, whose comptime reflection unwrapped `@TypeOf(RenderImpl.getTextureInfo).@"fn".return_type`.

gfx 1.21.0's `GfxRendererWith.getTextureInfo` is declared

```zig
pub fn getTextureInfo(self: *const Self, id: TextureId) ?@TypeOf(self.inner).TextureInfo { ... }
```

Its return type references the `self` **parameter**, which makes the wrapper a **generic** function — so `@"fn".return_type` reflects as `null` and `.?` fails at comptime. This is true for **every** `GfxRendererWith` backend (raylib/sokol/bgfx/null); games on gfx < 1.21.0 escaped only because they lacked the `TileMapRendererType` decl (`supported()` false → `void` no-op). The engine's own tilemap test passed because its `MockRender.getTextureInfo` used a *concrete* return type — not faithful to `GfxRendererWith`.

## Fix

- **`Runtime`** derives its backend `Texture` from the **concrete** `TileMapRendererType.TextureResolver.resolveFn` signature (`fn (…) ?Texture`) instead of the generic `getTextureInfo` return type. `getTextureInfo` is still *called* at runtime, where its generic return type resolves fine.
- **`supported()`** gains `hasReflectableSeam()`: beyond the four `@hasDecl` names it verifies (guarded, no compile error on malformed input) that the seam is concretely reflectable in the exact shape `Runtime` needs — struct `TileMapRendererType` with a `map` pointer + `tilesets`, a `TextureResolver` with a concrete `resolveFn`, and a non-generic error-union `loadTextureFromMemory`. Anything short of that degrades to the `void` side-table no-op rather than failing the build.
- Re-export `engine.tilemapSupported` so a renderer can be probed without configuring a whole `Game`.

Real backends and the null/headless backend now all build with tilemaps functional.

## Tests

- The tilemap test's `MockRender.getTextureInfo` is now **generic**, byte-for-byte the `GfxRendererWith` shape — so the entire existing suite (decode / post-sprite draw / save+load / teardown) exercises the previously-broken seam. Pre-fix the whole binary fails to compile; post-fix 12/12 green.
- `regression: a GENERIC getTextureInfo seam is still supported (null-backend / gfx 1.21.0)` — asserts the seam is generic, then `supported()` true + `TilemapRuntimeType != void`.
- `supported() rejects a backend whose texture seam is not concretely reflectable` — non-reflectable + bare stub → false.
- Verified end-to-end against the **real** null backend: `labelle-assembler` asset-streaming-smoke (`GfxRendererWith(null, …, .up)` + gfx 1.21.0) crashes with the exact CI error against v1.75.0, and generates → builds → runs headless clean against this branch.

`zig build test` green on 0.16.0; `zig fmt` clean; version bumped to **1.75.1**.

Do not merge — release + assembler re-pin gated by the author.

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw