### PR TITLE
sprite_animation: progress/duration query, per-animation speed, events (#625)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -103,6 +103,7 @@ pub fn build(b: *std.Build) void {
         "test/tween_test.zig",
         "test/sprite_animation_test.zig",
         "test/sprite_animation_tick_test.zig",
+        "test/sprite_animation_events_test.zig",
         "test/sprite_by_field_test.zig",
         "test/sprite_by_field_tick_test.zig",
         "test/scene_assets_hooks_test.zig",

--- a/src/animation_events.zig
+++ b/src/animation_events.zig
@@ -19,7 +19,6 @@
 /// All event bookkeeping (pending buffers, `finished_emitted` bits,
 /// repetition counters) is runtime-only and never serialized — mirrors
 /// the existing frame/timer save policy.
-
 const std = @import("std");
 
 /// Fired when a clip-frame carrying a marker becomes current.
@@ -110,5 +109,14 @@ pub const PendingBuf = struct {
 /// of a 4-frame clip would overflow u16 in ~1.2h; saturate, don't wrap).
 pub fn satAddU16(a: u16, b: u16) u16 {
     const sum: u32 = @as(u32, a) + @as(u32, b);
+    return if (sum > std.math.maxInt(u16)) std.math.maxInt(u16) else @intCast(sum);
+}
+
+/// Saturating add of a `usize` delta onto the u16 repetition counter.
+/// Lets a multi-wrap tick bump `repetition` arithmetically (O(1)) instead
+/// of iterating once per wrap — a huge `dt` (tab resume, debugger pause)
+/// stays bounded. Saturates at `maxInt(u16)`.
+pub fn satAddU16Count(a: u16, b: usize) u16 {
+    const sum: usize = @as(usize, a) + b;
     return if (sum > std.math.maxInt(u16)) std.math.maxInt(u16) else @intCast(sum);
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -293,6 +293,39 @@ pub const Events = struct {
         paused: bool,
     };
 
+    // ── SpriteAnimation playback events (#625) ────────────────────────
+    //
+    // Emitted by the engine's `sprite_animation_tick` driver (NOT the
+    // in-process `HookPayload` path — these have no HookPayload mirror,
+    // like the input events above). A project opts in purely by declaring
+    // the variant on its `GameEvents`; when absent, the driver's whole
+    // events path folds away and the tick uses the plain `advance`. Wire
+    // a flow / hook to `engine__anim_frame` for footstep / hit cues,
+    // `engine__anim_complete` for one-shot `.once` clips, and
+    // `engine__anim_loop` for loop-wrap / ping-pong-reversal cadence.
+
+    /// Fired the tick a `SpriteAnimation` LANDS on a frame listed in its
+    /// `event_frames` (footstep / hit / spawn cue). `frame` is the 0-based
+    /// index it landed on.
+    pub const anim_frame = struct {
+        entity: u32,
+        frame: u8 = 0,
+    };
+
+    /// Fired exactly once when a `.once` `SpriteAnimation` reaches its
+    /// final frame. `.loop` / `.ping_pong` clips never emit this.
+    pub const anim_complete = struct {
+        entity: u32,
+    };
+
+    /// Fired on every `.loop` wrap and every `.ping_pong` endpoint
+    /// reversal. `repetition` is the saturating loop/reversal count at
+    /// the moment it fired.
+    pub const anim_loop = struct {
+        entity: u32,
+        repetition: u16 = 0,
+    };
+
     // ── Input events (labelle-gui#208, Option B) ─────────────────
     // Engine-hosted input events scanned in `Game.tick` through the
     // unified `InputInterface`. Flows handle them via

--- a/src/sprite_animation.zig
+++ b/src/sprite_animation.zig
@@ -67,6 +67,30 @@ pub const SpriteAnimation = struct {
     fps: f32,
     mode: AnimationMode = .loop,
 
+    /// Per-animation playback-speed multiplier (#625), applied ON TOP of
+    /// the global `time_scale` by the tick (`advance` receives an
+    /// already-speed-scaled `dt`). `1.0` reproduces today's behavior;
+    /// `2.0` plays twice as fast; `0` pauses just this animation.
+    /// NEGATIVE values are treated as paused — the tick clamps the
+    /// effective rate to `>= 0`, so a negative `speed` never runs the
+    /// clip in reverse (reverse playback is a deferred #625 item).
+    ///
+    /// Because the multiply lives in the tick, the component's internal
+    /// clock (`timer`/`frame`) stays in clip-time, so `progress()` /
+    /// `elapsed()` are speed-INDEPENDENT fractions; only the wall-clock
+    /// `duration()` folds `speed` in.
+    speed: f32 = 1.0,
+
+    /// Frame indices (0-based) that fire an `engine__anim_frame` event
+    /// the tick the animation LANDS on them — footstep / hit / spawn
+    /// cue frames (#625). Borrowed comptime slice, like `frames`; empty
+    /// (the default) means no per-frame events and reproduces today's
+    /// behavior. v1 detects "landed on", not "crossed": a `dt` spike
+    /// that steps PAST a marked frame without landing on it misses it
+    /// (documented follow-up — the `AnimationDef` path already does
+    /// crossing-accurate markers via beat iteration).
+    event_frames: []const u8 = &.{},
+
     // Runtime state — excluded from save.
     timer: f32 = 0,
     frame: u8 = 0,
@@ -206,7 +230,28 @@ pub const SpriteAnimation = struct {
                 }
             },
         }
+
+        // #625 per-frame events: fire when the tick LANDED the animation
+        // on a marked frame. Runs after the mode switch so it's uniform
+        // across loop/once/ping_pong. Only emitted when the frame changed
+        // (steady-state ticks never re-fire) and only when an event sink
+        // is present (plain `advance` skips this entirely).
+        if (out) |o| {
+            if (self.frame != old_frame and self.frameIsMarked(self.frame)) {
+                _ = o.append(.{ .kind = .marker, .frame = self.frame });
+            }
+        }
+
         return self.frame != old_frame;
+    }
+
+    /// True when `f` is listed in `event_frames`. Linear scan — the list
+    /// is a handful of cue frames in practice.
+    fn frameIsMarked(self: *const SpriteAnimation, f: u8) bool {
+        for (self.event_frames) |m| {
+            if (m == f) return true;
+        }
+        return false;
     }
 
     fn emitReversal(self: *SpriteAnimation, out: ?*anim_events.PendingBuf) void {
@@ -236,5 +281,70 @@ pub const SpriteAnimation = struct {
     pub fn isFinished(self: *const SpriteAnimation) bool {
         if (self.mode != .once or self.frames.len == 0) return false;
         return @as(usize, self.frame) + 1 >= self.frames.len;
+    }
+
+    // ── Progress / duration queries (#625) ──────────────────────────
+    //
+    // All pure reads of the current state — no mutation, no dependency
+    // on the tick. `elapsed()` / `clipDuration()` / `progress()` work in
+    // CLIP-TIME (the animation's own `timer`/`frame` clock, which the
+    // speed-scaled tick advances), so they're speed-INDEPENDENT. Only
+    // `duration()` folds `speed` in to report wall-clock seconds.
+
+    /// `true` once a `.once` clip has played through to its last frame
+    /// (alias of `isFinished`, named per #625). `.loop` / `.ping_pong`
+    /// never complete; a zero-frame clip never completes.
+    pub fn isComplete(self: *const SpriteAnimation) bool {
+        return self.isFinished();
+    }
+
+    /// Effective playback rate: `speed` when positive, else `0` (paused).
+    /// Negative `speed` is paused, never reverse (see the field doc).
+    fn effectiveSpeed(self: *const SpriteAnimation) f32 {
+        return if (self.speed > 0) self.speed else 0;
+    }
+
+    /// Clip-seconds a single frame is shown at `fps` (speed-independent).
+    /// `0` for a degenerate `fps <= 0`.
+    pub fn frameDuration(self: *const SpriteAnimation) f32 {
+        if (self.fps <= 0) return 0;
+        return 1.0 / self.fps;
+    }
+
+    /// Intrinsic clip length in clip-seconds: `frames.len / fps`
+    /// (speed-independent — the span `timer`/`frame` measure against).
+    /// `0` for a degenerate clip (no frames or `fps <= 0`).
+    pub fn clipDuration(self: *const SpriteAnimation) f32 {
+        return @as(f32, @floatFromInt(self.frames.len)) * self.frameDuration();
+    }
+
+    /// Total clip play time in WALL-CLOCK seconds, adjusted by `speed`:
+    /// `clipDuration() / speed`. At `speed = 2` a 1s clip reports `0.5s`.
+    /// When paused (`speed <= 0`) there IS no finite wall-clock duration,
+    /// so this reports the intrinsic `clipDuration()` (the `speed = 1`
+    /// length) rather than infinity. `0` for a degenerate clip.
+    pub fn duration(self: *const SpriteAnimation) f32 {
+        const s = self.effectiveSpeed();
+        if (s <= 0) return self.clipDuration();
+        return self.clipDuration() / s;
+    }
+
+    /// Clip-seconds consumed so far: `frame * frameDuration + timer`
+    /// (speed-independent). For a looping clip this ramps 0 → clip length
+    /// each cycle; for `.ping_pong` it tracks the current frame position.
+    pub fn elapsed(self: *const SpriteAnimation) f32 {
+        return @as(f32, @floatFromInt(self.frame)) * self.frameDuration() + self.timer;
+    }
+
+    /// Playback progress in `[0, 1]`: `elapsed() / clipDuration()`,
+    /// clamped. Speed-independent (both terms are clip-time). Returns
+    /// exactly `1.0` once `isComplete()` (a finished `.once` clip lands
+    /// on its last frame with `timer` short of a full frame, so the raw
+    /// ratio would read just under 1). `0` for a degenerate clip.
+    pub fn progress(self: *const SpriteAnimation) f32 {
+        if (self.isComplete()) return 1.0;
+        const total = self.clipDuration();
+        if (total <= 0) return 0;
+        return std.math.clamp(self.elapsed() / total, 0, 1);
     }
 };

--- a/src/sprite_animation.zig
+++ b/src/sprite_animation.zig
@@ -300,7 +300,9 @@ pub const SpriteAnimation = struct {
 
     /// Effective playback rate: `speed` when positive, else `0` (paused).
     /// Negative `speed` is paused, never reverse (see the field doc).
-    fn effectiveSpeed(self: *const SpriteAnimation) f32 {
+    /// Single source of truth for the clamped rate — the tick multiplies
+    /// `dt` by this, and `duration()` divides by it.
+    pub fn effectiveSpeed(self: *const SpriteAnimation) f32 {
         return if (self.speed > 0) self.speed else 0;
     }
 

--- a/src/sprite_animation.zig
+++ b/src/sprite_animation.zig
@@ -83,13 +83,22 @@ pub const SpriteAnimation = struct {
 
     /// Frame indices (0-based) that fire an `engine__anim_frame` event
     /// the tick the animation LANDS on them — footstep / hit / spawn
-    /// cue frames (#625). Borrowed comptime slice, like `frames`; empty
-    /// (the default) means no per-frame events and reproduces today's
-    /// behavior. v1 detects "landed on", not "crossed": a `dt` spike
-    /// that steps PAST a marked frame without landing on it misses it
-    /// (documented follow-up — the `AnimationDef` path already does
-    /// crossing-accurate markers via beat iteration).
-    event_frames: []const u8 = &.{},
+    /// cue frames (#625). Borrowed slice; empty (the default) means no
+    /// per-frame events and reproduces today's behavior.
+    ///
+    /// `u16` (not `u8`) ON PURPOSE: the JSONC scene-bridge deserializer
+    /// special-cases every `[]const u8` field as a STRING (for the intern
+    /// pool), so a `[]const u8` here couldn't be authored as a number
+    /// array — `"event_frames": [2, 5]` would be parsed as a string. A
+    /// `[]const u16` falls through to the generic slice→number-array
+    /// branch, so scenes / prefabs can author it. Indices `>= frames.len`
+    /// (or above the `u8` frame ceiling) simply never match — harmless.
+    ///
+    /// v1 detects "landed on", not "crossed": a `dt` spike that steps
+    /// PAST a marked frame without landing on it misses it (documented
+    /// follow-up — the `AnimationDef` path already does crossing-accurate
+    /// markers via beat iteration).
+    event_frames: []const u16 = &.{},
 
     // Runtime state — excluded from save.
     timer: f32 = 0,
@@ -105,6 +114,19 @@ pub const SpriteAnimation = struct {
     finished_emitted: bool = false,
     repetition: u16 = 0,
 
+    /// Comptime selector of which event KINDS `advanceEventsMasked` queues
+    /// into the `PendingBuf` (#625). The tick builds this from the
+    /// project's declared `engine__anim_*` variants so the fixed-capacity
+    /// buffer only ever holds events the game will consume — a project
+    /// listening to only `anim_frame` never has its buffer crowded out by
+    /// `loop_end` events from a multi-wrap tick. Defaults to all-on (what
+    /// the back-compat `advanceEvents` requests).
+    pub const EventMask = struct {
+        frame: bool = true,
+        clip_end: bool = true,
+        loop_end: bool = true,
+    };
+
     /// Advance the animation by `dt` seconds. Pure state machine —
     /// does not touch the entity's Sprite. The caller (a tick system
     /// that walks `view(.{SpriteAnimation, Sprite}, .{})`) decides
@@ -116,19 +138,39 @@ pub const SpriteAnimation = struct {
     /// which is the common case for single-frame animations or ticks
     /// that fall within the same frame.
     pub fn advance(self: *SpriteAnimation, dt: f32) bool {
-        return self.advanceImpl(dt, null);
+        return self.advanceImpl(dt, null, .{});
     }
 
-    /// Like `advance`, but appends lifecycle events (#670) to `out`:
-    /// `AnimClipEnd` once when a `.once` clip finishes, `AnimLoopEnd` on
-    /// each `.loop` wrap and each `.ping_pong` endpoint reversal. The
-    /// driver adds the entity and forwards `out` to `game.emit`. Props
-    /// have no per-frame markers in v1 (lifecycle only).
+    /// Like `advance`, but appends ALL event kinds to `out`: `AnimClipEnd`
+    /// once when a `.once` clip finishes, `AnimLoopEnd` on each `.loop`
+    /// wrap and each `.ping_pong` endpoint reversal, and a per-frame marker
+    /// when landing on an `event_frames` index. The driver adds the entity
+    /// and forwards `out` to `game.emit`. Kept for callers that want every
+    /// kind (e.g. #670 tests); the tick uses `advanceEventsMasked`.
     pub fn advanceEvents(self: *SpriteAnimation, dt: f32, out: *anim_events.PendingBuf) bool {
-        return self.advanceImpl(dt, out);
+        return self.advanceImpl(dt, out, .{});
     }
 
-    fn advanceImpl(self: *SpriteAnimation, dt: f32, out: ?*anim_events.PendingBuf) bool {
+    /// Like `advanceEvents`, but only queues the event kinds selected by
+    /// the comptime `mask` (#625) — the fixed `PendingBuf` then holds only
+    /// events the project actually listens to. The `repetition` counter
+    /// still advances arithmetically across every wrap even for kinds that
+    /// aren't queued, so counts stay accurate if the game later reads them.
+    pub fn advanceEventsMasked(
+        self: *SpriteAnimation,
+        dt: f32,
+        out: *anim_events.PendingBuf,
+        comptime mask: EventMask,
+    ) bool {
+        return self.advanceImpl(dt, out, mask);
+    }
+
+    fn advanceImpl(
+        self: *SpriteAnimation,
+        dt: f32,
+        out: ?*anim_events.PendingBuf,
+        comptime mask: EventMask,
+    ) bool {
         // Degenerate case: empty frames or zero/negative fps. No
         // advance, no mutation. Protects against malformed data
         // (e.g. a prefab with `"frames": []`) without a compile-time
@@ -166,14 +208,31 @@ pub const SpriteAnimation = struct {
                 const total: usize = @as(usize, self.frame) + steps;
                 self.frame = @intCast(total % self.frames.len);
                 if (out) |o| {
-                    // One AnimLoopEnd per boundary crossed this tick. The
-                    // repetition counter advances for EVERY wrap even when
-                    // the buffer caps emission — it must stay arithmetically
-                    // accurate across the full span.
-                    var wraps: usize = total / self.frames.len;
-                    while (wraps > 0) : (wraps -= 1) {
-                        self.repetition = anim_events.satAddU16(self.repetition, 1);
-                        _ = o.append(.{ .kind = .loop_end, .repetition = self.repetition });
+                    const wraps: usize = total / self.frames.len;
+                    if (wraps > 0) {
+                        const start_rep = self.repetition;
+                        // Advance the running count arithmetically — O(1),
+                        // accurate even on a huge multi-wrap `dt` spike (tab
+                        // resume, debugger pause) that a per-wrap loop would
+                        // turn into an unbounded traversal.
+                        self.repetition = anim_events.satAddU16Count(start_rep, wraps);
+                        if (comptime mask.loop_end) {
+                            // Emit at most a buffer's worth of AnimLoopEnd —
+                            // the overflow tail is dropped (same observable
+                            // result as the old append-until-full loop, but
+                            // now bounded by `max_pending`, not `wraps`).
+                            // Each emitted event carries its true running
+                            // repetition.
+                            const room: usize = anim_events.max_pending - o.len;
+                            const emit_n: usize = @min(wraps, room);
+                            var k: usize = 1;
+                            while (k <= emit_n) : (k += 1) {
+                                _ = o.append(.{
+                                    .kind = .loop_end,
+                                    .repetition = anim_events.satAddU16Count(start_rep, k),
+                                });
+                            }
+                        }
                     }
                 }
             },
@@ -186,9 +245,11 @@ pub const SpriteAnimation = struct {
                 if (out) |o| {
                     // Fire AnimClipEnd exactly once, the tick it lands on
                     // the final frame.
-                    if (self.frame + 1 >= len_u8 and !self.finished_emitted) {
-                        self.finished_emitted = true;
-                        _ = o.append(.{ .kind = .clip_end });
+                    if (comptime mask.clip_end) {
+                        if (self.frame + 1 >= len_u8 and !self.finished_emitted) {
+                            self.finished_emitted = true;
+                            _ = o.append(.{ .kind = .clip_end });
+                        }
                     }
                 }
             },
@@ -213,7 +274,7 @@ pub const SpriteAnimation = struct {
                             if (self.frame + 1 >= len_u8) {
                                 self.forward = false;
                                 self.frame -= 1;
-                                self.emitReversal(out); // #670: endpoint reversal
+                                self.emitReversal(out, mask.loop_end); // #670: endpoint reversal
                             } else {
                                 self.frame += 1;
                             }
@@ -221,7 +282,7 @@ pub const SpriteAnimation = struct {
                             if (self.frame == 0) {
                                 self.forward = true;
                                 self.frame += 1;
-                                self.emitReversal(out);
+                                self.emitReversal(out, mask.loop_end);
                             } else {
                                 self.frame -= 1;
                             }
@@ -236,30 +297,37 @@ pub const SpriteAnimation = struct {
         // across loop/once/ping_pong. Only emitted when the frame changed
         // (steady-state ticks never re-fire) and only when an event sink
         // is present (plain `advance` skips this entirely).
-        if (out) |o| {
-            if (self.frame != old_frame and self.frameIsMarked(self.frame)) {
-                _ = o.append(.{ .kind = .marker, .frame = self.frame });
+        if (comptime mask.frame) {
+            if (out) |o| {
+                if (self.frame != old_frame and self.frameIsMarked(self.frame)) {
+                    _ = o.append(.{ .kind = .marker, .frame = self.frame });
+                }
             }
         }
 
         return self.frame != old_frame;
     }
 
-    /// True when `f` is listed in `event_frames`. Linear scan — the list
-    /// is a handful of cue frames in practice.
+    /// True when the current frame `f` is listed in `event_frames`. Linear
+    /// scan — the list is a handful of cue frames in practice. `f` is the
+    /// `u8` frame index widened to compare against the `u16` cue values.
     fn frameIsMarked(self: *const SpriteAnimation, f: u8) bool {
         for (self.event_frames) |m| {
-            if (m == f) return true;
+            if (m == @as(u16, f)) return true;
         }
         return false;
     }
 
-    fn emitReversal(self: *SpriteAnimation, out: ?*anim_events.PendingBuf) void {
+    /// Record a `.ping_pong` endpoint reversal: always bump the running
+    /// `repetition`, and append an `AnimLoopEnd` only when `emit_loop`
+    /// (the project listens for loop events). Bumping regardless keeps the
+    /// count accurate even when loop events aren't queued.
+    fn emitReversal(self: *SpriteAnimation, out: ?*anim_events.PendingBuf, comptime emit_loop: bool) void {
         if (out) |o| {
-            // Count the reversal even when the buffer is full — the
-            // repetition counter must not lag actual playback.
             self.repetition = anim_events.satAddU16(self.repetition, 1);
-            _ = o.append(.{ .kind = .loop_end, .repetition = self.repetition });
+            if (comptime emit_loop) {
+                _ = o.append(.{ .kind = .loop_end, .repetition = self.repetition });
+            }
         }
     }
 

--- a/src/sprite_animation_tick.zig
+++ b/src/sprite_animation_tick.zig
@@ -29,11 +29,16 @@
 //! across two files (and two PRs).
 
 const SpriteAnimation = @import("sprite_animation.zig").SpriteAnimation;
+const anim_events = @import("animation_events.zig");
 
 /// Advance all `SpriteAnimation` components by `dt` and update their
 /// sibling Sprite on frame flips.
 ///
 /// Semantics:
+/// - `dt` is the time-scaled frame delta. Each animation's per-clip
+///   `speed` (#625) is applied ON TOP here (`dt * max(0, speed)`), so a
+///   `speed = 2` clip advances twice as fast and `speed <= 0` pauses it
+///   (negative is paused, never reverse).
 /// - Entities without both `SpriteAnimation` and `Sprite` are skipped.
 /// - On a frame flip, `Sprite.sprite_name` is written. Atlas fields
 ///   (`source_rect`, `texture`, `display_*`) are NOT touched here —
@@ -42,16 +47,42 @@ const SpriteAnimation = @import("sprite_animation.zig").SpriteAnimation;
 ///   scaling.
 /// - Idle ticks (sub-frame `dt`) write nothing and cost only the
 ///   timer bookkeeping inside `advance`.
+///
+/// ## Playback events (#625)
+///
+/// When the project's `GameEvents` declares any of `engine__anim_frame`
+/// / `engine__anim_complete` / `engine__anim_loop`, the tick advances
+/// through `advanceEvents` and forwards the queued lifecycle / frame-cue
+/// events to `game.emit` (buffered; drained end-of-frame), injecting the
+/// entity the pure `advance` methods don't know. When NONE are wanted the
+/// whole events path folds away at comptime and the tick uses the plain
+/// `advance` — an events-less game pays nothing.
 pub fn tick(game: anytype, dt: f32) void {
     const Game = @TypeOf(game.*);
     const Sprite = Game.SpriteComp;
+
+    const events_wanted = comptime Game.engineEventWanted("engine__anim_frame") or
+        Game.engineEventWanted("engine__anim_complete") or
+        Game.engineEventWanted("engine__anim_loop");
 
     var view = game.ecs_backend.view(.{ SpriteAnimation, Sprite }, .{});
     defer view.deinit();
 
     while (view.next()) |entity| {
         const anim = game.ecs_backend.getComponent(entity, SpriteAnimation) orelse continue;
-        if (!anim.advance(dt)) continue;
+
+        // Per-clip playback speed on top of the (already time-scaled) dt.
+        // `max(0, speed)`: 0 / negative → paused, never reverse.
+        const eff_dt = dt * @max(@as(f32, 0), anim.speed);
+
+        const changed = if (comptime events_wanted) blk: {
+            var buf: anim_events.PendingBuf = .{};
+            const c = anim.advanceEvents(eff_dt, &buf);
+            forwardEvents(game, entity, &buf);
+            break :blk c;
+        } else anim.advance(eff_dt);
+
+        if (!changed) continue;
 
         const new_name = anim.currentSprite() orelse continue;
         const sprite = game.ecs_backend.getComponent(entity, Sprite) orelse continue;
@@ -64,5 +95,21 @@ pub fn tick(game: anytype, dt: f32) void {
         // only place the visual change gets signalled, so the call
         // has to stay here rather than being pushed downstream.
         game.renderer.markVisualDirty(entity);
+    }
+}
+
+/// Forward the entity-less `PendingBuf` produced by `advanceEvents` to
+/// the game's buffered event bus, mapping each `PendingKind` onto its
+/// `engine__anim_*` variant and injecting the entity. `emitEngineEvent`
+/// folds away per-tag when a given variant isn't declared, so a project
+/// that listens to only one of the three pays for only that one.
+fn forwardEvents(game: anytype, entity: anytype, buf: *const anim_events.PendingBuf) void {
+    const id: u32 = @intCast(entity);
+    for (buf.slice()) |e| {
+        switch (e.kind) {
+            .marker => game.emitEngineEvent("engine__anim_frame", .{ .entity = id, .frame = e.frame }),
+            .clip_end => game.emitEngineEvent("engine__anim_complete", .{ .entity = id }),
+            .loop_end => game.emitEngineEvent("engine__anim_loop", .{ .entity = id, .repetition = e.repetition }),
+        }
     }
 }

--- a/src/sprite_animation_tick.zig
+++ b/src/sprite_animation_tick.zig
@@ -61,9 +61,17 @@ pub fn tick(game: anytype, dt: f32) void {
     const Game = @TypeOf(game.*);
     const Sprite = Game.SpriteComp;
 
-    const events_wanted = comptime Game.engineEventWanted("engine__anim_frame") or
-        Game.engineEventWanted("engine__anim_complete") or
-        Game.engineEventWanted("engine__anim_loop");
+    // Queue ONLY the event kinds this project declared. A project that
+    // listens to just `anim_frame` must not have its fixed `PendingBuf`
+    // filled with `loop_end` events from a multi-wrap tick (which would
+    // crowd out / drop the frame events it wants). The mask is comptime,
+    // so unwanted kinds are never even queued.
+    const mask = comptime SpriteAnimation.EventMask{
+        .frame = Game.engineEventWanted("engine__anim_frame"),
+        .clip_end = Game.engineEventWanted("engine__anim_complete"),
+        .loop_end = Game.engineEventWanted("engine__anim_loop"),
+    };
+    const events_wanted = comptime mask.frame or mask.clip_end or mask.loop_end;
 
     var view = game.ecs_backend.view(.{ SpriteAnimation, Sprite }, .{});
     defer view.deinit();
@@ -77,7 +85,7 @@ pub fn tick(game: anytype, dt: f32) void {
 
         const changed = if (comptime events_wanted) blk: {
             var buf: anim_events.PendingBuf = .{};
-            const c = anim.advanceEvents(eff_dt, &buf);
+            const c = anim.advanceEventsMasked(eff_dt, &buf, mask);
             // Most ticks queue nothing (sub-frame or an event-less frame);
             // skip the entity cast + slice walk unless something fired.
             if (buf.len > 0) forwardEvents(game, entity, &buf);

--- a/src/sprite_animation_tick.zig
+++ b/src/sprite_animation_tick.zig
@@ -72,13 +72,15 @@ pub fn tick(game: anytype, dt: f32) void {
         const anim = game.ecs_backend.getComponent(entity, SpriteAnimation) orelse continue;
 
         // Per-clip playback speed on top of the (already time-scaled) dt.
-        // `max(0, speed)`: 0 / negative → paused, never reverse.
-        const eff_dt = dt * @max(@as(f32, 0), anim.speed);
+        // `effectiveSpeed()`: 0 / negative → paused, never reverse.
+        const eff_dt = dt * anim.effectiveSpeed();
 
         const changed = if (comptime events_wanted) blk: {
             var buf: anim_events.PendingBuf = .{};
             const c = anim.advanceEvents(eff_dt, &buf);
-            forwardEvents(game, entity, &buf);
+            // Most ticks queue nothing (sub-frame or an event-less frame);
+            // skip the entity cast + slice walk unless something fired.
+            if (buf.len > 0) forwardEvents(game, entity, &buf);
             break :blk c;
         } else anim.advance(eff_dt);
 

--- a/test/jsonc/deserializer_test.zig
+++ b/test/jsonc/deserializer_test.zig
@@ -37,6 +37,46 @@ test "deserialize: integer to u8 (out of range returns null)" {
     try testing.expect(deserializer.deserialize(u8, v, testing.allocator) == null);
 }
 
+test "deserialize: integer array to []const u16 (event_frames authorable)" {
+    // Regression for #718 codex P2 #1: `SpriteAnimation.event_frames` must
+    // be authorable as a NUMBER array in JSONC. `[]const u8` is string-
+    // special-cased (interned), so the field is `[]const u16`, which lands
+    // in the generic slice→int branch below.
+    var items = [_]SceneValue{ .{ .integer = 2 }, .{ .integer = 5 } };
+    const v = SceneValue{ .array = .{ .items = &items } };
+    const out = deserializer.deserialize([]const u16, v, testing.allocator).?;
+    defer testing.allocator.free(out);
+    try testing.expectEqual(@as(usize, 2), out.len);
+    try testing.expectEqual(@as(u16, 2), out[0]);
+    try testing.expectEqual(@as(u16, 5), out[1]);
+}
+
+test "deserialize: SpriteAnimation with event_frames [2, 5] round-trips" {
+    // End-to-end proof that a scene/prefab can author `event_frames`. Only
+    // the no-default fields (`frames`, `fps`) plus `event_frames` are set;
+    // everything else falls back to struct defaults.
+    const SpriteAnimation = engine.SpriteAnimation;
+    var frame_names = [_]SceneValue{ .{ .string = "a.png" }, .{ .string = "b.png" } };
+    var cue_frames = [_]SceneValue{ .{ .integer = 2 }, .{ .integer = 5 } };
+    var entries = [_]SceneValue.Object.Entry{
+        .{ .key = "frames", .value = .{ .array = .{ .items = &frame_names } } },
+        .{ .key = "fps", .value = .{ .integer = 6 } },
+        .{ .key = "event_frames", .value = .{ .array = .{ .items = &cue_frames } } },
+    };
+    const obj = SceneValue{ .object = .{ .entries = &entries } };
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const anim = deserializer.deserialize(SpriteAnimation, obj, arena.allocator()).?;
+
+    try testing.expectEqual(@as(f32, 6), anim.fps);
+    try testing.expectEqual(@as(usize, 2), anim.event_frames.len);
+    try testing.expectEqual(@as(u16, 2), anim.event_frames[0]);
+    try testing.expectEqual(@as(u16, 5), anim.event_frames[1]);
+    // Untouched fields keep their defaults.
+    try testing.expectEqual(@as(f32, 1.0), anim.speed);
+}
+
 test "deserialize: bool" {
     const t = SceneValue{ .boolean = true };
     const f = SceneValue{ .boolean = false };

--- a/test/sprite_animation_events_test.zig
+++ b/test/sprite_animation_events_test.zig
@@ -1,0 +1,213 @@
+//! SpriteAnimation playback events end-to-end (#625).
+//!
+//! Drives the `sprite_animation_tick` against a Game whose `GameEvents`
+//! declares the three `engine__anim_*` variants and a recorder hook, then
+//! drains `dispatchEvents` to observe what the tick forwarded:
+//!
+//!   engine__anim_frame     — landed on a frame listed in `event_frames`
+//!   engine__anim_complete  — a `.once` clip reached its last frame
+//!   engine__anim_loop      — a `.loop` wrap / `.ping_pong` reversal
+//!
+//! The forwarding is comptime-gated on `@hasField(GameEvents, tag)`, so an
+//! events-less game (`GameEvents = void`) never enters this path — that
+//! zero-cost case is covered by `sprite_animation_tick_test.zig`, which
+//! runs the identical tick with no events union.
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+const core = @import("labelle-core");
+
+const SpriteAnimation = engine.SpriteAnimation;
+const spriteAnimationTick = engine.spriteAnimationTick;
+
+const game_mod = engine.game_mod;
+const scene_mod = engine.scene_mod;
+const ComponentRegistry = scene_mod.ComponentRegistry;
+
+const TestComponents = ComponentRegistry(.{
+    .SpriteAnimation = SpriteAnimation,
+});
+
+const MockEcs = core.MockEcsBackend(u32);
+
+// ── GameEvents union with the three playback variants ──────────────
+const AnimGameEvents = union(enum) {
+    engine__anim_frame: engine.Events.anim_frame,
+    engine__anim_complete: engine.Events.anim_complete,
+    engine__anim_loop: engine.Events.anim_loop,
+};
+
+// ── Recorder hook ──────────────────────────────────────────────────
+const Recorder = struct {
+    frame_count: usize = 0,
+    complete_count: usize = 0,
+    loop_count: usize = 0,
+
+    last_frame_entity: u32 = 0,
+    last_frame_index: u8 = 255,
+    last_complete_entity: u32 = 0,
+    last_loop_repetition: u16 = 0,
+
+    pub fn engine__anim_frame(self: *Recorder, info: anytype) void {
+        self.frame_count += 1;
+        self.last_frame_entity = info.entity;
+        self.last_frame_index = info.frame;
+    }
+    pub fn engine__anim_complete(self: *Recorder, info: anytype) void {
+        self.complete_count += 1;
+        self.last_complete_entity = info.entity;
+    }
+    pub fn engine__anim_loop(self: *Recorder, info: anytype) void {
+        self.loop_count += 1;
+        self.last_loop_repetition = info.repetition;
+    }
+};
+
+const AnimGame = game_mod.GameConfig(
+    core.StubRender(MockEcs.Entity),
+    MockEcs,
+    engine.input_mod.StubInput,
+    engine.audio_mod.StubAudio,
+    engine.StubVideo,
+    engine.gui_mod.StubGui,
+    *Recorder,
+    core.StubLogSink,
+    TestComponents,
+    &.{},
+    AnimGameEvents,
+);
+
+const Sprite = AnimGame.SpriteComp;
+const frames = [4][]const u8{ "a.png", "b.png", "c.png", "d.png" };
+
+fn newGame(recorder: *Recorder) AnimGame {
+    var game = AnimGame.init(testing.allocator);
+    game.setHooks(recorder);
+    game.dispatchEvents();
+    recorder.* = .{};
+    return game;
+}
+
+test "tick: landing on an event frame emits engine__anim_frame with entity + index" {
+    var recorder = Recorder{};
+    var game = newGame(&recorder);
+    defer game.deinit();
+
+    const marked = [_]u8{2};
+    const entity = game.createEntity();
+    game.active_world.ecs_backend.addComponent(entity, Sprite{ .sprite_name = "a.png" });
+    game.active_world.ecs_backend.addComponent(entity, SpriteAnimation{
+        .frames = &frames,
+        .fps = 6,
+        .mode = .loop,
+        .event_frames = &marked,
+    });
+
+    // Advance straight to frame 2.
+    spriteAnimationTick(&game, 2.0 / 6.0);
+    game.dispatchEvents();
+
+    try testing.expectEqual(@as(usize, 1), recorder.frame_count);
+    try testing.expectEqual(entity, recorder.last_frame_entity);
+    try testing.expectEqual(@as(u8, 2), recorder.last_frame_index);
+    try testing.expectEqual(@as(usize, 0), recorder.complete_count);
+}
+
+test "tick: a .once clip emits engine__anim_complete exactly once" {
+    var recorder = Recorder{};
+    var game = newGame(&recorder);
+    defer game.deinit();
+
+    const entity = game.createEntity();
+    game.active_world.ecs_backend.addComponent(entity, Sprite{ .sprite_name = "a.png" });
+    game.active_world.ecs_backend.addComponent(entity, SpriteAnimation{
+        .frames = &frames,
+        .fps = 6,
+        .mode = .once,
+    });
+
+    spriteAnimationTick(&game, 1.0); // run through all 4 frames
+    game.dispatchEvents();
+    try testing.expectEqual(@as(usize, 1), recorder.complete_count);
+    try testing.expectEqual(entity, recorder.last_complete_entity);
+
+    // Further ticks: no re-fire (frame is parked on the last one).
+    spriteAnimationTick(&game, 10.0);
+    game.dispatchEvents();
+    try testing.expectEqual(@as(usize, 1), recorder.complete_count);
+}
+
+test "tick: a .loop wrap emits engine__anim_loop with the repetition count" {
+    var recorder = Recorder{};
+    var game = newGame(&recorder);
+    defer game.deinit();
+
+    const entity = game.createEntity();
+    game.active_world.ecs_backend.addComponent(entity, Sprite{ .sprite_name = "a.png" });
+    game.active_world.ecs_backend.addComponent(entity, SpriteAnimation{
+        .frames = &frames,
+        .fps = 6,
+        .mode = .loop,
+    });
+
+    // 4 frames @ 6 fps → one wrap after 4/6 s of play from frame 0.
+    spriteAnimationTick(&game, 4.0 / 6.0);
+    game.dispatchEvents();
+    try testing.expectEqual(@as(usize, 1), recorder.loop_count);
+    try testing.expectEqual(@as(u16, 1), recorder.last_loop_repetition);
+}
+
+test "tick: speed 2 advances twice as fast; speed 0 pauses" {
+    var recorder = Recorder{};
+    var game = newGame(&recorder);
+    defer game.deinit();
+
+    const fast = game.createEntity();
+    game.active_world.ecs_backend.addComponent(fast, Sprite{ .sprite_name = "a.png" });
+    game.active_world.ecs_backend.addComponent(fast, SpriteAnimation{
+        .frames = &frames,
+        .fps = 6,
+        .mode = .loop,
+        .speed = 2.0,
+    });
+
+    const paused = game.createEntity();
+    game.active_world.ecs_backend.addComponent(paused, Sprite{ .sprite_name = "a.png" });
+    game.active_world.ecs_backend.addComponent(paused, SpriteAnimation{
+        .frames = &frames,
+        .fps = 6,
+        .mode = .loop,
+        .speed = 0,
+    });
+
+    // One frame-duration of dt. At speed 2 the fast clip advances 2
+    // frames (a → c); the paused clip does not move.
+    spriteAnimationTick(&game, 1.0 / 6.0);
+
+    const fa = game.active_world.ecs_backend.getComponent(fast, SpriteAnimation).?;
+    try testing.expectEqual(@as(u8, 2), fa.frame);
+    const pa = game.active_world.ecs_backend.getComponent(paused, SpriteAnimation).?;
+    try testing.expectEqual(@as(u8, 0), pa.frame);
+    try testing.expectEqual(@as(f32, 0), pa.timer);
+}
+
+test "tick: negative speed is treated as paused, not reverse" {
+    var recorder = Recorder{};
+    var game = newGame(&recorder);
+    defer game.deinit();
+
+    const entity = game.createEntity();
+    game.active_world.ecs_backend.addComponent(entity, Sprite{ .sprite_name = "a.png" });
+    game.active_world.ecs_backend.addComponent(entity, SpriteAnimation{
+        .frames = &frames,
+        .fps = 6,
+        .mode = .loop,
+        .speed = -3.0,
+    });
+
+    spriteAnimationTick(&game, 1.0);
+    const anim = game.active_world.ecs_backend.getComponent(entity, SpriteAnimation).?;
+    try testing.expectEqual(@as(u8, 0), anim.frame);
+    try testing.expectEqual(@as(f32, 0), anim.timer);
+}

--- a/test/sprite_animation_events_test.zig
+++ b/test/sprite_animation_events_test.zig
@@ -94,7 +94,7 @@ test "tick: landing on an event frame emits engine__anim_frame with entity + ind
     var game = newGame(&recorder);
     defer game.deinit();
 
-    const marked = [_]u8{2};
+    const marked = [_]u16{2};
     const entity = game.createEntity();
     game.active_world.ecs_backend.addComponent(entity, Sprite{ .sprite_name = "a.png" });
     game.active_world.ecs_backend.addComponent(entity, SpriteAnimation{

--- a/test/sprite_animation_test.zig
+++ b/test/sprite_animation_test.zig
@@ -340,7 +340,7 @@ fn countKind(buf: *const PendingBuf, kind: Kind) usize {
 }
 
 test "SpriteAnimation: advanceEvents fires a marker when landing on an event frame" {
-    const marked = [_]u8{2};
+    const marked = [_]u16{2};
     var anim = SpriteAnimation{
         .frames = &pipe_frames,
         .fps = 6,
@@ -393,7 +393,7 @@ test "SpriteAnimation: a full-period wrap back to the same frame fires no marker
     // exactly one full period (returns to the same index) intentionally
     // doesn't re-fire that frame's marker — only the loop_end fires. A
     // crossing-accurate design (deferred #625 follow-up) would catch it.
-    const marked = [_]u8{0};
+    const marked = [_]u16{0};
     var anim = SpriteAnimation{
         .frames = &pipe_frames,
         .fps = 6,
@@ -405,4 +405,40 @@ test "SpriteAnimation: a full-period wrap back to the same frame fires no marker
     try testing.expectEqual(@as(u8, 0), anim.frame);
     try testing.expectEqual(@as(usize, 0), countKind(&buf, .marker));
     try testing.expectEqual(@as(usize, 1), countKind(&buf, .loop_end));
+}
+
+test "SpriteAnimation: advanceEventsMasked queues only the selected kinds" {
+    // #718 codex P2 #2: a project listening to only anim_frame must not
+    // have its buffer filled with loop_end events. Mask loop_end/clip_end
+    // OFF; a wrapping tick that lands on a marked frame yields ONLY the
+    // marker — the wanted event isn't crowded out.
+    const marked = [_]u16{2};
+    var anim = SpriteAnimation{
+        .frames = &pipe_frames,
+        .fps = 6,
+        .mode = .loop,
+        .event_frames = &marked,
+    };
+    var buf = PendingBuf{};
+    // From frame 0: 8 steps → one wrap, lands on frame 2 (marked).
+    _ = anim.advanceEventsMasked(8.0 / 6.0, &buf, .{ .frame = true, .clip_end = false, .loop_end = false });
+    try testing.expectEqual(@as(u8, 2), anim.frame);
+    try testing.expectEqual(@as(usize, 1), countKind(&buf, .marker));
+    try testing.expectEqual(@as(usize, 0), countKind(&buf, .loop_end));
+    try testing.expectEqual(@as(usize, 1), buf.len);
+    // repetition still tracked even though loop_end wasn't queued.
+    try testing.expectEqual(@as(u16, 1), anim.repetition);
+}
+
+test "SpriteAnimation: a huge-dt loop tick is bounded and repetition saturates" {
+    // #718 codex P2 #3: a multi-wrap dt spike (tab resume / debugger
+    // pause) must be O(bounded), not O(wraps). ~100k wraps in one tick:
+    // repetition is computed arithmetically (saturates at u16 max) and
+    // emission is capped by the fixed buffer, not the wrap count.
+    var anim = SpriteAnimation{ .frames = &pipe_frames, .fps = 6, .mode = .loop };
+    var buf = PendingBuf{};
+    _ = anim.advanceEvents(100000.0, &buf);
+    try testing.expectEqual(@as(u16, std.math.maxInt(u16)), anim.repetition);
+    // Buffer filled to capacity, not beyond — the overflow tail is dropped.
+    try testing.expectEqual(@as(usize, buf.items.len), @as(usize, buf.len));
 }

--- a/test/sprite_animation_test.zig
+++ b/test/sprite_animation_test.zig
@@ -251,3 +251,158 @@ test "SpriteAnimation: sub-zero timer from FP residual does not panic" {
     try testing.expect(!anim.advance(0));
     try testing.expectEqual(@as(f32, 0), anim.timer);
 }
+
+// ── #625 progress / duration queries ──────────────────────────────
+
+test "SpriteAnimation: clipDuration / frameDuration from frames + fps" {
+    const anim = SpriteAnimation{ .frames = &pipe_frames, .fps = 6, .mode = .loop };
+    // 6 frames @ 6 fps → 1s total, 1/6s per frame.
+    try testing.expectApproxEqAbs(@as(f32, 1.0 / 6.0), anim.frameDuration(), 1e-6);
+    try testing.expectApproxEqAbs(@as(f32, 1.0), anim.clipDuration(), 1e-6);
+}
+
+test "SpriteAnimation: duration folds speed in, clipDuration does not" {
+    var anim = SpriteAnimation{ .frames = &pipe_frames, .fps = 6, .mode = .loop };
+    // speed 1 → wall == clip.
+    try testing.expectApproxEqAbs(@as(f32, 1.0), anim.duration(), 1e-6);
+    // speed 2 → half the wall-clock; clip length unchanged.
+    anim.speed = 2.0;
+    try testing.expectApproxEqAbs(@as(f32, 0.5), anim.duration(), 1e-6);
+    try testing.expectApproxEqAbs(@as(f32, 1.0), anim.clipDuration(), 1e-6);
+    // paused (speed 0) → report the intrinsic length, not infinity.
+    anim.speed = 0;
+    try testing.expectApproxEqAbs(@as(f32, 1.0), anim.duration(), 1e-6);
+}
+
+test "SpriteAnimation: progress ramps 0 → 1 across a loop cycle" {
+    var anim = SpriteAnimation{ .frames = &pipe_frames, .fps = 6, .mode = .loop };
+    try testing.expectApproxEqAbs(@as(f32, 0), anim.progress(), 1e-6);
+    try testing.expectApproxEqAbs(@as(f32, 0), anim.elapsed(), 1e-6);
+    // Advance to frame 3 (halfway through 6 frames).
+    _ = anim.advance(3.0 / 6.0);
+    try testing.expectEqual(@as(u8, 3), anim.frame);
+    try testing.expectApproxEqAbs(@as(f32, 0.5), anim.progress(), 1e-6);
+    try testing.expectApproxEqAbs(@as(f32, 0.5), anim.elapsed(), 1e-6);
+}
+
+test "SpriteAnimation: progress is speed-independent (fraction, not wall-clock)" {
+    // The tick pre-scales dt by speed, so from the state machine's view
+    // a fast clip has simply advanced further in clip-time. Progress
+    // reads the same fraction regardless of what speed produced it.
+    var slow = SpriteAnimation{ .frames = &pipe_frames, .fps = 6, .mode = .loop, .speed = 0.5 };
+    var fast = SpriteAnimation{ .frames = &pipe_frames, .fps = 6, .mode = .loop, .speed = 2.0 };
+    _ = slow.advance(0.5);
+    _ = fast.advance(0.5);
+    try testing.expectApproxEqAbs(slow.progress(), fast.progress(), 1e-6);
+}
+
+test "SpriteAnimation: once clip reads progress 1.0 and isComplete once finished" {
+    var anim = SpriteAnimation{ .frames = &pipe_frames, .fps = 6, .mode = .once };
+    try testing.expect(!anim.isComplete());
+    try testing.expect(anim.progress() < 1.0);
+    _ = anim.advance(1.0); // run through all frames
+    try testing.expect(anim.isComplete());
+    try testing.expectEqual(@as(f32, 1.0), anim.progress());
+}
+
+test "SpriteAnimation: loop and ping_pong never isComplete" {
+    var loop_anim = SpriteAnimation{ .frames = &pipe_frames, .fps = 6, .mode = .loop };
+    var pp_anim = SpriteAnimation{ .frames = &pipe_frames, .fps = 6, .mode = .ping_pong };
+    _ = loop_anim.advance(100.0);
+    _ = pp_anim.advance(100.0);
+    try testing.expect(!loop_anim.isComplete());
+    try testing.expect(!pp_anim.isComplete());
+}
+
+test "SpriteAnimation: degenerate clip queries are zero, not NaN" {
+    const empty: []const []const u8 = &.{};
+    const anim = SpriteAnimation{ .frames = empty, .fps = 6, .mode = .loop };
+    try testing.expectEqual(@as(f32, 0), anim.clipDuration());
+    try testing.expectEqual(@as(f32, 0), anim.duration());
+    try testing.expectEqual(@as(f32, 0), anim.progress());
+    // Zero fps → zero frame duration (no divide-by-zero).
+    const zfps = SpriteAnimation{ .frames = &pipe_frames, .fps = 0, .mode = .loop };
+    try testing.expectEqual(@as(f32, 0), zfps.frameDuration());
+    try testing.expectEqual(@as(f32, 0), zfps.progress());
+}
+
+// ── #625 per-frame + lifecycle events via advanceEvents ────────────
+
+const PendingBuf = engine.AnimPendingBuf;
+const Kind = engine.AnimEventKind;
+
+fn countKind(buf: *const PendingBuf, kind: Kind) usize {
+    var c: usize = 0;
+    for (buf.slice()) |e| {
+        if (e.kind == kind) c += 1;
+    }
+    return c;
+}
+
+test "SpriteAnimation: advanceEvents fires a marker when landing on an event frame" {
+    const marked = [_]u8{2};
+    var anim = SpriteAnimation{
+        .frames = &pipe_frames,
+        .fps = 6,
+        .mode = .loop,
+        .event_frames = &marked,
+    };
+    var buf = PendingBuf{};
+    // Land exactly on frame 2.
+    _ = anim.advanceEvents(2.0 / 6.0, &buf);
+    try testing.expectEqual(@as(u8, 2), anim.frame);
+    try testing.expectEqual(@as(usize, 1), countKind(&buf, .marker));
+    try testing.expectEqual(@as(u8, 2), buf.slice()[0].frame);
+}
+
+test "SpriteAnimation: unmarked frames fire no marker" {
+    var anim = SpriteAnimation{ .frames = &pipe_frames, .fps = 6, .mode = .loop };
+    var buf = PendingBuf{};
+    _ = anim.advanceEvents(2.0 / 6.0, &buf);
+    try testing.expectEqual(@as(usize, 0), countKind(&buf, .marker));
+}
+
+test "SpriteAnimation: once clip fires clip_end exactly once" {
+    var anim = SpriteAnimation{ .frames = &pipe_frames, .fps = 6, .mode = .once };
+    var buf = PendingBuf{};
+    _ = anim.advanceEvents(1.0, &buf); // through all frames
+    try testing.expectEqual(@as(usize, 1), countKind(&buf, .clip_end));
+    // No re-fire on further advances.
+    var buf2 = PendingBuf{};
+    _ = anim.advanceEvents(10.0, &buf2);
+    try testing.expectEqual(@as(usize, 0), countKind(&buf2, .clip_end));
+}
+
+test "SpriteAnimation: loop wrap fires loop_end with rising repetition" {
+    var anim = SpriteAnimation{ .frames = &pipe_frames, .fps = 6, .mode = .loop };
+    var buf = PendingBuf{};
+    // 1s @ 6 fps over 6 frames → one full wrap back to frame 0.
+    _ = anim.advanceEvents(1.0, &buf);
+    try testing.expectEqual(@as(u8, 0), anim.frame);
+    try testing.expectEqual(@as(usize, 1), countKind(&buf, .loop_end));
+    try testing.expectEqual(@as(u16, 1), anim.repetition);
+    // Two more full wraps → repetition climbs, one loop_end each.
+    var buf2 = PendingBuf{};
+    _ = anim.advanceEvents(2.0, &buf2);
+    try testing.expectEqual(@as(usize, 2), countKind(&buf2, .loop_end));
+    try testing.expectEqual(@as(u16, 3), anim.repetition);
+}
+
+test "SpriteAnimation: a full-period wrap back to the same frame fires no marker" {
+    // The landed-on marker gate requires a NET frame change, so a dt of
+    // exactly one full period (returns to the same index) intentionally
+    // doesn't re-fire that frame's marker — only the loop_end fires. A
+    // crossing-accurate design (deferred #625 follow-up) would catch it.
+    const marked = [_]u8{0};
+    var anim = SpriteAnimation{
+        .frames = &pipe_frames,
+        .fps = 6,
+        .mode = .loop,
+        .event_frames = &marked,
+    };
+    var buf = PendingBuf{};
+    _ = anim.advanceEvents(1.0, &buf); // wraps exactly back to frame 0
+    try testing.expectEqual(@as(u8, 0), anim.frame);
+    try testing.expectEqual(@as(usize, 0), countKind(&buf, .marker));
+    try testing.expectEqual(@as(usize, 1), countKind(&buf, .loop_end));
+}


### PR DESCRIPTION
Enriches the `SpriteAnimation` playback primitive per #625. Fully additive and backward-compatible: every new field defaults to today's behavior, and all existing `SpriteAnimation` tests stay green.

## What landed

### 1. Progress / duration query API (pure reads, no tick change)
- `frameDuration()` / `clipDuration()` — clip-time (speed-independent).
- `duration()` — wall-clock, speed-adjusted (`clipDuration()/speed`; paused reports the intrinsic length rather than infinity).
- `elapsed()` — clip-seconds consumed.
- `progress()` — `[0,1]`, clamped; returns exactly `1.0` once `isComplete()`.
- `isComplete()` — alias of `isFinished()` (true once a `.once` clip lands on its last frame; `.loop`/`.ping_pong` never complete).

`progress`/`elapsed` are speed-independent fractions (the tick pre-scales `dt` by `speed`, so the internal clock stays in clip-time); only `duration()` folds speed in.

### 2. Per-animation playback speed
New `speed: f32 = 1.0`, applied on top of the global `time_scale` in the tick: `dt * @max(0, speed)`. `2.0` = twice as fast, `0` = paused. Negative is treated as paused (never reverse — reverse is deferred).

### 3. Events (design chosen: full emit path via the existing pattern)
The #670 `advanceEvents` / `PendingBuf` primitives already existed but were never driven by the sprite tick. This wires them through: when the project's `GameEvents` declares any of the three new `engine.Events` variants, the tick advances via `advanceEvents` and forwards the queued events to `game.emit` (buffered, drained end-of-frame), injecting the entity:

- `engine__anim_frame` — landed on a frame listed in the new `event_frames: []const u8` (footstep/hit/spawn cues).
- `engine__anim_complete` — a `.once` clip reached its last frame (fires once).
- `engine__anim_loop` — `.loop` wrap / `.ping_pong` reversal, carrying the saturating `repetition`.

Comptime-gated exactly like the input events (`engineEventWanted` + `emitEngineEvent`): when no variant is declared, the whole events path folds away and the tick uses the plain `advance` — an events-less game pays nothing. This is the ticket's preferred zero-cost-when-unused shape; it fit the engine's existing pattern cleanly, so no fallback was needed.

## Deferred (out of scope)
- seek / start-offset, per-entity pause beyond `speed=0`, reverse playback (the ticket's "possibly" items).
- Crossing-accurate frame markers: v1 fires on the **landed** frame, so a `dt` spike that steps past a marked frame without landing on it misses it (the `AnimationDef` path already does crossing-accurate markers via beat iteration — a natural follow-up).

## Tests
`zig build test`, `zig build spec`, and `zig fmt` all clean on Zig 0.16.0. New tests in `test/sprite_animation_test.zig` (query/speed/marker via `advanceEvents`) and a new `test/sprite_animation_events_test.zig` (end-to-end emit path with a `GameEvents` union + recorder hook).

Refs #625 (leave open — gated for release).

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw