### PR TITLE
feat(animation): clip-major per-variant overrides (#666 reshape, studio#61 companion)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xe8a81a8dc7f48c87,
     .name = .engine,
-    .version = "1.76.0",
+    .version = "1.77.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         // Requires labelle-core >= v1.20.0 — font_types aliases core's

--- a/src/animation_def.zig
+++ b/src/animation_def.zig
@@ -21,11 +21,12 @@
 /// a slot showing for `run` beats. The count form has run 1 everywhere, so
 /// `beat_count == slot_count` and playback is bit-identical to pre-#664.
 ///
-/// Entry lists are PER-VARIANT (#684): a variant's `.overrides` may replace
-/// a clip's `.frames` with any of the three forms, so every derived table
-/// (beat→slot, marker→beat, sprite names) is keyed `[clip][variant]`. A
-/// variant with no `.frames` override shares the base clip's entry list,
-/// so defs without overrides generate exactly the tables they always did.
+/// Entry lists are PER-VARIANT (#684): a clip's `.overrides` sub-map, keyed
+/// by variant name, may replace that clip's `.frames` with any of the three
+/// forms for a single variant, so every derived table (beat→slot,
+/// marker→beat, sprite names) is keyed `[clip][variant]`. A (clip, variant)
+/// pair with no override shares the base clip's entry list, so defs without
+/// overrides generate exactly the tables they always did.
 
 const std = @import("std");
 const anim_timing = @import("anim_timing.zig");
@@ -83,6 +84,14 @@ fn clipIdxByName(comptime clip_fields: anytype, comptime name: []const u8) ?u8 {
     return null;
 }
 
+/// Comptime variant-name → ordinal lookup over the `.variants` list.
+fn variantIdxByName(comptime variant_list: anytype, comptime name: []const u8) ?u8 {
+    inline for (variant_list, 0..) |v, i| {
+        if (std.mem.eql(u8, v, name)) return @intCast(i);
+    }
+    return null;
+}
+
 /// Normalize any of the three `.frames` forms into a slot list. Pure
 /// comptime; the returned slice points at comptime memory. Rejects
 /// malformed data with a clear message (empty, run 0, f out of the
@@ -133,31 +142,18 @@ fn checkedF(comptime f: anytype) u16 {
     return @intCast(f);
 }
 
-/// A `.variants` element is either a string (`"m_bald"`) or a struct
-/// `.{ .name = "w_ginger", .overrides = .{ ... } }` (#666). Resolve its
-/// display name either way.
-fn variantNameOf(comptime elem: anytype) []const u8 {
-    const info = @typeInfo(@TypeOf(elem));
-    if (info == .pointer) return elem; // string literal (*const [N:0]u8)
-    if (info == .@"struct") {
-        if (!@hasField(@TypeOf(elem), "name")) @compileError("variant struct needs a `.name` field");
-        return elem.name;
-    }
-    @compileError("variant must be a string or a `.{ .name, .overrides }` struct");
-}
-
 /// Reject any override field that isn't `frames`/`speed`/`mode`/`folder`
 /// — overrides may change clip content, never its identity (#666).
 fn validateOverrideFields(comptime T: type, comptime clip_name: []const u8, comptime variant_name: []const u8) void {
     if (@typeInfo(T) != .@"struct")
-        @compileError("variant '" ++ variant_name ++ "' override for clip '" ++ clip_name ++
+        @compileError("clip '" ++ clip_name ++ "' override for variant '" ++ variant_name ++
             "' must be a struct like `.{ .frames = 4 }`");
     inline for (@typeInfo(T).@"struct".fields) |f| {
         const ok = std.mem.eql(u8, f.name, "frames") or
             std.mem.eql(u8, f.name, "speed") or
             std.mem.eql(u8, f.name, "mode") or
             std.mem.eql(u8, f.name, "folder");
-        if (!ok) @compileError("variant '" ++ variant_name ++ "' override for clip '" ++ clip_name ++
+        if (!ok) @compileError("clip '" ++ clip_name ++ "' override for variant '" ++ variant_name ++
             "' has unknown field '" ++ f.name ++ "' (only frames/speed/mode/folder allowed)");
     }
 }
@@ -205,12 +201,12 @@ pub fn AnimationDef(comptime zon: anytype) type {
 
     const Clip = @Enum(u8, .exhaustive, &ClipNames.names, &ClipNames.values);
 
-    // Build Variant enum fields (name from a string element or its `.name`).
+    // Build Variant enum fields (the `.variants` list is plain strings).
     const VariantNames = blk: {
         var names: [variant_count][]const u8 = undefined;
         var values: [variant_count]u8 = undefined;
-        inline for (variant_list, 0..) |velem, i| {
-            names[i] = variantNameOf(velem);
+        for (0..variant_count) |i| {
+            names[i] = variant_list[i];
             values[i] = i;
         }
         break :blk .{ .names = names, .values = values };
@@ -230,8 +226,8 @@ pub fn AnimationDef(comptime zon: anytype) type {
 
     // Per-variant slot lists (#684) — the single source the meta, name,
     // beat, and marker tables all derive from. Row [ci][vi] is the base
-    // list unless variant vi overrides that clip's `.frames` (any of the
-    // three #664 forms, through the same `normalizeFrames`). Non-
+    // list unless clip ci overrides its `.frames` for variant vi (any of
+    // the three #664 forms, through the same `normalizeFrames`). Non-
     // overriding rows alias the base slice, so defs without overrides
     // derive tables identical to the pre-#684 per-clip ones.
     const clip_entries_2d: [clip_count][variant_count][]const FrameEntry = blk: {
@@ -240,16 +236,16 @@ pub fn AnimationDef(comptime zon: anytype) type {
         for (0..clip_count) |ci| {
             for (0..variant_count) |vi| arr[ci][vi] = clip_entries[ci];
         }
-        inline for (variant_list, 0..) |velem, vi| {
-            const vinfo = @typeInfo(@TypeOf(velem));
-            if (vinfo == .@"struct" and @hasField(@TypeOf(velem), "overrides")) {
-                inline for (@typeInfo(@TypeOf(velem.overrides)).@"struct".fields) |of| {
-                    // Unknown clip names are reported by clip_meta_2d's
+        inline for (clip_fields, 0..) |cf, ci| {
+            const clip_data = @field(zon.clips, cf.name);
+            if (@hasField(@TypeOf(clip_data), "overrides")) {
+                inline for (@typeInfo(@TypeOf(clip_data.overrides)).@"struct".fields) |of| {
+                    // Unknown variant names are reported by clip_meta_2d's
                     // validation below — skip here to keep one error site.
-                    if (clipIdxByName(clip_fields, of.name)) |cidx| {
-                        const override = @field(velem.overrides, of.name);
+                    if (variantIdxByName(variant_list, of.name)) |vidx| {
+                        const override = @field(clip_data.overrides, of.name);
                         if (@hasField(@TypeOf(override), "frames")) {
-                            arr[cidx][vi] = normalizeFrames(override.frames);
+                            arr[ci][vidx] = normalizeFrames(override.frames);
                         }
                     }
                 }
@@ -298,10 +294,10 @@ pub fn AnimationDef(comptime zon: anytype) type {
     };
 
     // Per-variant ClipMeta (#666): start from the base, then patch each
-    // variant's `.overrides` block. Overrides change clip CONTENT (frames/
-    // speed/mode/folder) only — never structure — so the single Clip/
-    // Variant enum pair still drives every skin (Unity Sprite Library
-    // Variant's structural-consistency rule).
+    // clip's `.overrides` sub-map (keyed by variant name). Overrides change
+    // clip CONTENT (frames/speed/mode/folder) only — never structure — so
+    // the single Clip/Variant enum pair still drives every skin (Unity
+    // Sprite Library Variant's structural-consistency rule).
     //
     // A `.frames` override accepts any of the three #664 forms (#684):
     // its counts are derived from the variant's own entry row in
@@ -313,22 +309,20 @@ pub fn AnimationDef(comptime zon: anytype) type {
         for (0..clip_count) |ci| {
             for (0..variant_count) |vi| table[ci][vi] = clip_meta_table[ci];
         }
-        inline for (variant_list, 0..) |velem, vi| {
-            const vinfo = @typeInfo(@TypeOf(velem));
-            if (vinfo == .@"struct" and @hasField(@TypeOf(velem), "overrides")) {
-                const ov = velem.overrides;
+        inline for (clip_fields, 0..) |cf, ci| {
+            const clip_data = @field(zon.clips, cf.name);
+            if (@hasField(@TypeOf(clip_data), "overrides")) {
+                const ov = clip_data.overrides;
                 if (@typeInfo(@TypeOf(ov)) != .@"struct")
-                    @compileError("variant '" ++ variantNameOf(velem) ++
-                        "' `.overrides` must be a struct of clip overrides");
+                    @compileError("clip '" ++ cf.name ++ "' `.overrides` must be a struct of per-variant overrides");
                 inline for (@typeInfo(@TypeOf(ov)).@"struct".fields) |of| {
-                    const cidx = clipIdxByName(clip_fields, of.name) orelse
-                        @compileError("variant '" ++ variantNameOf(velem) ++
-                        "' overrides unknown clip '" ++ of.name ++ "'");
+                    const vidx = variantIdxByName(variant_list, of.name) orelse
+                        @compileError("clip '" ++ cf.name ++ "' overrides unknown variant '" ++ of.name ++ "'");
                     const override = @field(ov, of.name);
-                    validateOverrideFields(@TypeOf(override), of.name, variantNameOf(velem));
-                    var m = clip_meta_table[cidx];
+                    validateOverrideFields(@TypeOf(override), cf.name, of.name);
+                    var m = clip_meta_table[ci];
                     if (@hasField(@TypeOf(override), "frames")) {
-                        const ventries = clip_entries_2d[cidx][vi];
+                        const ventries = clip_entries_2d[ci][vidx];
                         var beats: u16 = 0;
                         for (ventries) |e| beats += e.run;
                         m.frame_count = @intCast(ventries.len);
@@ -338,17 +332,16 @@ pub fn AnimationDef(comptime zon: anytype) type {
                     if (@hasField(@TypeOf(override), "speed")) m.speed = override.speed;
                     if (@hasField(@TypeOf(override), "mode")) m.mode = override.mode;
                     if (@hasField(@TypeOf(override), "folder")) m.folder = override.folder;
-                    // Same rule as the base table: a clip that is .static
-                    // FOR THIS VARIANT (inherited or overridden) only ever
-                    // shows slot 0, so holds in its effective entry list
-                    // are meaningless — reject the combination.
+                    // A clip that is .static FOR THIS VARIANT only ever shows
+                    // slot 0, so per-slot holds in its effective entry list are
+                    // meaningless — reject the combination.
                     if (m.mode == .static) {
-                        for (clip_entries_2d[cidx][vi]) |e| {
-                            if (e.run != 1) @compileError("variant '" ++ variantNameOf(velem) ++ "' makes clip '" ++
-                                of.name ++ "' .static with per-slot holds — holds are meaningless when frame is always slot 0");
+                        for (clip_entries_2d[ci][vidx]) |e| {
+                            if (e.run != 1) @compileError("clip '" ++ cf.name ++ "' variant '" ++ of.name ++
+                                "' is .static with per-slot holds — holds are meaningless when frame is always slot 0");
                         }
                     }
-                    table[cidx][vi] = m;
+                    table[ci][vidx] = m;
                 }
             }
         }

--- a/src/animation_def_runtime.zig
+++ b/src/animation_def_runtime.zig
@@ -36,6 +36,17 @@ pub const FrameEntry = animation_def.FrameEntry;
 
 const Zoir = std.zig.Zoir;
 
+/// A parsed per-(clip, variant) override (clip-major `.overrides`).
+/// `entries` and `folder` are heap-owned when non-null.
+const VariantOverride = struct {
+    clip: u8,
+    variant: u8,
+    entries: ?[]FrameEntry, // owned; null = frames not overridden
+    speed: ?f32,
+    mode: ?Mode,
+    folder: ?[]const u8, // owned; null = folder not overridden
+};
+
 pub const RuntimeAnimationDef = struct {
     allocator: std.mem.Allocator,
     /// Clip names in declaration order; index == the `u8` in AnimationState.clip.
@@ -50,10 +61,17 @@ pub const RuntimeAnimationDef = struct {
     /// to slots 1..N with run 1. Heap-owned (marker strings included).
     clip_entries: [][]FrameEntry,
     /// Precomputed sprite-name strings, `[clip][variant][slot]`. Jagged:
-    /// row length is that clip's `frame_count`. Byte-equal to the comptime
-    /// table's `"{folder}/{variant}_{f:04}.png"` (slot i names file
-    /// `entries[i].f`, so reorders/reuse resolve identically).
+    /// row length is that (clip, variant)'s effective slot count (an
+    /// override may lengthen/shorten a single variant's row). Byte-equal to
+    /// the comptime table's `"{folder}/{variant}_{f:04}.png"` (slot i names
+    /// file `entries[i].f`, so reorders/reuse resolve identically).
     sprite_names: [][][][]const u8,
+    /// Sparse clip-major `.overrides`: one entry per (clip, variant) pair
+    /// that actually overrides something — non-overridden pairs are absent
+    /// and inherit the base. The sprite-name table above already bakes
+    /// overrides in; this list drives `clipMetaFor`/`refreshState`. Each
+    /// element's `entries` + `folder` are heap-owned (freed in `deinit`).
+    overrides: []VariantOverride,
 
     /// Parse a `.zon` animation definition. On any malformed input (parse
     /// error, missing `.variants`/`.clips`, bad field type, frame count
@@ -184,6 +202,105 @@ pub const RuntimeAnimationDef = struct {
             }
         }
 
+        // ── per-variant overrides (clip-major `.overrides`) ───
+        // Sparse: only the (clip, variant) pairs that override something.
+        // Parsed BEFORE the sprite-name table so that table can bake in the
+        // effective per-variant entries/folder. `clipMetaFor`/`refreshState`
+        // read this list to patch meta for the overridden variant.
+        var override_list: std.ArrayList(VariantOverride) = .empty;
+        errdefer {
+            for (override_list.items) |*o| {
+                if (o.entries) |es| freeEntries(allocator, es);
+                if (o.folder) |f| allocator.free(f);
+            }
+            override_list.deinit(allocator);
+        }
+        {
+            var ci: u32 = 0;
+            while (ci < ccount) : (ci += 1) {
+                const cnode = cstruct.vals.at(ci);
+                const ov_node = findField(zoir, cnode, "overrides") orelse continue;
+                const ov_struct = switch (ov_node.get(zoir)) {
+                    .struct_literal => |s| s,
+                    else => return error.BadOverrides,
+                };
+                var j: u32 = 0;
+                while (j < ov_struct.names.len) : (j += 1) {
+                    // Field NAME is a variant name → its index (or reject).
+                    const vname = ov_struct.names[j].get(zoir);
+                    var vidx_opt: ?u8 = null;
+                    for (variant_names, 0..) |vn, vi2| {
+                        if (std.mem.eql(u8, vn, vname)) {
+                            vidx_opt = @intCast(vi2);
+                            break;
+                        }
+                    }
+                    const vidx = vidx_opt orelse return error.UnknownVariant;
+
+                    // Field VALUE is the per-variant override struct.
+                    const val_node = ov_struct.vals.at(j);
+                    const ov_val = switch (val_node.get(zoir)) {
+                        .struct_literal => |s| s,
+                        else => return error.BadOverride,
+                    };
+                    var entries: ?[]FrameEntry = null;
+                    var ov_speed: ?f32 = null;
+                    var ov_mode: ?Mode = null;
+                    var ov_folder: ?[]const u8 = null;
+                    // Frees a partially-parsed override on any error below
+                    // (incl. the static-hold reject); on a clean append the
+                    // scope exits normally and ownership passes to the list.
+                    errdefer {
+                        if (entries) |es| freeEntries(allocator, es);
+                        if (ov_folder) |f| allocator.free(f);
+                    }
+                    var k: u32 = 0;
+                    while (k < ov_val.names.len) : (k += 1) {
+                        const fname = ov_val.names[k].get(zoir);
+                        const fnode = ov_val.vals.at(k);
+                        if (std.mem.eql(u8, fname, "frames")) {
+                            entries = try parseFrames(allocator, zoir, fnode);
+                        } else if (std.mem.eql(u8, fname, "speed")) {
+                            ov_speed = try getFloat(zoir, fnode);
+                        } else if (std.mem.eql(u8, fname, "mode")) {
+                            ov_mode = try modeFromName(try getEnumName(zoir, fnode));
+                        } else if (std.mem.eql(u8, fname, "folder")) {
+                            ov_folder = try allocator.dupe(u8, try getString(zoir, fnode));
+                        } else {
+                            return error.UnknownOverrideField;
+                        }
+                    }
+                    // Comptime parity: a clip that is .static FOR THIS
+                    // VARIANT (override mode, else base) only shows slot 0,
+                    // so per-slot holds in its entries are meaningless.
+                    const eff_mode = ov_mode orelse clip_meta[ci].mode;
+                    if (eff_mode == .static) {
+                        if (entries) |es| {
+                            for (es) |e| {
+                                if (e.run != 1) return error.HoldOnStaticClip;
+                            }
+                        }
+                    }
+                    try override_list.append(allocator, .{
+                        .clip = @intCast(ci),
+                        .variant = vidx,
+                        .entries = entries,
+                        .speed = ov_speed,
+                        .mode = ov_mode,
+                        .folder = ov_folder,
+                    });
+                }
+            }
+        }
+        const overrides = try override_list.toOwnedSlice(allocator);
+        errdefer {
+            for (overrides) |*o| {
+                if (o.entries) |es| freeEntries(allocator, es);
+                if (o.folder) |f| allocator.free(f);
+            }
+            allocator.free(overrides);
+        }
+
         // ── sprite-name table [clip][variant][slot] ───────────
         const sprite_names = try allocator.alloc([][][]const u8, ccount);
         var sn_clips: usize = 0;
@@ -200,8 +317,6 @@ pub const RuntimeAnimationDef = struct {
         {
             var ci: usize = 0;
             while (ci < ccount) : (ci += 1) {
-                const fc = clip_meta[ci].frame_count;
-                const folder = clip_meta[ci].folder;
                 const block = try allocator.alloc([][]const u8, vcount);
                 var blk_rows: usize = 0;
                 errdefer {
@@ -213,6 +328,19 @@ pub const RuntimeAnimationDef = struct {
                 }
                 var vi: usize = 0;
                 while (vi < vcount) : (vi += 1) {
+                    // Effective (per-variant) entries + folder: an override
+                    // for THIS (clip, variant) replaces them, else the base.
+                    // Row length is jagged — a shorter/longer override row.
+                    var eff_entries = clip_entries[ci];
+                    var eff_folder = clip_meta[ci].folder;
+                    for (overrides) |*o| {
+                        if (@as(usize, o.clip) == ci and @as(usize, o.variant) == vi) {
+                            if (o.entries) |es| eff_entries = es;
+                            if (o.folder) |f| eff_folder = f;
+                            break;
+                        }
+                    }
+                    const fc = eff_entries.len;
                     const row = try allocator.alloc([]const u8, fc);
                     var row_f: usize = 0;
                     errdefer {
@@ -223,7 +351,7 @@ pub const RuntimeAnimationDef = struct {
                     while (fi < fc) : (fi += 1) {
                         // Slot fi names file `entries[fi].f` (not fi+1),
                         // matching the comptime table for reorders/reuse.
-                        row[fi] = try std.fmt.allocPrint(allocator, "{s}/{s}_{d:0>4}.png", .{ folder, variant_names[vi], clip_entries[ci][fi].f });
+                        row[fi] = try std.fmt.allocPrint(allocator, "{s}/{s}_{d:0>4}.png", .{ eff_folder, variant_names[vi], eff_entries[fi].f });
                         row_f += 1;
                     }
                     block[vi] = row;
@@ -241,6 +369,7 @@ pub const RuntimeAnimationDef = struct {
             .clip_meta = clip_meta,
             .clip_entries = clip_entries,
             .sprite_names = sprite_names,
+            .overrides = overrides,
         };
     }
 
@@ -254,6 +383,11 @@ pub const RuntimeAnimationDef = struct {
             a.free(blk);
         }
         a.free(self.sprite_names);
+        for (self.overrides) |*o| {
+            if (o.entries) |es| freeEntries(a, es);
+            if (o.folder) |f| a.free(f);
+        }
+        a.free(self.overrides);
         for (self.clip_entries) |es| freeEntries(a, es);
         a.free(self.clip_entries);
         for (self.clip_meta) |m| a.free(m.folder);
@@ -290,12 +424,42 @@ pub const RuntimeAnimationDef = struct {
     }
 
     /// Look up a precomputed sprite name; returns "" for any out-of-range
-    /// clip/variant/frame (never indexes OOB).
+    /// clip/variant/frame (never indexes OOB). The frame bound is the actual
+    /// per-(clip, variant) ROW length, so a shorter/longer overridden row
+    /// resolves correctly.
     pub fn spriteName(self: *const RuntimeAnimationDef, clip: u8, variant: u8, frame: u8) []const u8 {
         if (clip >= self.clip_meta.len) return "";
-        if (frame >= self.clip_meta[clip].frame_count) return "";
         if (variant >= self.variant_names.len) return "";
-        return self.sprite_names[clip][variant][frame];
+        const row = self.sprite_names[clip][variant];
+        if (frame >= row.len) return "";
+        return row[frame];
+    }
+
+    /// Find a sparse override for a (clip, variant) pair, or null.
+    fn overrideFor(self: *const RuntimeAnimationDef, clip: u8, variant: u8) ?*const VariantOverride {
+        for (self.overrides) |*o| if (o.clip == clip and o.variant == variant) return o;
+        return null;
+    }
+
+    /// Metadata for a clip AS SEEN BY a variant — base patched by the
+    /// variant's clip-major `.overrides`, if any.
+    pub fn clipMetaFor(self: *const RuntimeAnimationDef, clip: u8, variant: u8) ClipMeta {
+        var m = self.clipMeta(clip);
+        if (clip < self.clip_meta.len) {
+            if (self.overrideFor(clip, variant)) |o| {
+                if (o.entries) |es| {
+                    var beats: u16 = 0;
+                    for (es) |e| beats += e.run;
+                    m.frame_count = @intCast(es.len);
+                    m.entry_count = @intCast(es.len);
+                    m.beat_count = beats;
+                }
+                if (o.speed) |s| m.speed = s;
+                if (o.mode) |md| m.mode = md;
+                if (o.folder) |f| m.folder = f;
+            }
+        }
+        return m;
     }
 
     /// The slot shown at a given beat of a clip — the runtime mirror of
@@ -497,7 +661,9 @@ pub fn refreshState(state: anytype, def: *const RuntimeAnimationDef) void {
     if (def.variant_names.len > 0 and rawIndex(state.variant) >= def.variant_names.len) {
         setIndex(&state.variant, @intCast(def.variant_names.len - 1));
     }
-    const meta = def.clip_meta[rawIndex(state.clip)];
+    // Read the meta AS SEEN BY the (clamped) variant so the preview applies
+    // that variant's per-clip override (speed/frame_count/mode).
+    const meta = def.clipMetaFor(rawIndex(state.clip), rawIndex(state.variant));
     state.frame_count = meta.frame_count;
     state.speed = meta.speed;
     state.mode = meta.mode;

--- a/src/animation_def_runtime.zig
+++ b/src/animation_def_runtime.zig
@@ -222,6 +222,11 @@ pub const RuntimeAnimationDef = struct {
                 const ov_node = findField(zoir, cnode, "overrides") orelse continue;
                 const ov_struct = switch (ov_node.get(zoir)) {
                     .struct_literal => |s| s,
+                    // `.overrides = .{}` lowers to empty_literal — an empty
+                    // map is a no-op (the comptime path accepts it), not a
+                    // parse error. The editor emits this when it opens the
+                    // field before any variant is overridden.
+                    .empty_literal => continue,
                     else => return error.BadOverrides,
                 };
                 var j: u32 = 0;
@@ -237,12 +242,6 @@ pub const RuntimeAnimationDef = struct {
                     }
                     const vidx = vidx_opt orelse return error.UnknownVariant;
 
-                    // Field VALUE is the per-variant override struct.
-                    const val_node = ov_struct.vals.at(j);
-                    const ov_val = switch (val_node.get(zoir)) {
-                        .struct_literal => |s| s,
-                        else => return error.BadOverride,
-                    };
                     var entries: ?[]FrameEntry = null;
                     var ov_speed: ?f32 = null;
                     var ov_mode: ?Mode = null;
@@ -254,31 +253,43 @@ pub const RuntimeAnimationDef = struct {
                         if (entries) |es| freeEntries(allocator, es);
                         if (ov_folder) |f| allocator.free(f);
                     }
-                    var k: u32 = 0;
-                    while (k < ov_val.names.len) : (k += 1) {
-                        const fname = ov_val.names[k].get(zoir);
-                        const fnode = ov_val.vals.at(k);
-                        if (std.mem.eql(u8, fname, "frames")) {
-                            entries = try parseFrames(allocator, zoir, fnode);
-                        } else if (std.mem.eql(u8, fname, "speed")) {
-                            ov_speed = try getFloat(zoir, fnode);
-                        } else if (std.mem.eql(u8, fname, "mode")) {
-                            ov_mode = try modeFromName(try getEnumName(zoir, fnode));
-                        } else if (std.mem.eql(u8, fname, "folder")) {
-                            ov_folder = try allocator.dupe(u8, try getString(zoir, fnode));
-                        } else {
-                            return error.UnknownOverrideField;
-                        }
+                    // Field VALUE is the per-variant override struct. `.{}`
+                    // (empty_literal) is a valid inherit-everything no-op —
+                    // the comptime path accepts it, and the editor emits it
+                    // for a just-created override with no field set yet.
+                    switch (ov_struct.vals.at(j).get(zoir)) {
+                        .empty_literal => {},
+                        .struct_literal => |ov_val| {
+                            var k: u32 = 0;
+                            while (k < ov_val.names.len) : (k += 1) {
+                                const fname = ov_val.names[k].get(zoir);
+                                const fnode = ov_val.vals.at(k);
+                                if (std.mem.eql(u8, fname, "frames")) {
+                                    entries = try parseFrames(allocator, zoir, fnode);
+                                } else if (std.mem.eql(u8, fname, "speed")) {
+                                    ov_speed = try getFloat(zoir, fnode);
+                                } else if (std.mem.eql(u8, fname, "mode")) {
+                                    ov_mode = try modeFromName(try getEnumName(zoir, fnode));
+                                } else if (std.mem.eql(u8, fname, "folder")) {
+                                    ov_folder = try allocator.dupe(u8, try getString(zoir, fnode));
+                                } else {
+                                    return error.UnknownOverrideField;
+                                }
+                            }
+                        },
+                        else => return error.BadOverride,
                     }
-                    // Comptime parity: a clip that is .static FOR THIS
-                    // VARIANT (override mode, else base) only shows slot 0,
-                    // so per-slot holds in its entries are meaningless.
+                    // Comptime parity: a clip that is .static FOR THIS VARIANT
+                    // (override mode, else base) only shows slot 0, so per-slot
+                    // holds in its EFFECTIVE entries are meaningless. Check the
+                    // effective list — the override's own entries, or the
+                    // inherited base — so a variant that overrides ONLY
+                    // `.mode = .static` over a held base is still rejected.
                     const eff_mode = ov_mode orelse clip_meta[ci].mode;
                     if (eff_mode == .static) {
-                        if (entries) |es| {
-                            for (es) |e| {
-                                if (e.run != 1) return error.HoldOnStaticClip;
-                            }
+                        const eff_entries = entries orelse clip_entries[ci];
+                        for (eff_entries) |e| {
+                            if (e.run != 1) return error.HoldOnStaticClip;
                         }
                     }
                     try override_list.append(allocator, .{
@@ -462,17 +473,26 @@ pub const RuntimeAnimationDef = struct {
         return m;
     }
 
-    /// The slot shown at a given beat of a clip — the runtime mirror of
-    /// the comptime `slotForBeat`, computed on the fly by walking the
-    /// entry runs (no baked beat table; the runtime path is preview-only,
-    /// so O(entries) per lookup is inside budget). Returns 0 for any
-    /// out-of-range clip; wraps `beat` past the clip's beat_count.
-    pub fn slotForBeat(self: *const RuntimeAnimationDef, clip: u8, beat: u16) u8 {
+    /// The slot shown at a given beat of a clip AS SEEN BY a variant — the
+    /// runtime mirror of the comptime `slotForBeat`, computed on the fly by
+    /// walking the (per-variant) entry runs (no baked beat table; the
+    /// runtime path is preview-only, so O(entries) per lookup is inside
+    /// budget). A `.frames` override changes a variant's run structure, so
+    /// this reads the EFFECTIVE entries (the override's, else the base) — a
+    /// base-only walk would resolve the wrong slot/marker for an overridden
+    /// variant. Returns 0 for any out-of-range clip; wraps `beat` past the
+    /// (variant's) beat_count.
+    pub fn slotForBeat(self: *const RuntimeAnimationDef, clip: u8, variant: u8, beat: u16) u8 {
         if (clip >= self.clip_entries.len) return 0;
-        const bc = self.clip_meta[clip].beat_count;
+        const entries = if (self.overrideFor(clip, variant)) |o|
+            (o.entries orelse self.clip_entries[clip])
+        else
+            self.clip_entries[clip];
+        var bc: u16 = 0;
+        for (entries) |e| bc += e.run;
         if (bc == 0) return 0;
         var b = beat % bc;
-        for (self.clip_entries[clip], 0..) |e, si| {
+        for (entries, 0..) |e, si| {
             if (b < e.run) return @intCast(si);
             b -= e.run;
         }

--- a/test/animation_def_runtime_test.zig
+++ b/test/animation_def_runtime_test.zig
@@ -373,3 +373,117 @@ test "RuntimeAnimDefs: replacing a def retires the old generation alive (no UAF)
     try testing.expectEqual(@as(f32, 1.0), gen0.clipMeta(0).speed);
     // store.deinit() frees both generations; testing.allocator asserts no leak.
 }
+
+// ── Clip-major per-variant overrides (studio#61) ──
+
+// Mirrors the comptime `override_zon`: drink shrinks + slows for w_ginger,
+// carry re-folders for w_ginger. m_bald/m_beard inherit the base.
+const override_src =
+    \\.{
+    \\    .variants = .{ "m_bald", "m_beard", "w_ginger" },
+    \\    .clips = .{
+    \\        .idle = .{ .frames = 1, .mode = .static },
+    \\        .drink = .{ .frames = 10, .mode = .time, .speed = 5.0, .overrides = .{
+    \\            .w_ginger = .{ .frames = 8, .speed = 4.0 },
+    \\        } },
+    \\        .carry = .{ .frames = 4, .mode = .distance, .speed = 15.0, .folder = "take", .overrides = .{
+    \\            .w_ginger = .{ .folder = "take_ginger" },
+    \\        } },
+    \\    },
+    \\}
+;
+
+test "RuntimeAnimationDef: clip-major overrides patch meta + sprite names" {
+    var rt = try RuntimeAnimationDef.load(testing.allocator, override_src);
+    defer rt.deinit();
+
+    const idle = rt.clipIndex("idle").?;
+    const drink = rt.clipIndex("drink").?;
+    const carry = rt.clipIndex("carry").?;
+    const m_bald = rt.variantIndex("m_bald").?;
+    const w_ginger = rt.variantIndex("w_ginger").?;
+
+    // drink: base (m_bald) keeps 10 @ 5.0; w_ginger sees 8 @ 4.0, with
+    // mode + folder inherited from the base clip.
+    const base = rt.clipMetaFor(drink, m_bald);
+    try testing.expectEqual(@as(u8, 10), base.frame_count);
+    try testing.expectEqual(@as(f32, 5.0), base.speed);
+    try testing.expectEqualStrings("drink", base.folder);
+
+    const ginger = rt.clipMetaFor(drink, w_ginger);
+    try testing.expectEqual(@as(u8, 8), ginger.frame_count);
+    try testing.expectEqual(@as(u8, 8), ginger.entry_count);
+    try testing.expectEqual(@as(u16, 8), ginger.beat_count);
+    try testing.expectEqual(@as(f32, 4.0), ginger.speed);
+    try testing.expectEqual(engine.AnimMode.time, ginger.mode); // inherited
+    try testing.expectEqualStrings("drink", ginger.folder); // inherited
+
+    // carry: w_ginger only re-folders (frames/speed inherited).
+    const carry_ginger = rt.clipMetaFor(carry, w_ginger);
+    try testing.expectEqual(@as(u8, 4), carry_ginger.frame_count);
+    try testing.expectEqual(@as(f32, 15.0), carry_ginger.speed);
+    try testing.expectEqualStrings("take_ginger", carry_ginger.folder);
+    try testing.expectEqualStrings("take", rt.clipMetaFor(carry, m_bald).folder);
+
+    // A clip w_ginger does NOT override inherits the base meta exactly.
+    try testing.expectEqual(rt.clipMeta(idle).frame_count, rt.clipMetaFor(idle, w_ginger).frame_count);
+
+    // Sprite names honor the overridden folder + per-variant frame count.
+    try testing.expectEqualStrings("take/m_bald_0001.png", rt.spriteName(carry, m_bald, 0));
+    try testing.expectEqualStrings("take_ginger/w_ginger_0001.png", rt.spriteName(carry, w_ginger, 0));
+    try testing.expectEqualStrings("drink/m_bald_0010.png", rt.spriteName(drink, m_bald, 9));
+    try testing.expectEqualStrings("drink/w_ginger_0008.png", rt.spriteName(drink, w_ginger, 7));
+    // w_ginger's drink row is 8 long — frame 8 is past it, but the base
+    // (m_bald) still resolves its own longer row.
+    try testing.expectEqualStrings("", rt.spriteName(drink, w_ginger, 8));
+    try testing.expectEqualStrings("drink/m_bald_0009.png", rt.spriteName(drink, m_bald, 8));
+}
+
+test "RuntimeAnimationDef: refreshState applies the variant's override meta" {
+    var def = try RuntimeAnimationDef.load(testing.allocator, override_src);
+    defer def.deinit();
+
+    const drink = def.clipIndex("drink").?;
+    const m_bald = def.variantIndex("m_bald").?;
+    const w_ginger = def.variantIndex("w_ginger").?;
+
+    // Entity on w_ginger drinking: refreshState copies the OVERRIDE meta,
+    // not the base — 8 frames @ 4.0, mode inherited as .time.
+    var ginger_state = AnimationState{ .clip = drink, .variant = w_ginger, .frame = 0, .frame_count = 99, .speed = 1.0, .mode = .static };
+    refreshState(&ginger_state, &def);
+    try testing.expectEqual(@as(u8, 8), ginger_state.frame_count);
+    try testing.expectEqual(@as(f32, 4.0), ginger_state.speed);
+    try testing.expectEqual(engine.AnimMode.time, ginger_state.mode);
+    try testing.expect(ginger_state.dirty);
+
+    // Entity on the base variant gets the (unpatched) base meta.
+    var base_state = AnimationState{ .clip = drink, .variant = m_bald, .frame = 0, .frame_count = 99, .speed = 1.0, .mode = .static };
+    refreshState(&base_state, &def);
+    try testing.expectEqual(@as(u8, 10), base_state.frame_count);
+    try testing.expectEqual(@as(f32, 5.0), base_state.speed);
+    try testing.expectEqual(engine.AnimMode.time, base_state.mode);
+}
+
+test "RuntimeAnimationDef.load: clip-major override errors mirror the comptime rejects" {
+    const a = testing.allocator;
+    // Override key names a variant that doesn't exist.
+    try testing.expectError(error.UnknownVariant, RuntimeAnimationDef.load(a,
+        \\.{ .variants = .{ "a" }, .clips = .{ .c = .{ .frames = 2, .mode = .time, .speed = 1.0, .overrides = .{ .nope = .{ .frames = 1 } } } } }
+    ));
+    // Override carries a field outside frames/speed/mode/folder.
+    try testing.expectError(error.UnknownOverrideField, RuntimeAnimationDef.load(a,
+        \\.{ .variants = .{ "a" }, .clips = .{ .c = .{ .frames = 2, .mode = .time, .speed = 1.0, .overrides = .{ .a = .{ .bogus = 3 } } } } }
+    ));
+    // Effective .static (base mode) + per-slot hold in the override entries.
+    try testing.expectError(error.HoldOnStaticClip, RuntimeAnimationDef.load(a,
+        \\.{ .variants = .{ "a" }, .clips = .{ .c = .{ .frames = 1, .mode = .static, .overrides = .{ .a = .{ .frames = .{ .{ .f = 1, .run = 2 } } } } } } }
+    ));
+    // Top-level `.overrides` that isn't a struct of per-variant overrides.
+    try testing.expectError(error.BadOverrides, RuntimeAnimationDef.load(a,
+        \\.{ .variants = .{ "a" }, .clips = .{ .c = .{ .frames = 2, .mode = .time, .speed = 1.0, .overrides = 5 } } }
+    ));
+    // A per-variant override VALUE that isn't a struct.
+    try testing.expectError(error.BadOverride, RuntimeAnimationDef.load(a,
+        \\.{ .variants = .{ "a" }, .clips = .{ .c = .{ .frames = 2, .mode = .time, .speed = 1.0, .overrides = .{ .a = 5 } } } }
+    ));
+}

--- a/test/animation_def_runtime_test.zig
+++ b/test/animation_def_runtime_test.zig
@@ -57,7 +57,7 @@ test "RuntimeAnimationDef: byte-equal sprite names + index compatibility (#672)"
             while (b < cm.beat_count) : (b += 1) {
                 try testing.expectEqual(
                     WorkerAnim.slotForBeat(clip, variant, b),
-                    rt.slotForBeat(ci, b),
+                    rt.slotForBeat(ci, vi, b),
                 );
             }
         }
@@ -98,10 +98,10 @@ test "RuntimeAnimationDef: entry-list frames parse holds/reuse/markers (#685)" {
 
     // Slot 3 renders file 2 again; the held slot spans beats 2 and 3.
     try testing.expectEqualStrings("swing/m_bald_0002.png", rt.spriteName(ci, 0, 3));
-    try testing.expectEqual(@as(u8, 2), rt.slotForBeat(ci, 2));
-    try testing.expectEqual(@as(u8, 2), rt.slotForBeat(ci, 3));
-    try testing.expectEqual(@as(u8, 3), rt.slotForBeat(ci, 4));
-    try testing.expectEqual(@as(u8, 0), rt.slotForBeat(ci, 5)); // wraps
+    try testing.expectEqual(@as(u8, 2), rt.slotForBeat(ci, 0, 2));
+    try testing.expectEqual(@as(u8, 2), rt.slotForBeat(ci, 0, 3));
+    try testing.expectEqual(@as(u8, 3), rt.slotForBeat(ci, 0, 4));
+    try testing.expectEqual(@as(u8, 0), rt.slotForBeat(ci, 0, 5)); // wraps
 }
 
 test "RuntimeAnimationDef: minimal clip gets the comptime defaults (#672)" {
@@ -486,4 +486,77 @@ test "RuntimeAnimationDef.load: clip-major override errors mirror the comptime r
     try testing.expectError(error.BadOverride, RuntimeAnimationDef.load(a,
         \\.{ .variants = .{ "a" }, .clips = .{ .c = .{ .frames = 2, .mode = .time, .speed = 1.0, .overrides = .{ .a = 5 } } } }
     ));
+}
+
+test "RuntimeAnimationDef.load: an empty `.overrides = .{}` map is a no-op (editor-emitted)" {
+    // Zoir lowers `.{}` to empty_literal, not struct_literal — the runtime
+    // must accept it as "no overrides" (the comptime path does), because the
+    // editor writes it the instant it opens the field before setting one.
+    var rt = try RuntimeAnimationDef.load(testing.allocator,
+        \\.{ .variants = .{ "a", "b" }, .clips = .{ .c = .{ .frames = 3, .mode = .time, .speed = 1.0, .overrides = .{} } } }
+    );
+    defer rt.deinit();
+    const c = rt.clipIndex("c").?;
+    // Both variants see the base — nothing was overridden.
+    try testing.expectEqual(@as(u8, 3), rt.clipMetaFor(c, 0).frame_count);
+    try testing.expectEqual(@as(u8, 3), rt.clipMetaFor(c, 1).frame_count);
+    try testing.expectEqualStrings("c/b_0001.png", rt.spriteName(c, 1, 0));
+}
+
+test "RuntimeAnimationDef.load: an empty override VALUE `.{}` inherits everything" {
+    // `.b = .{}` — the variant is listed but sets no field, so it inherits
+    // the base clip wholesale (comptime accepts it as a no-op patch).
+    var rt = try RuntimeAnimationDef.load(testing.allocator,
+        \\.{ .variants = .{ "a", "b" }, .clips = .{ .c = .{ .frames = 3, .mode = .time, .speed = 2.0, .folder = "f", .overrides = .{ .b = .{} } } } }
+    );
+    defer rt.deinit();
+    const c = rt.clipIndex("c").?;
+    const b = rt.variantIndex("b").?;
+    const m = rt.clipMetaFor(c, b);
+    try testing.expectEqual(@as(u8, 3), m.frame_count);
+    try testing.expectEqual(@as(f32, 2.0), m.speed);
+    try testing.expectEqual(engine.AnimMode.time, m.mode);
+    try testing.expectEqualStrings("f", m.folder);
+    try testing.expectEqualStrings("f/b_0001.png", rt.spriteName(c, b, 0));
+}
+
+test "RuntimeAnimationDef.load: a `.mode=.static`-only override over a HELD base is rejected" {
+    // The variant overrides ONLY the mode; the base's held entries (run 2)
+    // are inherited, so the effective (static, holds) pair is illegal — the
+    // comptime path rejects it, and the runtime must too even though the
+    // override carries no `.frames` of its own.
+    try testing.expectError(error.HoldOnStaticClip, RuntimeAnimationDef.load(testing.allocator,
+        \\.{ .variants = .{ "a", "b" }, .clips = .{
+        \\    .c = .{ .frames = .{ .{ .f = 1, .run = 2 }, 2 }, .mode = .time, .speed = 1.0, .overrides = .{ .b = .{ .mode = .static } } },
+        \\} }
+    ));
+}
+
+test "RuntimeAnimationDef: slotForBeat is variant-aware (override changes the run structure)" {
+    // swing base is a 4-frame count-form clip; `heavy` overrides it with a
+    // held+reordered entry list. slotForBeat must walk the VARIANT's entries.
+    var rt = try RuntimeAnimationDef.load(testing.allocator,
+        \\.{ .variants = .{ "base", "heavy" }, .clips = .{
+        \\    .swing = .{ .frames = 4, .mode = .time, .speed = 1.0, .overrides = .{
+        \\        .heavy = .{ .frames = .{ .{ .f = 1, .run = 2 }, 2, 3 } },
+        \\    } },
+        \\} }
+    );
+    defer rt.deinit();
+    const swing = rt.clipIndex("swing").?;
+    const base = rt.variantIndex("base").?;
+    const heavy = rt.variantIndex("heavy").?;
+
+    // base: identity count-form row over 4 beats.
+    try testing.expectEqual(@as(u8, 0), rt.slotForBeat(swing, base, 0));
+    try testing.expectEqual(@as(u8, 1), rt.slotForBeat(swing, base, 1));
+    try testing.expectEqual(@as(u8, 3), rt.slotForBeat(swing, base, 3));
+    // heavy: slot 0 held two beats {0,0,1,2}, beat_count 4.
+    try testing.expectEqual(@as(u8, 0), rt.slotForBeat(swing, heavy, 0));
+    try testing.expectEqual(@as(u8, 0), rt.slotForBeat(swing, heavy, 1)); // held
+    try testing.expectEqual(@as(u8, 1), rt.slotForBeat(swing, heavy, 2));
+    try testing.expectEqual(@as(u8, 2), rt.slotForBeat(swing, heavy, 3));
+    try testing.expectEqual(@as(u8, 0), rt.slotForBeat(swing, heavy, 4)); // wraps
+    // clipMetaFor already reports the overridden beat_count; slotForBeat now agrees.
+    try testing.expectEqual(@as(u16, 4), rt.clipMetaFor(swing, heavy).beat_count);
 }

--- a/test/animation_def_test.zig
+++ b/test/animation_def_test.zig
@@ -290,6 +290,29 @@ test "AnimationDef: spriteName honors overridden folder and frame count (#666)" 
     try testing.expectEqualStrings("", OverrideAnim.spriteName(.drink, .w_ginger, 8));
 }
 
+// Parity anchor for the runtime parser (studio#61): an empty `.overrides`
+// map and an empty per-variant override VALUE are both accepted here as
+// no-ops. The runtime `RuntimeAnimationDef.load` mirrors this — a mismatch
+// would break the editor's hot-push, which emits exactly these shapes.
+const empty_override_zon = .{
+    .variants = .{ "a", "b" },
+    .clips = .{
+        .c = .{ .frames = 3, .mode = .time, .speed = 2.0, .overrides = .{} },
+        .d = .{ .frames = 4, .mode = .time, .speed = 1.0, .overrides = .{ .b = .{} } },
+    },
+};
+const EmptyOverrideAnim = AnimationDef(empty_override_zon);
+
+test "AnimationDef: empty override map + empty override value compile as base no-ops (#666)" {
+    // Empty map: every variant sees the base clip.
+    try testing.expectEqual(@as(u8, 3), EmptyOverrideAnim.clipMetaFor(.c, .a).frame_count);
+    try testing.expectEqual(@as(u8, 3), EmptyOverrideAnim.clipMetaFor(.c, .b).frame_count);
+    // Empty value: the listed variant inherits everything.
+    try testing.expectEqual(@as(u8, 4), EmptyOverrideAnim.clipMetaFor(.d, .b).frame_count);
+    try testing.expectEqual(@as(f32, 1.0), EmptyOverrideAnim.clipMetaFor(.d, .b).speed);
+    try testing.expectEqualStrings("d/b_0001.png", EmptyOverrideAnim.spriteName(.d, .b, 0));
+}
+
 // ── Per-variant frame-ENTRY overrides (#684) ──────────────
 
 const entry_override_zon = .{

--- a/test/animation_def_test.zig
+++ b/test/animation_def_test.zig
@@ -239,28 +239,25 @@ test "AnimationDef: advanceState maps beats to held slots (#664)" {
 // ── Per-variant clip overrides (#666) ─────────────────────
 
 const override_zon = .{
-    .variants = .{
-        "m_bald",
-        "m_beard",
-        .{ .name = "w_ginger", .overrides = .{
-            .drink = .{ .frames = 8, .speed = 4.0 }, // fewer frames, slower
-            .carry = .{ .folder = "take_ginger" }, // different sprite folder
-        } },
-    },
+    .variants = .{ "m_bald", "m_beard", "w_ginger" },
     .clips = .{
         .idle = .{ .frames = 1, .mode = .static },
-        .drink = .{ .frames = 10, .mode = .time, .speed = 5.0 },
-        .carry = .{ .frames = 4, .mode = .distance, .speed = 15.0, .folder = "take" },
+        .drink = .{ .frames = 10, .mode = .time, .speed = 5.0, .overrides = .{
+            .w_ginger = .{ .frames = 8, .speed = 4.0 }, // fewer frames, slower
+        } },
+        .carry = .{ .frames = 4, .mode = .distance, .speed = 15.0, .folder = "take", .overrides = .{
+            .w_ginger = .{ .folder = "take_ginger" }, // different sprite folder
+        } },
     },
 };
 const OverrideAnim = AnimationDef(override_zon);
 
-test "AnimationDef: mixed string/struct variants keep enum order and names (#666)" {
+test "AnimationDef: variant enum order and names with clip overrides (#666)" {
     try testing.expectEqual(@as(u8, 0), @intFromEnum(OverrideAnim.variants.m_bald));
     try testing.expectEqual(@as(u8, 1), @intFromEnum(OverrideAnim.variants.m_beard));
     try testing.expectEqual(@as(u8, 2), @intFromEnum(OverrideAnim.variants.w_ginger));
     try testing.expectEqualStrings("w_ginger", OverrideAnim.variantName(.w_ginger));
-    // #665 name resolution still works for a struct-declared variant.
+    // #665 name resolution still works for a variant a clip overrides.
     const V = OverrideAnim.variants;
     try testing.expectEqual(@as(?V, V.w_ginger), OverrideAnim.variantFromName("w_ginger"));
 }
@@ -296,25 +293,19 @@ test "AnimationDef: spriteName honors overridden folder and frame count (#666)" 
 // ── Per-variant frame-ENTRY overrides (#684) ──────────────
 
 const entry_override_zon = .{
-    .variants = .{
-        "base_gal",
-        // Entry-list override on a count-form base clip: hold + reorder
-        // + a marker the base doesn't have.
-        .{ .name = "heavy", .overrides = .{
-            .swing = .{ .frames = .{ .{ .f = 1, .run = 2 }, .{ .f = 3, .marker = "impact" }, 2 } },
-        } },
-        // Count-form override on an entry-list base clip (the "vice
-        // versa" direction): flattens holds/markers/reuse away.
-        .{ .name = "swift", .overrides = .{
-            .combo = .{ .frames = 2, .speed = 9.0 },
-        } },
-    },
+    .variants = .{ "base_gal", "heavy", "swift" },
     .clips = .{
-        // Count-form base; `heavy` replaces it with an entry list.
-        .swing = .{ .frames = 4, .mode = .time, .speed = 1.0 },
-        // Entry-list base (hold + marker + file reuse); `swift` replaces
-        // it with a bare count.
-        .combo = .{ .frames = .{ .{ .f = 1, .run = 3, .marker = "windup" }, 2, .{ .f = 1 } }, .mode = .time, .speed = 1.0 },
+        // Count-form base clip; `heavy` overrides it with an entry list
+        // (hold + reorder + a marker the base doesn't have).
+        .swing = .{ .frames = 4, .mode = .time, .speed = 1.0, .overrides = .{
+            .heavy = .{ .frames = .{ .{ .f = 1, .run = 2 }, .{ .f = 3, .marker = "impact" }, 2 } },
+        } },
+        // Entry-list base (hold + marker + file reuse); `swift` overrides it
+        // with a bare count (the "vice versa" direction — flattens the
+        // holds/markers/reuse away).
+        .combo = .{ .frames = .{ .{ .f = 1, .run = 3, .marker = "windup" }, 2, .{ .f = 1 } }, .mode = .time, .speed = 1.0, .overrides = .{
+            .swift = .{ .frames = 2, .speed = 9.0 },
+        } },
     },
 };
 const EntryOverrideAnim = AnimationDef(entry_override_zon);
@@ -449,7 +440,7 @@ test "AnimationDef: no-override defs keep base-identical per-variant rows (#684)
 
 // Comptime-error cases (verified by construction; the repo has no
 // compile-failure harness, so these stay documented rather than run):
-//   - override key naming a nonexistent clip → "overrides unknown clip '…'"
+//   - override key naming a nonexistent VARIANT → "overrides unknown variant '…'"
 //   - override field other than frames/speed/mode/folder → "unknown field '…'"
-//   - a variant whose effective (mode, frames) pair is .static with a
-//     .run > 1 → "holds are meaningless when frame is always slot 0"
+//   - a (clip, variant) whose effective (mode, frames) pair is .static with
+//     a .run > 1 → "holds are meaningless when frame is always slot 0"


### PR DESCRIPTION
Companion engine change for **labelle-studio#61**. The studio editor edits per-variant animation overrides in the **clip row** (clip-major), so the engine's `.zon` override format is reshaped to match: overrides now live in each **clip**, keyed by variant name, and `.variants` goes back to a plain string list.

## Before → after

**Before (variant-major)** — overrides nested under a struct variant:

```zig
.{
    .variants = .{
        "m_bald", "m_beard",
        .{ .name = "w_ginger", .overrides = .{
            .drink = .{ .frames = 8, .speed = 4.0 },
            .carry = .{ .folder = "take_ginger" },
        } },
    },
    .clips = .{
        .idle  = .{ .frames = 1,  .mode = .static },
        .drink = .{ .frames = 10, .mode = .time, .speed = 5.0 },
        .carry = .{ .frames = 4,  .mode = .distance, .speed = 15.0, .folder = "take" },
    },
}
```

**After (clip-major)** — plain-string `.variants`; each clip carries an optional `.overrides` sub-map keyed by variant name:

```zig
.{
    .variants = .{ "m_bald", "m_beard", "w_ginger" },
    .clips = .{
        .idle  = .{ .frames = 1,  .mode = .static },
        .drink = .{ .frames = 10, .mode = .time, .speed = 5.0, .overrides = .{
            .w_ginger = .{ .frames = 8, .speed = 4.0 },
        } },
        .carry = .{ .frames = 4,  .mode = .distance, .speed = 15.0, .folder = "take", .overrides = .{
            .w_ginger = .{ .folder = "take_ginger" },
        } },
    },
}
```

Semantics are **identical**: an override patches the base clip's meta (frames/speed/mode/folder) for that one variant; non-overridden `(clip, variant)` pairs inherit the base. The derived tables stay keyed `[clip][variant]`, so nothing downstream changed.

## Constraints (unchanged, reworded clip-major)

- A clip's `.overrides` must be a **struct** of per-variant overrides.
- Each override **value** may only carry `frames` / `speed` / `mode` / `folder` — never clip identity.
- An override **key** must name a **declared variant** (comptime `@compileError` / runtime `error.UnknownVariant`).
- An effective `.static` clip (for that variant) with **per-slot holds** (`.run > 1`) is rejected — holds are meaningless when the frame is always slot 0.
- `.frames` still accepts **any of the three #664 forms** per variant (count / index list / entry structs with holds+markers) — no "count-form only" restriction.

## Both parsers updated

- **`src/animation_def.zig`** (comptime, source of truth): `clip_entries_2d` and `clip_meta_2d` now walk each clip's `.overrides` keyed by variant name; added `variantIdxByName`; deleted the now-unused `variantNameOf`; the `.variants` enum builds from plain strings again.
- **`src/animation_def_runtime.zig`** (runtime preview/hot-reload): **previously a no-op** for per-variant overrides — now parses a sparse `[]VariantOverride` list and applies it to the jagged sprite-name table, plus a new `clipMetaFor(clip, variant)` and an override-aware `refreshState`. New parse errors mirror the comptime rejects: `UnknownVariant`, `UnknownOverrideField`, `HoldOnStaticClip`, `BadOverrides` (top-level not a struct), `BadOverride` (per-variant value not a struct). `spriteName` now bounds-checks against the actual per-variant row length so shorter/longer overridden rows resolve correctly.

## Migration

**No `.zon` data def used the old variant-major shape** (verified across the repo), so this is a **tests-only migration** — the two engine test fixtures (`animation_def_test.zig`, `animation_def_runtime_test.zig`) were reshaped, and new runtime tests cover meta/sprite patching, `refreshState`, and the five error paths.

Engine version bump **1.76.0 → 1.77.0**. `zig build test` is green (757/757).

https://claude.ai/code/session_01P7YLw4hXFCCaY2LAUt4G1j
