### PR TITLE
feat(engine): Camera built-in component + studio editor bridge (camera-prefabs MVP) — #714

### DIFF
--- a/src/camera.zig
+++ b/src/camera.zig
@@ -1,0 +1,65 @@
+//! Camera component (camera-prefabs MVP, labelle-engine#714 / RFC-CAMERA-PREFABS).
+//!
+//! A `Camera` entity makes the game camera an AUTHORED / seed entity the
+//! studio can select, inspect, gizmo, and save — WITHOUT taking the camera
+//! away from games that drive it from a gameplay script. The component is a
+//! **seed, not a leash**: it seeds `getCamera()` once on scene load and is
+//! re-applied every frame WHILE PAUSED (when no gameplay script is ticking to
+//! fight it); on resume the script drives again and the component lies
+//! dormant. See the RFC "soft ownership" section.
+//!
+//! **Engine built-in, NOT a `ComponentRegistry` component.** Like `Position`
+//! and `Tilemap` (`src/tilemap.zig`), `Camera` is handled by dedicated
+//! built-in channels — the scene loader (`jsonc/component_apply.zig`), the
+//! seed/apply sync (`game/camera_mixin.zig`), the studio digest, and the
+//! editor bridge (`editor_api.zig`). Do not register it in a game's
+//! `ComponentRegistry`.
+//!
+//! **Renderer-agnostic.** The engine takes no gfx dependency, so `Viewport`
+//! below is an engine-local rect — it deliberately does NOT reference gfx's
+//! `ScreenViewport`. It is INERT in the single-camera MVP (the runtime always
+//! renders fullscreen and ignores a non-null value); it is carried now so the
+//! deferred multi-camera work (split-screen / minimap / PiP) is purely
+//! additive rather than a breaking component change.
+
+/// Screen-space viewport placement for a camera (split-screen / minimap /
+/// PiP). Engine-local and inert in the MVP — see the module header. All fields
+/// default so a partial authored/patched `viewport` round-trips cleanly.
+pub const Viewport = struct {
+    x: i32 = 0,
+    y: i32 = 0,
+    width: i32 = 0,
+    height: i32 = 0,
+};
+
+/// The `Camera` component — the AUTHORED / seed camera state. Reachable on a
+/// configured game as `Game.CameraComp`. The camera's world CENTER is its
+/// `Position` (xy); this component carries only what `Position` doesn't.
+pub const Camera = struct {
+    /// World→screen zoom. Seeds `getCamera().setZoom` on load; the gfx camera
+    /// clamps it to its own `min_zoom`/`max_zoom`.
+    zoom: f32 = 1.0,
+
+    /// Optional screen-space viewport placement. `null` = fullscreen. Inert in
+    /// the single-camera MVP (always fullscreen); carried for forward-compat
+    /// with the deferred multi-camera authoring work.
+    viewport: ?Viewport = null,
+
+    // Reserved for a future declarative follow target (entity id + offset +
+    // deadzone). Deferred: shipping games express "follow" in their gameplay
+    // script (soft ownership), so v1 does not model it — but the shape is
+    // reserved so a later `follow` field is additive, not a rename.
+    // follow: ?Follow = null,
+};
+
+/// True when game type `G` exposes a SETTABLE camera — i.e. its renderer has a
+/// real `CameraType` (not the `void` a camera-less/stub renderer publishes)
+/// with `setPosition`/`setZoom`. Used to comptime-fold the whole seed /
+/// apply-while-paused path away on camera-less renderers. Mirrors
+/// `editor_api.gameHasCamera`; the `!= void` guard short-circuits before the
+/// `@hasDecl(G.CameraType, …)` reflection so `void` never reaches it.
+pub fn hasSettableCamera(comptime G: type) bool {
+    if (!@hasDecl(G, "CameraType")) return false;
+    if (G.CameraType == void) return false;
+    return @hasDecl(G.CameraType, "setPosition") and @hasDecl(G.CameraType, "setZoom");
+}

--- a/src/editor_api.zig
+++ b/src/editor_api.zig
@@ -72,6 +72,7 @@ const VTable = struct {
     load_animation_def: *const fn (name: []const u8, src: []const u8) i32,
     reload_prefab: *const fn (name: []const u8, src: []const u8) i32,
     set_entity_position: *const fn (id: u64, x: f32, y: f32) void,
+    set_component: *const fn (id: u64, name: []const u8, json: []const u8) i32,
     scene_digest: *const fn (out: []u8) usize,
     apply_camera: *const fn (x: f32, y: f32, zoom: f32) void,
 };
@@ -123,11 +124,23 @@ pub fn shouldTick() bool {
 }
 
 /// Per-frame editor pass, called by the generated main AFTER the sim
-/// tick (and its camera-writing scripts) and BEFORE `g.render()`:
-/// re-asserts the editor camera while the override is engaged so the
-/// frame about to be rendered uses it; a no-op otherwise, and a
-/// comptime no-op for games whose renderer has no camera.
+/// tick (and its camera-writing scripts) and BEFORE `g.render()`.
+/// Two jobs, in precedence order:
+///
+///   1. **Apply-while-paused** (camera-prefabs #714): while the sim is
+///      PAUSED and no look-around override is engaged, re-seed the gfx
+///      camera from the authored `Camera` component every frame, so
+///      inspector/gizmo edits show live. Safe precisely because the sim
+///      is paused — no gameplay camera script is ticking to fight it. On
+///      resume the script drives and this stops asserting.
+///   2. **Look-around override**: re-asserts the editor camera while the
+///      override is engaged so the frame about to be rendered uses it.
+///      Applied LAST so it wins over both the component and the script.
+///
+/// A no-op when neither is active, and a comptime no-op for games whose
+/// renderer has no camera (or no `Camera` seed path).
 pub fn frame(g: anytype) void {
+    if (editor_paused and camera_override == null) applyCameraComponentTo(g);
     if (camera_override) |c| applyCameraTo(g, c);
 }
 
@@ -276,6 +289,37 @@ pub export fn editor_set_entity_position(id: u64, x: f32, y: f32) void {
     vt.set_entity_position(id, x, y);
 }
 
+/// Set component `name` on entity `id` from a JSON object — the general
+/// per-component edit seam (editor-bridge contract **v1.5**, camera-prefabs
+/// #714). `editor_set_entity_position` stays the drag hot-path; this is the
+/// general path the inspector grows into.
+///
+/// **Allowlisted** (MVP): only the vetted `"Camera"` built-in is accepted — a
+/// `{"zoom":…}` (and, when authored, `"viewport":{…}`) object. Any other name
+/// returns -1; there is deliberately no blanket apply-any-component path.
+///
+/// **Merge/patch semantics**: only the keys PRESENT in the JSON overwrite the
+/// entity's existing `Camera` — a `{"zoom":…}` patch preserves a prior
+/// `viewport`. A default `Camera` is materialized when the entity has none. On
+/// success the live `getCamera()` is re-seeded so a paused preview updates
+/// immediately.
+///
+/// Returns 0 = ok; -1 = not bound / unknown id / unknown-or-unvetted
+/// component; -2 = parse/validation failure (entity untouched — the parse runs
+/// before any mutation). The buffers are copied; the caller may free them
+/// right after the call. Optional on older builds like v1.1–v1.4: a studio
+/// that finds no `editor_set_component` degrades to today's behavior.
+pub export fn editor_set_component(
+    id: u64,
+    name_ptr: [*]const u8,
+    name_len: usize,
+    json_ptr: [*]const u8,
+    json_len: usize,
+) i32 {
+    const vt = vtable orelse return -1;
+    return vt.set_component(id, name_ptr[0..name_len], json_ptr[0..json_len]);
+}
+
 /// v1: always -1 — the studio picks client-side from the scene digest.
 pub export fn editor_pick(x: f32, y: f32) i64 {
     _ = x;
@@ -286,9 +330,15 @@ pub export fn editor_pick(x: f32, y: f32) i64 {
 /// Write a JSON digest of the current scene into `out` (capacity
 /// `cap`) and return the number of bytes written. Shape:
 /// `{"scene":"...","state":"...","paused":0|1,"entity_count":N,
-///   "entities":[{"id":<u64>,"prefab":"?","sprite":"?","x":f,"y":f},...]}`
-/// `prefab`/`sprite` appear only when known; `x`/`y` are WORLD
-/// coordinates (the same space `editor_set_entity_position` consumes).
+///   "entities":[{"id":<u64>,"prefab":"?","sprite":"?","tilemap":"?",
+///     "camera":{"zoom":f,"viewport"?:{x,y,width,height},
+///               "view":{x,y,width,height}},"x":f,"y":f},...]}`
+/// `prefab`/`sprite`/`tilemap`/`camera` appear only when the entity
+/// carries them; a Camera entity's `viewport` is present only when
+/// authored, while `view` is the derived WORLD-space visible rect
+/// (`getCamera().getViewport()`) the studio draws its gizmo from. `x`/`y`
+/// are WORLD coordinates (the same space `editor_set_entity_position`
+/// consumes).
 /// The entity list is
 /// truncated to fit `cap` while `entity_count` keeps the full count —
 /// the output is always valid JSON (worst case `{}`; 0 bytes only when
@@ -337,6 +387,18 @@ fn applyCameraTo(g: anytype, c: CameraOverride) void {
     cam.setZoom(c.zoom);
 }
 
+/// The apply-while-paused pass (camera-prefabs #714): re-seed the gfx camera
+/// from the authored `Camera` component. Dispatches to the engine's
+/// `seedCameraFromComponent`, which is itself comptime-gated on the renderer
+/// having a settable camera. The extra `@hasDecl` gate here lets the minimal
+/// camera stand-ins used by the override tests (`CameraGame`, which duck-types
+/// only `getCamera`) still compile — they carry no `Camera` seed path.
+fn applyCameraComponentTo(g: anytype) void {
+    const G = @typeInfo(@TypeOf(g)).pointer.child;
+    if (comptime !@hasDecl(G, "seedCameraFromComponent")) return;
+    g.seedCameraFromComponent();
+}
+
 /// One instantiation per concrete (Game-pointer, Runner) pair. The
 /// container-level `var`s give the plain vtable fns a place to find
 /// the typed pointers without any runtime type erasure gymnastics.
@@ -354,6 +416,7 @@ fn Holder(comptime GP: type, comptime RP: type) type {
             .load_animation_def = &loadAnimationDefImpl,
             .reload_prefab = &reloadPrefabImpl,
             .set_entity_position = &setEntityPositionImpl,
+            .set_component = &setComponentImpl,
             .scene_digest = &sceneDigestImpl,
             .apply_camera = &applyCameraImpl,
         };
@@ -476,6 +539,25 @@ fn Holder(comptime GP: type, comptime RP: type) type {
             game.setWorldPosition(ent, .{ .x = x, .y = y });
         }
 
+        fn setComponentImpl(id: u64, name: []const u8, json: []const u8) i32 {
+            // Allowlist (FLAG B): only the vetted "Camera" built-in in the
+            // MVP. An unknown/unvetted name is refused up front — no blanket
+            // apply-any-component path is wired.
+            if (!std.mem.eql(u8, name, "Camera")) return -1;
+            const Entity = G.EntityType;
+            if (comptime @typeInfo(Entity) != .int) return -1;
+            const ent = std.math.cast(Entity, id) orelse return -1;
+            // Unknown/dead id → -1 (distinct from a parse failure, which is
+            // -2). The entity need NOT already carry a `Camera` — the first
+            // edit materializes one.
+            if (!game.ecs_backend.entityExists(ent)) return -1;
+            // MERGE the JSON patch into the entity's `Camera` and re-seed
+            // getCamera(). The parse happens before any mutation, so a
+            // parse/validation failure (-2) leaves the entity untouched.
+            game.applyCameraComponentJson(ent, json) catch return -2;
+            return 0;
+        }
+
         fn applyCameraImpl(x: f32, y: f32, zoom: f32) void {
             applyCameraTo(game, .{ .x = x, .y = y, .zoom = zoom });
         }
@@ -549,6 +631,37 @@ fn Holder(comptime GP: type, comptime RP: type) type {
                 if (game.getComponent(ent, G.TilemapComp)) |tm| {
                     try appendLit(buf, cur, ",\"tilemap\":");
                     try appendJsonString(buf, cur, tm.asset_name);
+                }
+            }
+            // Camera (camera-prefabs MVP, #714) — the authored `zoom` and
+            // (when set) `viewport` so the studio round-trips them, plus the
+            // derived WORLD-space visible rect `view` from
+            // `getCamera().getViewport()` — the rect the studio draws its
+            // draggable gizmo from. Emitted only for Camera-bearing entities,
+            // exactly like the sprite/tilemap optional-field pattern above.
+            if (comptime @hasDecl(G, "CameraComp")) {
+                if (game.getComponent(ent, G.CameraComp)) |cam| {
+                    try appendFmt(buf, cur, ",\"camera\":{{\"zoom\":{d}", .{jsonSafeFloat(cam.zoom)});
+                    if (cam.viewport) |vp| {
+                        try appendFmt(buf, cur, ",\"viewport\":{{\"x\":{d},\"y\":{d},\"width\":{d},\"height\":{d}}}", .{
+                            vp.x, vp.y, vp.width, vp.height,
+                        });
+                    }
+                    // The derived world view-rect — only for renderers whose
+                    // camera reports one (`getViewport`). Nested comptime block
+                    // (not an `and`) so `getViewport` is never reflected on a
+                    // `void` camera — mirrors tilemap_mixin's `camera_cullable`.
+                    const emit_view = comptime blk: {
+                        if (!gameHasCamera(G)) break :blk false;
+                        break :blk @hasDecl(G.CameraType, "getViewport");
+                    };
+                    if (emit_view) {
+                        const vr = game.getCamera().getViewport();
+                        try appendFmt(buf, cur, ",\"view\":{{\"x\":{d},\"y\":{d},\"width\":{d},\"height\":{d}}}", .{
+                            jsonSafeFloat(vr.x), jsonSafeFloat(vr.y), jsonSafeFloat(vr.width), jsonSafeFloat(vr.height),
+                        });
+                    }
+                    try appendLit(buf, cur, "}");
                 }
             }
             // WORLD coordinates, not the raw (parent-relative) Position

--- a/src/editor_api.zig
+++ b/src/editor_api.zig
@@ -59,6 +59,12 @@ const core = @import("labelle-core");
 
 var editor_paused: bool = false;
 var pending_steps: u32 = 0;
+/// Whether the CURRENT frame consumed an `editor_step` (i.e. `g.tick` ran for
+/// it while paused). Set by `shouldTick`, read by `frame` to SKIP the
+/// apply-while-paused re-seed on a stepped frame — otherwise single-step
+/// debugging would clobber the just-ticked camera with the authored seed
+/// before render (finding #2). One shouldTick→frame pair per loop iteration.
+var stepped_this_frame: bool = false;
 
 pub const CameraOverride = struct { x: f32, y: f32, zoom: f32 };
 var camera_override: ?CameraOverride = null;
@@ -107,6 +113,7 @@ pub fn unbind() void {
     vtable = null;
     editor_paused = false;
     pending_steps = 0;
+    stepped_this_frame = false;
     camera_override = null;
 }
 
@@ -115,11 +122,16 @@ pub fn unbind() void {
 /// count per call and returns true for it; false otherwise (render
 /// continues either way — only `g.tick` is gated on this).
 pub fn shouldTick() bool {
-    if (!editor_paused) return true;
-    if (pending_steps > 0) {
-        pending_steps -= 1;
+    if (!editor_paused) {
+        stepped_this_frame = false;
         return true;
     }
+    if (pending_steps > 0) {
+        pending_steps -= 1;
+        stepped_this_frame = true; // this frame ticks — frame() must not re-seed
+        return true;
+    }
+    stepped_this_frame = false;
     return false;
 }
 
@@ -132,7 +144,10 @@ pub fn shouldTick() bool {
 ///      camera from the authored `Camera` component every frame, so
 ///      inspector/gizmo edits show live. Safe precisely because the sim
 ///      is paused — no gameplay camera script is ticking to fight it. On
-///      resume the script drives and this stops asserting.
+///      resume the script drives and this stops asserting. SKIPPED on a
+///      STEPPED frame (one this `shouldTick` advanced): `g.tick` just ran
+///      and may have moved the camera, so single-step debugging must render
+///      that ticked frame, not the re-seeded authored camera (finding #2).
 ///   2. **Look-around override**: re-asserts the editor camera while the
 ///      override is engaged so the frame about to be rendered uses it.
 ///      Applied LAST so it wins over both the component and the script.
@@ -140,7 +155,7 @@ pub fn shouldTick() bool {
 /// A no-op when neither is active, and a comptime no-op for games whose
 /// renderer has no camera (or no `Camera` seed path).
 pub fn frame(g: anytype) void {
-    if (editor_paused and camera_override == null) applyCameraComponentTo(g);
+    if (editor_paused and camera_override == null and !stepped_this_frame) applyCameraComponentTo(g);
     if (camera_override) |c| applyCameraTo(g, c);
 }
 
@@ -544,6 +559,11 @@ fn Holder(comptime GP: type, comptime RP: type) type {
             // MVP. An unknown/unvetted name is refused up front — no blanket
             // apply-any-component path is wired.
             if (!std.mem.eql(u8, name, "Camera")) return -1;
+            // Defer to a project that registered its OWN `Camera` (finding #1):
+            // the built-in bridge is off for such projects — refuse rather than
+            // materialize a conflicting second component. Routing "Camera" to
+            // the registry path is a later, studio-side change.
+            if (comptime !G.camera_is_builtin) return -1;
             const Entity = G.EntityType;
             if (comptime @typeInfo(Entity) != .int) return -1;
             const ent = std.math.cast(Entity, id) orelse return -1;
@@ -639,7 +659,10 @@ fn Holder(comptime GP: type, comptime RP: type) type {
             // `getCamera().getViewport()` — the rect the studio draws its
             // draggable gizmo from. Emitted only for Camera-bearing entities,
             // exactly like the sprite/tilemap optional-field pattern above.
-            if (comptime @hasDecl(G, "CameraComp")) {
+            // Suppressed when a project registered its own `Camera` (finding
+            // #1): the built-in feature defers, so its component is never
+            // injected/published here.
+            if (comptime @hasDecl(G, "CameraComp") and G.camera_is_builtin) {
                 if (game.getComponent(ent, G.CameraComp)) |cam| {
                     try appendFmt(buf, cur, ",\"camera\":{{\"zoom\":{d}", .{jsonSafeFloat(cam.zoom)});
                     if (cam.viewport) |vp| {

--- a/src/game.zig
+++ b/src/game.zig
@@ -60,6 +60,8 @@ const game_init_mod = @import("game/game_init.zig");
 const tilemap_mod = @import("tilemap.zig");
 const tilemap_runtime = @import("tilemap_runtime.zig");
 const tilemap_mixin = @import("game/tilemap_mixin.zig");
+const camera_mod = @import("camera.zig");
+const camera_mixin = @import("game/camera_mixin.zig");
 
 /// Full game configuration — the assembler fills ALL comptime slots.
 /// RenderImpl is a renderer plugin (e.g. gfx.GfxRenderer) satisfying RenderInterface.
@@ -222,6 +224,14 @@ pub fn GameConfigWithYAxis(
         pub const PrefabInstanceComp = PrefabInstance;
         pub const PrefabChildComp = PrefabChildT;
 
+        // ── Camera (camera-prefabs MVP, #714) ────────────────────
+        /// Engine built-in `Camera` component — the authored / seed camera
+        /// state (`zoom` + optional inert `viewport`; the camera's world
+        /// center is its `Position`). Handled by dedicated built-in channels
+        /// (scene loader, seed/apply sync, digest, editor bridge) — NOT a
+        /// `ComponentRegistry` component. See `src/camera.zig`.
+        pub const CameraComp = camera_mod.Camera;
+
         // ── Tilemap (T2 Phase 2) ─────────────────────────────────
         /// Engine built-in `Tilemap` component (references a `.tmx` asset
         /// by name). Handled by dedicated built-in channels (scene loader,
@@ -358,6 +368,7 @@ pub fn GameConfigWithYAxis(
         const PrefabRuntimeMixin = prefab_runtime_mixin.Mixin(Self);
         const RosterMixin = roster_mod.Mixin(Self);
         const TilemapMixin = tilemap_mixin.Mixin(Self);
+        const CameraMixin = camera_mixin.Mixin(Self);
         // VideoImpl/AudioImpl are `GameConfig` fn params (not `Self`
         // decls), so the construction mixin takes them explicitly.
         const InitMixin = game_init_mod.Mixin(Self, VideoImpl, AudioImpl);
@@ -1287,6 +1298,16 @@ pub fn GameConfigWithYAxis(
 
         /// Get the camera manager (for multi-camera / split-screen).
         pub const getCameraManager = if (has_camera) MiscMixin.getCameraManagerImpl else void;
+
+        // ── Camera component seed / sync (#714) ───────────────────
+        /// Seed `getCamera()` from the authored `Camera` component (world
+        /// position + zoom). Called once after scene instantiation and every
+        /// paused frame from `editor_api.frame`. Comptime no-op on renderers
+        /// without a settable camera. See `game/camera_mixin.zig`.
+        pub const seedCameraFromComponent = CameraMixin.seedCameraFromComponent;
+        /// MERGE a JSON patch into an entity's `Camera` component and re-seed.
+        /// Backs the `editor_set_component("Camera", …)` bridge export.
+        pub const applyCameraComponentJson = CameraMixin.applyCameraComponentJson;
 
         // ── Atlas ─────────────────────────────────────────────────
 

--- a/src/game.zig
+++ b/src/game.zig
@@ -231,6 +231,16 @@ pub fn GameConfigWithYAxis(
         /// (scene loader, seed/apply sync, digest, editor bridge) — NOT a
         /// `ComponentRegistry` component. See `src/camera.zig`.
         pub const CameraComp = camera_mod.Camera;
+        /// True when the engine's built-in `Camera` feature is ACTIVE — i.e.
+        /// the project did NOT register its own `Camera` in its
+        /// `ComponentRegistry`. When a project registers `Camera`, every
+        /// built-in Camera channel (seed / apply-while-paused / digest / the
+        /// `editor_set_component` bridge / save-load) DEFERS to the project's
+        /// component so the two never fight over the name — mirroring the
+        /// scene-loader `!Components.has("Camera")` guard in
+        /// `jsonc/component_apply.zig`. The `@hasDecl` guard keeps this sound
+        /// for any `ComponentRegistry` shape that predates a `has` decl.
+        pub const camera_is_builtin = !(@hasDecl(ComponentsType, "has") and ComponentsType.has("Camera"));
 
         // ── Tilemap (T2 Phase 2) ─────────────────────────────────
         /// Engine built-in `Tilemap` component (references a `.tmx` asset

--- a/src/game/camera_mixin.zig
+++ b/src/game/camera_mixin.zig
@@ -33,6 +33,9 @@ pub fn Mixin(comptime Game: type) type {
         /// the first Camera entity wins.
         pub fn seedCameraFromComponent(self: *Game) void {
             if (comptime !camera_mod.hasSettableCamera(Game)) return;
+            // Defer to a project that registered its OWN `Camera` (finding #1):
+            // the built-in seed is off for such projects.
+            if (comptime !Game.camera_is_builtin) return;
             var v = self.ecs_backend.view(.{ Position, CameraComp }, .{});
             defer v.deinit();
             while (v.next()) |ent| {
@@ -73,20 +76,27 @@ pub fn Mixin(comptime Game: type) type {
                 comp.zoom = @floatFromInt(z);
             }
 
-            if (obj.getObject("viewport")) |vp| {
-                // Merge sub-fields into the existing (or default) viewport so a
-                // partial viewport patch is also additive.
-                var out = comp.viewport orelse camera_mod.Viewport{};
-                // Bounds-check the JSON int → i32 narrowing: an out-of-range
-                // value from studio JSON must fail the patch (-2, entity
-                // untouched — this returns before `setComponent` below), NOT
-                // panic via a raw `@intCast` (gemini on #719).
-                if (vp.getInteger("x")) |x| out.x = std.math.cast(i32, x) orelse return error.InvalidCameraComponentJson;
-                if (vp.getInteger("y")) |y| out.y = std.math.cast(i32, y) orelse return error.InvalidCameraComponentJson;
-                if (vp.getInteger("width")) |w| out.width = std.math.cast(i32, w) orelse return error.InvalidCameraComponentJson;
-                if (vp.getInteger("height")) |h| out.height = std.math.cast(i32, h) orelse return error.InvalidCameraComponentJson;
-                comp.viewport = out;
-            }
+            // A PRESENT `viewport` key drives the merge; distinguish an
+            // explicit JSON `null` (→ clear back to fullscreen, finding #4)
+            // from an absent key (→ leave the viewport untouched).
+            if (obj.get("viewport")) |vp_val| switch (vp_val) {
+                .null_value => comp.viewport = null,
+                .object => |vp| {
+                    // Merge sub-fields into the existing (or default) viewport
+                    // so a partial viewport patch is also additive.
+                    var out = comp.viewport orelse camera_mod.Viewport{};
+                    // Bounds-check the JSON int → i32 narrowing: an out-of-range
+                    // value from studio JSON must fail the patch (-2, entity
+                    // untouched — this returns before `setComponent` below), NOT
+                    // panic via a raw `@intCast` (gemini on #719).
+                    if (vp.getInteger("x")) |x| out.x = std.math.cast(i32, x) orelse return error.InvalidCameraComponentJson;
+                    if (vp.getInteger("y")) |y| out.y = std.math.cast(i32, y) orelse return error.InvalidCameraComponentJson;
+                    if (vp.getInteger("width")) |w| out.width = std.math.cast(i32, w) orelse return error.InvalidCameraComponentJson;
+                    if (vp.getInteger("height")) |h| out.height = std.math.cast(i32, h) orelse return error.InvalidCameraComponentJson;
+                    comp.viewport = out;
+                },
+                else => {}, // a non-object, non-null viewport is ignored
+            };
 
             self.setComponent(ent, comp);
             seedCameraFromComponent(self);

--- a/src/game/camera_mixin.zig
+++ b/src/game/camera_mixin.zig
@@ -64,42 +64,59 @@ pub fn Mixin(comptime Game: type) type {
             defer arena.deinit();
             var parser = jsonc.JsoncParser.init(arena.allocator(), source);
             const value = try parser.parse();
+            // Reject trailing junk after the object (`{...}garbage`): `parse`
+            // already consumed trailing whitespace/comments, so any remaining
+            // byte is a malformed payload → validation failure, not a silent
+            // success that mutates the entity (codex on #719).
+            if (parser.pos < parser.source.len) return error.InvalidCameraComponentJson;
             const obj = value.asObject() orelse return error.InvalidCameraComponentJson;
 
             // Read-existing-then-overlay: start from the live component (or a
             // default) so unprovided keys survive the patch.
             var comp: CameraComp = if (self.ecs_backend.getComponent(ent, CameraComp)) |c| c.* else .{};
 
-            if (obj.getFloat("zoom")) |z| {
-                comp.zoom = @floatCast(z);
-            } else if (obj.getInteger("zoom")) |z| {
-                comp.zoom = @floatFromInt(z);
-            }
+            // A PRESENT `zoom` must be numeric — a wrong-shaped value (e.g.
+            // `{"zoom":"2"}`) is a validation failure, NOT a silently-ignored
+            // key that would author a default zoom (codex on #719). An ABSENT
+            // key leaves the existing/default zoom untouched.
+            if (obj.get("zoom")) |z_val| switch (z_val) {
+                .float => |f| comp.zoom = @floatCast(f),
+                .integer => |i| comp.zoom = @floatFromInt(i),
+                else => return error.InvalidCameraComponentJson,
+            };
 
             // A PRESENT `viewport` key drives the merge; distinguish an
             // explicit JSON `null` (→ clear back to fullscreen, finding #4)
-            // from an absent key (→ leave the viewport untouched).
+            // from an absent key (→ leave the viewport untouched). A present
+            // but wrong-shaped `viewport` (or sub-field) is a validation
+            // failure, same as `zoom`.
             if (obj.get("viewport")) |vp_val| switch (vp_val) {
                 .null_value => comp.viewport = null,
                 .object => |vp| {
                     // Merge sub-fields into the existing (or default) viewport
                     // so a partial viewport patch is also additive.
                     var out = comp.viewport orelse camera_mod.Viewport{};
-                    // Bounds-check the JSON int → i32 narrowing: an out-of-range
-                    // value from studio JSON must fail the patch (-2, entity
-                    // untouched — this returns before `setComponent` below), NOT
-                    // panic via a raw `@intCast` (gemini on #719).
-                    if (vp.getInteger("x")) |x| out.x = std.math.cast(i32, x) orelse return error.InvalidCameraComponentJson;
-                    if (vp.getInteger("y")) |y| out.y = std.math.cast(i32, y) orelse return error.InvalidCameraComponentJson;
-                    if (vp.getInteger("width")) |w| out.width = std.math.cast(i32, w) orelse return error.InvalidCameraComponentJson;
-                    if (vp.getInteger("height")) |h| out.height = std.math.cast(i32, h) orelse return error.InvalidCameraComponentJson;
+                    if (vp.get("x")) |v| out.x = try viewportInt(v);
+                    if (vp.get("y")) |v| out.y = try viewportInt(v);
+                    if (vp.get("width")) |v| out.width = try viewportInt(v);
+                    if (vp.get("height")) |v| out.height = try viewportInt(v);
                     comp.viewport = out;
                 },
-                else => {}, // a non-object, non-null viewport is ignored
+                else => return error.InvalidCameraComponentJson,
             };
 
             self.setComponent(ent, comp);
             seedCameraFromComponent(self);
+        }
+
+        /// A viewport sub-field: must be a JSON integer in `i32` range. A
+        /// non-integer or out-of-range value fails the patch (codex/gemini on
+        /// #719) — never a silent skip nor a panicking raw `@intCast`.
+        fn viewportInt(v: jsonc.Value) !i32 {
+            return switch (v) {
+                .integer => |i| std.math.cast(i32, i) orelse error.InvalidCameraComponentJson,
+                else => error.InvalidCameraComponentJson,
+            };
         }
     };
 }

--- a/src/game/camera_mixin.zig
+++ b/src/game/camera_mixin.zig
@@ -1,0 +1,91 @@
+//! Camera mixin (camera-prefabs MVP, labelle-engine#714) — the `Game`-side
+//! seed / sync lifecycle for the built-in `Camera` component (`src/camera.zig`).
+//!
+//! Two entry points, both comptime-folded to nothing on camera-less renderers:
+//!   - `seedCameraFromComponent` — find the (first) Camera entity, read its
+//!     WORLD position + `zoom`, and apply them to `getCamera()`. Called once
+//!     after scene instantiation (seed-on-load) and again every PAUSED frame
+//!     from `editor_api.frame` (apply-while-paused). It is the same operation
+//!     both times: the component reaches the live gfx camera, never the other
+//!     way around.
+//!   - `applyCameraComponentJson` — MERGE a JSON patch into an entity's Camera
+//!     component (creating a default one when absent), then re-seed. Backs the
+//!     `editor_set_component("Camera", …)` bridge export.
+
+const std = @import("std");
+const core = @import("labelle-core");
+const jsonc = @import("jsonc");
+const camera_mod = @import("../camera.zig");
+
+pub fn Mixin(comptime Game: type) type {
+    const Entity = Game.EntityType;
+    const CameraComp = Game.CameraComp;
+    const Position = core.Position;
+
+    return struct {
+        /// Seed the active gfx camera from the authored `Camera` component:
+        /// locate the first entity carrying both `Position` and `Camera`, read
+        /// its WORLD position (`getWorldPosition`, matching the digest and
+        /// `editor_set_entity_position`) plus `Camera.zoom`, and apply them to
+        /// `getCamera()`. A no-op — and a comptime no-op that never touches the
+        /// (possibly `void`) camera seam — when the renderer has no settable
+        /// camera or the scene declares no Camera entity. Single-camera MVP:
+        /// the first Camera entity wins.
+        pub fn seedCameraFromComponent(self: *Game) void {
+            if (comptime !camera_mod.hasSettableCamera(Game)) return;
+            var v = self.ecs_backend.view(.{ Position, CameraComp }, .{});
+            defer v.deinit();
+            while (v.next()) |ent| {
+                const cam = self.ecs_backend.getComponent(ent, CameraComp) orelse continue;
+                const wp = self.getWorldPosition(ent);
+                const camera = self.getCamera();
+                camera.setPosition(wp.x, wp.y);
+                camera.setZoom(cam.zoom);
+                return;
+            }
+        }
+
+        /// MERGE a JSON patch into entity `ent`'s `Camera` component, then
+        /// re-seed `getCamera()` so a paused preview updates live. Only the
+        /// keys PRESENT in the patch are overwritten — a `{"zoom":…}` patch
+        /// leaves an existing `viewport` intact (FLAG C, patch semantics). When
+        /// the entity has no `Camera` yet, a default one is materialized and
+        /// patched (the studio's first gizmo edit authors the component).
+        ///
+        /// Errors (leaving the entity untouched) when `source` is unparseable
+        /// or its top level is not a JSON object. The parse tree lives in a
+        /// call-scoped arena; `Camera` has no string fields, so nothing aliases
+        /// `source` past the call and the caller may free it immediately.
+        pub fn applyCameraComponentJson(self: *Game, ent: Entity, source: []const u8) !void {
+            var arena = std.heap.ArenaAllocator.init(self.allocator);
+            defer arena.deinit();
+            var parser = jsonc.JsoncParser.init(arena.allocator(), source);
+            const value = try parser.parse();
+            const obj = value.asObject() orelse return error.InvalidCameraComponentJson;
+
+            // Read-existing-then-overlay: start from the live component (or a
+            // default) so unprovided keys survive the patch.
+            var comp: CameraComp = if (self.ecs_backend.getComponent(ent, CameraComp)) |c| c.* else .{};
+
+            if (obj.getFloat("zoom")) |z| {
+                comp.zoom = @floatCast(z);
+            } else if (obj.getInteger("zoom")) |z| {
+                comp.zoom = @floatFromInt(z);
+            }
+
+            if (obj.getObject("viewport")) |vp| {
+                // Merge sub-fields into the existing (or default) viewport so a
+                // partial viewport patch is also additive.
+                var out = comp.viewport orelse camera_mod.Viewport{};
+                if (vp.getInteger("x")) |x| out.x = @intCast(x);
+                if (vp.getInteger("y")) |y| out.y = @intCast(y);
+                if (vp.getInteger("width")) |w| out.width = @intCast(w);
+                if (vp.getInteger("height")) |h| out.height = @intCast(h);
+                comp.viewport = out;
+            }
+
+            self.setComponent(ent, comp);
+            seedCameraFromComponent(self);
+        }
+    };
+}

--- a/src/game/camera_mixin.zig
+++ b/src/game/camera_mixin.zig
@@ -77,10 +77,14 @@ pub fn Mixin(comptime Game: type) type {
                 // Merge sub-fields into the existing (or default) viewport so a
                 // partial viewport patch is also additive.
                 var out = comp.viewport orelse camera_mod.Viewport{};
-                if (vp.getInteger("x")) |x| out.x = @intCast(x);
-                if (vp.getInteger("y")) |y| out.y = @intCast(y);
-                if (vp.getInteger("width")) |w| out.width = @intCast(w);
-                if (vp.getInteger("height")) |h| out.height = @intCast(h);
+                // Bounds-check the JSON int → i32 narrowing: an out-of-range
+                // value from studio JSON must fail the patch (-2, entity
+                // untouched — this returns before `setComponent` below), NOT
+                // panic via a raw `@intCast` (gemini on #719).
+                if (vp.getInteger("x")) |x| out.x = std.math.cast(i32, x) orelse return error.InvalidCameraComponentJson;
+                if (vp.getInteger("y")) |y| out.y = std.math.cast(i32, y) orelse return error.InvalidCameraComponentJson;
+                if (vp.getInteger("width")) |w| out.width = std.math.cast(i32, w) orelse return error.InvalidCameraComponentJson;
+                if (vp.getInteger("height")) |h| out.height = std.math.cast(i32, h) orelse return error.InvalidCameraComponentJson;
                 comp.viewport = out;
             }
 

--- a/src/game/loop_mixin.zig
+++ b/src/game/loop_mixin.zig
@@ -180,6 +180,11 @@ pub fn Mixin(comptime Game: type) type {
                             );
                         };
                         self.loading_scene_name = null;
+                        // Re-seed the gfx camera from the authored `Camera`
+                        // component after a hot reload rebuilds the scene
+                        // (camera-prefabs #714). Comptime-folds away on
+                        // camera-less renderers.
+                        self.seedCameraFromComponent();
                         self.emitHook(.{ .scene_load = .{ .name = name } });
                         // Engine `Events` dual-emit (#578).
                         self.emitEngineEvent("engine__scene_loaded", .{ .name = name });

--- a/src/game/save_load/load.zig
+++ b/src/game/save_load/load.zig
@@ -580,6 +580,36 @@ pub fn Mixin(comptime Game: type) type {
                         self.addTilemap(entity, .{ .asset_name = name_dup, .layer_bindings = bindings });
                     }
                 }
+
+                // Restore Camera (built-in, camera-prefabs #714) — counterpart
+                // to the save block. Plain POD (no strings / no runtime), so a
+                // straight `addComponent` re-attaches it; the seed re-applies to
+                // the live camera on the next scene bind / paused frame. Gated
+                // on `camera_is_builtin` like the save side.
+                if (comptime Game.camera_is_builtin) {
+                    if (components.get("Camera")) |cam_val| blk: {
+                        const cam_obj = switch (cam_val) {
+                            .object => |o| o,
+                            else => break :blk,
+                        };
+                        var cam: Game.CameraComp = .{};
+                        // Preserve the 1.0 default if a (malformed) save omits
+                        // zoom — `getNumberField` would otherwise yield 0.
+                        if (cam_obj.get("zoom") != null) cam.zoom = getNumberField(cam_obj, "zoom");
+                        if (cam_obj.get("viewport")) |vp_val| {
+                            if (vp_val == .object) {
+                                const vp = vp_val.object;
+                                cam.viewport = .{
+                                    .x = @intFromFloat(getNumberField(vp, "x")),
+                                    .y = @intFromFloat(getNumberField(vp, "y")),
+                                    .width = @intFromFloat(getNumberField(vp, "width")),
+                                    .height = @intFromFloat(getNumberField(vp, "height")),
+                                };
+                            }
+                        }
+                        self.addComponent(entity, cam);
+                    }
+                }
             }
 
             // Step 4: Restore ref arrays ([]const u64 slices)

--- a/src/game/save_load/save.zig
+++ b/src/game/save_load/save.zig
@@ -142,6 +142,23 @@ pub fn Mixin(comptime Game: type) type {
                 }
             }
 
+            // Auto-collect Camera entities (camera-prefabs #714). Same
+            // rationale as the Tilemap sweep: the built-in `Camera` carries no
+            // registry component, so a camera-only entity would otherwise be
+            // missed by the registry sweep. Gated on `camera_is_builtin` so a
+            // project that registered its own `Camera` uses the registry path.
+            if (comptime Game.camera_is_builtin) {
+                var cam_view = self.active_world.ecs_backend.view(.{Game.CameraComp}, .{});
+                defer cam_view.deinit();
+                while (cam_view.next()) |entity| {
+                    const id = Common.entityToU64(entity);
+                    if (!entity_set.contains(id)) {
+                        try entity_set.put(id, {});
+                        try entity_list.append(allocator, id);
+                    }
+                }
+            }
+
             var alloc_writer: std.Io.Writer.Allocating = .init(allocator);
             defer alloc_writer.deinit();
             const writer = &alloc_writer.writer;
@@ -294,6 +311,23 @@ pub fn Mixin(comptime Game: type) type {
                                 try writer.writeAll("}");
                             }
                             try writer.writeAll("]");
+                        }
+                        try writer.writeAll("}");
+                        first_comp = false;
+                    }
+                }
+
+                // Save Camera (built-in, camera-prefabs #714). `zoom` is a
+                // scalar and `viewport` a small optional flat rect — no strings,
+                // so (unlike Tilemap) nothing needs arena-duping. Gated on
+                // `camera_is_builtin`: a project that registered its own
+                // `Camera` goes through the registry serde sweep below instead.
+                if (comptime Game.camera_is_builtin) {
+                    if (self.active_world.ecs_backend.getComponent(entity, Game.CameraComp)) |cam| {
+                        if (!first_comp) try writer.writeAll(",");
+                        try writer.print("\n        \"Camera\": {{\"zoom\": {d}", .{cam.zoom});
+                        if (cam.viewport) |vp| {
+                            try writer.print(", \"viewport\": {{\"x\": {d}, \"y\": {d}, \"width\": {d}, \"height\": {d}}}", .{ vp.x, vp.y, vp.width, vp.height });
                         }
                         try writer.writeAll("}");
                         first_comp = false;

--- a/src/game/scene_mixin.zig
+++ b/src/game/scene_mixin.zig
@@ -518,6 +518,11 @@ pub fn Mixin(comptime Game: type) type {
                     defer self.loading_scene_name = null;
                     try entry.loader_fn(self);
                 }
+                // Seed the gfx camera from the authored `Camera` component now
+                // that the scene's entities exist (camera-prefabs #714) — the
+                // authored starting point, before scripts take the wheel on the
+                // first tick. Comptime-folds away on camera-less renderers.
+                self.seedCameraFromComponent();
                 self.current_scene_name = self.allocator.dupe(u8, name) catch null;
                 self.emitHook(.{ .scene_load = .{ .name = name } });
                 // Engine `Events` dual-emit (#578).
@@ -690,6 +695,10 @@ pub fn Mixin(comptime Game: type) type {
                 defer self.loading_scene_name = null;
                 try entry.loader_fn(self);
             }
+            // Seed the gfx camera from the authored `Camera` component now that
+            // the fresh ECS is populated (camera-prefabs #714). Comptime-folds
+            // away on camera-less renderers.
+            self.seedCameraFromComponent();
             self.current_scene_name = self.allocator.dupe(u8, name) catch null;
             self.emitHook(.{ .scene_load = .{ .name = name } });
             // Engine `Events` dual-emit (#578).

--- a/src/game/scene_mixin.zig
+++ b/src/game/scene_mixin.zig
@@ -518,11 +518,6 @@ pub fn Mixin(comptime Game: type) type {
                     defer self.loading_scene_name = null;
                     try entry.loader_fn(self);
                 }
-                // Seed the gfx camera from the authored `Camera` component now
-                // that the scene's entities exist (camera-prefabs #714) — the
-                // authored starting point, before scripts take the wheel on the
-                // first tick. Comptime-folds away on camera-less renderers.
-                self.seedCameraFromComponent();
                 self.current_scene_name = self.allocator.dupe(u8, name) catch null;
                 self.emitHook(.{ .scene_load = .{ .name = name } });
                 // Engine `Events` dual-emit (#578).
@@ -530,6 +525,13 @@ pub fn Mixin(comptime Game: type) type {
                 if (entry.hooks.onLoad) |onLoad| {
                     onLoad(self);
                 }
+                // Seed the gfx camera from the authored `Camera` component
+                // (camera-prefabs #714) — the authored starting point before
+                // scripts take the wheel. Runs AFTER `onLoad` (finding #3) so a
+                // scene that finalizes the camera's Position/zoom in its hook is
+                // reflected on the first rendered frame. Comptime-folds away on
+                // camera-less renderers.
+                self.seedCameraFromComponent();
             } else if (self.jsonc_scenes.get(name)) |_| {
                 // Runtime JSONC scene — loaded at runtime by the game loop
                 // The actual loading is deferred: the generated code or game code
@@ -695,10 +697,6 @@ pub fn Mixin(comptime Game: type) type {
                 defer self.loading_scene_name = null;
                 try entry.loader_fn(self);
             }
-            // Seed the gfx camera from the authored `Camera` component now that
-            // the fresh ECS is populated (camera-prefabs #714). Comptime-folds
-            // away on camera-less renderers.
-            self.seedCameraFromComponent();
             self.current_scene_name = self.allocator.dupe(u8, name) catch null;
             self.emitHook(.{ .scene_load = .{ .name = name } });
             // Engine `Events` dual-emit (#578).
@@ -707,6 +705,11 @@ pub fn Mixin(comptime Game: type) type {
             if (entry.hooks.onLoad) |onLoad| {
                 onLoad(self);
             }
+            // Seed the gfx camera from the authored `Camera` component AFTER
+            // `onLoad` (finding #3), so a scene finalizing the camera in its
+            // hook is reflected on the first rendered frame (camera-prefabs
+            // #714). Comptime-folds away on camera-less renderers.
+            self.seedCameraFromComponent();
 
             if (previous_name) |p| {
                 const prev_assets: []const []const u8 = if (self.scenes.get(p)) |e| e.assets else &.{};

--- a/src/jsonc/component_apply.zig
+++ b/src/jsonc/component_apply.zig
@@ -132,6 +132,22 @@ pub fn ComponentApply(comptime GameType: type, comptime Components: type) type {
                 }
             }
 
+            // Camera (camera-prefabs MVP, #714) — built-in, attaches as a
+            // plain POD component (no runtime/side-table, unlike Tilemap). The
+            // engine seeds the live gfx camera from it after instantiation
+            // (`seedCameraFromComponent`). Guarded `!Components.has("Camera")`
+            // exactly like Tilemap so a project-registered `Camera` still wins
+            // (the built-in branch compiles out, routing `"Camera"` to the
+            // registered type via the generic dispatch below).
+            if (comptime !Components.has("Camera")) {
+                if (std.mem.eql(u8, name, "Camera")) {
+                    if (deserializer.deserialize(GameType.CameraComp, value, comp_alloc)) |camera| {
+                        game.addComponent(entity, camera);
+                    }
+                    return;
+                }
+            }
+
             // All other components — comptime dispatch via
             // Components registry.
             const filtered = stripEntityArrayFields(value, game.allocator);

--- a/src/root.zig
+++ b/src/root.zig
@@ -72,6 +72,16 @@ pub const TilemapLayerBinding = @import("tilemap.zig").LayerBinding;
 /// `Game`. See `src/tilemap_runtime.zig`.
 pub const tilemapSupported = @import("tilemap_runtime.zig").supported;
 
+// ── Camera (camera-prefabs MVP, #714) ──
+/// Engine built-in `Camera` component — the authored / seed camera state
+/// (`zoom` + optional inert `viewport`; the camera's world center is the
+/// entity's `Position`). Reachable on a configured game as `Game.CameraComp`.
+/// See `src/camera.zig` / `RFC-CAMERA-PREFABS.md`.
+pub const Camera = @import("camera.zig").Camera;
+/// Engine-local screen-space viewport rect carried by `Camera.viewport`
+/// (renderer-agnostic; inert in the single-camera MVP). See `src/camera.zig`.
+pub const CameraViewport = @import("camera.zig").Viewport;
+
 // ── Input ──
 pub const InputInterface = input_mod.InputInterface;
 pub const StubInput = input_mod.StubInput;

--- a/test/editor_api_test.zig
+++ b/test/editor_api_test.zig
@@ -942,6 +942,24 @@ const CameraTestGame = engine.GameConfig(
     void,
 );
 
+/// A project that registers its OWN `Camera` in its ComponentRegistry — the
+/// engine built-in Camera feature must DEFER to it (finding #1).
+const ProjectCamera = struct { zoom: f32 = 1.0, mode: u8 = 0 };
+const RegisteredCameraComponents = engine.ComponentRegistry(.{ .Camera = ProjectCamera });
+const RegisteredCameraGame = engine.GameConfig(
+    CamRender(CamMockEcs.Entity),
+    CamMockEcs,
+    engine.input_mod.StubInput,
+    engine.audio_mod.StubAudio,
+    engine.StubVideo,
+    engine.gui_mod.StubGui,
+    void,
+    core.StubLogSink,
+    RegisteredCameraComponents,
+    &.{},
+    void,
+);
+
 /// Read a JSON number as f64 regardless of whether it serialized as an
 /// integer (`{d}` on a whole f32 drops the fraction, e.g. `400`) or a float
 /// (`533.333…`).
@@ -1231,4 +1249,142 @@ test "editor_set_component: Camera MERGES (a prior viewport survives a zoom-only
     try testing.expectEqual(@as(i32, -2), editor_api.editor_set_component(@intCast(cam_ent), "Camera", 6, oor.ptr, oor.len));
     testing.allocator.free(oor);
     try testing.expectEqual(@as(i32, 99), game.getComponent(cam_ent, engine.Camera).?.viewport.?.width); // unchanged by the rejected patch
+
+    // An explicit `{"viewport":null}` CLEARS the viewport back to fullscreen —
+    // distinct from an ABSENT key, which leaves it alone (finding #4).
+    const null_patch = try testing.allocator.dupe(u8, "{\"viewport\":null}");
+    try testing.expectEqual(@as(i32, 0), editor_api.editor_set_component(@intCast(cam_ent), "Camera", 6, null_patch.ptr, null_patch.len));
+    testing.allocator.free(null_patch);
+    const comp3 = game.getComponent(cam_ent, engine.Camera).?;
+    try testing.expect(comp3.viewport == null);
+    try testing.expectEqual(@as(f32, 2.0), comp3.zoom); // an absent zoom key leaves zoom alone
+}
+
+test "camera built-in DEFERS to a project's own registered Camera (finding #1)" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    // The comptime gate flips off exactly when a project registers "Camera".
+    try testing.expect(CameraTestGame.camera_is_builtin);
+    try testing.expect(!RegisteredCameraGame.camera_is_builtin);
+
+    var game = RegisteredCameraGame.init(testing.allocator);
+    defer game.deinit();
+    const e = game.createEntity();
+    game.setPosition(e, .{ .x = 0, .y = 0 });
+
+    var runner = DummyRunner{};
+    editor_api.bind(&game, &runner);
+
+    // `editor_set_component("Camera", …)` REFUSES with -1 on such a project —
+    // the built-in bridge is off, so it won't materialize a conflicting second
+    // component (rather than silently corrupting the authoring model).
+    try testing.expectEqual(@as(i32, -1), editor_api.editor_set_component(@intCast(e), "Camera", 6, "{\"zoom\":2}", 10));
+    // The built-in Camera component was never attached.
+    try testing.expect(game.getComponent(e, engine.Camera) == null);
+}
+
+test "camera apply-while-paused: a STEPPED frame keeps the ticked camera (single-step debug, finding #2)" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = CameraTestGame.init(testing.allocator);
+    defer game.deinit();
+    const cam_ent = game.createEntity();
+    game.setPosition(cam_ent, .{ .x = 400, .y = 300 });
+    game.addComponent(cam_ent, engine.Camera{ .zoom = 1.5 });
+
+    var runner = DummyRunner{};
+    editor_api.bind(&game, &runner);
+    editor_api.editor_pause(1);
+    editor_api.editor_step(1);
+
+    // The generated loop is `if (shouldTick()) g.tick(dt); frame();`. This frame
+    // TICKS (consumes the step): shouldTick returns true, a camera script moves
+    // the camera during the "tick", and frame() must NOT re-seed — single-step
+    // debugging must render the just-ticked camera, not the authored seed.
+    try testing.expect(editor_api.shouldTick());
+    game.getCamera().setPosition(999, 888); // "script" moved it during the tick
+    game.getCamera().setZoom(0.9);
+    editor_api.frame(&game);
+    try testing.expectEqual(@as(f32, 999), game.getCamera().x);
+    try testing.expectEqual(@as(f32, 0.9), game.getCamera().zoom);
+
+    // The next PAUSED frame does NOT tick (no pending step): shouldTick returns
+    // false and frame() re-seeds from the authored component again.
+    try testing.expect(!editor_api.shouldTick());
+    editor_api.frame(&game);
+    try testing.expectEqual(@as(f32, 400), game.getCamera().x);
+    try testing.expectEqual(@as(f32, 1.5), game.getCamera().zoom);
+}
+
+test "camera seed-on-load: seeds AFTER onLoad, reflecting a camera the hook finalizes (finding #3)" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = CameraTestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const loader = struct {
+        fn load(g: *CameraTestGame) anyerror!void {
+            const e = g.createEntity();
+            g.setPosition(e, .{ .x = 100, .y = 100 });
+            g.addComponent(e, engine.Camera{ .zoom = 1.0 });
+            g.trackSceneEntity(e);
+        }
+    }.load;
+    const hooks = struct {
+        fn onLoad(g: *CameraTestGame) void {
+            // The scene finalizes the camera in its onLoad hook.
+            var v = g.ecs_backend.view(.{ core.Position, engine.Camera }, .{});
+            defer v.deinit();
+            while (v.next()) |e| {
+                g.setPosition(e, .{ .x = 700, .y = 500 });
+                g.getComponent(e, engine.Camera).?.zoom = 3.0;
+            }
+        }
+    };
+    game.registerScene("cam_hook", loader, .{ .onLoad = hooks.onLoad });
+    try game.setScene("cam_hook");
+
+    // The seed ran AFTER onLoad → the live camera reflects the hook's values,
+    // not the loader's initial (100,100)/1.0.
+    try testing.expectEqual(@as(f32, 700), game.getCamera().x);
+    try testing.expectEqual(@as(f32, 500), game.getCamera().y);
+    try testing.expectEqual(@as(f32, 3.0), game.getCamera().zoom);
+}
+
+test "save/load: the built-in Camera round-trips zoom + viewport (finding #5)" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = CameraTestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const cam_ent = game.createEntity();
+    game.setPosition(cam_ent, .{ .x = 640, .y = 360 });
+    game.addComponent(cam_ent, engine.Camera{
+        .zoom = 2.5,
+        .viewport = .{ .x = 5, .y = 6, .width = 320, .height = 240 },
+    });
+
+    const save_path = "test_save_camera_714.json";
+    try game.saveGameState(save_path);
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, save_path) catch {};
+
+    // Wipe the ECS and reload from disk.
+    game.resetEcsBackend();
+    try game.loadGameState(save_path);
+
+    // The built-in Camera save/load channel restored zoom + viewport (Position
+    // persists via its own channel).
+    var restored: ?*engine.Camera = null;
+    var v = game.active_world.ecs_backend.view(.{ core.Position, engine.Camera }, .{});
+    defer v.deinit();
+    while (v.next()) |e| restored = game.active_world.ecs_backend.getComponent(e, engine.Camera);
+    try testing.expect(restored != null);
+    try testing.expectEqual(@as(f32, 2.5), restored.?.zoom);
+    try testing.expect(restored.?.viewport != null);
+    try testing.expectEqual(@as(i32, 320), restored.?.viewport.?.width);
+    try testing.expectEqual(@as(i32, 6), restored.?.viewport.?.y);
 }

--- a/test/editor_api_test.zig
+++ b/test/editor_api_test.zig
@@ -1223,4 +1223,12 @@ test "editor_set_component: Camera MERGES (a prior viewport survives a zoom-only
     try testing.expectEqual(@as(f32, 2.0), comp2.zoom); // untouched by a viewport patch
     try testing.expectEqual(@as(i32, 99), comp2.viewport.?.width);
     try testing.expectEqual(@as(i32, 2), comp2.viewport.?.y); // prior sub-field survives
+
+    // Out-of-range viewport int → -2 (bounds-checked i32 narrowing, NOT a
+    // raw @intCast panic — gemini HIGH on #719); entity untouched.
+    // 3_000_000_000 parses as i64 but exceeds i32 max.
+    const oor = try testing.allocator.dupe(u8, "{\"viewport\":{\"width\":3000000000}}");
+    try testing.expectEqual(@as(i32, -2), editor_api.editor_set_component(@intCast(cam_ent), "Camera", 6, oor.ptr, oor.len));
+    testing.allocator.free(oor);
+    try testing.expectEqual(@as(i32, 99), game.getComponent(cam_ent, engine.Camera).?.viewport.?.width); // unchanged by the rejected patch
 }

--- a/test/editor_api_test.zig
+++ b/test/editor_api_test.zig
@@ -1258,6 +1258,16 @@ test "editor_set_component: Camera MERGES (a prior viewport survives a zoom-only
     const comp3 = game.getComponent(cam_ent, engine.Camera).?;
     try testing.expect(comp3.viewport == null);
     try testing.expectEqual(@as(f32, 2.0), comp3.zoom); // an absent zoom key leaves zoom alone
+
+    // A present-but-wrong-TYPE `zoom` (`"2"` string) → -2, not a silent skip
+    // that would author a default zoom (codex on #719); entity untouched.
+    try testing.expectEqual(@as(i32, -2), editor_api.editor_set_component(@intCast(cam_ent), "Camera", 6, "{\"zoom\":\"2\"}", 12));
+    try testing.expectEqual(@as(f32, 2.0), game.getComponent(cam_ent, engine.Camera).?.zoom);
+
+    // Trailing junk after a valid object (`{...}garbage`) → -2 (parse must
+    // reach EOF), not a partial-parse success (codex on #719).
+    try testing.expectEqual(@as(i32, -2), editor_api.editor_set_component(@intCast(cam_ent), "Camera", 6, "{\"zoom\":5}garbage", 17));
+    try testing.expectEqual(@as(f32, 2.0), game.getComponent(cam_ent, engine.Camera).?.zoom);
 }
 
 test "camera built-in DEFERS to a project's own registered Camera (finding #1)" {

--- a/test/editor_api_test.zig
+++ b/test/editor_api_test.zig
@@ -81,6 +81,9 @@ test "pre-bind: every export is a safe no-op" {
     // Void setters silently ignore.
     editor_api.editor_set_entity_position(42, 1.0, 2.0);
 
+    // Generic per-component edit (v1.5) reports "not bound" pre-bind.
+    try testing.expectEqual(@as(i32, -1), editor_api.editor_set_component(42, "Camera", 6, "{\"zoom\":1}", 10));
+
     // Pick is the documented v1 stub.
     try testing.expectEqual(@as(i64, -1), editor_api.editor_pick(10.0, 20.0));
 
@@ -799,4 +802,425 @@ test "reloadPrefabSource: a push BEFORE any scene load creates the cache the boo
     try testing.expectEqualStrings("v2-overlay", game.ecs_backend.getComponent(e, PipeOverlay).?.text);
     const c = game.spawnPrefab("condenser", .{ .x = 0, .y = 0 }).?;
     try testing.expectEqualStrings("v1-overlay", game.ecs_backend.getComponent(c, PipeOverlay).?.text);
+}
+
+// ── Camera prefabs (contract v1.5, #714) ────────────────────────────
+//
+// A camera-CAPABLE game: a stub renderer that additionally exposes the
+// camera seam (`CameraType` with setPosition/setZoom/getViewport +
+// getCamera), configured with a MockEcs so it can hold `Camera` entities.
+// This is the shape the seed / apply-while-paused / digest / set-component
+// paths need — the default `engine.Game` (StubRender) has no camera and
+// folds them all away at comptime.
+
+const EmptyComponents = struct {
+    pub fn has(comptime _: []const u8) bool {
+        return false;
+    }
+    pub fn getType(comptime _: []const u8) type {
+        return void;
+    }
+    pub fn names() []const []const u8 {
+        return &.{};
+    }
+};
+
+/// Camera stand-in exposing the full seam the camera-prefabs paths touch:
+/// setPosition/setZoom (the `gameHasCamera` gate) + getViewport (the digest
+/// `view`). `getViewport` returns the world rect centered on the camera,
+/// sized by an 800×600 design surface over `zoom` — the same math gfx's
+/// `CameraWith.getViewport` uses.
+const CamCamera = struct {
+    x: f32 = 0,
+    y: f32 = 0,
+    zoom: f32 = 1,
+
+    const ViewRect = struct { x: f32, y: f32, width: f32, height: f32 };
+
+    pub fn setPosition(self: *CamCamera, x: f32, y: f32) void {
+        self.x = x;
+        self.y = y;
+    }
+    pub fn setZoom(self: *CamCamera, level: f32) void {
+        self.zoom = level;
+    }
+    pub fn getViewport(self: *const CamCamera) ViewRect {
+        const w = 800.0 / self.zoom;
+        const h = 600.0 / self.zoom;
+        return .{ .x = self.x - w / 2.0, .y = self.y - h / 2.0, .width = w, .height = h };
+    }
+};
+
+/// Stub renderer mirroring `core.StubRender`'s no-op surface plus the camera
+/// seam (as `GfxRendererWith` exposes it: `CameraType`/`CameraManagerType` +
+/// `getCamera`/`getCameraManager`).
+fn CamRender(comptime Entity: type) type {
+    return struct {
+        const Self = @This();
+
+        pub const Sprite = struct {
+            sprite_name: []const u8 = "",
+            visible: bool = true,
+            z_index: i16 = 0,
+            layer: enum { default } = .default,
+        };
+        pub const Shape = struct {
+            shape: union(enum) {
+                rectangle: struct { width: f32 = 10, height: f32 = 10 },
+                circle: struct { radius: f32 = 10 },
+            } = .{ .rectangle = .{} },
+            color: struct { r: u8 = 255, g: u8 = 255, b: u8 = 255, a: u8 = 255 } = .{},
+            visible: bool = true,
+            z_index: i16 = 0,
+            layer: enum { default } = .default,
+        };
+        pub const Text = struct {
+            text: [:0]const u8 = "",
+            visible: bool = true,
+            z_index: i16 = 0,
+        };
+        pub const Icon = struct {
+            name: []const u8 = "",
+            visible: bool = true,
+        };
+
+        pub const CameraType = CamCamera;
+        pub const CameraManagerType = struct {};
+
+        camera: CamCamera = .{},
+        tracked_count: usize = 0,
+        render_count: usize = 0,
+
+        pub fn init(_: std.mem.Allocator) Self {
+            return .{};
+        }
+        pub fn deinit(_: *Self) void {}
+        pub fn trackEntity(self: *Self, _: Entity, _: core.render.VisualType) void {
+            self.tracked_count += 1;
+        }
+        pub fn untrackEntity(self: *Self, _: Entity) void {
+            if (self.tracked_count > 0) self.tracked_count -= 1;
+        }
+        pub fn markPositionDirty(_: *Self, _: Entity) void {}
+        pub fn markPositionDirtyWithChildren(_: *Self, comptime _: type, _: anytype, _: Entity) void {}
+        pub fn updateHierarchyFlag(_: *Self, _: Entity, _: bool) void {}
+        pub fn markVisualDirty(_: *Self, _: Entity) void {}
+        pub fn sync(_: *Self, comptime _: type, _: anytype) void {}
+        pub fn render(self: *Self) void {
+            self.render_count += 1;
+        }
+        pub fn setScreenHeight(_: *Self, _: f32) void {}
+        pub fn clear(self: *Self) void {
+            self.tracked_count = 0;
+        }
+        pub fn renderGizmoDraws(_: *Self, _: []const core.gizmos.GizmoDraw) void {}
+        pub fn hasEntity(_: *const Self, _: Entity) bool {
+            return false;
+        }
+        pub fn getCamera(self: *Self) *CamCamera {
+            return &self.camera;
+        }
+        pub fn getCameraManager(self: *Self) *CameraManagerType {
+            _ = self;
+            return undefined;
+        }
+    };
+}
+
+const CamMockEcs = core.MockEcsBackend(u32);
+const CameraTestGame = engine.GameConfig(
+    CamRender(CamMockEcs.Entity),
+    CamMockEcs,
+    engine.input_mod.StubInput,
+    engine.audio_mod.StubAudio,
+    engine.StubVideo,
+    engine.gui_mod.StubGui,
+    void,
+    core.StubLogSink,
+    EmptyComponents,
+    &.{},
+    void,
+);
+
+/// Read a JSON number as f64 regardless of whether it serialized as an
+/// integer (`{d}` on a whole f32 drops the fraction, e.g. `400`) or a float
+/// (`533.333…`).
+fn jsonNum(v: std.json.Value) f64 {
+    return switch (v) {
+        .integer => |i| @floatFromInt(i),
+        .float => |f| f,
+        else => unreachable,
+    };
+}
+
+test "camera seed: reads the WORLD position of the (parented) camera entity, not the raw local" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = CameraTestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const rig = game.createEntity();
+    game.setPosition(rig, .{ .x = 100, .y = 200 });
+    const cam_ent = game.createEntity();
+    game.setPosition(cam_ent, .{ .x = 10, .y = 20 }); // local to rig
+    game.setParent(cam_ent, rig, .{});
+    game.addComponent(cam_ent, engine.Camera{ .zoom = 2.0 });
+
+    // FLAG A: the seed reads getWorldPosition (100+10, 200+20), matching the
+    // digest / editor_set_entity_position — NOT the raw local Position.
+    game.seedCameraFromComponent();
+    const cam = game.getCamera();
+    try testing.expectEqual(@as(f32, 110), cam.x);
+    try testing.expectEqual(@as(f32, 220), cam.y);
+    try testing.expectEqual(@as(f32, 2.0), cam.zoom);
+}
+
+test "camera seed-on-load: setScene seeds the camera from a scene-loaded Camera entity" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = CameraTestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const loader = struct {
+        fn load(g: *CameraTestGame) anyerror!void {
+            const e = g.createEntity();
+            g.setPosition(e, .{ .x = 640, .y = 360 });
+            g.addComponent(e, engine.Camera{ .zoom = 2.5 });
+            g.trackSceneEntity(e);
+        }
+    }.load;
+    game.registerSceneSimple("cam_scene", loader);
+    try game.setScene("cam_scene");
+
+    // setScene ran seedCameraFromComponent after the loader instantiated
+    // the entities — the authored camera is live without a manual call.
+    try testing.expectEqual(@as(f32, 640), game.getCamera().x);
+    try testing.expectEqual(@as(f32, 360), game.getCamera().y);
+    try testing.expectEqual(@as(f32, 2.5), game.getCamera().zoom);
+}
+
+test "scene loader: a scene-authored \"Camera\" component attaches as the built-in and seeds" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = CameraTestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const Bridge = engine.JsoncSceneBridge(CameraTestGame, EmptyComponents);
+    try Bridge.loadSceneFromSource(&game,
+        \\{ "entities": [
+        \\   { "components": { "Position": { "x": 512, "y": 384 }, "Camera": { "zoom": 3.0 } } }
+        \\ ] }
+    , "prefabs");
+
+    // component_apply's built-in "Camera" branch attached the POD (rather
+    // than warning it as an unknown component).
+    var found: ?*engine.Camera = null;
+    var v = game.ecs_backend.view(.{ core.Position, engine.Camera }, .{});
+    defer v.deinit();
+    while (v.next()) |e| found = game.getComponent(e, engine.Camera);
+    try testing.expect(found != null);
+    try testing.expectEqual(@as(f32, 3.0), found.?.zoom);
+
+    // …and the built-in seed applies its world position + zoom.
+    game.seedCameraFromComponent();
+    try testing.expectEqual(@as(f32, 512), game.getCamera().x);
+    try testing.expectEqual(@as(f32, 3.0), game.getCamera().zoom);
+}
+
+test "camera apply-while-paused: paused frame re-seeds from the component; override wins; unpaused leaves it" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = CameraTestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const cam_ent = game.createEntity();
+    game.setPosition(cam_ent, .{ .x = 400, .y = 300 });
+    game.addComponent(cam_ent, engine.Camera{ .zoom = 1.5 });
+
+    var runner = DummyRunner{};
+    editor_api.bind(&game, &runner);
+
+    // UNPAUSED: frame does NOT apply the component — the gameplay script owns
+    // the camera on resume. A "script" write survives the frame.
+    game.getCamera().setPosition(0, 0);
+    game.getCamera().setZoom(1.0);
+    editor_api.frame(&game);
+    try testing.expectEqual(@as(f32, 0), game.getCamera().x);
+    try testing.expectEqual(@as(f32, 1.0), game.getCamera().zoom);
+
+    // PAUSED: frame re-seeds the camera from the authored component every
+    // frame, so a script write between frames is overwritten by the seed.
+    editor_api.editor_pause(1);
+    game.getCamera().setPosition(0, 0);
+    game.getCamera().setZoom(1.0);
+    editor_api.frame(&game);
+    try testing.expectEqual(@as(f32, 400), game.getCamera().x);
+    try testing.expectEqual(@as(f32, 300), game.getCamera().y);
+    try testing.expectEqual(@as(f32, 1.5), game.getCamera().zoom);
+
+    // A live inspector edit (component mutated in place) shows on the next
+    // paused frame — this is what makes editing feel live.
+    game.getComponent(cam_ent, engine.Camera).?.zoom = 2.0;
+    editor_api.frame(&game);
+    try testing.expectEqual(@as(f32, 2.0), game.getCamera().zoom);
+
+    // The look-around override still wins on top, applied last by frame().
+    editor_api.editor_set_camera(-50, 60, 0.5);
+    editor_api.frame(&game);
+    try testing.expectEqual(@as(f32, -50), game.getCamera().x);
+    try testing.expectEqual(@as(f32, 0.5), game.getCamera().zoom);
+
+    // Release → the paused frame hands back to the authored component.
+    editor_api.editor_release_camera();
+    editor_api.frame(&game);
+    try testing.expectEqual(@as(f32, 400), game.getCamera().x);
+    try testing.expectEqual(@as(f32, 2.0), game.getCamera().zoom);
+}
+
+test "camera apply-while-paused: comptime-folds away on a camera-less (stub) renderer" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    // Default engine.Game is StubRender — CameraType == void.
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const e = game.createEntity();
+    game.setPosition(e, .{ .x = 1, .y = 2 });
+    // A Camera component can still attach (inert POD); the seed/apply path
+    // that would consume it folds to nothing at comptime.
+    game.addComponent(e, engine.Camera{ .zoom = 3.0 });
+
+    var runner = DummyRunner{};
+    editor_api.bind(&game, &runner);
+
+    // Paused frame with a Camera present: nothing to apply, no crash, no
+    // getCamera() (which is `void` here) ever touched.
+    editor_api.editor_pause(1);
+    editor_api.frame(&game);
+    game.seedCameraFromComponent(); // also a comptime no-op
+}
+
+test "digest: camera entity publishes zoom, optional viewport, and the derived world view-rect" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = CameraTestGame.init(testing.allocator);
+    defer game.deinit();
+
+    // Camera A — no authored viewport: digest emits zoom + derived view only.
+    const cam_a = game.createEntity();
+    game.setPosition(cam_a, .{ .x = 400, .y = 300 });
+    game.addComponent(cam_a, engine.Camera{ .zoom = 1.5 });
+    game.seedCameraFromComponent(); // so getCamera() (→ `view`) reflects it
+
+    var runner = DummyRunner{};
+    editor_api.bind(&game, &runner);
+
+    var buf: [4096]u8 = undefined;
+    {
+        const json = digestInto(&buf);
+        var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+        defer parsed.deinit();
+
+        var saw = false;
+        for (parsed.value.object.get("entities").?.array.items) |item| {
+            const obj = item.object;
+            if (obj.get("id").?.integer != @as(i64, @intCast(cam_a))) continue;
+            const cam = obj.get("camera").?.object;
+            try testing.expectEqual(@as(f64, 1.5), jsonNum(cam.get("zoom").?));
+            try testing.expect(cam.get("viewport") == null); // not authored
+            // Derived world view-rect from getViewport(): 800/1.5 × 600/1.5,
+            // centered on (400, 300).
+            const view = cam.get("view").?.object;
+            try testing.expectApproxEqAbs(@as(f64, 800.0 / 1.5), jsonNum(view.get("width").?), 0.01);
+            try testing.expectApproxEqAbs(@as(f64, 600.0 / 1.5), jsonNum(view.get("height").?), 0.01);
+            try testing.expectApproxEqAbs(@as(f64, 400.0 - (800.0 / 1.5) / 2.0), jsonNum(view.get("x").?), 0.01);
+            saw = true;
+        }
+        try testing.expect(saw);
+    }
+
+    // Camera B — authored viewport round-trips in the digest (FLAG C).
+    const cam_b = game.createEntity();
+    game.setPosition(cam_b, .{ .x = 0, .y = 0 });
+    game.addComponent(cam_b, engine.Camera{ .zoom = 1.0, .viewport = .{ .x = 10, .y = 20, .width = 30, .height = 40 } });
+    {
+        const json = digestInto(&buf);
+        var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+        defer parsed.deinit();
+        var saw_vp = false;
+        for (parsed.value.object.get("entities").?.array.items) |item| {
+            const obj = item.object;
+            if (obj.get("id").?.integer != @as(i64, @intCast(cam_b))) continue;
+            const vp = obj.get("camera").?.object.get("viewport").?.object;
+            try testing.expectEqual(@as(i64, 10), vp.get("x").?.integer);
+            try testing.expectEqual(@as(i64, 20), vp.get("y").?.integer);
+            try testing.expectEqual(@as(i64, 30), vp.get("width").?.integer);
+            try testing.expectEqual(@as(i64, 40), vp.get("height").?.integer);
+            saw_vp = true;
+        }
+        try testing.expect(saw_vp);
+    }
+}
+
+test "editor_set_component: Camera MERGES (a prior viewport survives a zoom-only patch), reseeds, and guards" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = CameraTestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const cam_ent = game.createEntity();
+    game.setPosition(cam_ent, .{ .x = 400, .y = 300 });
+    game.addComponent(cam_ent, engine.Camera{
+        .zoom = 1.0,
+        .viewport = .{ .x = 1, .y = 2, .width = 3, .height = 4 },
+    });
+
+    var runner = DummyRunner{};
+    editor_api.bind(&game, &runner);
+    editor_api.editor_pause(1);
+
+    // Patch ONLY zoom, from a transient buffer (the studio frees its wasm
+    // buffer immediately after the call).
+    const patch = try testing.allocator.dupe(u8, "{\"zoom\":2.0}");
+    try testing.expectEqual(@as(i32, 0), editor_api.editor_set_component(@intCast(cam_ent), "Camera", 6, patch.ptr, patch.len));
+    testing.allocator.free(patch);
+
+    // MERGE (FLAG C): zoom updated, the prior viewport SURVIVED — the patch
+    // did not whole-replace the component.
+    const comp = game.getComponent(cam_ent, engine.Camera).?;
+    try testing.expectEqual(@as(f32, 2.0), comp.zoom);
+    try testing.expect(comp.viewport != null);
+    try testing.expectEqual(@as(i32, 3), comp.viewport.?.width);
+    try testing.expectEqual(@as(i32, 4), comp.viewport.?.height);
+
+    // Re-seed on success → the live camera reflects the patched zoom.
+    try testing.expectEqual(@as(f32, 2.0), game.getCamera().zoom);
+
+    // Allowlist (FLAG B): a non-"Camera" name is refused with -1 (no blanket
+    // apply-any-component path), entity untouched.
+    try testing.expectEqual(@as(i32, -1), editor_api.editor_set_component(@intCast(cam_ent), "Sprite", 6, "{}", 2));
+    try testing.expectEqual(@as(f32, 2.0), game.getComponent(cam_ent, engine.Camera).?.zoom);
+
+    // Unknown/dead id → -1 (distinct from a parse failure).
+    try testing.expectEqual(@as(i32, -1), editor_api.editor_set_component(999_999, "Camera", 6, "{\"zoom\":9}", 10));
+
+    // Parse failure → -2, entity untouched (parse precedes any mutation).
+    try testing.expectEqual(@as(i32, -2), editor_api.editor_set_component(@intCast(cam_ent), "Camera", 6, "{\"zoom\":", 8));
+    try testing.expectEqual(@as(f32, 2.0), game.getComponent(cam_ent, engine.Camera).?.zoom);
+
+    // A subsequent viewport-only patch also merges: zoom (2.0) survives.
+    const vp_patch = try testing.allocator.dupe(u8, "{\"viewport\":{\"width\":99}}");
+    try testing.expectEqual(@as(i32, 0), editor_api.editor_set_component(@intCast(cam_ent), "Camera", 6, vp_patch.ptr, vp_patch.len));
+    testing.allocator.free(vp_patch);
+    const comp2 = game.getComponent(cam_ent, engine.Camera).?;
+    try testing.expectEqual(@as(f32, 2.0), comp2.zoom); // untouched by a viewport patch
+    try testing.expectEqual(@as(i32, 99), comp2.viewport.?.width);
+    try testing.expectEqual(@as(i32, 2), comp2.viewport.?.y); // prior sub-field survives
 }


### PR DESCRIPTION
Implements the **engine spine of #714** — the Camera-prefabs FOUNDATION from RFC-CAMERA-PREFABS (PR #715). Makes the game camera an **authored, studio-editable entity** without migrating any game's camera script: the component is a **seed, not a leash** (soft ownership — applied live only while the sim is paused, when no gameplay script is ticking to fight it).

Closes the engine half of #714. Built to the accepted spec (does not wait on the RFC PR).

## What's here

- **`Camera` built-in component** (`src/camera.zig`) — `{ zoom: f32 = 1.0, viewport: ?Viewport = null }`, handled by dedicated built-in channels exactly like `Tilemap` (NOT a `ComponentRegistry` component). `Viewport` is an **engine-local** rect — renderer-agnostic, it deliberately does **not** reference gfx's `ScreenViewport`, and is inert in the single-camera MVP (carried so multi-camera is later additive). `follow` reserved in a comment. Position provides xy.
- **Seed-on-load** — `game.seedCameraFromComponent()` finds the Camera entity, reads its **`getWorldPosition`** + `zoom`, and seeds `getCamera().setPosition/setZoom` once. Wired in after instantiation in `setScene` / `setSceneAtomic` / hot-reload. Comptime-folds away on camera-less renderers.
- **Apply-while-paused** — `editor_api.frame` re-seeds from the component every paused frame while no `editor_set_camera` override is engaged; the look-around override still applies **last** and wins. Gated on the existing `gameHasCamera`.
- **Digest** — optional per-entity `"camera"` object.
- **`editor_set_component(id, name, json)` export** — editor-bridge contract **v1.5**.
- **Scene-loader `"Camera"` branch** in `component_apply.zig`, guarded `!Components.has("Camera")` like Tilemap so a project-registered override wins.

## Flags implemented: A, B, C

- **FLAG A** — seed & apply-while-paused read **world** position (`getWorldPosition`), matching the digest & `editor_set_entity_position`, not the raw `Position`.
- **FLAG B** — `editor_set_component` is **allowlist-gated** to `"Camera"` only; any other name → -1 (no blanket apply-any-component path).
- **FLAG C** — `editor_set_component` uses **MERGE/patch** semantics (a `{"zoom":…}` patch preserves a prior `viewport`); the digest publishes the **authored** `zoom`/`viewport` for round-trip **plus** the derived world `view`.

## Digest shape

```jsonc
{ "id": 7, "x": 400, "y": 300,
  "camera": {
    "zoom": 1.5,
    "viewport": { "x": 10, "y": 20, "width": 30, "height": 40 }, // only when authored
    "view":     { "x": 133, "y": 100, "width": 533, "height": 400 } // derived, world-space, from getCamera().getViewport()
  } }
```
`camera` appears only on Camera-bearing entities (sprite/tilemap optional-field pattern); `view` only on renderers whose camera reports `getViewport()`.

## `editor_set_component` contract (v1.5)

`editor_set_component(id, name_ptr, name_len, json_ptr, json_len) i32`
- Allowlisted to `"Camera"` (FLAG B); MERGE into the existing component (FLAG C); re-seeds `getCamera()` on success so the paused preview updates live.
- Returns **0** ok / **-1** not bound · unknown id · unknown-or-unvetted component / **-2** parse-or-validation failure (entity untouched — parse precedes any mutation). Buffers copied; caller may free immediately. Optional-on-older-builds like v1.1–v1.4.

## Tests — `zig build test` + `zig build spec` green

Added to `test/editor_api_test.zig` (with a camera-capable stub renderer + MockEcs game): seed reads **world** position (parented camera), seed-on-load via `setScene`, scene-loader attaches the built-in, apply-while-paused re-seeds + override-wins + **folds away on a stub renderer**, digest emits `camera:{zoom,viewport?,view}`, and `editor_set_component` **MERGE** (prior `viewport` survives a zoom-only patch) + allowlist(-1) + unknown-id(-1) + parse(-2) guards. Verified a test exercises the new path (broke the world-seed assertion → failed `expected 111, found 110` → restored).

## Out of scope (other tickets)

- Default-camera insertion / `ensureDefaultCamera` — #564 / assembler #569.
- Studio tree / inspector / gizmo / `.jsonc` round-trip — #67.
- **Deferred:** `Camera.zoom` save/load — not part of the #714 5-item spine (`Position` already persists via the built-in channel); a small additive follow-up.

https://claude.ai/code/session_01P7YLw4hXFCCaY2LAUt4G1j
