### PR TITLE
fix(engine): surface swallowed errors on the loading→gameplay transition (#697)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -203,6 +203,12 @@ pub fn build(b: *std.Build) void {
         // The cascade iterates a snapshot so the per-child unlink can't
         // invalidate the walk.
         "test/destroy_unlink_test.zig",
+        // #697 — silent-failure hardening on the loading→gameplay
+        // transition: the hot-reload loader swallow (`catch {}`) now
+        // surfaces a loader failure through `game.log.err` instead of
+        // vanishing. Drives a hot reload with a fail-on-demand loader and
+        // asserts the error reaches a capturing log sink.
+        "test/loading_transition_hardening_test.zig",
     };
 
     for (test_files) |test_file| {

--- a/src/game/loop_mixin.zig
+++ b/src/game/loop_mixin.zig
@@ -164,7 +164,21 @@ pub fn Mixin(comptime Game: type) type {
                         // Scene-source override resolution (Play mode /
                         // editor_api) — same pattern as `setScene`.
                         self.loading_scene_name = name;
-                        entry.loader_fn(self) catch {};
+                        // Hot-reload loader failure must NOT vanish (#697).
+                        // `tick` returns void, so there's no caller to
+                        // propagate to — surface it via the engine log
+                        // instead of a bare `catch {}`. Control flow is
+                        // otherwise unchanged: `loading_scene_name` is
+                        // cleared and the scene-load hooks fire below, just
+                        // as they did before, so a partial reload leaves the
+                        // game in the same (best-effort) state — only now
+                        // the failure is visible in the log.
+                        entry.loader_fn(self) catch |err| {
+                            self.log.err(
+                                "[Scene] hot-reload loader for '{s}' failed: {s}",
+                                .{ name, @errorName(err) },
+                            );
+                        };
                         self.loading_scene_name = null;
                         self.emitHook(.{ .scene_load = .{ .name = name } });
                         // Engine `Events` dual-emit (#578).

--- a/src/game/scene_mixin.zig
+++ b/src/game/scene_mixin.zig
@@ -206,7 +206,18 @@ fn bridgeImageAssetsToAtlasManager(game: anytype, assets: []const []const u8) vo
         // Both are normal: the first means we already bridged on
         // an earlier setScene; the second means the asset name
         // doesn't correspond to a registered atlas (e.g. audio).
-        game.atlas_manager.markPendingLoaded(asset_name, handle, null) catch {};
+        // Those two are the only errors `markPendingLoaded` can
+        // return today, so swallow exactly those — but surface
+        // anything else instead of a blanket `catch {}` so a future
+        // genuine bind failure can't vanish silently (#697).
+        game.atlas_manager.markPendingLoaded(asset_name, handle, null) catch |err| {
+            if (err != error.AtlasNotPending and err != error.AtlasNotFound) {
+                game.log.err(
+                    "bridgeImageAssetsToAtlasManager: unexpected atlas bind failure for '{s}': {s}",
+                    .{ asset_name, @errorName(err) },
+                );
+            }
+        };
     }
 }
 
@@ -258,7 +269,20 @@ fn bridgeAllReadyImageAssets_impl(game: anytype) void {
             .image => |t| t,
             else => continue,
         };
-        game.atlas_manager.markPendingLoaded(kv.key_ptr.*, handle, null) catch {};
+        // Idempotent per-tick walk: AtlasNotPending (already bridged)
+        // and AtlasNotFound are expected and swallowed. Anything else
+        // is a genuine bind failure — surface it rather than letting a
+        // blanket `catch {}` hide it (#697). The guard keeps the normal
+        // per-frame path silent (no log spam), since those two are the
+        // only errors `markPendingLoaded` returns today.
+        game.atlas_manager.markPendingLoaded(kv.key_ptr.*, handle, null) catch |err| {
+            if (err != error.AtlasNotPending and err != error.AtlasNotFound) {
+                game.log.err(
+                    "bridgeAllReadyImageAssets: unexpected atlas bind failure for '{s}': {s}",
+                    .{ kv.key_ptr.*, @errorName(err) },
+                );
+            }
+        };
     }
 }
 
@@ -288,7 +312,16 @@ pub fn Mixin(comptime Game: type) type {
             self.scenes.put(name, .{
                 .loader_fn = wrapper,
                 .hooks = hooks_val,
-            }) catch {};
+            }) catch |err| {
+                // A dropped registration silently vanishes here and only
+                // resurfaces much later as an opaque `error.SceneNotFound`
+                // from `setScene('{name}')` with no clue why. Surface the
+                // real cause (OOM) at the point of failure (#697).
+                self.log.err(
+                    "registerScene('{s}') failed: {s} — scene will be missing at setScene time",
+                    .{ name, @errorName(err) },
+                );
+            };
         }
 
         pub fn registerSceneSimple(

--- a/test/loading_transition_hardening_test.zig
+++ b/test/loading_transition_hardening_test.zig
@@ -1,0 +1,124 @@
+//! Silent-failure hardening on the loading→gameplay transition (#697).
+//!
+//! The per-frame hot-reload block in `game/loop_mixin.zig` re-invokes the
+//! current scene's loader. It used to swallow a loader failure with a bare
+//! `catch {}`, so a genuine loader/atlas error on that transition path
+//! vanished with no log. `tick` returns `void` — there is no caller to
+//! propagate to — so the fix surfaces the error through the engine log
+//! (`game.log.err`) while preserving control flow.
+//!
+//! These tests build a Game wired to a capturing log sink, drive a
+//! hot-reload with a loader that fails on demand, and assert the failure
+//! reaches the log (and, as a control, that a successful reload stays
+//! silent so we're catching the real failure, not incidental noise).
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+
+const core = engine.core;
+const game_mod = engine.game_mod;
+
+// ── Capturing log sink ──────────────────────────────────────────────────
+// Records error-level writes so a test can assert the transition surfaces
+// a swallowed loader failure. `err` passes every `min_level` (all / info+ /
+// warn+), so this works regardless of the build's optimize mode.
+const CapturingSink = struct {
+    var err_count: usize = 0;
+    var last_level: ?core.LogLevel = null;
+
+    pub fn write(
+        level: core.LogLevel,
+        comptime _: []const u8,
+        _: f64,
+        comptime _: []const u8,
+        _: anytype,
+    ) void {
+        last_level = level;
+        if (level == .err) err_count += 1;
+    }
+
+    fn reset() void {
+        err_count = 0;
+        last_level = null;
+    }
+};
+
+const EmptyComponents = struct {
+    pub fn has(comptime _: []const u8) bool {
+        return false;
+    }
+    pub fn names() []const []const u8 {
+        return &.{};
+    }
+};
+
+// Game wired to the capturing sink; stubs everywhere else. Mirrors the
+// `GameWith(void)` shape used elsewhere in the test suite, swapping only
+// the log-sink slot so `game.log.err(...)` lands in `CapturingSink`.
+const TestGame = game_mod.GameConfig(
+    core.StubRender(core.MockEcsBackend(u32).Entity),
+    core.MockEcsBackend(u32),
+    engine.StubInput,
+    engine.StubAudio,
+    engine.StubVideo,
+    engine.StubGui,
+    void, // no hooks
+    CapturingSink, // capture logs
+    EmptyComponents,
+    &.{}, // no gizmo categories
+    void, // no game events
+);
+
+// Loader that fails only when armed. The first `setScene` runs it in
+// success mode so the scene commits (`current_scene_name` set); a later
+// hot-reload re-invokes it in failure mode to exercise the swallow site.
+var loader_should_fail = false;
+
+fn flakyLoader(game: *TestGame) anyerror!void {
+    _ = game;
+    if (loader_should_fail) return error.LoaderBoom;
+}
+
+test "hot-reload loader failure is logged, not silently swallowed (#697)" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    loader_should_fail = false;
+    game.registerSceneSimple("main", flakyLoader);
+    try game.setScene("main");
+    try testing.expect(game.getCurrentSceneName() != null);
+
+    // Arm the loader to fail and request a hot reload of the current scene.
+    loader_should_fail = true;
+    game.hot_reload_dirty = true;
+    CapturingSink.reset();
+
+    // The hot-reload block re-invokes the (now failing) loader. Before the
+    // fix this vanished; now it must reach the log at error level.
+    game.tick(0.016);
+
+    try testing.expectEqual(@as(usize, 1), CapturingSink.err_count);
+    try testing.expectEqual(core.LogLevel.err, CapturingSink.last_level.?);
+    // The gate consumed the dirty flag exactly once.
+    try testing.expect(!game.hot_reload_dirty);
+}
+
+test "successful hot-reload logs no error (#697 control)" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    loader_should_fail = false;
+    game.registerSceneSimple("main", flakyLoader);
+    try game.setScene("main");
+
+    game.hot_reload_dirty = true;
+    CapturingSink.reset();
+
+    // Loader succeeds this time — the transition must stay silent, proving
+    // the failure test above is catching the real loader error and not
+    // incidental error logging from the tick pipeline.
+    game.tick(0.016);
+
+    try testing.expectEqual(@as(usize, 0), CapturingSink.err_count);
+}


### PR DESCRIPTION
## What & why

Closes the silent-failure surfaces on the loading→gameplay transition called out in #697. A genuine loader/atlas failure on that path used to vanish with no log, making it undiagnosable (the class of thing that masqueraded as the bgfx #683 investigation).

### Part 1 — swallowed loader/atlas errors (this PR)

- **`loop_mixin.zig` hot-reload loader (the focal `entry.loader_fn(self) catch {}`)** — the per-frame hot-reload block re-invokes the current scene's loader; a failure was dropped silently. `tick` returns `void`, so there is no caller to propagate to — now surfaced via `game.log.err(...)` while **preserving control flow** (`loading_scene_name` still clears, scene-load hooks still fire).
- **`scene_mixin.zig` `registerScene`** — an OOM on `scenes.put` was dropped silently and only resurfaced much later as an opaque `error.SceneNotFound` from `setScene` with no clue why. Now `log.err` at the point of failure.
- **`scene_mixin.zig` atlas-bridge sites** (`bridgeImageAssetsToAtlasManager` ~L209, `bridgeAllReadyImageAssets` ~L261) — `markPendingLoaded`'s entire error set is `{AtlasNotPending, AtlasNotFound}`, both expected/benign idempotency signals (already-bridged / not-an-atlas e.g. audio). These are still swallowed (logging them would spam every frame for every already-bound atlas), but a **guard now `log.err`s any _other_ (genuine) bind failure** instead of a blanket `catch {}`, so a future genuine-failure variant can't vanish. Zero runtime change / no spam on the normal path.

### Test

Adds `test/loading_transition_hardening_test.zig`: builds a `Game` wired to a capturing log sink, drives a hot reload with a fail-on-demand loader, and asserts the failure reaches the log at error level — with a success-path control proving it's catching the real loader error, not incidental noise. Verified with a **negative control**: reverting the `loop_mixin` fix makes the test fail (`expected 1, found 0`).

`zig build test`, `zig build spec`, and `zig build` all green.

### Deferred — Part 2 (Windows native-fatal `std_options.logFn` visibility)

The engine intentionally has no `std_options`/`logFn` of its own — the executable's `logFn` is wired by the **assembler-generated entry point**. Ensuring `std_options.logFn` is set on Windows so native/bgfx-level fatals surface is therefore an assembler entry-point-generation change, not a labelle-engine change (cross-refs cli#277). Deferred to that repo; out of scope for this engine PR. Left as the remaining item on #697.

https://claude.ai/code/session_01P7YLw4hXFCCaY2LAUt4G1j
