### PR TITLE
feat(mirror): game-facing render-target API (createRenderTarget + mirror)

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -39,6 +39,7 @@ const video_mixin = @import("game/video_mixin.zig");
 const gui_mixin = @import("game/gui_mixin.zig");
 const gizmo_mixin = @import("game/gizmo_mixin.zig");
 const mesh_mixin = @import("game/mesh_mixin.zig");
+const render_target_mixin = @import("game/render_target_mixin.zig");
 const scene_mixin = @import("game/scene_mixin.zig");
 const save_load_mixin = @import("game/save_load_mixin.zig");
 const state_mixin = @import("game/state_mixin.zig");
@@ -292,6 +293,7 @@ pub fn GameConfigWithYAxis(
         const GuiMixin = gui_mixin.Mixin(Self);
         const GizmoMixin = gizmo_mixin.Mixin(Self);
         const MeshMixin = mesh_mixin.Mixin(Self);
+        const RenderTargetMixin = render_target_mixin.Mixin(Self);
         const SceneMixin = scene_mixin.Mixin(Self);
         const SaveLoadMixin = save_load_mixin.Mixin(Self);
         const StateMixin = state_mixin.Mixin(Self);
@@ -1141,6 +1143,18 @@ pub fn GameConfigWithYAxis(
         /// on renderers/backends that don't declare it. Plugins call this from
         /// a `Systems.renderMeshes(game)` callback (see `SystemRegistry`).
         pub const drawMesh = MeshMixin.drawMesh;
+
+        // ── Offscreen render targets / transport mirror (mixin) ──
+        /// Render a scene into a texture instead of the screen, then draw that
+        /// texture elsewhere (the "transport mirror") — same primitive as headless
+        /// capture (labelle-bgfx#36). Opaque `u32` handles. Each forwards to the
+        /// renderer's optional render-target op; a no-op / INVALID on renderers or
+        /// backends that don't declare it (bgfx today; raylib/sokol/… omit it).
+        pub const createRenderTarget = RenderTargetMixin.createRenderTarget;
+        pub const beginRenderTarget = RenderTargetMixin.beginRenderTarget;
+        pub const endRenderTarget = RenderTargetMixin.endRenderTarget;
+        pub const drawRenderTarget = RenderTargetMixin.drawRenderTarget;
+        pub const destroyRenderTarget = RenderTargetMixin.destroyRenderTarget;
 
         // ── Scene Management (mixin) ─────────────────────────────
         pub const registerScene = SceneMixin.registerScene;

--- a/src/game/render_target_mixin.zig
+++ b/src/game/render_target_mixin.zig
@@ -1,0 +1,66 @@
+/// Render-target mixin — offscreen render-to-texture for game code: the
+/// transport mirror (render a scene into a texture and draw it somewhere else)
+/// and, underneath, the same primitive as headless capture (labelle-bgfx#36).
+///
+/// Mirrors the `drawMesh` seam (`mesh_mixin.zig`): each method forwards to the
+/// renderer's optional render-target op (the gfx `GfxRenderer`/`RetainedEngine`
+/// API, labelle-gfx), gated on `@hasDecl` so renderers/backends that don't
+/// declare them (raylib/sokol/wgpu/sdl today, and the engine's `StubRender`)
+/// compile to a no-op / INVALID. Adding it is therefore non-breaking for every
+/// existing game and backend.
+///
+/// Handles are opaque `u32` ids (like a texture handle), never a backend struct.
+const std = @import("std");
+
+/// The id returned by `createRenderTarget` on a renderer without support (or on
+/// a create failure); never a valid target. Kept in sync with the backend's
+/// `INVALID_RENDER_TARGET` and the gfx forwarder's `0` fallback.
+pub const INVALID_RENDER_TARGET: u32 = 0;
+
+/// Returns the render-target mixin for a given Game type.
+pub fn Mixin(comptime Game: type) type {
+    return struct {
+        /// Create an offscreen render target `w`×`h`. Returns an opaque id, or
+        /// `INVALID_RENDER_TARGET` (0) when the active renderer has no render-target
+        /// support or the backend fails to allocate it. Hand the id back to
+        /// `beginRenderTarget` / `drawRenderTarget` / `destroyRenderTarget`.
+        pub fn createRenderTarget(self: *Game, w: u16, h: u16) u32 {
+            const Renderer = @TypeOf(self.renderer.*);
+            if (@hasDecl(Renderer, "createRenderTarget")) {
+                return self.renderer.createRenderTarget(w, h);
+            }
+            return INVALID_RENDER_TARGET;
+        }
+
+        /// Point subsequent draws at target `id`: every following draw
+        /// (`drawRectangle`, sprites, text, `drawMesh`, …) fills the target's
+        /// texture instead of the screen, until `endRenderTarget`. No-op on an
+        /// unknown id or a renderer without support.
+        pub fn beginRenderTarget(self: *Game, id: u32) void {
+            const Renderer = @TypeOf(self.renderer.*);
+            if (@hasDecl(Renderer, "beginRenderTarget")) self.renderer.beginRenderTarget(id);
+        }
+
+        /// Stop drawing into the current render target — subsequent draws return
+        /// to the screen (or the enclosing target).
+        pub fn endRenderTarget(self: *Game) void {
+            const Renderer = @TypeOf(self.renderer.*);
+            if (@hasDecl(Renderer, "endRenderTarget")) self.renderer.endRenderTarget();
+        }
+
+        /// Draw a finished target `id` into the CURRENT view (call OUTSIDE its own
+        /// begin/end) at `x,y` sized `width`×`height`, modulated by the `r,g,b,a`
+        /// tint (255,255,255,255 = untinted) — the mirror. No-op on an unknown id
+        /// or a renderer without support.
+        pub fn drawRenderTarget(self: *Game, id: u32, x: f32, y: f32, width: f32, height: f32, r: u8, g: u8, b: u8, a: u8) void {
+            const Renderer = @TypeOf(self.renderer.*);
+            if (@hasDecl(Renderer, "drawRenderTarget")) self.renderer.drawRenderTarget(id, x, y, width, height, r, g, b, a);
+        }
+
+        /// Free target `id`. No-op on an unknown id or a renderer without support.
+        pub fn destroyRenderTarget(self: *Game, id: u32) void {
+            const Renderer = @TypeOf(self.renderer.*);
+            if (@hasDecl(Renderer, "destroyRenderTarget")) self.renderer.destroyRenderTarget(id);
+        }
+    };
+}

--- a/src/game/render_target_mixin.zig
+++ b/src/game/render_target_mixin.zig
@@ -10,7 +10,6 @@
 /// existing game and backend.
 ///
 /// Handles are opaque `u32` ids (like a texture handle), never a backend struct.
-const std = @import("std");
 
 /// The id returned by `createRenderTarget` on a renderer without support (or on
 /// a create failure); never a valid target. Kept in sync with the backend's
@@ -37,6 +36,7 @@ pub fn Mixin(comptime Game: type) type {
         /// texture instead of the screen, until `endRenderTarget`. No-op on an
         /// unknown id or a renderer without support.
         pub fn beginRenderTarget(self: *Game, id: u32) void {
+            if (id == INVALID_RENDER_TARGET) return;
             const Renderer = @TypeOf(self.renderer.*);
             if (@hasDecl(Renderer, "beginRenderTarget")) self.renderer.beginRenderTarget(id);
         }
@@ -52,13 +52,20 @@ pub fn Mixin(comptime Game: type) type {
         /// begin/end) at `x,y` sized `width`×`height`, modulated by the `r,g,b,a`
         /// tint (255,255,255,255 = untinted) — the mirror. No-op on an unknown id
         /// or a renderer without support.
+        ///
+        /// Coordinates are SCREEN space — top-left origin, Y-down, in pixels — NOT
+        /// world/`y_axis` space and not camera-transformed: compositing a render
+        /// target is a screen operation (a mirror panel / minimap / HUD element),
+        /// like raylib's `DrawTextureRec` of a `RenderTexture2D`.
         pub fn drawRenderTarget(self: *Game, id: u32, x: f32, y: f32, width: f32, height: f32, r: u8, g: u8, b: u8, a: u8) void {
+            if (id == INVALID_RENDER_TARGET) return;
             const Renderer = @TypeOf(self.renderer.*);
             if (@hasDecl(Renderer, "drawRenderTarget")) self.renderer.drawRenderTarget(id, x, y, width, height, r, g, b, a);
         }
 
         /// Free target `id`. No-op on an unknown id or a renderer without support.
         pub fn destroyRenderTarget(self: *Game, id: u32) void {
+            if (id == INVALID_RENDER_TARGET) return;
             const Renderer = @TypeOf(self.renderer.*);
             if (@hasDecl(Renderer, "destroyRenderTarget")) self.renderer.destroyRenderTarget(id);
         }


### PR DESCRIPTION
**PR 3 of 3** in the mirror-to-games rollout (labelle-bgfx#41 = PR 1, labelle-gfx#301 = PR 2). Exposes offscreen render-to-texture — the **transport mirror**, the same primitive as headless capture (labelle-bgfx#36) — to game code, modelled exactly on the `drawMesh` seam (`mesh_mixin.zig`).

## Change
- **`src/game/render_target_mixin.zig`** (new): `createRenderTarget` / `beginRenderTarget` / `endRenderTarget` / `drawRenderTarget` / `destroyRenderTarget`, each gated on `@hasDecl(Renderer, ...)`. Opaque `u32` handles; `drawRenderTarget` takes primitive dest + rgba (the `drawMesh` convention).
- **`game.zig`**: wired as `Game` methods (`game.createRenderTarget` …), mirroring `drawMesh`'s `import → Mixin(Self) → pub const`.

Non-breaking: a no-op / INVALID on renderers/backends without support (bgfx has it today via PR 1/2; raylib/sokol/wgpu/sdl and the engine's `StubRender` omit it), so every existing game and backend is unaffected.

## Usage (once all three repos are released + pinned)
```zig
const rt = game.createRenderTarget(256, 256);
game.beginRenderTarget(rt);
// … draw the player / scene …
game.endRenderTarget();
game.drawRenderTarget(rt, 500, 40, 128, 128, 255, 255, 255, 255); // the mirror
```

## Validation
`zig build` (library module) compiles clean with the mixin. `zig build test` currently has **pre-existing** failures from local labelle-core drift in unrelated test files (`asset_streaming_shim_test`, preview tests) — identical with this change stashed; engine CI uses the pinned core and is unaffected. The real end-to-end path type-checks when a demo game is assembled against bgfx.

## Remaining
A demo game exercising the mirror, then the release + pin-bump across labelle-bgfx → labelle-gfx → labelle-engine so games can actually call it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)