### PR TITLE
feat: promote flat-array behavior_tree interpreter as a game-agnostic AI facility (#616)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -101,6 +101,7 @@ pub fn build(b: *std.Build) void {
         "test/animation_def_runtime_test.zig",
         "test/animation_events_test.zig",
         "test/tween_test.zig",
+        "test/behavior_tree_test.zig",
         "test/sprite_animation_test.zig",
         "test/sprite_animation_tick_test.zig",
         "test/sprite_animation_events_test.zig",

--- a/src/behavior_tree.zig
+++ b/src/behavior_tree.zig
@@ -140,7 +140,10 @@ pub fn BehaviorTree(comptime opts: Options) type {
             }
 
             fn tickSequence(self: *Self, node: *Node, context: *anyopaque, action_fn: ActionFn, condition_fn: ConditionFn) Status {
-                if (node.child_count == 0) return .success;
+                // A negative first_child is the leaf sentinel; combined with a
+                // zero child_count it means "no children". Guard it explicitly
+                // so a malformed/hand-built node can't panic the @intCast below.
+                if (node.child_count == 0 or node.first_child < 0) return .success;
                 const first: u16 = @intCast(node.first_child);
                 const start: u16 = if (node.state == .running) node.running_child else 0;
 
@@ -165,7 +168,8 @@ pub fn BehaviorTree(comptime opts: Options) type {
             }
 
             fn tickSelector(self: *Self, node: *Node, context: *anyopaque, action_fn: ActionFn, condition_fn: ConditionFn) Status {
-                if (node.child_count == 0) return .failure;
+                // See tickSequence: guard the negative-first_child sentinel.
+                if (node.child_count == 0 or node.first_child < 0) return .failure;
                 const first: u16 = @intCast(node.first_child);
                 const start: u16 = if (node.state == .running) node.running_child else 0;
 
@@ -203,9 +207,11 @@ pub fn BehaviorTree(comptime opts: Options) type {
             fn tickRepeater(self: *Self, node: *Node, context: *anyopaque, action_fn: ActionFn, condition_fn: ConditionFn) Status {
                 if (node.first_child < 0 or node.child_count == 0) return .failure;
                 const child_idx: u16 = @intCast(node.first_child);
-                const repeat_count: u32 = node.data;
-                // Guard: running_child is u16, so repeat count must fit.
-                std.debug.assert(repeat_count <= std.math.maxInt(u16));
+                // running_child is u16, so the resumable iteration index must
+                // fit in u16. Clamp rather than assert (asserts compile out in
+                // release, turning an over-large count into UB on the @intCast
+                // below). A count above 65535 simply saturates at 65535.
+                const repeat_count: u32 = @min(node.data, std.math.maxInt(u16));
                 // Resume from the iteration that was running on the previous tick.
                 const start: u32 = if (node.state == .running) node.running_child else 0;
 
@@ -280,12 +286,12 @@ pub fn BehaviorTree(comptime opts: Options) type {
 
             /// Open a sequence composite scope.
             pub fn beginSequence(self: *SelfBuilder) error{TreeFull}!void {
-                self.beginComposite(.sequence);
+                return self.beginComposite(.sequence);
             }
 
             /// Open a selector composite scope.
             pub fn beginSelector(self: *SelfBuilder) error{TreeFull}!void {
-                self.beginComposite(.selector);
+                return self.beginComposite(.selector);
             }
 
             /// Close the current composite scope. Appends the composite node
@@ -314,7 +320,9 @@ pub fn BehaviorTree(comptime opts: Options) type {
                 // Register the finalized composite with the parent scope.
                 if (self.depth > 0) {
                     const parent = &self.scope_stack[self.depth - 1];
-                    std.debug.assert(parent.child_count < MAX_CHILDREN);
+                    // Too many direct children is a data/config constraint, not
+                    // a programmer bug — surface it as error.TreeFull.
+                    if (parent.child_count >= MAX_CHILDREN) return error.TreeFull;
                     // Store a copy of the composite node so tick can find it
                     // via the parent's first_child + i offset.
                     parent.children[parent.child_count] = self.tree.nodes[composite_idx];
@@ -338,8 +346,10 @@ pub fn BehaviorTree(comptime opts: Options) type {
             // Internal helpers
             // ----------------------------------------------------------------
 
-            fn beginComposite(self: *SelfBuilder, kind: NodeKind) void {
-                std.debug.assert(self.depth < MAX_DEPTH);
+            fn beginComposite(self: *SelfBuilder, kind: NodeKind) error{TreeFull}!void {
+                // Exceeding the nesting depth is a data/config constraint, not
+                // a programmer bug — surface it as error.TreeFull.
+                if (self.depth >= MAX_DEPTH) return error.TreeFull;
                 self.scope_stack[self.depth] = .{ .kind = kind };
                 self.depth += 1;
             }
@@ -352,7 +362,8 @@ pub fn BehaviorTree(comptime opts: Options) type {
                 // Buffer into the current scope; the real tree index is
                 // assigned when the enclosing end() copies children.
                 const scope = &self.scope_stack[self.depth - 1];
-                std.debug.assert(scope.child_count < MAX_CHILDREN);
+                // Too many direct children — surface as error.TreeFull.
+                if (scope.child_count >= MAX_CHILDREN) return error.TreeFull;
                 scope.children[scope.child_count] = .{ .kind = kind, .data = data };
                 scope.child_count += 1;
                 // Return 0 as a placeholder — callers of action()/condition()

--- a/src/behavior_tree.zig
+++ b/src/behavior_tree.zig
@@ -1,0 +1,377 @@
+// Behavior Tree — a game-agnostic AI facility for labelle-engine.
+//
+// A flat-array (not pointer-based) behavior-tree interpreter. Because the
+// whole tree — topology *and* runtime state — lives in a single fixed-size
+// array, a `Tree` value is trivially serializable for save/load: copy the
+// bytes and you have the AI's exact resume point.
+//
+// The interpreter is domain-agnostic. It knows how to run composites
+// (sequence / selector / inverter / repeater) but nothing about what an
+// "action" or "condition" *means*. The game supplies that via two function
+// pointers plus an opaque `context` — the same parameterization shape used by
+// `Ecs(Backend)` in labelle-core and the `CommandBuffer(Command)` facility:
+// mechanism in the engine, domain verbs in the callbacks.
+//
+// Promoted from flying-platform-labelle's in-tree `behavior_tree` plugin
+// (labelle-engine#616). Capacities that were hardcoded constants there
+// (`MAX_NODES` / `MAX_CHILDREN` / `MAX_DEPTH`) are comptime-tunable here via
+// `BehaviorTree(Options)`; the module-level `Tree` / `TreeBuilder` aliases
+// keep the original defaults for callers that don't care.
+
+const std = @import("std");
+
+// ============================================================================
+// Domain-agnostic vocabulary (capacity-independent)
+// ============================================================================
+
+pub const Status = enum(u8) {
+    success,
+    failure,
+    running,
+};
+
+/// Node kinds — each serializable as an enum tag.
+pub const NodeKind = enum(u8) {
+    sequence, // Run children in order, fail on first failure
+    selector, // Try children in order, succeed on first success
+    condition, // Check a predicate
+    action, // Execute a behavior
+    inverter, // Invert child result
+    repeater, // Repeat child N times or until failure
+};
+
+pub const Node = struct {
+    kind: NodeKind,
+    /// Index of first child in the node array (-1 = leaf)
+    first_child: i32 = -1,
+    /// Number of children
+    child_count: u16 = 0,
+    /// Node-specific data (action ID, condition ID, repeat count, etc.)
+    data: u32 = 0,
+    /// Runtime state — this is what gets saved
+    state: Status = .failure,
+    /// For running nodes: which child is currently active
+    running_child: u16 = 0,
+};
+
+/// Called for action nodes. `data` field identifies which action.
+pub const ActionFn = *const fn (action_id: u32, context: *anyopaque) Status;
+/// Called for condition nodes. `data` field identifies which condition.
+pub const ConditionFn = *const fn (condition_id: u32, context: *anyopaque) bool;
+
+// ============================================================================
+// Capacity parameterization
+// ============================================================================
+
+/// Comptime-tunable capacity limits. Defaults mirror the original
+/// flying-platform facility so existing trees fit unchanged.
+pub const Options = struct {
+    /// Max total nodes in a tree (topology + inline runtime state).
+    max_nodes: u16 = 64,
+    /// Max *direct* children per composite (not total descendants).
+    max_children: u8 = 32,
+    /// Max nesting depth of open composite scopes in `TreeBuilder`.
+    max_depth: u8 = 16,
+};
+
+/// Build a behavior-tree facility with the given capacities. Returns a
+/// namespace exposing `Tree` and `TreeBuilder` bound to `opts`.
+///
+///     const BT = engine.BehaviorTree(.{ .max_nodes = 128 });
+///     var tree = BT.Tree{};
+pub fn BehaviorTree(comptime opts: Options) type {
+    comptime std.debug.assert(opts.max_nodes >= 1);
+    comptime std.debug.assert(opts.max_children >= 1);
+    comptime std.debug.assert(opts.max_depth >= 1);
+
+    return struct {
+        const Facility = @This();
+
+        pub const options = opts;
+
+        pub const Tree = struct {
+            nodes: [MAX_NODES]Node = undefined,
+            len: usize = 0,
+            /// Index of the root node. Set after building the tree.
+            root: u16 = 0,
+
+            const Self = @This();
+            pub const MAX_NODES = opts.max_nodes;
+
+            /// Append a node to the tree. Returns its index.
+            pub fn addNode(self: *Self, node: Node) error{TreeFull}!u16 {
+                if (self.len >= MAX_NODES) return error.TreeFull;
+                const idx: u16 = @intCast(self.len);
+                self.nodes[idx] = node;
+                self.len += 1;
+                return idx;
+            }
+
+            /// Tick the tree from the root node, returning the root's status.
+            pub fn tick(self: *Self, context: *anyopaque, action_fn: ActionFn, condition_fn: ConditionFn) Status {
+                if (self.len == 0) return .failure;
+                return self.tickNode(self.root, context, action_fn, condition_fn);
+            }
+
+            /// Clear all runtime state (status + running_child) on every node.
+            pub fn reset(self: *Self) void {
+                for (0..self.len) |i| {
+                    self.nodes[i].state = .failure;
+                    self.nodes[i].running_child = 0;
+                }
+            }
+
+            // ----------------------------------------------------------------
+            // Internal tick logic
+            // ----------------------------------------------------------------
+
+            fn tickNode(self: *Self, idx: u16, context: *anyopaque, action_fn: ActionFn, condition_fn: ConditionFn) Status {
+                const node = &self.nodes[idx];
+                const result: Status = switch (node.kind) {
+                    .sequence => self.tickSequence(node, context, action_fn, condition_fn),
+                    .selector => self.tickSelector(node, context, action_fn, condition_fn),
+                    .action => action_fn(node.data, context),
+                    .condition => if (condition_fn(node.data, context)) .success else .failure,
+                    .inverter => self.tickInverter(node, context, action_fn, condition_fn),
+                    .repeater => self.tickRepeater(node, context, action_fn, condition_fn),
+                };
+                node.state = result;
+                return result;
+            }
+
+            fn tickSequence(self: *Self, node: *Node, context: *anyopaque, action_fn: ActionFn, condition_fn: ConditionFn) Status {
+                if (node.child_count == 0) return .success;
+                const first: u16 = @intCast(node.first_child);
+                const start: u16 = if (node.state == .running) node.running_child else 0;
+
+                var i: u16 = start;
+                while (i < node.child_count) : (i += 1) {
+                    const child_idx = first + i;
+                    const child_status = self.tickNode(child_idx, context, action_fn, condition_fn);
+                    switch (child_status) {
+                        .running => {
+                            node.running_child = i;
+                            return .running;
+                        },
+                        .failure => {
+                            node.running_child = 0;
+                            return .failure;
+                        },
+                        .success => {},
+                    }
+                }
+                node.running_child = 0;
+                return .success;
+            }
+
+            fn tickSelector(self: *Self, node: *Node, context: *anyopaque, action_fn: ActionFn, condition_fn: ConditionFn) Status {
+                if (node.child_count == 0) return .failure;
+                const first: u16 = @intCast(node.first_child);
+                const start: u16 = if (node.state == .running) node.running_child else 0;
+
+                var i: u16 = start;
+                while (i < node.child_count) : (i += 1) {
+                    const child_idx = first + i;
+                    const child_status = self.tickNode(child_idx, context, action_fn, condition_fn);
+                    switch (child_status) {
+                        .running => {
+                            node.running_child = i;
+                            return .running;
+                        },
+                        .success => {
+                            node.running_child = 0;
+                            return .success;
+                        },
+                        .failure => {},
+                    }
+                }
+                node.running_child = 0;
+                return .failure;
+            }
+
+            fn tickInverter(self: *Self, node: *Node, context: *anyopaque, action_fn: ActionFn, condition_fn: ConditionFn) Status {
+                if (node.first_child < 0 or node.child_count == 0) return .failure;
+                const child_idx: u16 = @intCast(node.first_child);
+                const child_status = self.tickNode(child_idx, context, action_fn, condition_fn);
+                return switch (child_status) {
+                    .success => .failure,
+                    .failure => .success,
+                    .running => .running,
+                };
+            }
+
+            fn tickRepeater(self: *Self, node: *Node, context: *anyopaque, action_fn: ActionFn, condition_fn: ConditionFn) Status {
+                if (node.first_child < 0 or node.child_count == 0) return .failure;
+                const child_idx: u16 = @intCast(node.first_child);
+                const repeat_count: u32 = node.data;
+                // Guard: running_child is u16, so repeat count must fit.
+                std.debug.assert(repeat_count <= std.math.maxInt(u16));
+                // Resume from the iteration that was running on the previous tick.
+                const start: u32 = if (node.state == .running) node.running_child else 0;
+
+                var i: u32 = start;
+                while (i < repeat_count) : (i += 1) {
+                    const child_status = self.tickNode(child_idx, context, action_fn, condition_fn);
+                    switch (child_status) {
+                        .running => {
+                            node.running_child = @intCast(i);
+                            return .running;
+                        },
+                        .failure => {
+                            node.running_child = 0;
+                            return .failure;
+                        },
+                        .success => {},
+                    }
+                }
+                node.running_child = 0;
+                return .success;
+            }
+        };
+
+        // ====================================================================
+        // TreeBuilder — ergonomic helper for constructing trees
+        // ====================================================================
+
+        /// A stack-based builder that automatically manages contiguous child
+        /// layout.
+        ///
+        /// Children of a composite MUST be contiguous in the nodes array for
+        /// the tick logic (`first_child + i`) to work. With nested composites,
+        /// a reserve-first strategy interleaves subtree nodes between siblings,
+        /// breaking this invariant.  For example, `Selector(Sequence(A), B)`
+        /// would produce `[Sel, Seq, A, B]` — Selector sees children at
+        /// indices 1 and 2, but index 2 is `A` (child of Sequence), not `B`.
+        ///
+        /// Instead, each scope buffers its direct children in a temporary
+        /// array. When `end()` is called, the composite node is appended to the
+        /// tree followed by copies of its buffered direct children —
+        /// guaranteeing contiguity.  Nested composites that were already
+        /// finalized via their own `end()` call are stored in the buffer as
+        /// "redirect" nodes whose `first_child` points to the real composite's
+        /// index in the tree. The copy pass writes these redirect nodes into
+        /// the contiguous child slots so the parent's `first_child + i`
+        /// resolves correctly.
+        pub const TreeBuilder = struct {
+            tree: *Facility.Tree,
+            /// Stack of open composite scopes.
+            scope_stack: [MAX_DEPTH]Scope = undefined,
+            depth: u8 = 0,
+
+            const SelfBuilder = @This();
+            const MAX_DEPTH = opts.max_depth;
+            /// Max direct children per composite (not total descendants).
+            const MAX_CHILDREN = opts.max_children;
+
+            const Scope = struct {
+                kind: NodeKind,
+                /// Buffered direct children, copied into the tree on `end()`.
+                /// Leaf nodes are stored with their full data.
+                /// Already-finalized composites are stored with `first_child`
+                /// pointing to their real index in the tree (a redirect).
+                children: [MAX_CHILDREN]Node = undefined,
+                /// Number of direct children buffered so far.
+                child_count: u8 = 0,
+            };
+
+            pub fn init(tree: *Facility.Tree) SelfBuilder {
+                return .{ .tree = tree };
+            }
+
+            /// Open a sequence composite scope.
+            pub fn beginSequence(self: *SelfBuilder) error{TreeFull}!void {
+                self.beginComposite(.sequence);
+            }
+
+            /// Open a selector composite scope.
+            pub fn beginSelector(self: *SelfBuilder) error{TreeFull}!void {
+                self.beginComposite(.selector);
+            }
+
+            /// Close the current composite scope. Appends the composite node
+            /// followed by contiguous copies of its direct children, then
+            /// returns the composite's index in the tree.
+            pub fn end(self: *SelfBuilder) error{TreeFull}!u16 {
+                std.debug.assert(self.depth > 0);
+                self.depth -= 1;
+                const scope = self.scope_stack[self.depth];
+
+                // Append the composite node first with a placeholder first_child.
+                const composite_idx = try self.tree.addNode(.{
+                    .kind = scope.kind,
+                    .first_child = -1,
+                    .child_count = @as(u16, scope.child_count),
+                });
+
+                // Children start right after the composite in the array.
+                self.tree.nodes[composite_idx].first_child = @as(i32, @intCast(self.tree.len));
+
+                // Copy buffered direct children into contiguous slots.
+                for (0..scope.child_count) |i| {
+                    _ = try self.tree.addNode(scope.children[i]);
+                }
+
+                // Register the finalized composite with the parent scope.
+                if (self.depth > 0) {
+                    const parent = &self.scope_stack[self.depth - 1];
+                    std.debug.assert(parent.child_count < MAX_CHILDREN);
+                    // Store a copy of the composite node so tick can find it
+                    // via the parent's first_child + i offset.
+                    parent.children[parent.child_count] = self.tree.nodes[composite_idx];
+                    parent.child_count += 1;
+                }
+
+                return composite_idx;
+            }
+
+            /// Add a condition leaf to the current composite.
+            pub fn condition(self: *SelfBuilder, id: u32) error{TreeFull}!u16 {
+                return self.addLeaf(.condition, id);
+            }
+
+            /// Add an action leaf to the current composite.
+            pub fn action(self: *SelfBuilder, id: u32) error{TreeFull}!u16 {
+                return self.addLeaf(.action, id);
+            }
+
+            // ----------------------------------------------------------------
+            // Internal helpers
+            // ----------------------------------------------------------------
+
+            fn beginComposite(self: *SelfBuilder, kind: NodeKind) void {
+                std.debug.assert(self.depth < MAX_DEPTH);
+                self.scope_stack[self.depth] = .{ .kind = kind };
+                self.depth += 1;
+            }
+
+            fn addLeaf(self: *SelfBuilder, kind: NodeKind, data: u32) error{TreeFull}!u16 {
+                if (self.depth == 0) {
+                    // Top-level leaf — append directly to the tree.
+                    return self.tree.addNode(.{ .kind = kind, .data = data });
+                }
+                // Buffer into the current scope; the real tree index is
+                // assigned when the enclosing end() copies children.
+                const scope = &self.scope_stack[self.depth - 1];
+                std.debug.assert(scope.child_count < MAX_CHILDREN);
+                scope.children[scope.child_count] = .{ .kind = kind, .data = data };
+                scope.child_count += 1;
+                // Return 0 as a placeholder — callers of action()/condition()
+                // inside a scope should not rely on the returned index.
+                return 0;
+            }
+        };
+    };
+}
+
+// ============================================================================
+// Default-capacity aliases
+// ============================================================================
+//
+// Mirrors the original flying-platform capacities (MAX_NODES=64,
+// MAX_CHILDREN=32, MAX_DEPTH=16). Reach for `BehaviorTree(.{...})` when you
+// need bigger trees.
+
+const Default = BehaviorTree(.{});
+
+pub const Tree = Default.Tree;
+pub const TreeBuilder = Default.TreeBuilder;

--- a/src/root.zig
+++ b/src/root.zig
@@ -724,6 +724,20 @@ pub const ControllerManagerEvent = controller_manager_mod.ManagerEvent;
 pub const NO_PLAYER = controller_manager_mod.NO_PLAYER;
 pub const NO_CONTROLLER = controller_manager_mod.NO_CONTROLLER;
 
+// ── Behavior Tree (game-agnostic AI facility, #616) ──
+// Flat-array (serializable) behavior-tree interpreter promoted from
+// flying-platform-labelle. `engine.BehaviorTree(.{...})` builds a facility
+// with custom capacities; the module also exposes default-capacity `Tree` /
+// `TreeBuilder` aliases (`engine.behavior_tree.Tree`).
+pub const behavior_tree = @import("behavior_tree.zig");
+pub const BehaviorTree = behavior_tree.BehaviorTree;
+pub const BehaviorTreeOptions = behavior_tree.Options;
+pub const BehaviorTreeStatus = behavior_tree.Status;
+pub const BehaviorTreeNode = behavior_tree.Node;
+pub const BehaviorTreeNodeKind = behavior_tree.NodeKind;
+pub const BehaviorTreeActionFn = behavior_tree.ActionFn;
+pub const BehaviorTreeConditionFn = behavior_tree.ConditionFn;
+
 // ── Core Re-exports ──
 pub const Position = core.Position;
 pub const Ecs = core.Ecs;

--- a/test/behavior_tree_test.zig
+++ b/test/behavior_tree_test.zig
@@ -445,6 +445,59 @@ test "TreeBuilder: nested composites" {
 }
 
 // ============================================================================
+// Robustness: malformed data + capacity limits degrade gracefully (#732 review)
+// ============================================================================
+
+test "tick guards a negative first_child instead of panicking" {
+    // A composite claiming children but with the -1 leaf sentinel for
+    // first_child (malformed / hand-built) must not panic the @intCast.
+    var tree = Tree{};
+    tree.root = try tree.addNode(.{ .kind = .sequence, .first_child = -1, .child_count = 2 });
+    var ctx = TestContext{};
+    try std.testing.expectEqual(Status.success, tree.tick(@ptrCast(&ctx), &testAction, &testCondition));
+
+    var sel = Tree{};
+    sel.root = try sel.addNode(.{ .kind = .selector, .first_child = -1, .child_count = 2 });
+    try std.testing.expectEqual(Status.failure, sel.tick(@ptrCast(&ctx), &testAction, &testCondition));
+}
+
+test "repeater clamps an over-u16 repeat count instead of asserting" {
+    // node.data above u16 max would overflow running_child's @intCast.
+    // It must saturate rather than panic; a failing child returns cleanly.
+    var tree = Tree{};
+    const child = try tree.addNode(.{ .kind = .action, .data = 0 });
+    tree.root = try tree.addNode(.{ .kind = .repeater, .first_child = @as(i32, child), .child_count = 1, .data = 100_000 });
+
+    var ctx = TestContext{};
+    ctx.action_results[0] = .failure; // stop on first iteration
+    try std.testing.expectEqual(Status.failure, tree.tick(@ptrCast(&ctx), &testAction, &testCondition));
+    try std.testing.expectEqual(@as(u32, 1), ctx.action_call_counts[0]);
+}
+
+test "TreeBuilder: exceeding MAX_CHILDREN returns error.TreeFull" {
+    const BT = engine.BehaviorTree(.{ .max_children = 2 });
+    var tree = BT.Tree{};
+    var b = BT.TreeBuilder.init(&tree);
+
+    try b.beginSequence();
+    _ = try b.action(0);
+    _ = try b.action(1);
+    // Third direct child overflows the 2-child scope.
+    try std.testing.expectError(error.TreeFull, b.action(2));
+}
+
+test "TreeBuilder: exceeding MAX_DEPTH returns error.TreeFull" {
+    const BT = engine.BehaviorTree(.{ .max_depth = 2 });
+    var tree = BT.Tree{};
+    var b = BT.TreeBuilder.init(&tree);
+
+    try b.beginSequence(); // depth 1
+    try b.beginSelector(); // depth 2
+    // Opening a third scope overflows the 2-deep stack.
+    try std.testing.expectError(error.TreeFull, b.beginSequence());
+}
+
+// ============================================================================
 // Comptime-tunable capacity (labelle-engine#616 generalization)
 // ============================================================================
 

--- a/test/behavior_tree_test.zig
+++ b/test/behavior_tree_test.zig
@@ -1,0 +1,474 @@
+const std = @import("std");
+const engine = @import("engine");
+
+const bt = engine.behavior_tree;
+const Tree = bt.Tree;
+const Node = bt.Node;
+const NodeKind = bt.NodeKind;
+const Status = bt.Status;
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+const TestContext = struct {
+    /// Each action_id maps to a status it should return.
+    action_results: [8]Status = .{.success} ** 8,
+    /// Each condition_id maps to a bool.
+    condition_results: [8]bool = .{false} ** 8,
+    /// Track how many times each action was called.
+    action_call_counts: [8]u32 = .{0} ** 8,
+    /// Track how many times each condition was called.
+    condition_call_counts: [8]u32 = .{0} ** 8,
+};
+
+fn testAction(action_id: u32, context: *anyopaque) Status {
+    const ctx: *TestContext = @ptrCast(@alignCast(context));
+    ctx.action_call_counts[action_id] += 1;
+    return ctx.action_results[action_id];
+}
+
+fn testCondition(condition_id: u32, context: *anyopaque) bool {
+    const ctx: *TestContext = @ptrCast(@alignCast(context));
+    ctx.condition_call_counts[condition_id] += 1;
+    return ctx.condition_results[condition_id];
+}
+
+// ============================================================================
+// Sequence tests
+// ============================================================================
+
+test "sequence: children execute in order, all succeed" {
+    // Sequence with 3 action children (IDs 0, 1, 2)
+    var tree = Tree{};
+    const a0 = try tree.addNode(.{ .kind = .action, .data = 0 });
+    _ = try tree.addNode(.{ .kind = .action, .data = 1 });
+    _ = try tree.addNode(.{ .kind = .action, .data = 2 });
+    tree.root = try tree.addNode(.{ .kind = .sequence, .first_child = @as(i32, a0), .child_count = 3 });
+
+    var ctx = TestContext{};
+    ctx.action_results = .{ .success, .success, .success, .success, .success, .success, .success, .success };
+
+    const result = tree.tick(@ptrCast(&ctx), &testAction, &testCondition);
+    try std.testing.expectEqual(Status.success, result);
+    // All three children called exactly once
+    try std.testing.expectEqual(@as(u32, 1), ctx.action_call_counts[0]);
+    try std.testing.expectEqual(@as(u32, 1), ctx.action_call_counts[1]);
+    try std.testing.expectEqual(@as(u32, 1), ctx.action_call_counts[2]);
+}
+
+test "sequence: fails on first failure, stops traversal" {
+    var tree = Tree{};
+    const a0 = try tree.addNode(.{ .kind = .action, .data = 0 });
+    _ = try tree.addNode(.{ .kind = .action, .data = 1 });
+    _ = try tree.addNode(.{ .kind = .action, .data = 2 });
+    tree.root = try tree.addNode(.{ .kind = .sequence, .first_child = @as(i32, a0), .child_count = 3 });
+
+    var ctx = TestContext{};
+    ctx.action_results[0] = .success;
+    ctx.action_results[1] = .failure; // second child fails
+    ctx.action_results[2] = .success;
+
+    const result = tree.tick(@ptrCast(&ctx), &testAction, &testCondition);
+    try std.testing.expectEqual(Status.failure, result);
+    try std.testing.expectEqual(@as(u32, 1), ctx.action_call_counts[0]);
+    try std.testing.expectEqual(@as(u32, 1), ctx.action_call_counts[1]);
+    try std.testing.expectEqual(@as(u32, 0), ctx.action_call_counts[2]); // not reached
+}
+
+// ============================================================================
+// Selector tests
+// ============================================================================
+
+test "selector: first success stops traversal" {
+    var tree = Tree{};
+    const a0 = try tree.addNode(.{ .kind = .action, .data = 0 });
+    _ = try tree.addNode(.{ .kind = .action, .data = 1 });
+    _ = try tree.addNode(.{ .kind = .action, .data = 2 });
+    tree.root = try tree.addNode(.{ .kind = .selector, .first_child = @as(i32, a0), .child_count = 3 });
+
+    var ctx = TestContext{};
+    ctx.action_results[0] = .failure;
+    ctx.action_results[1] = .success; // second child succeeds
+    ctx.action_results[2] = .success;
+
+    const result = tree.tick(@ptrCast(&ctx), &testAction, &testCondition);
+    try std.testing.expectEqual(Status.success, result);
+    try std.testing.expectEqual(@as(u32, 1), ctx.action_call_counts[0]);
+    try std.testing.expectEqual(@as(u32, 1), ctx.action_call_counts[1]);
+    try std.testing.expectEqual(@as(u32, 0), ctx.action_call_counts[2]); // not reached
+}
+
+test "selector: all fail returns failure" {
+    var tree = Tree{};
+    const a0 = try tree.addNode(.{ .kind = .action, .data = 0 });
+    _ = try tree.addNode(.{ .kind = .action, .data = 1 });
+    tree.root = try tree.addNode(.{ .kind = .selector, .first_child = @as(i32, a0), .child_count = 2 });
+
+    var ctx = TestContext{};
+    ctx.action_results[0] = .failure;
+    ctx.action_results[1] = .failure;
+
+    const result = tree.tick(@ptrCast(&ctx), &testAction, &testCondition);
+    try std.testing.expectEqual(Status.failure, result);
+}
+
+// ============================================================================
+// Running action resumes on next tick
+// ============================================================================
+
+test "running action resumes on next tick" {
+    var tree = Tree{};
+    const a0 = try tree.addNode(.{ .kind = .action, .data = 0 });
+    _ = try tree.addNode(.{ .kind = .action, .data = 1 });
+    tree.root = try tree.addNode(.{ .kind = .sequence, .first_child = @as(i32, a0), .child_count = 2 });
+
+    var ctx = TestContext{};
+    // First tick: action 0 returns running
+    ctx.action_results[0] = .running;
+    ctx.action_results[1] = .success;
+
+    const result1 = tree.tick(@ptrCast(&ctx), &testAction, &testCondition);
+    try std.testing.expectEqual(Status.running, result1);
+    try std.testing.expectEqual(@as(u32, 1), ctx.action_call_counts[0]);
+    try std.testing.expectEqual(@as(u32, 0), ctx.action_call_counts[1]); // not reached yet
+
+    // Second tick: action 0 now succeeds
+    ctx.action_results[0] = .success;
+    const result2 = tree.tick(@ptrCast(&ctx), &testAction, &testCondition);
+    try std.testing.expectEqual(Status.success, result2);
+    try std.testing.expectEqual(@as(u32, 2), ctx.action_call_counts[0]); // called again
+    try std.testing.expectEqual(@as(u32, 1), ctx.action_call_counts[1]); // now reached
+}
+
+// ============================================================================
+// Reset clears all state
+// ============================================================================
+
+test "reset clears all state" {
+    var tree = Tree{};
+    const a0 = try tree.addNode(.{ .kind = .action, .data = 0 });
+    _ = try tree.addNode(.{ .kind = .action, .data = 1 });
+    tree.root = try tree.addNode(.{ .kind = .sequence, .first_child = @as(i32, a0), .child_count = 2 });
+
+    var ctx = TestContext{};
+    ctx.action_results[0] = .running;
+
+    _ = tree.tick(@ptrCast(&ctx), &testAction, &testCondition);
+    // Sequence should be running with running_child = 0
+    try std.testing.expectEqual(Status.running, tree.nodes[tree.root].state);
+
+    tree.reset();
+
+    // All states should be failure, running_child should be 0
+    for (0..tree.len) |i| {
+        try std.testing.expectEqual(Status.failure, tree.nodes[i].state);
+        try std.testing.expectEqual(@as(u16, 0), tree.nodes[i].running_child);
+    }
+}
+
+// ============================================================================
+// Inverter
+// ============================================================================
+
+test "inverter flips child result" {
+    var tree = Tree{};
+    const child = try tree.addNode(.{ .kind = .action, .data = 0 });
+    tree.root = try tree.addNode(.{ .kind = .inverter, .first_child = @as(i32, child), .child_count = 1 });
+
+    var ctx = TestContext{};
+
+    // success -> failure
+    ctx.action_results[0] = .success;
+    try std.testing.expectEqual(Status.failure, tree.tick(@ptrCast(&ctx), &testAction, &testCondition));
+
+    // failure -> success
+    ctx.action_results[0] = .failure;
+    try std.testing.expectEqual(Status.success, tree.tick(@ptrCast(&ctx), &testAction, &testCondition));
+
+    // running -> running (not inverted)
+    ctx.action_results[0] = .running;
+    try std.testing.expectEqual(Status.running, tree.tick(@ptrCast(&ctx), &testAction, &testCondition));
+}
+
+// ============================================================================
+// Serialize / deserialize preserves running state
+// ============================================================================
+
+test "serialize/deserialize preserves running state" {
+    var tree = Tree{};
+    const a0 = try tree.addNode(.{ .kind = .action, .data = 0 });
+    _ = try tree.addNode(.{ .kind = .action, .data = 1 });
+    tree.root = try tree.addNode(.{ .kind = .sequence, .first_child = @as(i32, a0), .child_count = 2 });
+
+    var ctx = TestContext{};
+    ctx.action_results[0] = .running;
+    _ = tree.tick(@ptrCast(&ctx), &testAction, &testCondition);
+
+    // "Serialize" by copying the raw bytes
+    const bytes = std.mem.asBytes(&tree);
+    var restored: Tree = undefined;
+    @memcpy(std.mem.asBytes(&restored), bytes);
+
+    // Verify the restored tree has the same running state
+    try std.testing.expectEqual(tree.len, restored.len);
+    try std.testing.expectEqual(tree.root, restored.root);
+    try std.testing.expectEqual(Status.running, restored.nodes[restored.root].state);
+    try std.testing.expectEqual(@as(u16, 0), restored.nodes[restored.root].running_child);
+    try std.testing.expectEqual(Status.running, restored.nodes[0].state);
+
+    // Continue ticking the restored tree — action 0 now succeeds
+    ctx.action_results[0] = .success;
+    ctx.action_results[1] = .success;
+    const result = restored.tick(@ptrCast(&ctx), &testAction, &testCondition);
+    try std.testing.expectEqual(Status.success, result);
+}
+
+// ============================================================================
+// Condition nodes
+// ============================================================================
+
+test "condition node returns success/failure based on predicate" {
+    var tree = Tree{};
+    tree.root = try tree.addNode(.{ .kind = .condition, .data = 3 });
+
+    var ctx = TestContext{};
+
+    ctx.condition_results[3] = true;
+    try std.testing.expectEqual(Status.success, tree.tick(@ptrCast(&ctx), &testAction, &testCondition));
+
+    ctx.condition_results[3] = false;
+    try std.testing.expectEqual(Status.failure, tree.tick(@ptrCast(&ctx), &testAction, &testCondition));
+}
+
+// ============================================================================
+// Repeater
+// ============================================================================
+
+test "repeater runs child N times" {
+    var tree = Tree{};
+    const child = try tree.addNode(.{ .kind = .action, .data = 0 });
+    tree.root = try tree.addNode(.{ .kind = .repeater, .first_child = @as(i32, child), .child_count = 1, .data = 3 });
+
+    var ctx = TestContext{};
+    ctx.action_results[0] = .success;
+
+    const result = tree.tick(@ptrCast(&ctx), &testAction, &testCondition);
+    try std.testing.expectEqual(Status.success, result);
+    try std.testing.expectEqual(@as(u32, 3), ctx.action_call_counts[0]);
+}
+
+test "repeater stops on child failure" {
+    var tree = Tree{};
+    const child = try tree.addNode(.{ .kind = .action, .data = 0 });
+    tree.root = try tree.addNode(.{ .kind = .repeater, .first_child = @as(i32, child), .child_count = 1, .data = 5 });
+
+    var ctx = TestContext{};
+    // Verify that failure on first call stops the repeater.
+    ctx.action_results[0] = .failure;
+    const result = tree.tick(@ptrCast(&ctx), &testAction, &testCondition);
+    try std.testing.expectEqual(Status.failure, result);
+    try std.testing.expectEqual(@as(u32, 1), ctx.action_call_counts[0]); // stopped after 1
+}
+
+test "repeater resumes iteration count across ticks" {
+    // Repeater(3): child returns running on tick 1 (iteration 0),
+    // then succeeds on tick 2. Tick 2 should complete iterations 0-2 and return success.
+    var tree = Tree{};
+    const child = try tree.addNode(.{ .kind = .action, .data = 0 });
+    tree.root = try tree.addNode(.{ .kind = .repeater, .first_child = @as(i32, child), .child_count = 1, .data = 3 });
+
+    var ctx = TestContext{};
+
+    // Tick 1: child running on iteration 0
+    ctx.action_results[0] = .running;
+    const r1 = tree.tick(@ptrCast(&ctx), &testAction, &testCondition);
+    try std.testing.expectEqual(Status.running, r1);
+    try std.testing.expectEqual(@as(u32, 1), ctx.action_call_counts[0]);
+
+    // Tick 2: child now succeeds — resumes from iteration 0, finishes all 3
+    ctx.action_results[0] = .success;
+    const r2 = tree.tick(@ptrCast(&ctx), &testAction, &testCondition);
+    try std.testing.expectEqual(Status.success, r2);
+    // Called once in tick 1 (running) + 3 times in tick 2 (iter 0,1,2)
+    try std.testing.expectEqual(@as(u32, 4), ctx.action_call_counts[0]);
+}
+
+// ============================================================================
+// Tree capacity
+// ============================================================================
+
+test "addNode returns error when tree is full" {
+    var tree = Tree{};
+    for (0..Tree.MAX_NODES) |_| {
+        _ = try tree.addNode(.{ .kind = .action, .data = 0 });
+    }
+    try std.testing.expectError(error.TreeFull, tree.addNode(.{ .kind = .action, .data = 0 }));
+}
+
+test "empty tree tick returns failure" {
+    var tree = Tree{};
+    var ctx = TestContext{};
+    try std.testing.expectEqual(Status.failure, tree.tick(@ptrCast(&ctx), &testAction, &testCondition));
+}
+
+// ============================================================================
+// Empty composite guards
+// ============================================================================
+
+test "sequence with no children returns success" {
+    var tree = Tree{};
+    tree.root = try tree.addNode(.{ .kind = .sequence, .child_count = 0 });
+    var ctx = TestContext{};
+    try std.testing.expectEqual(Status.success, tree.tick(@ptrCast(&ctx), &testAction, &testCondition));
+}
+
+test "selector with no children returns failure" {
+    var tree = Tree{};
+    tree.root = try tree.addNode(.{ .kind = .selector, .child_count = 0 });
+    var ctx = TestContext{};
+    try std.testing.expectEqual(Status.failure, tree.tick(@ptrCast(&ctx), &testAction, &testCondition));
+}
+
+// ============================================================================
+// Repeater resumes iteration on running child
+// ============================================================================
+
+test "repeater resumes iteration when child returns running" {
+    var tree = Tree{};
+    const child = try tree.addNode(.{ .kind = .action, .data = 0 });
+    tree.root = try tree.addNode(.{ .kind = .repeater, .first_child = @as(i32, child), .child_count = 1, .data = 3 });
+
+    var ctx = TestContext{};
+
+    // Tick 1: child returns running on first iteration (i=0)
+    ctx.action_results[0] = .running;
+    const r1 = tree.tick(@ptrCast(&ctx), &testAction, &testCondition);
+    try std.testing.expectEqual(Status.running, r1);
+    try std.testing.expectEqual(@as(u32, 1), ctx.action_call_counts[0]);
+
+    // Tick 2: child now succeeds — should resume from i=0 and continue to i=1, i=2
+    ctx.action_results[0] = .success;
+    const r2 = tree.tick(@ptrCast(&ctx), &testAction, &testCondition);
+    try std.testing.expectEqual(Status.success, r2);
+    // Called 3 more times (iterations 0, 1, 2 from resume)
+    try std.testing.expectEqual(@as(u32, 4), ctx.action_call_counts[0]);
+}
+
+test "repeater resumes from correct iteration index" {
+    var tree = Tree{};
+    const child = try tree.addNode(.{ .kind = .action, .data = 0 });
+    tree.root = try tree.addNode(.{ .kind = .repeater, .first_child = @as(i32, child), .child_count = 1, .data = 5 });
+
+    var call_count: u32 = 0;
+
+    var ctx = TestContext{};
+    // First two iterations succeed, third returns running
+    ctx.action_results[0] = .success;
+
+    // We need a way to make it return running on the 3rd call.
+    // Tick once with all success — should complete all 5.
+    const r = tree.tick(@ptrCast(&ctx), &testAction, &testCondition);
+    try std.testing.expectEqual(Status.success, r);
+    call_count = ctx.action_call_counts[0];
+    try std.testing.expectEqual(@as(u32, 5), call_count);
+}
+
+// ============================================================================
+// TreeBuilder
+// ============================================================================
+
+test "TreeBuilder: basic sequence" {
+    var tree = Tree{};
+    var b = bt.TreeBuilder.init(&tree);
+
+    try b.beginSequence();
+    _ = try b.action(0);
+    _ = try b.action(1);
+    const seq = try b.end();
+
+    tree.root = seq;
+    const node = tree.nodes[seq];
+    try std.testing.expectEqual(NodeKind.sequence, node.kind);
+    try std.testing.expectEqual(@as(u16, 2), node.child_count);
+
+    var ctx = TestContext{};
+    ctx.action_results[0] = .success;
+    ctx.action_results[1] = .success;
+    try std.testing.expectEqual(Status.success, tree.tick(@ptrCast(&ctx), &testAction, &testCondition));
+}
+
+// ============================================================================
+// Repeater u16 overflow guard
+// ============================================================================
+
+test "repeater accepts repeat count at u16 max" {
+    // Ensure that the maximum valid u16 value is accepted (no assertion failure).
+    // We won't actually iterate 65535 times — just verify the guard passes
+    // by building the node and having the child fail immediately.
+    var tree = Tree{};
+    const child = try tree.addNode(.{ .kind = .action, .data = 0 });
+    tree.root = try tree.addNode(.{ .kind = .repeater, .first_child = @as(i32, child), .child_count = 1, .data = std.math.maxInt(u16) });
+
+    var ctx = TestContext{};
+    ctx.action_results[0] = .failure; // fail immediately so we don't loop 65535 times
+
+    const result = tree.tick(@ptrCast(&ctx), &testAction, &testCondition);
+    try std.testing.expectEqual(Status.failure, result);
+    try std.testing.expectEqual(@as(u32, 1), ctx.action_call_counts[0]);
+}
+
+test "TreeBuilder: nested composites" {
+    var tree = Tree{};
+    var b = bt.TreeBuilder.init(&tree);
+
+    try b.beginSelector();
+    {
+        try b.beginSequence();
+        _ = try b.condition(0);
+        _ = try b.action(0);
+        _ = try b.end();
+    }
+    _ = try b.action(1);
+    const root = try b.end();
+
+    tree.root = root;
+
+    // Root selector has 2 children: sequence and action
+    try std.testing.expectEqual(@as(u16, 2), tree.nodes[root].child_count);
+
+    var ctx = TestContext{};
+    // Condition fails -> sequence fails -> selector tries action 1
+    ctx.condition_results[0] = false;
+    ctx.action_results[1] = .success;
+    try std.testing.expectEqual(Status.success, tree.tick(@ptrCast(&ctx), &testAction, &testCondition));
+}
+
+// ============================================================================
+// Comptime-tunable capacity (labelle-engine#616 generalization)
+// ============================================================================
+
+test "BehaviorTree(Options) honors custom capacities" {
+    const Big = engine.BehaviorTree(.{ .max_nodes = 128, .max_children = 4, .max_depth = 4 });
+    try std.testing.expectEqual(@as(u16, 128), Big.Tree.MAX_NODES);
+
+    var tree = Big.Tree{};
+    // Fill beyond the default 64 to prove the larger capacity is real.
+    for (0..100) |_| {
+        _ = try tree.addNode(.{ .kind = .action, .data = 0 });
+    }
+    try std.testing.expectEqual(@as(usize, 100), tree.len);
+
+    // A tree built via the parameterized builder ticks like any other.
+    var built = Big.Tree{};
+    var b = Big.TreeBuilder.init(&built);
+    try b.beginSequence();
+    _ = try b.action(0);
+    _ = try b.action(1);
+    built.root = try b.end();
+
+    var ctx = TestContext{};
+    ctx.action_results[0] = .success;
+    ctx.action_results[1] = .success;
+    try std.testing.expectEqual(Status.success, built.tick(@ptrCast(&ctx), &testAction, &testCondition));
+}


### PR DESCRIPTION
## Summary

Promotes flying-platform-labelle's flat-array behavior-tree interpreter into `labelle-engine` as a game-agnostic AI facility (per #616). This is a lift of the mechanism plus one comptime parameterization — the interpreter was already structured the right way (mechanism in the lib, domain verbs via callbacks).

## What landed

- **`src/behavior_tree.zig`** — the interpreter (`tickNode` over composites: sequence / selector / condition / action / inverter / repeater), `TreeBuilder`, and the serializable vocabulary (`Status` / `Node` / `NodeKind` / `ActionFn` / `ConditionFn`). Flat-array layout ⇒ a whole tree (topology + inline runtime state) is trivially save/load-serializable.
- **Generalization** — the hardcoded `MAX_NODES=64` / `MAX_CHILDREN=32` / `MAX_DEPTH=16` become comptime-tunable via `BehaviorTree(Options)`, mirroring the CommandBuffer graduation's capacity treatment (#615). Module-level `Tree` / `TreeBuilder` aliases preserve the original defaults.
- **`test/behavior_tree_test.zig`** — the full FP suite (sequence/selector/inverter/repeater/condition/serialize-resume/builder + capacity guards) plus a new test exercising a custom-capacity `BehaviorTree(.{...})`. Wired into `build.zig` `test_files`.
- **`src/root.zig`** — re-exported under a `// ── Behavior Tree ──` section: `engine.behavior_tree` (module, with `.Tree` / `.TreeBuilder` default aliases), `engine.BehaviorTree` (the generic fn), `engine.BehaviorTreeOptions`, and the `Status`/`Node`/`NodeKind`/`ActionFn`/`ConditionFn` types.

## Public API

```zig
const bt = engine.behavior_tree;         // default-capacity module
var tree = bt.Tree{};                     // MAX_NODES=64
var b = bt.TreeBuilder.init(&tree);
// ...or custom capacities:
const BT = engine.BehaviorTree(.{ .max_nodes = 128, .max_children = 8 });
var big = BT.Tree{};
const status = tree.tick(ctx, action_fn, condition_fn); // .success/.failure/.running
```

## Scope

Engine-only. The game keeps its domain trees (`bandit_*`) and its `BanditBt` component, supplying them to this facility. The Controller lifecycle-wrapper promotion (with parameterized component name) is a natural follow-up but out of scope for this interpreter lift.

## Verification

`zig build test` → exit 0 (Zig 0.16). The `behavior_tree_test` binary: **All 22 tests passed.**

Closes #616

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw