### PR TITLE
feat(animation_def): variantFromName for stable variant identity (#665)

### DIFF
--- a/src/animation_def.zig
+++ b/src/animation_def.zig
@@ -188,10 +188,7 @@ pub fn AnimationDef(comptime zon: anytype) type {
         /// (e.g. variant 0 + a warning) since the engine can't know the
         /// game's default skin.
         pub fn variantFromName(name: []const u8) ?Variant {
-            inline for (@typeInfo(Variant).@"enum".fields) |field| {
-                if (std.mem.eql(u8, field.name, name)) return @field(Variant, field.name);
-            }
-            return null;
+            return std.meta.stringToEnum(Variant, name);
         }
     };
 }

--- a/src/animation_def.zig
+++ b/src/animation_def.zig
@@ -165,11 +165,33 @@ pub fn AnimationDef(comptime zon: anytype) type {
         }
 
         /// Map an index to a variant, with fallback to the last variant.
+        ///
+        /// Deprecated as a *persistence* path (#665): a raw index makes
+        /// the `.variants` order load-bearing, so any reorder/rename
+        /// silently corrupts saves. Persist the variant NAME and resolve
+        /// via `variantFromName` instead. `variantFromIndex` remains only
+        /// for migrating pre-manifest saves (translate a saved index
+        /// through the save-time name manifest, then re-resolve by name).
         pub fn variantFromIndex(idx: usize) Variant {
             if (idx < variant_count) {
                 return @enumFromInt(idx);
             }
             return @enumFromInt(variant_count - 1);
+        }
+
+        /// Resolve a variant NAME to its `Variant`, or `null` when no
+        /// variant carries that name (renamed or deleted). This is the
+        /// stable-identity persistence path (#665): unlike an index, a
+        /// name survives reordering the `.variants` list. Comptime-
+        /// unrolled string compare — one branch per variant, no
+        /// allocation. Callers translate `null` into their own fallback
+        /// (e.g. variant 0 + a warning) since the engine can't know the
+        /// game's default skin.
+        pub fn variantFromName(name: []const u8) ?Variant {
+            inline for (@typeInfo(Variant).@"enum".fields) |field| {
+                if (std.mem.eql(u8, field.name, name)) return @field(Variant, field.name);
+            }
+            return null;
         }
     };
 }

--- a/test/animation_def_test.zig
+++ b/test/animation_def_test.zig
@@ -67,6 +67,22 @@ test "AnimationDef: variantFromIndex with valid and out-of-range" {
     try testing.expectEqual(TestAnim.variants.w_india, TestAnim.variantFromIndex(99));
 }
 
+test "AnimationDef: variantFromName hit, miss, round-trip (#665)" {
+    const V = TestAnim.variants;
+    // Hit — resolves each name to its variant regardless of position.
+    try testing.expectEqual(@as(?V, V.m_bald), TestAnim.variantFromName("m_bald"));
+    try testing.expectEqual(@as(?V, V.m_beard), TestAnim.variantFromName("m_beard"));
+    try testing.expectEqual(@as(?V, V.w_india), TestAnim.variantFromName("w_india"));
+    // Miss — a renamed/deleted variant resolves to null (caller falls back).
+    try testing.expectEqual(@as(?V, null), TestAnim.variantFromName("does_not_exist"));
+    try testing.expectEqual(@as(?V, null), TestAnim.variantFromName(""));
+    // Round-trip: name → variant → name is the identity for every variant.
+    inline for (.{ "m_bald", "m_beard", "w_india" }) |nm| {
+        const v = TestAnim.variantFromName(nm).?;
+        try testing.expectEqualStrings(nm, TestAnim.variantName(v));
+    }
+}
+
 test "AnimationDef: clipName and variantName" {
     try testing.expectEqualStrings("walk", TestAnim.clipName(.walk));
     try testing.expectEqualStrings("m_beard", TestAnim.variantName(.m_beard));


### PR DESCRIPTION
Engine half of #665 — persist a character's animation variant by **name**, not a raw index, so reordering `.variants` can't corrupt saves.

## What this adds
- `AnimationDef(...).variantFromName(name: []const u8) ?Variant` — name → variant resolver (`std.meta.stringToEnum`), `null` on a renamed/deleted variant so the caller supplies its own fallback (the engine can't know the game's default skin).
- `variantFromIndex` gains a doc note deprecating it **as a persistence path** — it stays only for migrating pre-existing saves.
- Unit tests: hit / miss / empty-string / `name → variant → name` round-trip.

## Key finding (informs the FP half)
The ticket assumed labelle-core's `Saveable` serializes enum fields via `@intFromEnum` (making `.variants` order load-bearing). **That is no longer true.** As of labelle-core 1.24.0, `serde.writeComponent` writes enums by `@tagName` and `readComponent` reads them via `std.meta.stringToEnum(...) orelse error.InvalidEnumTag` — enums already persist **by name**. Combined with FP having already typed `Worker.variant` / `AnimationState.variant` as enums (post-#601 pack-wall flip), the core acceptance criterion (reorder-safety) is already met by name-based serde; the per-save **manifest** the ticket proposed is redundant and is intentionally NOT built. See the FP PR for the full write-up + the reorder-safety golden test.

`variantFromName` remains the useful engine primitive: the name→enum resolver that index-based pickers convert through, and the documented replacement for `variantFromIndex` in any persistence path.

## Out of scope
- Variant overrides/inheritance (#666 — depends on this).
- Clip identity by name (clips are re-derived by gameplay FSMs post-load).

Do not merge/tag — coordinated with the FP PR at gating.

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw