### PR TITLE
release: labelle-engine 1.81.0 — camera-prefabs foundation

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xe8a81a8dc7f48c87,
     .name = .engine,
-    .version = "1.80.0",
+    .version = "1.81.0",
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         // Requires labelle-core >= v1.20.0 — font_types aliases core's


### PR DESCRIPTION
Version bump only. Ships the camera-prefabs engine spine (#719) + RFC (#715) as v1.81.0 so assembler #569 and studio #67 can pin it.

https://claude.ai/code/session_01P7YLw4hXFCCaY2LAUt4G1j