### PR TITLE
feat(camera): tagged multi-camera seeding + getCameraByTag (camera-bound layers RFC #723, PR2)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -58,9 +58,17 @@
         // hand-rolled stand-in. `lazy` so downstream consumers of the engine
         // module never fetch it — it is reached only by the `test` step via
         // `b.lazyDependency`, mirroring `zspec`.
-        // DEV PIN — gfx#724 PR1 (camera-bound layers). Flip to gfx v1.26.0 tag
-        // at release. `lazy` is dropped: a `.path` dep is local, not fetched.
-        .labelle_gfx = .{ .path = "../labelle-gfx-724" },
+        // Bumped to gfx v1.26.0 for camera-bound layers (RFC #723): engine
+        // 1.83.0's tagged-camera seeding drives gfx's CameraManager
+        // setTag/findByTag/resetSecondary (added in 1.26.0). Test-only + lazy —
+        // the engine module takes no direct gfx dep (the renderer arrives via
+        // RenderImpl), so the effective gfx floor is enforced at the consuming
+        // game's build; this pin only feeds the tilemap sub-package test.
+        .labelle_gfx = .{
+            .url = "https://github.com/labelle-toolkit/labelle-gfx/archive/refs/tags/v1.26.0.tar.gz",
+            .hash = "labelle_gfx-1.26.0-nMpCPMYYBQBBX_7Js1AHBQKWYeI7Hm8U2aEL8t9cOIJO",
+            .lazy = true,
+        },
     },
     .paths = .{
         "build.zig",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -58,11 +58,9 @@
         // hand-rolled stand-in. `lazy` so downstream consumers of the engine
         // module never fetch it — it is reached only by the `test` step via
         // `b.lazyDependency`, mirroring `zspec`.
-        .labelle_gfx = .{
-            .url = "https://github.com/labelle-toolkit/labelle-gfx/archive/refs/tags/v1.24.0.tar.gz",
-            .hash = "labelle_gfx-1.24.0-nMpCPF3VBAANEcKU73ait49fJJ2rchmMJgsAW8gI2ntB",
-            .lazy = true,
-        },
+        // DEV PIN — gfx#724 PR1 (camera-bound layers). Flip to gfx v1.26.0 tag
+        // at release. `lazy` is dropped: a `.path` dep is local, not fetched.
+        .labelle_gfx = .{ .path = "../labelle-gfx-724" },
     },
     .paths = .{
         "build.zig",

--- a/src/camera.zig
+++ b/src/camera.zig
@@ -22,6 +22,23 @@
 //! deferred multi-camera work (split-screen / minimap / PiP) is purely
 //! additive rather than a breaking component change.
 
+const std = @import("std");
+
+/// Inline capacity of a camera `tag` (bytes, excluding the sentinel). Mirrors
+/// gfx `CameraWith.tag_buf` (`[16:0]u8`, ≤ 15 usable) so a tag authored here
+/// round-trips into the gfx camera without truncation.
+pub const tag_capacity: usize = 15;
+
+/// Build a sentinel-terminated tag buffer from a comptime string. Used for the
+/// `Camera.tag` default; over-long tags are a compile error (they would not
+/// fit the gfx camera's inline buffer either).
+pub fn makeTag(comptime s: []const u8) [16:0]u8 {
+    if (s.len > tag_capacity) @compileError("camera tag must be ≤ 15 bytes: '" ++ s ++ "'");
+    var b = [_:0]u8{0} ** 16;
+    @memcpy(b[0..s.len], s);
+    return b;
+}
+
 /// Screen-space viewport placement for a camera (split-screen / minimap /
 /// PiP). Engine-local and inert in the MVP — see the module header. All fields
 /// default so a partial authored/patched `viewport` round-trips cleanly.
@@ -45,11 +62,39 @@ pub const Camera = struct {
     /// with the deferred multi-camera authoring work.
     viewport: ?Viewport = null,
 
+    /// Camera tag (camera-bound layers, labelle-engine#723/#724). Names the
+    /// camera slot this entity seeds: `"main"` (the default) drives slot 0 —
+    /// the fullscreen game camera — exactly as before; any other tag claims a
+    /// secondary slot (1–3) that layers whose `LayerConfig.camera` equals the
+    /// tag render through. A world/screen layer with no `.camera` stays on the
+    /// main camera.
+    ///
+    /// Stored INLINE as a sentinel-terminated fixed buffer, NEVER a heap slice:
+    /// `applyCameraComponentJson` merges patches through a call-scoped arena
+    /// (`camera_mixin.zig`), so a `[]const u8` tag would dangle the moment that
+    /// arena is freed. The inline buffer mirrors gfx `CameraWith.tag_buf`.
+    tag: [16:0]u8 = makeTag("main"),
+
     // Reserved for a future declarative follow target (entity id + offset +
     // deadzone). Deferred: shipping games express "follow" in their gameplay
     // script (soft ownership), so v1 does not model it — but the shape is
     // reserved so a later `follow` field is additive, not a rename.
     // follow: ?Follow = null,
+
+    /// The tag as a string view (up to the sentinel). Cheap; no allocation.
+    pub fn tagSlice(self: *const Camera) []const u8 {
+        return std.mem.sliceTo(&self.tag, 0);
+    }
+
+    /// Overwrite the inline tag from a runtime string (JSONC / save-load
+    /// channels). Bytes past the 15-byte capacity are dropped so the buffer
+    /// always stays sentinel-terminated and interoperable with the gfx camera.
+    pub fn setTagSlice(self: *Camera, s: []const u8) void {
+        const n = @min(s.len, tag_capacity);
+        @memcpy(self.tag[0..n], s[0..n]);
+        // Zero the remainder so `tagSlice` (and any raw comparison) is stable.
+        @memset(self.tag[n..], 0);
+    }
 };
 
 /// True when game type `G` exposes a SETTABLE camera — i.e. its renderer has a

--- a/src/camera.zig
+++ b/src/camera.zig
@@ -108,3 +108,23 @@ pub fn hasSettableCamera(comptime G: type) bool {
     if (G.CameraType == void) return false;
     return @hasDecl(G.CameraType, "setPosition") and @hasDecl(G.CameraType, "setZoom");
 }
+
+/// True when game type `G`'s `CameraManagerType` is the TAGGED multi-camera
+/// manager (gfx ≥1.26) — i.e. it declares the full slot/tag seam the
+/// camera-bound-layers seeding drives (`resetSecondary` / `setTag` /
+/// `setActive` / `getCamera` / `findByTag`). Used to comptime-fold the new
+/// multi-slot tagged seeding — and `getCameraByTag` — away on a renderer that
+/// has a settable camera but an OLD, non-tagged manager (e.g. a `struct{}`
+/// placeholder), which then falls back to the pre-PR single-camera seed rather
+/// than failing to compile. The `!= void` guard short-circuits before the
+/// `@hasDecl(M, …)` reflection so a camera-less `void` manager never reaches it.
+pub fn hasTaggedCameraManager(comptime G: type) bool {
+    if (!@hasDecl(G, "CameraManagerType")) return false;
+    const M = G.CameraManagerType;
+    if (M == void) return false;
+    return @hasDecl(M, "resetSecondary") and
+        @hasDecl(M, "setTag") and
+        @hasDecl(M, "setActive") and
+        @hasDecl(M, "getCamera") and
+        @hasDecl(M, "findByTag");
+}

--- a/src/editor_api.zig
+++ b/src/editor_api.zig
@@ -305,18 +305,19 @@ pub export fn editor_set_entity_position(id: u64, x: f32, y: f32) void {
 }
 
 /// Set component `name` on entity `id` from a JSON object — the general
-/// per-component edit seam (editor-bridge contract **v1.5**, camera-prefabs
-/// #714). `editor_set_entity_position` stays the drag hot-path; this is the
-/// general path the inspector grows into.
+/// per-component edit seam (editor-bridge contract **v1.6**, camera-bound
+/// layers #723/#724; was v1.5 for camera-prefabs #714). `editor_set_entity_position`
+/// stays the drag hot-path; this is the general path the inspector grows into.
 ///
 /// **Allowlisted** (MVP): only the vetted `"Camera"` built-in is accepted — a
-/// `{"zoom":…}` (and, when authored, `"viewport":{…}`) object. Any other name
-/// returns -1; there is deliberately no blanket apply-any-component path.
+/// `{"zoom":…}` (and, when authored, `"viewport":{…}` / `"tag":"…"`) object.
+/// Any other name returns -1; there is deliberately no blanket
+/// apply-any-component path.
 ///
 /// **Merge/patch semantics**: only the keys PRESENT in the JSON overwrite the
 /// entity's existing `Camera` — a `{"zoom":…}` patch preserves a prior
-/// `viewport`. A default `Camera` is materialized when the entity has none. On
-/// success the live `getCamera()` is re-seeded so a paused preview updates
+/// `viewport` and `tag`. A default `Camera` is materialized when the entity has
+/// none. On success the live camera is re-seeded so a paused preview updates
 /// immediately.
 ///
 /// Returns 0 = ok; -1 = not bound / unknown id / unknown-or-unvetted
@@ -346,14 +347,15 @@ pub export fn editor_pick(x: f32, y: f32) i64 {
 /// `cap`) and return the number of bytes written. Shape:
 /// `{"scene":"...","state":"...","paused":0|1,"entity_count":N,
 ///   "entities":[{"id":<u64>,"prefab":"?","sprite":"?","tilemap":"?",
-///     "camera":{"zoom":f,"viewport"?:{x,y,width,height},
+///     "camera":{"zoom":f,"tag":"...","viewport"?:{x,y,width,height},
 ///               "view":{x,y,width,height}},"x":f,"y":f},...]}`
 /// `prefab`/`sprite`/`tilemap`/`camera` appear only when the entity
-/// carries them; a Camera entity's `viewport` is present only when
-/// authored, while `view` is the derived WORLD-space visible rect
-/// (`getCamera().getViewport()`) the studio draws its gizmo from. `x`/`y`
-/// are WORLD coordinates (the same space `editor_set_entity_position`
-/// consumes).
+/// carries them; a Camera entity's `tag` (camera-bound layers #723/#724,
+/// contract v1.6) is always present and its `viewport` only when authored,
+/// while `view` is the derived WORLD-space visible rect resolved against THAT
+/// camera's own slot (`getCameraByTag(tag) orelse getCamera()`) — the rect the
+/// studio draws its gizmo from. `x`/`y` are WORLD coordinates (the same space
+/// `editor_set_entity_position` consumes).
 /// The entity list is
 /// truncated to fit `cap` while `entity_count` keeps the full count —
 /// the output is always valid JSON (worst case `{}`; 0 bytes only when
@@ -665,6 +667,10 @@ fn Holder(comptime GP: type, comptime RP: type) type {
             if (comptime @hasDecl(G, "CameraComp") and G.camera_is_builtin) {
                 if (game.getComponent(ent, G.CameraComp)) |cam| {
                     try appendFmt(buf, cur, ",\"camera\":{{\"zoom\":{d}", .{jsonSafeFloat(cam.zoom)});
+                    // Camera tag (camera-bound layers, #723/#724) so the studio
+                    // round-trips the slot binding and can resolve `view` below.
+                    try appendLit(buf, cur, ",\"tag\":");
+                    try appendJsonString(buf, cur, cam.tagSlice());
                     if (cam.viewport) |vp| {
                         try appendFmt(buf, cur, ",\"viewport\":{{\"x\":{d},\"y\":{d},\"width\":{d},\"height\":{d}}}", .{
                             vp.x, vp.y, vp.width, vp.height,
@@ -679,7 +685,13 @@ fn Holder(comptime GP: type, comptime RP: type) type {
                         break :blk @hasDecl(G.CameraType, "getViewport");
                     };
                     if (emit_view) {
-                        const vr = game.getCamera().getViewport();
+                        // Resolve `view` against THIS camera's own slot: a
+                        // secondary camera's visible rect must come from the
+                        // slot its tag bound (findByTag), not slot 0. Falls back
+                        // to the primary camera when the tag isn't bound yet
+                        // (e.g. an unseeded "main"), preserving prior behavior.
+                        const view_cam = game.getCameraByTag(cam.tagSlice()) orelse game.getCamera();
+                        const vr = view_cam.getViewport();
                         try appendFmt(buf, cur, ",\"view\":{{\"x\":{d},\"y\":{d},\"width\":{d},\"height\":{d}}}", .{
                             jsonSafeFloat(vr.x), jsonSafeFloat(vr.y), jsonSafeFloat(vr.width), jsonSafeFloat(vr.height),
                         });

--- a/src/game.zig
+++ b/src/game.zig
@@ -1323,6 +1323,15 @@ pub fn GameConfigWithYAxis(
         /// Get the camera manager (for multi-camera / split-screen).
         pub const getCameraManager = if (has_camera) MiscMixin.getCameraManagerImpl else void;
 
+        /// Resolve a camera by tag (camera-bound layers, #723/#724). Returns
+        /// the lowest active slot carrying `tag`, or `null`. Comptime no-op
+        /// returning `null` on renderers without a settable camera.
+        pub const getCameraByTag = if (has_camera) MiscMixin.getCameraByTagImpl else struct {
+            fn f(_: *Self, _: []const u8) ?*CameraType {
+                return null;
+            }
+        }.f;
+
         // ── Camera component seed / sync (#714) ───────────────────
         /// Seed `getCamera()` from the authored `Camera` component (world
         /// position + zoom). Called once after scene instantiation and every

--- a/src/game.zig
+++ b/src/game.zig
@@ -1325,8 +1325,10 @@ pub fn GameConfigWithYAxis(
 
         /// Resolve a camera by tag (camera-bound layers, #723/#724). Returns
         /// the lowest active slot carrying `tag`, or `null`. Comptime no-op
-        /// returning `null` on renderers without a settable camera.
-        pub const getCameraByTag = if (has_camera) MiscMixin.getCameraByTagImpl else struct {
+        /// returning `null` on renderers without a settable camera OR without
+        /// the tagged (gfx ≥1.26) camera manager — the same gate the tagged
+        /// seeding uses, so a non-tagged manager never reaches `findByTag`.
+        pub const getCameraByTag = if (has_camera and camera_mod.hasTaggedCameraManager(@This())) MiscMixin.getCameraByTagImpl else struct {
             fn f(_: *Self, _: []const u8) ?*CameraType {
                 return null;
             }

--- a/src/game/camera_mixin.zig
+++ b/src/game/camera_mixin.zig
@@ -21,31 +21,150 @@ pub fn Mixin(comptime Game: type) type {
     const Entity = Game.EntityType;
     const CameraComp = Game.CameraComp;
     const Position = core.Position;
+    // The generated render-layer enum (or `void` on layer-less renderers). Its
+    // configs' `.camera` values, plus `"main"`, form the comptime tag
+    // vocabulary a seed can warn against. See `tagVocabularyCheckable`.
+    const LayerEnum = Game.RenderLayerEnum;
 
     return struct {
-        /// Seed the active gfx camera from the authored `Camera` component:
-        /// locate the first entity carrying both `Position` and `Camera`, read
-        /// its WORLD position (`getWorldPosition`, matching the digest and
-        /// `editor_set_entity_position`) plus `Camera.zoom`, and apply them to
-        /// `getCamera()`. A no-op — and a comptime no-op that never touches the
-        /// (possibly `void`) camera seam — when the renderer has no settable
-        /// camera or the scene declares no Camera entity. Single-camera MVP:
-        /// the first Camera entity wins.
+        // Latching warn-once flags (camera-bound layers). Seeding runs on every
+        // PAUSED frame (apply-while-paused), so each diagnostic is emitted at
+        // most once per process rather than every frame. Struct-scope statics:
+        // one instantiation per concrete `Game`.
+        var warned_unknown_tag = false;
+        var warned_extra_main = false;
+        var warned_extra_tag = false;
+        var warned_overflow = false;
+
+        /// Seed the gfx cameras from the authored `Camera` components
+        /// (camera-bound layers, labelle-engine#723/#724). Reset-then-seed:
+        ///
+        ///   1. `resetSecondary()` deactivates + untags slots 1–3 so a
+        ///      removed/renamed secondary camera never leaves a live bound
+        ///      slot. Slot 0 (`"main"`) is untouched.
+        ///   2. Iterate EVERY entity carrying `Position` + `Camera`, reading
+        ///      its WORLD position (`getWorldPosition`, matching the digest and
+        ///      `editor_set_entity_position`) plus `Camera.zoom`:
+        ///        * tag `"main"` → configure slot 0 via `getCamera()` (the
+        ///          existing single-camera behavior) and tag it `"main"`. First
+        ///          `"main"` wins; extras warn once.
+        ///        * any other tag → claim the next free secondary slot (1–3)
+        ///          via the camera manager. First camera per tag wins; extras
+        ///          and slot overflow past 3 warn once and are ignored.
+        ///
+        /// Zero Camera entities → nothing is seeded and slot 0's default camera
+        /// is left exactly as-is (the invariant: a scene with no Camera renders
+        /// as it did before this feature). A comptime no-op that never touches
+        /// the (possibly `void`) camera seam on camera-less renderers, and off
+        /// entirely for a project that registered its own `Camera` (finding #1).
         pub fn seedCameraFromComponent(self: *Game) void {
             if (comptime !camera_mod.hasSettableCamera(Game)) return;
-            // Defer to a project that registered its OWN `Camera` (finding #1):
-            // the built-in seed is off for such projects.
             if (comptime !Game.camera_is_builtin) return;
+
+            const mgr = self.getCameraManager();
+            // Clear stale secondary bindings before re-seeding (slot 0 kept).
+            mgr.resetSecondary();
+
+            var seen_main = false;
+            // First-per-tag bookkeeping for the ≤ 3 secondary slots. Inline
+            // fixed buffers — never heap (mirrors the tag-storage rule).
+            var claimed_buf: [3][camera_mod.tag_capacity]u8 = undefined;
+            var claimed_len: [3]usize = .{ 0, 0, 0 };
+            var claimed_count: usize = 0;
+            var next_slot: usize = 1; // slots 1..3; > 3 == exhausted
+
             var v = self.ecs_backend.view(.{ Position, CameraComp }, .{});
             defer v.deinit();
             while (v.next()) |ent| {
                 const cam = self.ecs_backend.getComponent(ent, CameraComp) orelse continue;
                 const wp = self.getWorldPosition(ent);
-                const camera = self.getCamera();
-                camera.setPosition(wp.x, wp.y);
-                camera.setZoom(cam.zoom);
-                return;
+                const tag = cam.tagSlice();
+
+                // Warn once on a tag no layer binds (comptime vocabulary).
+                if (comptime tagVocabularyCheckable()) {
+                    if (!tagInVocabulary(tag)) {
+                        warnOnce(self, &warned_unknown_tag, "camera tag '{s}' is bound by no layer", .{tag});
+                    }
+                }
+
+                if (std.mem.eql(u8, tag, "main")) {
+                    if (seen_main) {
+                        warnOnce(self, &warned_extra_main, "multiple 'main' camera entities; keeping the first", .{});
+                        continue;
+                    }
+                    seen_main = true;
+                    const camera = self.getCamera();
+                    camera.setPosition(wp.x, wp.y);
+                    camera.setZoom(cam.zoom);
+                    mgr.setTag(0, "main");
+                    continue;
+                }
+
+                // Secondary tag — first camera per tag wins.
+                var dup = false;
+                for (0..claimed_count) |i| {
+                    if (std.mem.eql(u8, claimed_buf[i][0..claimed_len[i]], tag)) {
+                        dup = true;
+                        break;
+                    }
+                }
+                if (dup) {
+                    warnOnce(self, &warned_extra_tag, "multiple camera entities tagged '{s}'; keeping the first", .{tag});
+                    continue;
+                }
+
+                if (next_slot > 3) {
+                    warnOnce(self, &warned_overflow, "more than 3 secondary cameras; tag '{s}' ignored", .{tag});
+                    continue;
+                }
+
+                const slot: u2 = @intCast(next_slot);
+                mgr.setActive(slot, true);
+                mgr.setTag(slot, tag);
+                const scam = mgr.getCamera(slot);
+                scam.setPosition(wp.x, wp.y);
+                scam.setZoom(cam.zoom);
+
+                if (claimed_count < 3) {
+                    const n = @min(tag.len, camera_mod.tag_capacity);
+                    @memcpy(claimed_buf[claimed_count][0..n], tag[0..n]);
+                    claimed_len[claimed_count] = n;
+                    claimed_count += 1;
+                }
+                next_slot += 1;
             }
+        }
+
+        /// Whether the render-layer enum is a genuine config-bearing enum whose
+        /// `LayerConfig` carries a `.camera` field — i.e. the tag vocabulary is
+        /// introspectable. False on layer-less renderers (`void`) or pre-#724
+        /// gfx (no `.camera`), where only `"main"` is a known tag and the
+        /// unknown-tag warning is suppressed rather than false-firing.
+        fn tagVocabularyCheckable() bool {
+            if (LayerEnum == void) return false;
+            if (@typeInfo(LayerEnum) != .@"enum") return false;
+            if (!@hasDecl(LayerEnum, "config")) return false;
+            const Cfg = @TypeOf(@field(LayerEnum, @typeInfo(LayerEnum).@"enum".fields[0].name).config());
+            return @hasField(Cfg, "camera");
+        }
+
+        /// True when `tag` is `"main"` or equals some layer's `.camera` binding.
+        /// Only reached under `comptime tagVocabularyCheckable()`, so the enum
+        /// reflection below is never analyzed on a `void`/pre-#724 layer enum.
+        fn tagInVocabulary(tag: []const u8) bool {
+            if (std.mem.eql(u8, tag, "main")) return true;
+            inline for (comptime std.enums.values(LayerEnum)) |l| {
+                if (l.config().camera) |c| {
+                    if (std.mem.eql(u8, c, tag)) return true;
+                }
+            }
+            return false;
+        }
+
+        fn warnOnce(self: *Game, flag: *bool, comptime fmt: []const u8, args: anytype) void {
+            if (flag.*) return;
+            flag.* = true;
+            self.log.warn(fmt, args);
         }
 
         /// MERGE a JSON patch into entity `ent`'s `Camera` component, then
@@ -57,8 +176,9 @@ pub fn Mixin(comptime Game: type) type {
         ///
         /// Errors (leaving the entity untouched) when `source` is unparseable
         /// or its top level is not a JSON object. The parse tree lives in a
-        /// call-scoped arena; `Camera` has no string fields, so nothing aliases
-        /// `source` past the call and the caller may free it immediately.
+        /// call-scoped arena; `Camera.tag` is copied INLINE (bounded buffer,
+        /// not a slice into `source`), so nothing aliases `source` past the
+        /// call and the caller may free it immediately.
         pub fn applyCameraComponentJson(self: *Game, ent: Entity, source: []const u8) !void {
             var arena = std.heap.ArenaAllocator.init(self.allocator);
             defer arena.deinit();
@@ -102,6 +222,16 @@ pub fn Mixin(comptime Game: type) type {
                     if (vp.get("height")) |v| out.height = try viewportInt(v);
                     comp.viewport = out;
                 },
+                else => return error.InvalidCameraComponentJson,
+            };
+
+            // A PRESENT `tag` must be a string; it seeds the inline bounded
+            // buffer (camera-bound layers, #723/#724). An ABSENT key leaves the
+            // existing/default tag untouched (patch semantics, like `zoom`). A
+            // wrong-shaped value is a validation failure. Because the tag is
+            // copied INLINE, nothing aliases the call-scoped `source` arena.
+            if (obj.get("tag")) |t_val| switch (t_val) {
+                .string => |s| comp.setTagSlice(s),
                 else => return error.InvalidCameraComponentJson,
             };
 

--- a/src/game/camera_mixin.zig
+++ b/src/game/camera_mixin.zig
@@ -57,9 +57,33 @@ pub fn Mixin(comptime Game: type) type {
         /// as it did before this feature). A comptime no-op that never touches
         /// the (possibly `void`) camera seam on camera-less renderers, and off
         /// entirely for a project that registered its own `Camera` (finding #1).
+        ///
+        /// The multi-slot tagged path requires the gfx ≥1.26 TAGGED manager
+        /// (`hasTaggedCameraManager`). A renderer with a settable camera but an
+        /// OLD, non-tagged manager falls back to the pre-PR single-camera seed
+        /// (first `{Position,Camera}` → `getCamera()`, no reset, no tags) so it
+        /// still compiles and behaves exactly as before.
         pub fn seedCameraFromComponent(self: *Game) void {
             if (comptime !camera_mod.hasSettableCamera(Game)) return;
             if (comptime !Game.camera_is_builtin) return;
+
+            if (comptime !camera_mod.hasTaggedCameraManager(Game)) {
+                // Pre-PR fallback: seed the first Camera entity onto the single
+                // renderer camera. No manager reset / tags — the non-tagged
+                // manager type declares none of those methods, so this branch
+                // must never reference them.
+                var v = self.ecs_backend.view(.{ Position, CameraComp }, .{});
+                defer v.deinit();
+                while (v.next()) |ent| {
+                    const cam = self.ecs_backend.getComponent(ent, CameraComp) orelse continue;
+                    const wp = self.getWorldPosition(ent);
+                    const camera = self.getCamera();
+                    camera.setPosition(wp.x, wp.y);
+                    camera.setZoom(cam.zoom);
+                    return;
+                }
+                return;
+            }
 
             const mgr = self.getCameraManager();
             // Clear stale secondary bindings before re-seeding (slot 0 kept).
@@ -93,7 +117,10 @@ pub fn Mixin(comptime Game: type) type {
                         continue;
                     }
                     seen_main = true;
-                    const camera = self.getCamera();
+                    // Seed slot 0 EXPLICITLY (not via `getCamera()`, which may
+                    // return the *selected* camera): the main transform and the
+                    // `"main"` tag must both land on slot 0.
+                    const camera = mgr.getCamera(0);
                     camera.setPosition(wp.x, wp.y);
                     camera.setZoom(cam.zoom);
                     mgr.setTag(0, "main");

--- a/src/game/misc_mixin.zig
+++ b/src/game/misc_mixin.zig
@@ -170,6 +170,15 @@ pub fn Mixin(comptime Game: type) type {
             return self.renderer.getCameraManager();
         }
 
+        /// The lowest ACTIVE camera slot carrying `tag`, or `null` if none
+        /// (camera-bound layers, labelle-engine#723/#724). `"main"` resolves to
+        /// slot 0 once a `Camera` component has seeded it; a secondary tag
+        /// resolves to whichever slot 1–3 the seed bound it to. Forwards to the
+        /// gfx camera manager's `findByTag`.
+        pub fn getCameraByTagImpl(self: *Game, tag: []const u8) ?*CameraType {
+            return self.renderer.getCameraManager().findByTag(tag);
+        }
+
         // ── Accessors ─────────────────────────────────────────────
 
         pub fn getRenderer(self: *Game) *RenderImpl {

--- a/src/game/save_load/load.zig
+++ b/src/game/save_load/load.zig
@@ -596,6 +596,9 @@ pub fn Mixin(comptime Game: type) type {
                         // Preserve the 1.0 default if a (malformed) save omits
                         // zoom — `getNumberField` would otherwise yield 0.
                         if (cam_obj.get("zoom") != null) cam.zoom = getNumberField(cam_obj, "zoom");
+                        // Camera tag (camera-bound layers, #723/#724). Absent in
+                        // pre-#724 saves → the `"main"` default is kept.
+                        if (getStringField(cam_obj, "tag")) |t| cam.setTagSlice(t);
                         if (cam_obj.get("viewport")) |vp_val| {
                             if (vp_val == .object) {
                                 const vp = vp_val.object;
@@ -743,6 +746,15 @@ pub fn Mixin(comptime Game: type) type {
             // itself — making loadGameState self-contained and retiring
             // the manual `assets.acquire(...)` loop games shipped (FP#542).
             self.armPostLoadRenderGate(saved_scene);
+
+            // Re-seed the gfx cameras from the just-restored `Camera`
+            // components (camera-bound layers, #723/#724). Without this a save
+            // that authored a tagged secondary camera comes back with its
+            // component reattached but no live camera slot bound — the layers
+            // it drives would fall back to the main camera. `reset-then-seed`
+            // also clears any stale secondary slot the pre-load scene left
+            // active. Comptime no-op on camera-less / project-Camera builds.
+            self.seedCameraFromComponent();
         }
 
         /// Arm the post-load render gate from the current scene's

--- a/src/game/save_load/save.zig
+++ b/src/game/save_load/save.zig
@@ -329,6 +329,10 @@ pub fn Mixin(comptime Game: type) type {
                         if (cam.viewport) |vp| {
                             try writer.print(", \"viewport\": {{\"x\": {d}, \"y\": {d}, \"width\": {d}, \"height\": {d}}}", .{ vp.x, vp.y, vp.width, vp.height });
                         }
+                        // Camera tag (camera-bound layers, #723/#724) — a short
+                        // authored identifier, emitted so the slot binding
+                        // round-trips through save/load.
+                        try writer.print(", \"tag\": \"{s}\"", .{cam.tagSlice()});
                         try writer.writeAll("}");
                         first_comp = false;
                     }

--- a/src/game/save_load/save.zig
+++ b/src/game/save_load/save.zig
@@ -329,10 +329,12 @@ pub fn Mixin(comptime Game: type) type {
                         if (cam.viewport) |vp| {
                             try writer.print(", \"viewport\": {{\"x\": {d}, \"y\": {d}, \"width\": {d}, \"height\": {d}}}", .{ vp.x, vp.y, vp.width, vp.height });
                         }
-                        // Camera tag (camera-bound layers, #723/#724) — a short
-                        // authored identifier, emitted so the slot binding
-                        // round-trips through save/load.
-                        try writer.print(", \"tag\": \"{s}\"", .{cam.tagSlice()});
+                        // Camera tag (camera-bound layers, #723/#724) — emitted
+                        // so the slot binding round-trips through save/load. Use
+                        // the escape helper (like every other string field): a
+                        // tag with a `"` or `\` must not corrupt the JSON.
+                        try writer.writeAll(", \"tag\": ");
+                        try writeJsonString(writer, cam.tagSlice());
                         try writer.writeAll("}");
                         first_comp = false;
                     }

--- a/src/jsonc/component_apply.zig
+++ b/src/jsonc/component_apply.zig
@@ -142,7 +142,19 @@ pub fn ComponentApply(comptime GameType: type, comptime Components: type) type {
             if (comptime !Components.has("Camera")) {
                 if (std.mem.eql(u8, name, "Camera")) {
                     if (deserializer.deserialize(GameType.CameraComp, value, comp_alloc)) |camera| {
-                        game.addComponent(entity, camera);
+                        var cam = camera;
+                        // `tag` is an INLINE bounded buffer (`[16:0]u8`), which
+                        // the generic struct deserializer doesn't map from a
+                        // JSON string — it would silently keep the `"main"`
+                        // default. Apply the authored tag here so the primary
+                        // authoring channel (`{"Camera":{"tag":"sky_parallax"}}`)
+                        // seeds the bounded field. Absent → default `"main"`.
+                        if (value.asObject()) |o| {
+                            if (o.get("tag")) |t| {
+                                if (t.asString()) |s| cam.setTagSlice(s);
+                            }
+                        }
+                        game.addComponent(entity, cam);
                     }
                     return;
                 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -81,6 +81,9 @@ pub const Camera = @import("camera.zig").Camera;
 /// Engine-local screen-space viewport rect carried by `Camera.viewport`
 /// (renderer-agnostic; inert in the single-camera MVP). See `src/camera.zig`.
 pub const CameraViewport = @import("camera.zig").Viewport;
+/// The `Camera` component module — exposes `makeTag` / `tag_capacity` for the
+/// inline camera-tag buffer (camera-bound layers, #723/#724).
+pub const camera_mod = @import("camera.zig");
 
 // ── Input ──
 pub const InputInterface = input_mod.InputInterface;

--- a/test/editor_api_test.zig
+++ b/test/editor_api_test.zig
@@ -1457,6 +1457,36 @@ test "save/load: the built-in Camera round-trips zoom + viewport (finding #5)" {
     try testing.expectEqual(@as(i32, 6), restored.?.viewport.?.y);
 }
 
+test "save/load: a Camera tag with JSON-special chars round-trips via the escape helper" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = CameraTestGame.init(testing.allocator);
+    defer game.deinit();
+
+    // A tag carrying a quote AND a backslash: a raw `"{s}"` print would emit
+    // malformed JSON and the reload would fail/corrupt. The save-side escape
+    // helper (writeJsonString) + the reader's un-escape must round-trip it.
+    const nasty = "a\"b\\c"; // 5 bytes: a " b \ c
+    const cam_ent = game.createEntity();
+    game.setPosition(cam_ent, .{ .x = 0, .y = 0 });
+    game.addComponent(cam_ent, engine.Camera{ .tag = engine.camera_mod.makeTag(nasty) });
+
+    const save_path = "test_save_camera_tag_escape.json";
+    try game.saveGameState(save_path);
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, save_path) catch {};
+
+    game.resetEcsBackend();
+    try game.loadGameState(save_path); // would error/mis-parse on unescaped JSON
+
+    var restored: ?*engine.Camera = null;
+    var v = game.active_world.ecs_backend.view(.{ core.Position, engine.Camera }, .{});
+    defer v.deinit();
+    while (v.next()) |e| restored = game.active_world.ecs_backend.getComponent(e, engine.Camera);
+    try testing.expect(restored != null);
+    try testing.expectEqualStrings(nasty, restored.?.tagSlice());
+}
+
 // ── Camera-bound layers: tagged multi-camera seeding (#723/#724) ─────────────
 
 test "Camera.tag defaults to \"main\" and round-trips through the bounded buffer" {

--- a/test/editor_api_test.zig
+++ b/test/editor_api_test.zig
@@ -834,6 +834,9 @@ const CamCamera = struct {
     x: f32 = 0,
     y: f32 = 0,
     zoom: f32 = 1,
+    // Inline tag buffer, mirroring gfx `CameraWith.tag_buf` (#723/#724).
+    tag_buf: [16:0]u8 = [_:0]u8{0} ** 16,
+    tag_len: u8 = 0,
 
     const ViewRect = struct { x: f32, y: f32, width: f32, height: f32 };
 
@@ -848,6 +851,60 @@ const CamCamera = struct {
         const w = 800.0 / self.zoom;
         const h = 600.0 / self.zoom;
         return .{ .x = self.x - w / 2.0, .y = self.y - h / 2.0, .width = w, .height = h };
+    }
+    pub fn setTag(self: *CamCamera, s: []const u8) void {
+        const n = @min(s.len, 15);
+        @memcpy(self.tag_buf[0..n], s[0..n]);
+        self.tag_buf[n] = 0;
+        self.tag_len = @intCast(n);
+    }
+    pub fn clearTag(self: *CamCamera) void {
+        self.tag_len = 0;
+        self.tag_buf[0] = 0;
+    }
+    pub fn hasTag(self: *const CamCamera, s: []const u8) bool {
+        return std.mem.eql(u8, self.tag_buf[0..self.tag_len], s);
+    }
+};
+
+/// 4-slot camera manager mirroring gfx `CameraManagerWith`'s tag API
+/// (camera-bound layers #723/#724): the exact seam the engine seed drives.
+const CamCameraManager = struct {
+    cameras: [4]CamCamera = .{ .{}, .{}, .{}, .{} },
+    active_mask: u4 = 0b0001,
+    selected: u2 = 0,
+
+    pub fn getCamera(self: *CamCameraManager, index: u2) *CamCamera {
+        return &self.cameras[index];
+    }
+    pub fn isActive(self: *const CamCameraManager, index: u2) bool {
+        return (self.active_mask & (@as(u4, 1) << index)) != 0;
+    }
+    pub fn setActive(self: *CamCameraManager, index: u2, active: bool) void {
+        if (active) {
+            self.active_mask |= (@as(u4, 1) << index);
+        } else {
+            self.active_mask &= ~(@as(u4, 1) << index);
+        }
+    }
+    pub fn setTag(self: *CamCameraManager, index: u2, s: []const u8) void {
+        self.cameras[index].setTag(s);
+    }
+    pub fn findByTag(self: *CamCameraManager, s: []const u8) ?*CamCamera {
+        var i: u3 = 0;
+        while (i < 4) : (i += 1) {
+            const idx: u2 = @intCast(i);
+            if (self.isActive(idx) and self.cameras[idx].hasTag(s)) return &self.cameras[idx];
+        }
+        return null;
+    }
+    pub fn resetSecondary(self: *CamCameraManager) void {
+        var i: u3 = 1;
+        while (i < 4) : (i += 1) {
+            const idx: u2 = @intCast(i);
+            self.setActive(idx, false);
+            self.cameras[idx].clearTag();
+        }
     }
 };
 
@@ -885,9 +942,9 @@ fn CamRender(comptime Entity: type) type {
         };
 
         pub const CameraType = CamCamera;
-        pub const CameraManagerType = struct {};
+        pub const CameraManagerType = CamCameraManager;
 
-        camera: CamCamera = .{},
+        mgr: CamCameraManager = .{},
         tracked_count: usize = 0,
         render_count: usize = 0,
 
@@ -918,11 +975,12 @@ fn CamRender(comptime Entity: type) type {
             return false;
         }
         pub fn getCamera(self: *Self) *CamCamera {
-            return &self.camera;
+            // The selected (primary) camera — slot 0 in single-camera mode,
+            // matching gfx `GfxRenderer.getCamera`.
+            return &self.mgr.cameras[self.mgr.selected];
         }
         pub fn getCameraManager(self: *Self) *CameraManagerType {
-            _ = self;
-            return undefined;
+            return &self.mgr;
         }
     };
 }
@@ -1397,4 +1455,313 @@ test "save/load: the built-in Camera round-trips zoom + viewport (finding #5)" {
     try testing.expect(restored.?.viewport != null);
     try testing.expectEqual(@as(i32, 320), restored.?.viewport.?.width);
     try testing.expectEqual(@as(i32, 6), restored.?.viewport.?.y);
+}
+
+// ── Camera-bound layers: tagged multi-camera seeding (#723/#724) ─────────────
+
+test "Camera.tag defaults to \"main\" and round-trips through the bounded buffer" {
+    var cam = engine.Camera{};
+    try testing.expectEqualStrings("main", cam.tagSlice());
+    cam.setTagSlice("sky_parallax");
+    try testing.expectEqualStrings("sky_parallax", cam.tagSlice());
+    // Over-long tags are truncated to the 15-byte capacity, never overrun.
+    cam.setTagSlice("0123456789abcdefGHIJK");
+    try testing.expectEqual(@as(usize, 15), cam.tagSlice().len);
+    try testing.expectEqualStrings("0123456789abcde", cam.tagSlice());
+}
+
+test "camera multi-seed: main → slot 0; secondary tags claim slots 1..3 (reset-then-seed)" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = CameraTestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const main_ent = game.createEntity();
+    game.setPosition(main_ent, .{ .x = 640, .y = 360 });
+    game.addComponent(main_ent, engine.Camera{ .zoom = 1.0 }); // default tag "main"
+
+    const sky_ent = game.createEntity();
+    game.setPosition(sky_ent, .{ .x = 100, .y = 50 });
+    game.addComponent(sky_ent, engine.Camera{ .zoom = 2.0, .tag = engine.camera_mod.makeTag("sky") });
+
+    const mini_ent = game.createEntity();
+    game.setPosition(mini_ent, .{ .x = 900, .y = 700 });
+    game.addComponent(mini_ent, engine.Camera{ .zoom = 0.5, .tag = engine.camera_mod.makeTag("minimap") });
+
+    game.seedCameraFromComponent();
+
+    const mgr = game.getCameraManager();
+    // Slot 0 = main, seeded via getCamera() and tagged "main".
+    try testing.expectEqual(@as(f32, 640), game.getCamera().x);
+    try testing.expectEqual(@as(f32, 360), game.getCamera().y);
+    try testing.expect(mgr.isActive(0));
+    try testing.expect(mgr.cameras[0].hasTag("main"));
+
+    // Each secondary tag resolves to an ACTIVE slot carrying its authored
+    // world position + zoom (resolution is tag-based, order-independent).
+    const sky = mgr.findByTag("sky") orelse return error.SkyNotBound;
+    try testing.expectEqual(@as(f32, 100), sky.x);
+    try testing.expectEqual(@as(f32, 50), sky.y);
+    try testing.expectEqual(@as(f32, 2.0), sky.zoom);
+
+    const mini = mgr.findByTag("minimap") orelse return error.MinimapNotBound;
+    try testing.expectEqual(@as(f32, 0.5), mini.zoom);
+
+    // Exactly two secondary slots claimed (1 and 2); slot 3 stays inactive.
+    try testing.expect(mgr.isActive(1));
+    try testing.expect(mgr.isActive(2));
+    try testing.expect(!mgr.isActive(3));
+}
+
+test "camera reseed: resetSecondary drops a removed secondary camera's slot" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = CameraTestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const sky_ent = game.createEntity();
+    game.setPosition(sky_ent, .{ .x = 100, .y = 50 });
+    game.addComponent(sky_ent, engine.Camera{ .zoom = 2.0, .tag = engine.camera_mod.makeTag("sky") });
+    game.seedCameraFromComponent();
+
+    const mgr = game.getCameraManager();
+    try testing.expect(mgr.findByTag("sky") != null);
+
+    // Remove the camera entity and re-seed: the stale secondary slot is
+    // deactivated + untagged (slot 0 is never touched).
+    game.destroyEntity(sky_ent);
+    game.seedCameraFromComponent();
+    try testing.expect(mgr.findByTag("sky") == null);
+    try testing.expect(!mgr.isActive(1));
+    try testing.expect(mgr.isActive(0)); // main slot survives
+}
+
+test "camera zero-noop: no Camera entities leaves the slot-0 default camera untouched" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = CameraTestGame.init(testing.allocator);
+    defer game.deinit();
+
+    // Author a distinctive slot-0 state, then seed a scene with NO Camera.
+    game.getCamera().setPosition(1234, 5678);
+    game.getCamera().setZoom(3.3);
+    game.seedCameraFromComponent();
+
+    // Invariant: a Camera-less scene renders exactly as before — slot 0 is
+    // left exactly as it was; no secondary slot is activated.
+    try testing.expectEqual(@as(f32, 1234), game.getCamera().x);
+    try testing.expectEqual(@as(f32, 3.3), game.getCamera().zoom);
+    const mgr = game.getCameraManager();
+    try testing.expect(!mgr.isActive(1));
+    try testing.expect(!mgr.isActive(2));
+    try testing.expect(!mgr.isActive(3));
+}
+
+test "camera first-per-tag: a duplicate tag keeps the first camera, ignores extras" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = CameraTestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const a = game.createEntity();
+    game.setPosition(a, .{ .x = 10, .y = 20 });
+    game.addComponent(a, engine.Camera{ .zoom = 1.0, .tag = engine.camera_mod.makeTag("hud") });
+
+    const b = game.createEntity();
+    game.setPosition(b, .{ .x = 999, .y = 888 });
+    game.addComponent(b, engine.Camera{ .zoom = 9.0, .tag = engine.camera_mod.makeTag("hud") });
+
+    game.seedCameraFromComponent();
+
+    const mgr = game.getCameraManager();
+    // Only ONE slot carries "hud" — the first-seen camera; the duplicate did
+    // not claim a second slot.
+    const hud = mgr.findByTag("hud") orelse return error.HudNotBound;
+    try testing.expectEqual(@as(f32, 10), hud.x);
+    try testing.expectEqual(@as(f32, 1.0), hud.zoom);
+    try testing.expect(mgr.isActive(1));
+    try testing.expect(!mgr.isActive(2)); // the duplicate was ignored
+}
+
+test "camera overflow: a 4th secondary tag past slots 1..3 is ignored" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = CameraTestGame.init(testing.allocator);
+    defer game.deinit();
+
+    inline for (.{ "a", "b", "c", "d" }) |t| {
+        const e = game.createEntity();
+        game.setPosition(e, .{ .x = 0, .y = 0 });
+        game.addComponent(e, engine.Camera{ .tag = engine.camera_mod.makeTag(t) });
+    }
+    game.seedCameraFromComponent();
+
+    const mgr = game.getCameraManager();
+    // Three of the four claimed slots 1..3; the fourth overflowed and was
+    // dropped. All three secondary slots are active.
+    try testing.expect(mgr.isActive(1));
+    try testing.expect(mgr.isActive(2));
+    try testing.expect(mgr.isActive(3));
+    var bound: usize = 0;
+    inline for (.{ "a", "b", "c", "d" }) |t| {
+        if (mgr.findByTag(t) != null) bound += 1;
+    }
+    try testing.expectEqual(@as(usize, 3), bound);
+}
+
+test "getCameraByTag: returns the lowest active slot carrying the tag" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = CameraTestGame.init(testing.allocator);
+    defer game.deinit();
+
+    // Drive the manager directly to place the SAME tag on two active slots,
+    // exercising the lowest-slot forwarder (the seed enforces first-per-tag,
+    // so this is the only way to construct the ambiguity).
+    const mgr = game.getCameraManager();
+    mgr.setActive(2, true);
+    mgr.setTag(2, "dup");
+    mgr.getCamera(2).setPosition(20, 0);
+    mgr.setActive(3, true);
+    mgr.setTag(3, "dup");
+    mgr.getCamera(3).setPosition(30, 0);
+
+    const got = game.getCameraByTag("dup") orelse return error.NotFound;
+    try testing.expectEqual(@as(f32, 20), got.x); // slot 2, the lowest
+    try testing.expect(game.getCameraByTag("absent") == null);
+}
+
+test "camera load-path: loadGameState reseeds tagged cameras into their slots" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = CameraTestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const main_ent = game.createEntity();
+    game.setPosition(main_ent, .{ .x = 640, .y = 360 });
+    game.addComponent(main_ent, engine.Camera{ .zoom = 1.0 });
+
+    const sky_ent = game.createEntity();
+    game.setPosition(sky_ent, .{ .x = 100, .y = 50 });
+    game.addComponent(sky_ent, engine.Camera{ .zoom = 2.0, .tag = engine.camera_mod.makeTag("sky") });
+
+    const save_path = "test_save_camera_724.json";
+    try game.saveGameState(save_path);
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, save_path) catch {};
+
+    // Wipe ECS *and* the camera slots, then load: loadGameState must both
+    // restore the tag onto the component AND re-seed the slot binding.
+    game.resetEcsBackend();
+    game.getCameraManager().resetSecondary();
+    try testing.expect(game.getCameraManager().findByTag("sky") == null);
+
+    try game.loadGameState(save_path);
+
+    // The tag round-tripped onto the component…
+    var restored_sky: ?*engine.Camera = null;
+    var v = game.active_world.ecs_backend.view(.{ core.Position, engine.Camera }, .{});
+    defer v.deinit();
+    while (v.next()) |e| {
+        const c = game.active_world.ecs_backend.getComponent(e, engine.Camera).?;
+        if (c.tagSlice().len > 0 and std.mem.eql(u8, c.tagSlice(), "sky")) restored_sky = c;
+    }
+    try testing.expect(restored_sky != null);
+    // …and the load reseeded a live secondary slot for it.
+    const sky = game.getCameraManager().findByTag("sky") orelse return error.SkyNotReseeded;
+    try testing.expectEqual(@as(f32, 2.0), sky.zoom);
+}
+
+test "scene JSONC: an authored Camera \"tag\" seeds the inline bounded field" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = CameraTestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const Bridge = engine.JsoncSceneBridge(CameraTestGame, EmptyComponents);
+    try Bridge.loadSceneFromSource(&game,
+        \\{ "entities": [
+        \\   { "components": { "Position": { "x": 512, "y": 384 }, "Camera": { "zoom": 1.0, "tag": "sky_parallax" } } }
+        \\ ] }
+    , "prefabs");
+
+    var found: ?*engine.Camera = null;
+    var v = game.ecs_backend.view(.{ core.Position, engine.Camera }, .{});
+    defer v.deinit();
+    while (v.next()) |e| found = game.getComponent(e, engine.Camera);
+    try testing.expect(found != null);
+    // The primary authoring channel parsed the string into the bounded field
+    // (not silently defaulted to "main").
+    try testing.expectEqualStrings("sky_parallax", found.?.tagSlice());
+}
+
+test "editor_set_component: a Camera \"tag\" patch updates the bounded field and merges" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = CameraTestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const cam_ent = game.createEntity();
+    game.setPosition(cam_ent, .{ .x = 0, .y = 0 });
+    game.addComponent(cam_ent, engine.Camera{ .zoom = 1.0 }); // default tag "main"
+
+    var runner = DummyRunner{};
+    editor_api.bind(&game, &runner);
+    editor_api.editor_pause(1);
+
+    const patch = try testing.allocator.dupe(u8, "{\"tag\":\"sky\"}");
+    try testing.expectEqual(@as(i32, 0), editor_api.editor_set_component(@intCast(cam_ent), "Camera", 6, patch.ptr, patch.len));
+    testing.allocator.free(patch);
+
+    const comp = game.getComponent(cam_ent, engine.Camera).?;
+    try testing.expectEqualStrings("sky", comp.tagSlice());
+    try testing.expectEqual(@as(f32, 1.0), comp.zoom); // zoom untouched by a tag-only patch
+
+    // A wrong-shaped tag is a validation failure (-2), entity untouched.
+    try testing.expectEqual(@as(i32, -2), editor_api.editor_set_component(@intCast(cam_ent), "Camera", 6, "{\"tag\":5}", 9));
+    try testing.expectEqualStrings("sky", game.getComponent(cam_ent, engine.Camera).?.tagSlice());
+}
+
+test "digest: a Camera entity publishes its tag and resolves view against its own slot" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = CameraTestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const sky_ent = game.createEntity();
+    game.setPosition(sky_ent, .{ .x = 100, .y = 50 });
+    game.addComponent(sky_ent, engine.Camera{ .zoom = 2.0, .tag = engine.camera_mod.makeTag("sky") });
+    game.seedCameraFromComponent();
+
+    var runner = DummyRunner{};
+    editor_api.bind(&game, &runner);
+
+    var buf: [4096]u8 = undefined;
+    const json = digestInto(&buf);
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+
+    var saw = false;
+    for (parsed.value.object.get("entities").?.array.items) |item| {
+        const obj = item.object;
+        if (obj.get("id").?.integer != @as(i64, @intCast(sky_ent))) continue;
+        const cam = obj.get("camera").?.object;
+        try testing.expectEqualStrings("sky", cam.get("tag").?.string);
+        // view resolves against the secondary slot the tag bound: centered on
+        // (100, 50), sized 800/2 × 600/2.
+        const view = cam.get("view").?.object;
+        try testing.expectApproxEqAbs(@as(f64, 400.0), jsonNum(view.get("width").?), 0.01);
+        try testing.expectApproxEqAbs(@as(f64, 100.0 - 200.0), jsonNum(view.get("x").?), 0.01);
+        saw = true;
+    }
+    try testing.expect(saw);
 }

--- a/test/editor_api_test.zig
+++ b/test/editor_api_test.zig
@@ -1018,6 +1018,99 @@ const RegisteredCameraGame = engine.GameConfig(
     void,
 );
 
+/// A renderer with a SETTABLE camera but an OLD, non-tagged `CameraManagerType`
+/// (no `resetSecondary`/`setTag`/`setActive`/`findByTag`) — the pre-gfx-1.26
+/// shape. The seeder must compile against it and fall back to the single-camera
+/// path (never referencing the missing tagged-manager methods). Mirrors
+/// `CamRender`'s no-op surface but swaps the manager.
+const OldCamManager = struct {}; // deliberately NO tag methods
+fn OldCamRender(comptime Entity: type) type {
+    return struct {
+        const Self = @This();
+
+        pub const Sprite = struct {
+            sprite_name: []const u8 = "",
+            visible: bool = true,
+            z_index: i16 = 0,
+            layer: enum { default } = .default,
+        };
+        pub const Shape = struct {
+            shape: union(enum) {
+                rectangle: struct { width: f32 = 10, height: f32 = 10 },
+                circle: struct { radius: f32 = 10 },
+            } = .{ .rectangle = .{} },
+            color: struct { r: u8 = 255, g: u8 = 255, b: u8 = 255, a: u8 = 255 } = .{},
+            visible: bool = true,
+            z_index: i16 = 0,
+            layer: enum { default } = .default,
+        };
+        pub const Text = struct {
+            text: [:0]const u8 = "",
+            visible: bool = true,
+            z_index: i16 = 0,
+        };
+        pub const Icon = struct {
+            name: []const u8 = "",
+            visible: bool = true,
+        };
+
+        pub const CameraType = CamCamera;
+        pub const CameraManagerType = OldCamManager;
+
+        camera: CamCamera = .{},
+        manager: OldCamManager = .{},
+        tracked_count: usize = 0,
+        render_count: usize = 0,
+
+        pub fn init(_: std.mem.Allocator) Self {
+            return .{};
+        }
+        pub fn deinit(_: *Self) void {}
+        pub fn trackEntity(self: *Self, _: Entity, _: core.render.VisualType) void {
+            self.tracked_count += 1;
+        }
+        pub fn untrackEntity(self: *Self, _: Entity) void {
+            if (self.tracked_count > 0) self.tracked_count -= 1;
+        }
+        pub fn markPositionDirty(_: *Self, _: Entity) void {}
+        pub fn markPositionDirtyWithChildren(_: *Self, comptime _: type, _: anytype, _: Entity) void {}
+        pub fn updateHierarchyFlag(_: *Self, _: Entity, _: bool) void {}
+        pub fn markVisualDirty(_: *Self, _: Entity) void {}
+        pub fn sync(_: *Self, comptime _: type, _: anytype) void {}
+        pub fn render(self: *Self) void {
+            self.render_count += 1;
+        }
+        pub fn setScreenHeight(_: *Self, _: f32) void {}
+        pub fn clear(self: *Self) void {
+            self.tracked_count = 0;
+        }
+        pub fn renderGizmoDraws(_: *Self, _: []const core.gizmos.GizmoDraw) void {}
+        pub fn hasEntity(_: *const Self, _: Entity) bool {
+            return false;
+        }
+        pub fn getCamera(self: *Self) *CamCamera {
+            return &self.camera;
+        }
+        pub fn getCameraManager(self: *Self) *OldCamManager {
+            return &self.manager;
+        }
+    };
+}
+
+const OldManagerGame = engine.GameConfig(
+    OldCamRender(CamMockEcs.Entity),
+    CamMockEcs,
+    engine.input_mod.StubInput,
+    engine.audio_mod.StubAudio,
+    engine.StubVideo,
+    engine.gui_mod.StubGui,
+    void,
+    core.StubLogSink,
+    EmptyComponents,
+    &.{},
+    void,
+);
+
 /// Read a JSON number as f64 regardless of whether it serialized as an
 /// integer (`{d}` on a whole f32 drops the fraction, e.g. `400`) or a float
 /// (`533.333…`).
@@ -1794,4 +1887,34 @@ test "digest: a Camera entity publishes its tag and resolves view against its ow
         saw = true;
     }
     try testing.expect(saw);
+}
+
+test "camera seed: an OLD non-tagged manager falls back to the single-camera seed (compiles)" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    // A renderer with a settable camera but a non-tagged manager: the seeder
+    // must NOT reference the tagged-manager methods (this test failing to
+    // COMPILE is the real regression guard). Behavior is the pre-PR single
+    // camera seed.
+    comptime std.debug.assert(!engine.camera_mod.hasTaggedCameraManager(OldManagerGame));
+
+    var game = OldManagerGame.init(testing.allocator);
+    defer game.deinit();
+
+    const cam_ent = game.createEntity();
+    game.setPosition(cam_ent, .{ .x = 320, .y = 240 });
+    game.addComponent(cam_ent, engine.Camera{ .zoom = 2.0, .tag = engine.camera_mod.makeTag("old_ignored") });
+
+    game.seedCameraFromComponent();
+
+    // Single-camera fallback: the (first) Camera entity's world transform
+    // reached the one renderer camera, tag notwithstanding.
+    try testing.expectEqual(@as(f32, 320), game.getCamera().x);
+    try testing.expectEqual(@as(f32, 240), game.getCamera().y);
+    try testing.expectEqual(@as(f32, 2.0), game.getCamera().zoom);
+
+    // getCameraByTag is a comptime no-op (null) on a non-tagged manager.
+    try testing.expect(game.getCameraByTag("old_ignored") == null);
+    try testing.expect(game.getCameraByTag("main") == null);
 }


### PR DESCRIPTION
**Phase-1 PR 2** of the Camera-Bound Layers RFC (#723 / RFC #724). Adds the engine half: `Camera.tag`, tagged multi-camera reset-then-seed, a `getCameraByTag` accessor, and tag round-trip through every Camera channel. Pins **gfx v1.26.0** (PR1, merged + released).

## Changes
- **`Camera.tag`** (`src/camera.zig`): inline sentinel-terminated `[16:0]u8`, default `"main"`, never a heap slice (the `applyCameraComponentJson` transient-arena constraint). Helpers `makeTag()`/`tagSlice()`/`setTagSlice()` (truncate at 15 to match gfx's `tag_buf`).
- **`seedCameraFromComponent` → reset-then-seed** (`camera_mixin.zig`): `getCameraManager().resetSecondary()` first, then iterate ALL `{Position, Camera}`. `"main"` → slot 0 (first wins); other tags → first-per-tag claims next free slot 1–3. Warn-once (latching) on unknown tag vs the comptime `LayerEnum` `.camera` vocabulary, extra main, duplicate tag, slot overflow. Zero cameras → slot 0 untouched (invariant).
- **`getCameraByTag(tag) ?*CameraType`** (`misc_mixin.zig`/`game.zig`): forwards to `findByTag` (lowest active slot); comptime null no-op on camera-less renderers.
- **`loadGameState` reseed**: re-seed after Camera components reattach (tagged cameras in a save would otherwise come back with dead slots).
- **Channels** (tag round-trips through all): scene/prefab JSONC (`component_apply.zig`), save/load serde, studio digest (adds `tag`, resolves `view` against the camera's own slot), `editor_set_component`. Editor-bridge contract doc bumped **v1.5 → v1.6**.

## Tests
+11 in `test/editor_api_test.zig`: multi-camera slot assignment, reseed-clears-removed, **zero-camera no-op invariant**, first-per-tag warn, overflow, `getCameraByTag` lowest-slot, load-path reseed, JSONC + set_component + digest tag round-trip, bounded-buffer truncation. The `CamRender` mock's `CameraManagerType` was upgraded from `struct{}` to a 4-slot tag manager mirroring gfx's contract. `zig build test` exit 0 against gfx v1.26.0.

Note: the engine is renderer-agnostic (gfx camera types arrive via `RenderImpl.CameraManagerType`), so tests exercise the manager contract through the in-tree mock; the real gfx↔engine integration is proven by FP PR4. Releases as engine **1.83.0** (follow-up release commit).

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw