### PR TITLE
release: labelle-engine 1.80.0 — SpriteAnimation richer playback (#625)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xe8a81a8dc7f48c87,
     .name = .engine,
-    .version = "1.79.0",
+    .version = "1.80.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         // Requires labelle-core >= v1.20.0 — font_types aliases core's


### PR DESCRIPTION
Version bump for #625 (merged as #718). Adds progress/duration queries + `isComplete`, a per-animation `speed` multiplier, and `event_frames` (`[]const u16`) + the `anim_frame`/`anim_complete`/`anim_loop` engine events, all comptime-folded to zero cost when unused. Additive — existing SpriteAnimation users unchanged.

Closes #625 on release.

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw