### PR TITLE
tilemap: render as world-space background (pre-sprite + camera transform) — v1.76.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xe8a81a8dc7f48c87,
     .name = .engine,
-    .version = "1.75.1",
+    .version = "1.76.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         // Requires labelle-core >= v1.20.0 — font_types aliases core's

--- a/src/game/loop_mixin.zig
+++ b/src/game/loop_mixin.zig
@@ -223,14 +223,17 @@ pub fn Mixin(comptime Game: type) type {
             // is suppressed, and only for the few frames the re-decode
             // takes. The common path (no gate armed) is unchanged.
             if (self.post_load_render_gate == null) {
-                self.renderer.render();
-                // Tilemap POST-SPRITE pass (T2 Phase 2): the engine owns
-                // pass ordering — entities first, tilemaps after. No-op
-                // when no Tilemap entities exist / renderer lacks the seam.
-                // Gated by the same post-load render gate as the world
-                // draw so restored tilemaps don't flash before their
-                // tileset textures re-bind.
+                // Tilemap PRE-SPRITE background pass (T2 Phase 3): terrain
+                // is the WORLD background, so it draws FIRST — under the
+                // gameplay sprites, not over them — and INSIDE the same
+                // world camera transform sprites use (pans/zooms with the
+                // world; see `renderTilemaps`). No-op when no Tilemap
+                // entities exist / the renderer lacks the seam. Gated by
+                // the same post-load render gate as the world draw so
+                // restored tilemaps don't flash before their tileset
+                // textures re-bind.
                 self.renderTilemaps();
+                self.renderer.render();
             }
             self.renderGizmos();
             self.clearGizmos();

--- a/src/game/tilemap_mixin.zig
+++ b/src/game/tilemap_mixin.zig
@@ -18,6 +18,20 @@ pub fn Mixin(comptime Game: type) type {
     const supported = Game.tilemap_supported;
     const Runtime = Game.TilemapRuntimeType;
 
+    // Whether the renderer plugin exposes a world camera the tilemap pass
+    // can render through: a `begin()/end()` camera reached via
+    // `Game.getCamera()` (gfx's `GfxRendererWith`/`CameraWith` satisfy
+    // this; `Game.CameraType != void` is set exactly when the renderer
+    // declares `CameraType`, and `getCamera` is wired on the same gate).
+    // When present, the pass runs INSIDE that camera transform so a
+    // tilemap pans/zooms with the world exactly like sprites (T2 Phase 3).
+    // When absent — a bare test stub or a screen-only backend — the pass
+    // falls back to raw screen space, which is the identity for a static
+    // view.
+    const camera_capable = Game.CameraType != void and
+        @hasDecl(Game.CameraType, "begin") and
+        @hasDecl(Game.CameraType, "end");
+
     return struct {
         /// Register raw bytes for a tilemap-related embedded asset — the
         /// `.tmx` document itself AND each tileset image it references,
@@ -104,10 +118,22 @@ pub fn Mixin(comptime Game: type) type {
             self.removeComponent(entity, Tilemap);
         }
 
-        /// The post-sprite tilemap pass: after the entity render pass, draw
-        /// every `Tilemap` entity's decoded map at its world `Position`.
-        /// The engine owns pass ordering here (entities first, tilemaps
-        /// after); gfx's `RetainedEngine` is untouched.
+        /// The tilemap BACKGROUND pass: before the entity render pass, draw
+        /// every `Tilemap` entity's decoded map at its world `Position`,
+        /// INSIDE the world camera transform. The engine owns pass ordering
+        /// here — tilemaps first (terrain under gameplay entities), sprites
+        /// after (see `loop_mixin.render`); gfx's `RetainedEngine` is
+        /// untouched.
+        ///
+        /// **World space (T2 Phase 3).** When the renderer exposes a camera
+        /// (`camera_capable`), the pass is wrapped in the SAME
+        /// `camera.begin()/end()` sprites render through, and each map draws
+        /// with `camera_x/camera_y = 0` — the camera MATRIX (not a software
+        /// offset) does the pan/zoom, so a Tilemap entity's `Position` is a
+        /// true world position that stays aligned with sprites at the same
+        /// world coords under any camera pan or zoom. A renderer with no
+        /// camera falls back to raw screen space (the identity for a static
+        /// view), preserving the T2 behaviour for headless/stub backends.
         ///
         /// **Y-axis (F3).** The map's world offset is flipped through the
         /// SAME `core.toScreenY` transform sprites use, so a tilemap and a
@@ -124,12 +150,22 @@ pub fn Mixin(comptime Game: type) type {
         /// never drawn: the table is keyed on the Game, not swapped with
         /// `active_world`, so it's guarded against the CURRENTLY active ECS.
         ///
-        /// T2 runs the pass in screen space (`camera_* = 0`). Camera-transform
-        /// alignment + Z-interleaving with sprite layers are deferred to T3.
+        /// Z-interleaving with individual sprite layers remains deferred:
+        /// the whole tilemap stack draws under the whole sprite stack.
         pub fn renderTilemaps(self: *Game) void {
             if (comptime !supported) return;
 
             reapGhostTilemaps(self);
+            if (self.tilemaps.count() == 0) return;
+
+            // Enter the SAME world camera transform sprites render through,
+            // so the tilemap pass is world-space: pans/zooms with the world.
+            // `camera_x/camera_y` passed to `draw` stay 0 — the camera matrix
+            // does the transform, matching how sprites use the camera. On a
+            // camera-less renderer this folds away and the pass runs in raw
+            // screen space (the T2 fallback).
+            if (comptime camera_capable) self.getCamera().begin();
+            defer if (comptime camera_capable) self.getCamera().end();
 
             const y_axis = Game.y_axis;
             const screen_h = tilemapScreenHeight(self);

--- a/src/game/tilemap_mixin.zig
+++ b/src/game/tilemap_mixin.zig
@@ -155,8 +155,12 @@ pub fn Mixin(comptime Game: type) type {
         pub fn renderTilemaps(self: *Game) void {
             if (comptime !supported) return;
 
-            reapGhostTilemaps(self);
+            // Fast path: games/scenes without tilemaps pay nothing per frame —
+            // skip the reap iterator entirely. `reapGhostTilemaps` only ever
+            // removes entries, so an empty table has nothing to reap.
             if (self.tilemaps.count() == 0) return;
+            reapGhostTilemaps(self);
+            if (self.tilemaps.count() == 0) return; // all entries were ghosts
 
             // Enter the SAME world camera transform sprites render through,
             // so the tilemap pass is world-space: pans/zooms with the world.
@@ -164,6 +168,14 @@ pub fn Mixin(comptime Game: type) type {
             // does the transform, matching how sprites use the camera. On a
             // camera-less renderer this folds away and the pass runs in raw
             // screen space (the T2 fallback).
+            //
+            // LIMITATION — single active camera: this wraps the primary camera
+            // ONCE. Under split-screen / multi-camera the renderer draws sprites
+            // once PER active camera (each viewport), but this background pass
+            // runs a single full-window time, so secondary viewports would show
+            // the primary camera's terrain. Per-camera tilemap backgrounds are
+            // tracked in engine#709; single-camera (the common case + the
+            // colony demo) is correct.
             if (comptime camera_capable) self.getCamera().begin();
             defer if (comptime camera_capable) self.getCamera().end();
 

--- a/test/tilemap_test.zig
+++ b/test/tilemap_test.zig
@@ -65,8 +65,34 @@ const minimal_tmx =
 const fake_png = "\x89PNG\r\n\x1a\n fake tileset pixels";
 
 /// The sprite pass emits one draw with this sentinel texture id, so the
-/// test can prove tilemap tiles are drawn strictly AFTER it (post-sprite).
+/// test can prove tilemap tiles are drawn strictly BEFORE it (the terrain
+/// is the background layer, under the gameplay sprites).
 const sprite_sentinel_id: u32 = 90001;
+
+/// A minimal world camera exposing the `begin()/end()` seam the engine
+/// wraps the tilemap pass in — mirrors gfx's `CameraWith`. `begin()`
+/// records a backend camera pass whose target reflects the camera
+/// position, so a test can prove the tilemap pass runs UNDER the camera
+/// transform and that a camera pan shifts that transform.
+const MockCamera = struct {
+    x: f32 = 0,
+    y: f32 = 0,
+    zoom: f32 = 1,
+
+    pub fn setPosition(self: *MockCamera, x: f32, y: f32) void {
+        self.x = x;
+        self.y = y;
+    }
+    pub fn begin(self: *const MockCamera) void {
+        MockBackend.beginMode2D(.{
+            .target = .{ .x = self.x, .y = self.y },
+            .zoom = self.zoom,
+        });
+    }
+    pub fn end(_: *const MockCamera) void {
+        MockBackend.endMode2D();
+    }
+};
 
 /// Renderer mock: satisfies `core.RenderInterface` and exposes the gfx
 /// 1.21.0 tilemap seam. `render()` emits a sentinel sprite-pass draw.
@@ -99,11 +125,20 @@ const MockRender = struct {
         pub const TextureInfo = struct { backend_texture: MockBackend.Texture };
     };
 
+    // ── camera seam (as GfxRendererWith exposes it) ──
+    // Present so the engine wraps the tilemap pass in the world camera
+    // transform (`camera_capable`), exactly as it does for `GfxRendererWith`.
+    // `CameraManagerType` is declared alongside `CameraType` because the
+    // engine's `has_camera` gate derives BOTH from the renderer.
+    pub const CameraType = MockCamera;
+    pub const CameraManagerType = struct {};
+
     inner: Inner = .{},
     alloc: std.mem.Allocator = undefined,
     textures: std.AutoHashMapUnmanaged(u32, MockBackend.Texture) = .empty,
     next_id: u32 = 1,
     render_count: usize = 0,
+    camera: MockCamera = .{},
     /// Logical screen height sprites (and the tilemap y-flip) flip against —
     /// mirrors `GfxRendererWith.screen_height` (set via `setScreenHeight`).
     screen_height: f32 = 600,
@@ -147,6 +182,13 @@ const MockRender = struct {
     pub fn sync(_: *Self, comptime _: type, _: anytype) void {}
     pub fn setScreenHeight(self: *Self, h: f32) void {
         self.screen_height = h;
+    }
+    pub fn getCamera(self: *Self) *MockCamera {
+        return &self.camera;
+    }
+    pub fn getCameraManager(self: *Self) *CameraManagerType {
+        _ = self;
+        return undefined;
     }
     pub fn renderGizmoDraws(_: *Self, _: []const core.gizmos.GizmoDraw) void {}
     pub fn hasEntity(_: *const Self, _: u32) bool {
@@ -273,7 +315,7 @@ test "addTilemap decodes the .tmx into a per-entity runtime" {
     try testing.expectEqualStrings("tiles.png", rt.map.tilesets[0].image_source);
 }
 
-test "tilemap renders as a POST-SPRITE pass at the entity's world offset" {
+test "tilemap renders as a PRE-SPRITE background pass at the entity's world offset" {
     const G = TilemapGame();
     var game = G.init(testing.allocator);
     defer game.deinit();
@@ -288,17 +330,23 @@ test "tilemap renders as a POST-SPRITE pass at the entity's world offset" {
     MockBackend.initMock(testing.allocator);
     defer MockBackend.deinitMock();
 
-    game.render(); // sprite pass (sentinel) THEN tilemap pass
+    game.render(); // tilemap BACKGROUND pass THEN sprite pass
 
     const calls = MockBackend.getDrawCalls();
-    // Sprite pass first, tiles after — proves post-sprite ordering.
+    // Tilemap draws FIRST (background), sprite sentinel LAST — proves the
+    // terrain renders UNDER the gameplay sprites (pre-sprite ordering).
     try testing.expect(calls.len >= 7);
-    try testing.expectEqual(sprite_sentinel_id, calls[0].texture_id);
+    try testing.expectEqual(sprite_sentinel_id, calls[calls.len - 1].texture_id);
 
     var tile_draws: usize = 0;
     var min_x: f32 = std.math.floatMax(f32);
     var min_y: f32 = std.math.floatMax(f32);
-    for (calls[1..]) |c| {
+    for (calls, 0..) |c, i| {
+        if (c.texture_id == sprite_sentinel_id) {
+            // The sentinel must be the very last draw — every tile precedes it.
+            try testing.expectEqual(calls.len - 1, i);
+            continue;
+        }
         try testing.expectEqual(tileset_handle, c.texture_id);
         tile_draws += 1;
         if (c.dest.x < min_x) min_x = c.dest.x;
@@ -307,11 +355,65 @@ test "tilemap renders as a POST-SPRITE pass at the entity's world offset" {
     // 3×2 fully-populated layer → 6 tile draws.
     try testing.expectEqual(@as(usize, 6), tile_draws);
     // X is not flipped: tile (0,0) dest.x = 0*16 + offset_x(100) + 8 = 108.
+    // This is the PRE-camera world→screen store offset (the camera matrix,
+    // recorded as a pass below, applies the pan/zoom on top).
     try testing.expectEqual(@as(f32, 108), min_x);
     // Y IS flipped for the default `.up` project (F3): the map's top-left
     // screen offset = toScreenY(.up, 50, 600) - pixelHeight(32) = 518, so the
     // top row draws at 518 + 8 (centre) = 526.
     try testing.expectEqual(@as(f32, 526), min_y);
+}
+
+test "tilemap background pass runs INSIDE the world camera transform" {
+    const G = TilemapGame();
+    var game = G.init(testing.allocator);
+    defer game.deinit();
+    try registerFixture(&game);
+
+    const e = game.createEntity();
+    game.setPosition(e, .{ .x = 0, .y = 0 });
+    game.addTilemap(e, .{ .asset_name = "level.tmx" });
+
+    // Frame 1: camera at the origin. The tilemap pass must enter the camera
+    // (one recorded backend camera pass) so tiles pan/zoom with the world.
+    {
+        MockBackend.initMock(testing.allocator);
+        defer MockBackend.deinitMock();
+        game.getCamera().setPosition(0, 0);
+        game.render();
+
+        const passes = MockBackend.getCameraPasses();
+        try testing.expect(passes.len >= 1);
+        // The pass carries the camera's target — proof the tilemap draws
+        // under the SAME transform sprites use, not in raw screen space.
+        try testing.expectEqual(@as(f32, 0), passes[0].target_x);
+        try testing.expectEqual(@as(f32, 0), passes[0].target_y);
+    }
+
+    // Frame 2: pan the camera. The recorded transform must shift with it —
+    // i.e. a camera pan moves the tilemap pass exactly as it moves sprites.
+    {
+        MockBackend.initMock(testing.allocator);
+        defer MockBackend.deinitMock();
+        game.getCamera().setPosition(200, 120);
+        game.render();
+
+        const passes = MockBackend.getCameraPasses();
+        try testing.expect(passes.len >= 1);
+        try testing.expectEqual(@as(f32, 200), passes[0].target_x);
+        try testing.expectEqual(@as(f32, 120), passes[0].target_y);
+
+        // The per-tile dest offsets stay in WORLD space (camera_x/y = 0):
+        // the pan lives in the camera transform, NOT baked into the tile
+        // positions — tile (0,0) dest.x is still 0*16 + offset_x(0) + 8 = 8,
+        // unchanged by the pan.
+        var min_x: f32 = std.math.floatMax(f32);
+        for (MockBackend.getDrawCalls()) |c| {
+            if (c.texture_id == sprite_sentinel_id) continue;
+            if (c.dest.x < min_x) min_x = c.dest.x;
+        }
+        try testing.expectEqual(@as(f32, 8), min_x);
+    }
 }
 
 test "save persists only asset_name; load rehydrates the runtime" {
@@ -426,7 +528,8 @@ test "F3: tilemap y-offset matches the sprite y-axis transform (.up)" {
     // centre), so the map's bottom edge = max centre-y + half a tile.
     const half_tile: f32 = 8;
     var max_center_y: f32 = -std.math.floatMax(f32);
-    for (MockBackend.getDrawCalls()[1..]) |c| {
+    for (MockBackend.getDrawCalls()) |c| {
+        if (c.texture_id == sprite_sentinel_id) continue; // skip sprite pass
         if (c.dest.y > max_center_y) max_center_y = c.dest.y;
     }
     const map_bottom_edge = max_center_y + half_tile;
@@ -454,7 +557,8 @@ test "F3: tilemap y-offset is the identity under .down" {
     // `.down`: offset_y = Position.y (identity, no height adjust). Top-left
     // tile (0,0) centre = 0*16 + 50 + 8 = 58.
     var min_y: f32 = std.math.floatMax(f32);
-    for (MockBackend.getDrawCalls()[1..]) |c| {
+    for (MockBackend.getDrawCalls()) |c| {
+        if (c.texture_id == sprite_sentinel_id) continue; // skip sprite pass
         if (c.dest.y < min_y) min_y = c.dest.y;
     }
     try testing.expectEqual(@as(f32, 58), min_y);


### PR DESCRIPTION
## Summary
Closes the two T2 tilemap-rendering gaps the **pack-colony-demo** exposed (engine 1.75.1): the tilemap pass ran POST-sprite and in SCREEN space, so opaque terrain painted OVER the gameplay sprites and needed a baked camera offset to line up. Both are now fixed — tilemaps render as a proper **world-space background**.

### 1. Pre-sprite ordering (background, not overlay)
`game/loop_mixin.zig` `render()` now runs `renderTilemaps()` **before** `renderer.render()`, so terrain draws UNDER the houses/workers/hazard sprites. Gizmos still render last (sprite/gizmo order unchanged relative to each other).

### 2. World-space camera transform (pans/zooms with the world)
`game/tilemap_mixin.zig` `renderTilemaps()` wraps the pass in the SAME `camera.begin()/end()` sprites render through — gated on the renderer exposing a `begin()/end()` camera (`Game.CameraType != void`). Each map still draws with `camera_x/camera_y = 0`: the camera **matrix** (not a software offset) applies the pan/zoom, so a `Tilemap` entity's `Position` is a true world position that stays aligned with sprites at the same world coords under any pan/zoom. A camera-less renderer (headless/stub) folds the wrap away and keeps the T2 screen-space fallback (identity for a static view). The pre-camera world→screen Y offset (F3 `core.toScreenY`) is unchanged.

## Tests
- Flipped the ordering assertion to **background-first** (tile draws precede the sprite sentinel, which is now last).
- New camera-capable mock (`MockCamera` → backend `beginMode2D`) + a test asserting the pass runs INSIDE the camera transform and that a **camera pan shifts the recorded transform** while per-tile dests stay in world space.
- Existing F1/F3/F4 tilemap tests stay green.
- `zig build test` → 754/754 pass; `zig fmt` clean; files <1000 lines.

## Version
`build.zig.zon` bumped to **1.76.0**.

## Demo proof
Verified on pack-colony-demo (world Tilemap Position corrected to its true origin `{0,0}`): terrain renders as background with the 3 houses + 5 workers + hazard visible on top at correct positions.

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw