### PR TITLE
Debug inspector: FPS counter + live profiler-overlay data API (#380)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -210,6 +210,12 @@ pub fn build(b: *std.Build) void {
         // vanishing. Drives a hot reload with a fail-on-demand loader and
         // asserts the error reaches a capturing log sink.
         "test/loading_transition_hardening_test.zig",
+        // #380 — debug inspector: FPS/frame-time tracker (FrameProfiler)
+        // + live per-script/per-plugin profiler-overlay data collection.
+        // The per-script profiler timings themselves shipped in v1.6.0;
+        // these cover the FPS counter and the overlay-facing surface.
+        "test/frame_profiler_test.zig",
+        "test/inspector_overlay_test.zig",
     };
 
     for (test_files) |test_file| {

--- a/scene/src/profiler.zig
+++ b/scene/src/profiler.zig
@@ -132,6 +132,105 @@ pub const Stat = struct {
 
 pub const Row = struct { name: []const u8, worst_ns: u64, avg_ns: u64 };
 
+// ── Live inspector overlay (labelle-engine#380) ──────────────────────
+//
+// The per-entry `Stat`s above are logged headless by `report()`. These
+// types re-shape the SAME data for an on-screen debug-inspector overlay:
+// stable layouts the `ScriptRunner` / `SystemRegistry` profile arrays
+// are, so `Game`'s opaque `script_profile_ptr` / `plugin_profile_ptr`
+// can be cast straight back to `[]const ScriptRow` / `[]const PluginRow`.
+
+/// One game script's live timing. Layout-shared with
+/// `ScriptRunner.ProfileEntry` so the Game's opaque pointer casts cleanly.
+pub const ScriptRow = struct {
+    name: []const u8,
+    tick: Stat = .{},
+    draw_gui: Stat = .{},
+};
+
+/// One plugin system's live timing. Layout-shared with
+/// `SystemRegistry.PluginProfileEntry`.
+pub const PluginRow = struct {
+    name: []const u8,
+    tick: Stat = .{},
+    post_tick: Stat = .{},
+};
+
+/// Traffic-light bucket for the inspector's color coding: green < 1 ms,
+/// yellow 1–5 ms, red > 5 ms (per the issue's spec).
+pub const Severity = enum { good, warn, bad };
+
+const warn_ns: u64 = 1_000_000; // 1 ms
+const bad_ns: u64 = 5_000_000; // 5 ms
+
+pub fn severityForNs(ns: u64) Severity {
+    if (ns >= bad_ns) return .bad;
+    if (ns >= warn_ns) return .warn;
+    return .good;
+}
+
+/// A flattened, render-ready row for the overlay: the live (`last_ns`)
+/// per-frame cost of an entry's primary phase (`tick`) and secondary
+/// phase (`drawGui` for scripts, `postTick` for plugins), already in ms
+/// with a severity bucket for coloring. Backend-agnostic — the debug
+/// plugin walks these and emits imgui/text; the shape is what makes the
+/// collector headless-testable.
+pub const OverlayRow = struct {
+    name: []const u8,
+    tick_ms: f32 = 0,
+    tick_severity: Severity = .good,
+    /// Secondary phase label ("drawGui" or "postTick").
+    aux_label: []const u8 = "",
+    aux_ms: f32 = 0,
+    aux_severity: Severity = .good,
+};
+
+fn nsToMs(ns: u64) f32 {
+    return @as(f32, @floatFromInt(ns)) / 1e6;
+}
+
+/// Fill `dst` from a slice of script profile rows using each entry's live
+/// `last_ns`. Returns the filled prefix (bounded by `dst.len`).
+pub fn collectScriptRows(dst: []OverlayRow, src: []const ScriptRow) []OverlayRow {
+    const n = @min(dst.len, src.len);
+    for (src[0..n], 0..) |e, i| {
+        dst[i] = .{
+            .name = e.name,
+            .tick_ms = nsToMs(e.tick.last_ns),
+            .tick_severity = severityForNs(e.tick.last_ns),
+            .aux_label = "drawGui",
+            .aux_ms = nsToMs(e.draw_gui.last_ns),
+            .aux_severity = severityForNs(e.draw_gui.last_ns),
+        };
+    }
+    return dst[0..n];
+}
+
+/// Fill `dst` from a slice of plugin profile rows using each entry's live
+/// `last_ns`. Returns the filled prefix (bounded by `dst.len`).
+pub fn collectPluginRows(dst: []OverlayRow, src: []const PluginRow) []OverlayRow {
+    const n = @min(dst.len, src.len);
+    for (src[0..n], 0..) |e, i| {
+        dst[i] = .{
+            .name = e.name,
+            .tick_ms = nsToMs(e.tick.last_ns),
+            .tick_severity = severityForNs(e.tick.last_ns),
+            .aux_label = "postTick",
+            .aux_ms = nsToMs(e.post_tick.last_ns),
+            .aux_severity = severityForNs(e.post_tick.last_ns),
+        };
+    }
+    return dst[0..n];
+}
+
+/// Sum of the primary + secondary live cost across `rows`, in ms — the
+/// "Total scripts" / "Total plugins" footer line.
+pub fn totalMs(rows: []const OverlayRow) f32 {
+    var sum: f32 = 0;
+    for (rows) |r| sum += r.tick_ms + r.aux_ms;
+    return sum;
+}
+
 /// Log a ranking of `rows` (sorted worst-first) under `label`, skipping
 /// entries below the threshold. `rows` is sorted in place. Emitted via
 /// `std.log.scoped(.profiler)` so it surfaces on stderr headless.

--- a/scene/src/system.zig
+++ b/scene/src/system.zig
@@ -41,12 +41,10 @@ pub fn SystemRegistry(comptime plugin_modules: anytype) type {
         pub const profiling_enabled = true;
 
         /// Plugin system timing (tick + postTick), rolling over the dump
-        /// window. Exposed via `Game.plugin_profile_ptr` for a live overlay.
-        pub const PluginProfileEntry = struct {
-            name: []const u8,
-            tick: profiler.Stat = .{},
-            post_tick: profiler.Stat = .{},
-        };
+        /// window. Exposed via `Game.plugin_profile_ptr` for the live
+        /// inspector overlay (#380). Aliases the shared `profiler.PluginRow`
+        /// so `Game`'s opaque pointer casts back to a stable layout.
+        pub const PluginProfileEntry = profiler.PluginRow;
         /// Frames since the last profiler log dump (advances only while recording).
         var prof_frame_counter: u64 = 0;
 

--- a/src/frame_profiler.zig
+++ b/src/frame_profiler.zig
@@ -1,0 +1,129 @@
+//! FrameProfiler — the engine-side FPS / frame-time tracker for the debug
+//! inspector (labelle-engine#380).
+//!
+//! Sibling to `scene/src/profiler.zig`: that module records per-script /
+//! per-plugin *dispatch* timings (env-gated by `LABELLE_PROFILE`); this one
+//! records the *whole-frame* dt every tick and derives an FPS reading for
+//! the always-visible inspector header. Unlike the per-script profiler it is
+//! NOT gated — the only cost is stashing one `f32` and an EMA update per
+//! frame, so it can always feed the inspector without a flag.
+//!
+//! Backend-agnostic and allocation-free: a fixed 120-frame ring plus a
+//! smoothed-dt accumulator. Nothing here touches a graphics backend, so it
+//! is fully headless-testable (see `test/frame_profiler_test.zig`).
+
+const std = @import("std");
+
+/// Rolling frame-time tracker. Owns a fixed window of the most recent frame
+/// durations (seconds) and a smoothed dt for a steady on-screen FPS number.
+pub const FrameProfiler = struct {
+    /// Number of frames retained for the min/avg/max window and the
+    /// inspector's frame-time mini-graph (~2 s at 60 FPS).
+    pub const window_size: usize = 120;
+
+    /// EMA smoothing factor for the displayed FPS. Small enough that the
+    /// headline number doesn't jitter frame-to-frame, large enough to react
+    /// to a sustained drop within a few frames.
+    pub const default_smoothing: f32 = 0.1;
+
+    /// Ring of recent frame times in **seconds**. Newest write is at
+    /// `(index - 1) % window_size`.
+    frame_times: [window_size]f32 = [_]f32{0} ** window_size,
+    /// Next write slot in the ring.
+    index: usize = 0,
+    /// Valid samples in the ring, saturating at `window_size`.
+    count: usize = 0,
+    /// Exponential moving average of frame time (seconds). 0 until the
+    /// first sample so `fps()` reports 0 rather than a divide-by-zero.
+    smoothed_dt: f32 = 0,
+    /// EMA alpha; see `default_smoothing`.
+    smoothing: f32 = default_smoothing,
+
+    /// Record one frame's duration. `dt` is the real (unscaled) frame time
+    /// in seconds. Non-positive / non-finite samples (a paused first frame,
+    /// a NaN from a stalled clock) are dropped so they can't poison the
+    /// average or push FPS to infinity.
+    pub fn record(self: *FrameProfiler, dt: f32) void {
+        // `!(dt > 0)` also rejects NaN (every comparison with NaN is false).
+        if (!(dt > 0) or !std.math.isFinite(dt)) return;
+        self.frame_times[self.index] = dt;
+        self.index = (self.index + 1) % window_size;
+        if (self.count < window_size) self.count += 1;
+        self.smoothed_dt = if (self.smoothed_dt <= 0)
+            dt
+        else
+            self.smoothed_dt + self.smoothing * (dt - self.smoothed_dt);
+    }
+
+    /// Smoothed frames-per-second. 0 before the first sample.
+    pub fn fps(self: *const FrameProfiler) f32 {
+        if (self.smoothed_dt <= 0) return 0;
+        return 1.0 / self.smoothed_dt;
+    }
+
+    /// Smoothed frame time in milliseconds (the "16.7ms" readout).
+    pub fn frameTimeMs(self: *const FrameProfiler) f32 {
+        return self.smoothed_dt * 1000.0;
+    }
+
+    /// Min / avg / max frame time (ms) plus derived FPS over the window.
+    pub const Stats = struct {
+        min_ms: f32 = 0,
+        avg_ms: f32 = 0,
+        max_ms: f32 = 0,
+        /// Smoothed FPS (same value as `fps()`), carried here so the
+        /// inspector can pull one struct.
+        fps: f32 = 0,
+        /// Valid samples the stats were computed from.
+        samples: usize = 0,
+    };
+
+    /// Compute min/avg/max over the retained window. Empty → all zero.
+    pub fn stats(self: *const FrameProfiler) Stats {
+        if (self.count == 0) return .{ .fps = self.fps() };
+        var min_s: f32 = std.math.floatMax(f32);
+        var max_s: f32 = 0;
+        var sum_s: f32 = 0;
+        var i: usize = 0;
+        while (i < self.count) : (i += 1) {
+            const v = self.frame_times[i];
+            if (v < min_s) min_s = v;
+            if (v > max_s) max_s = v;
+            sum_s += v;
+        }
+        const avg_s = sum_s / @as(f32, @floatFromInt(self.count));
+        return .{
+            .min_ms = min_s * 1000.0,
+            .avg_ms = avg_s * 1000.0,
+            .max_ms = max_s * 1000.0,
+            .fps = self.fps(),
+            .samples = self.count,
+        };
+    }
+
+    /// Copy the frame-time history (ms) into `dst` oldest-first, newest
+    /// last — the order a left-to-right mini-graph wants. Returns the
+    /// filled prefix. `dst` shorter than the sample count keeps only the
+    /// most recent `dst.len` frames.
+    pub fn history(self: *const FrameProfiler, dst: []f32) []f32 {
+        const n = @min(self.count, dst.len);
+        if (n == 0) return dst[0..0];
+        // Oldest retained sample sits `count` slots behind `index`.
+        var src = (self.index + window_size - self.count) % window_size;
+        // Skip ahead when dst can't hold the whole window (keep newest n).
+        var skip = self.count - n;
+        while (skip > 0) : (skip -= 1) src = (src + 1) % window_size;
+        var i: usize = 0;
+        while (i < n) : (i += 1) {
+            dst[i] = self.frame_times[src] * 1000.0;
+            src = (src + 1) % window_size;
+        }
+        return dst[0..n];
+    }
+
+    /// Clear all samples (e.g. on scene change so a load stall doesn't
+    /// linger in the graph).
+    pub fn reset(self: *FrameProfiler) void {
+        self.* = .{ .smoothing = self.smoothing };
+    }
+};

--- a/src/game.zig
+++ b/src/game.zig
@@ -63,6 +63,7 @@ const tilemap_runtime = @import("tilemap_runtime.zig");
 const tilemap_mixin = @import("game/tilemap_mixin.zig");
 const camera_mod = @import("camera.zig");
 const camera_mixin = @import("game/camera_mixin.zig");
+const frame_profiler_mod = @import("frame_profiler.zig");
 
 /// Full game configuration — the assembler fills ALL comptime slots.
 /// RenderImpl is a renderer plugin (e.g. gfx.GfxRenderer) satisfying RenderInterface.
@@ -816,6 +817,12 @@ pub fn GameConfigWithYAxis(
         plugin_profile_ptr: ?*const anyopaque = null,
         plugin_profile_count: usize = 0,
 
+        /// FPS / frame-time tracker for the debug inspector (#380). Fed one
+        /// `dt` per `tick` (see `loop_mixin`). Ungated — the per-frame cost
+        /// is a single ring write + EMA update — so the inspector's FPS
+        /// header always works even without `LABELLE_PROFILE`.
+        frame_profiler: frame_profiler_mod.FrameProfiler = .{},
+
         // Hot reload
         hot_reload_dirty: bool = false,
 
@@ -1388,6 +1395,13 @@ pub fn GameConfigWithYAxis(
         pub const getRenderer = MiscMixin.getRenderer;
         pub const getEcsBackend = MiscMixin.getEcsBackend;
         pub const entityCount = MiscMixin.entityCount;
+
+        // Debug inspector: FPS + profiler overlay (#380).
+        pub const fps = MiscMixin.fps;
+        pub const frameTimeMs = MiscMixin.frameTimeMs;
+        pub const frameStats = MiscMixin.frameStats;
+        pub const scriptProfileRows = MiscMixin.scriptProfileRows;
+        pub const pluginProfileRows = MiscMixin.pluginProfileRows;
     };
 }
 

--- a/src/game/loop_mixin.zig
+++ b/src/game/loop_mixin.zig
@@ -23,6 +23,12 @@ pub fn Mixin(comptime Game: type) type {
 
     return struct {
         pub fn tick(self: *Game, dt: f32) void {
+            // FPS / frame-time tracking for the debug inspector (#380).
+            // Record the REAL (unscaled) dt every frame — including paused
+            // frames that early-return below — so the inspector's FPS
+            // readout reflects true render cadence, not gameplay time_scale.
+            self.frame_profiler.record(dt);
+
             const scaled_dt = dt * self.time_scale;
             // Freeze the gameplay clock under EITHER pause path — the
             // `paused` flag (#465) doesn't zero `time_scale`, so guarding

--- a/src/game/misc_mixin.zig
+++ b/src/game/misc_mixin.zig
@@ -10,6 +10,8 @@
 
 const std = @import("std");
 const core = @import("labelle-core");
+const frame_profiler_mod = @import("../frame_profiler.zig");
+const profiler = @import("scene").profiler;
 
 /// Returns the misc-accessors mixin for a given Game type.
 pub fn Mixin(comptime Game: type) type {
@@ -191,6 +193,46 @@ pub fn Mixin(comptime Game: type) type {
 
         pub fn entityCount(self: *Game) usize {
             return @intCast(self.ecs_backend.entityCount());
+        }
+
+        // ── Debug inspector: FPS + profiler overlay (#380) ───────────
+
+        /// Smoothed frames-per-second for the inspector header. Always
+        /// available (the frame profiler is ungated).
+        pub fn fps(self: *const Game) f32 {
+            return self.frame_profiler.fps();
+        }
+
+        /// Smoothed frame time in milliseconds.
+        pub fn frameTimeMs(self: *const Game) f32 {
+            return self.frame_profiler.frameTimeMs();
+        }
+
+        /// Min/avg/max frame-time window stats (+ derived FPS) for the
+        /// inspector's frame-time section.
+        pub fn frameStats(self: *const Game) frame_profiler_mod.FrameProfiler.Stats {
+            return self.frame_profiler.stats();
+        }
+
+        /// The live per-script profile rows (`tick` + `drawGui` timings),
+        /// or an empty slice when the generated `main` hasn't wired the
+        /// pointer (unit-test games, or a build without scripts). The Game
+        /// stores this as `*const anyopaque`; the row layout is the shared
+        /// `profiler.ScriptRow`, so the cast is stable.
+        pub fn scriptProfileRows(self: *const Game) []const profiler.ScriptRow {
+            const ptr = self.script_profile_ptr orelse return &.{};
+            if (self.script_profile_count == 0) return &.{};
+            const many: [*]const profiler.ScriptRow = @ptrCast(@alignCast(ptr));
+            return many[0..self.script_profile_count];
+        }
+
+        /// The live per-plugin profile rows (`tick` + `postTick` timings),
+        /// or an empty slice when unwired. See `scriptProfileRows`.
+        pub fn pluginProfileRows(self: *const Game) []const profiler.PluginRow {
+            const ptr = self.plugin_profile_ptr orelse return &.{};
+            if (self.plugin_profile_count == 0) return &.{};
+            const many: [*]const profiler.PluginRow = @ptrCast(@alignCast(ptr));
+            return many[0..self.plugin_profile_count];
         }
     };
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -518,6 +518,13 @@ pub const MergeHookPayloads = core.MergeHookPayloads;
 /// runtime with `LABELLE_PROFILE=1`; ranks tick costs to the log.
 pub const profiler = scene_mod.profiler;
 
+/// FPS / frame-time tracker for the debug inspector (#380). Fed one `dt`
+/// per `Game.tick`; read via `game.fps()` / `game.frameStats()`. Ungated —
+/// always available. The per-script/per-plugin overlay rows come from
+/// `game.scriptProfileRows()` / `game.pluginProfileRows()` + the
+/// `profiler.collect*Rows` helpers.
+pub const FrameProfiler = @import("frame_profiler.zig").FrameProfiler;
+
 // ── Scene System ──
 pub const Scene = scene_mod.Scene;
 pub const PrefabRegistry = scene_mod.PrefabRegistry;

--- a/src/scene.zig
+++ b/src/scene.zig
@@ -8,6 +8,7 @@ pub const prefab = scene.prefab;
 pub const component = scene.component;
 pub const script = scene.script;
 pub const gizmo = scene.gizmo;
+pub const profiler = scene.profiler;
 
 // ── Types ──
 pub const RefInfo = scene.RefInfo;

--- a/src/script_runner.zig
+++ b/src/script_runner.zig
@@ -31,13 +31,11 @@ pub fn ScriptRunner(
         pub const profiling_enabled = true;
 
         /// Per-script timing (tick + drawGui), rolling over the current
-        /// dump window. Exposed via `Game.script_profile_ptr` for a live
-        /// overlay; ranked + logged by `dumpProfile`.
-        pub const ProfileEntry = struct {
-            name: []const u8,
-            tick: profiler.Stat = .{},
-            draw_gui: profiler.Stat = .{},
-        };
+        /// dump window. Exposed via `Game.script_profile_ptr` for the live
+        /// inspector overlay (#380); ranked + logged by `dumpProfile`.
+        /// Aliases the shared `profiler.ScriptRow` so `Game`'s opaque
+        /// pointer casts back to a stable, plugin-visible layout.
+        pub const ProfileEntry = profiler.ScriptRow;
 
         pub const script_count: usize = blk: {
             var count: usize = 0;

--- a/test/frame_profiler_test.zig
+++ b/test/frame_profiler_test.zig
@@ -1,0 +1,126 @@
+//! Tests for the FPS / frame-time tracker feeding the debug inspector
+//! (labelle-engine#380). Covers the FrameProfiler in isolation and its
+//! wiring onto `Game` (`game.fps()` / `game.frameStats()`). Fully headless
+//! — no window, no graphics backend.
+
+const std = @import("std");
+const testing = std.testing;
+
+const engine = @import("engine");
+const FrameProfiler = engine.FrameProfiler;
+const Game = engine.Game;
+
+test "frame profiler: empty state reports zero FPS" {
+    const fp = FrameProfiler{};
+    try testing.expectEqual(@as(f32, 0), fp.fps());
+    try testing.expectEqual(@as(usize, 0), fp.stats().samples);
+}
+
+test "frame profiler: steady 60 FPS frame time yields 60 FPS" {
+    var fp = FrameProfiler{};
+    const dt: f32 = 1.0 / 60.0;
+    var i: usize = 0;
+    while (i < 10) : (i += 1) fp.record(dt);
+    // Constant dt: the EMA seeds to dt on the first sample and never
+    // diverges, so FPS is exactly 60.
+    try testing.expectApproxEqAbs(@as(f32, 60.0), fp.fps(), 0.01);
+    try testing.expectApproxEqAbs(@as(f32, 1000.0 / 60.0), fp.frameTimeMs(), 0.01);
+}
+
+test "frame profiler: steady 30 FPS frame time yields 30 FPS" {
+    var fp = FrameProfiler{};
+    const dt: f32 = 1.0 / 30.0;
+    var i: usize = 0;
+    while (i < 5) : (i += 1) fp.record(dt);
+    try testing.expectApproxEqAbs(@as(f32, 30.0), fp.fps(), 0.01);
+}
+
+test "frame profiler: smoothing converges toward a sustained new frame time" {
+    var fp = FrameProfiler{};
+    // Warm up at 60 FPS (16.67 ms), then a sustained drop to 20 FPS (50 ms).
+    fp.record(1.0 / 60.0);
+    var i: usize = 0;
+    while (i < 200) : (i += 1) fp.record(1.0 / 20.0);
+    // After many frames the EMA has effectively settled on the new rate.
+    try testing.expectApproxEqAbs(@as(f32, 20.0), fp.fps(), 0.1);
+}
+
+test "frame profiler: rejects non-positive and non-finite samples" {
+    var fp = FrameProfiler{};
+    fp.record(0); // paused / zero-length frame
+    fp.record(-1.0); // clock went backwards
+    fp.record(std.math.nan(f32));
+    fp.record(std.math.inf(f32));
+    // Nothing recorded → still empty.
+    try testing.expectEqual(@as(usize, 0), fp.stats().samples);
+    try testing.expectEqual(@as(f32, 0), fp.fps());
+
+    fp.record(1.0 / 60.0);
+    try testing.expectEqual(@as(usize, 1), fp.stats().samples);
+}
+
+test "frame profiler: min/avg/max over the window" {
+    var fp = FrameProfiler{};
+    fp.record(0.010); // 10 ms
+    fp.record(0.020); // 20 ms
+    fp.record(0.030); // 30 ms
+    const s = fp.stats();
+    try testing.expectEqual(@as(usize, 3), s.samples);
+    try testing.expectApproxEqAbs(@as(f32, 10.0), s.min_ms, 0.001);
+    try testing.expectApproxEqAbs(@as(f32, 20.0), s.avg_ms, 0.001);
+    try testing.expectApproxEqAbs(@as(f32, 30.0), s.max_ms, 0.001);
+}
+
+test "frame profiler: history is oldest-first in milliseconds" {
+    var fp = FrameProfiler{};
+    fp.record(0.001);
+    fp.record(0.002);
+    fp.record(0.003);
+    var buf: [8]f32 = undefined;
+    const hist = fp.history(&buf);
+    try testing.expectEqual(@as(usize, 3), hist.len);
+    try testing.expectApproxEqAbs(@as(f32, 1.0), hist[0], 0.001);
+    try testing.expectApproxEqAbs(@as(f32, 2.0), hist[1], 0.001);
+    try testing.expectApproxEqAbs(@as(f32, 3.0), hist[2], 0.001);
+}
+
+test "frame profiler: history keeps the newest N when dst is smaller" {
+    var fp = FrameProfiler{};
+    fp.record(0.001);
+    fp.record(0.002);
+    fp.record(0.003);
+    var buf: [2]f32 = undefined;
+    const hist = fp.history(&buf);
+    try testing.expectEqual(@as(usize, 2), hist.len);
+    // Newest two: 2 ms then 3 ms.
+    try testing.expectApproxEqAbs(@as(f32, 2.0), hist[0], 0.001);
+    try testing.expectApproxEqAbs(@as(f32, 3.0), hist[1], 0.001);
+}
+
+test "frame profiler: ring wraps and retains only window_size samples" {
+    var fp = FrameProfiler{};
+    var i: usize = 0;
+    while (i < FrameProfiler.window_size + 50) : (i += 1) fp.record(0.016);
+    try testing.expectEqual(FrameProfiler.window_size, fp.stats().samples);
+}
+
+test "frame profiler: reset clears samples but keeps smoothing" {
+    var fp = FrameProfiler{ .smoothing = 0.25 };
+    fp.record(0.02);
+    fp.reset();
+    try testing.expectEqual(@as(usize, 0), fp.stats().samples);
+    try testing.expectEqual(@as(f32, 0.25), fp.smoothing);
+}
+
+test "game: fps accessor reflects recorded frame times" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    // Before any frame the readout is zero.
+    try testing.expectEqual(@as(f32, 0), game.fps());
+
+    game.frame_profiler.record(1.0 / 60.0);
+    try testing.expectApproxEqAbs(@as(f32, 60.0), game.fps(), 0.01);
+    try testing.expectApproxEqAbs(@as(f32, 1000.0 / 60.0), game.frameTimeMs(), 0.01);
+    try testing.expectEqual(@as(usize, 1), game.frameStats().samples);
+}

--- a/test/inspector_overlay_test.zig
+++ b/test/inspector_overlay_test.zig
@@ -1,0 +1,125 @@
+//! Tests for the debug-inspector overlay data collection (#380): the
+//! `profiler.collect*Rows` helpers that flatten the shipped per-script /
+//! per-plugin `Stat` data into render-ready `OverlayRow`s, plus the
+//! `Game.scriptProfileRows()` / `pluginProfileRows()` opaque-pointer
+//! round-trip the debug plugin reads. Backend-agnostic and headless.
+
+const std = @import("std");
+const testing = std.testing;
+
+const engine = @import("engine");
+const profiler = engine.profiler;
+const Game = engine.Game;
+
+fn stat(ns: u64) profiler.Stat {
+    return .{ .last_ns = ns };
+}
+
+test "severity: green < 1ms, yellow 1-5ms, red > 5ms" {
+    try testing.expectEqual(profiler.Severity.good, profiler.severityForNs(0));
+    try testing.expectEqual(profiler.Severity.good, profiler.severityForNs(999_999));
+    try testing.expectEqual(profiler.Severity.warn, profiler.severityForNs(1_000_000));
+    try testing.expectEqual(profiler.Severity.warn, profiler.severityForNs(4_999_999));
+    try testing.expectEqual(profiler.Severity.bad, profiler.severityForNs(5_000_000));
+    try testing.expectEqual(profiler.Severity.bad, profiler.severityForNs(12_000_000));
+}
+
+test "collectScriptRows: flattens live tick + drawGui into ms rows" {
+    const src = [_]profiler.ScriptRow{
+        .{ .name = "physics", .tick = stat(450_000), .draw_gui = stat(120_000) },
+        .{ .name = "worker_movement", .tick = stat(220_000) },
+    };
+    var dst: [8]profiler.OverlayRow = undefined;
+    const rows = profiler.collectScriptRows(&dst, &src);
+
+    try testing.expectEqual(@as(usize, 2), rows.len);
+    try testing.expectEqualStrings("physics", rows[0].name);
+    try testing.expectApproxEqAbs(@as(f32, 0.45), rows[0].tick_ms, 0.001);
+    try testing.expectEqualStrings("drawGui", rows[0].aux_label);
+    try testing.expectApproxEqAbs(@as(f32, 0.12), rows[0].aux_ms, 0.001);
+    try testing.expectEqual(profiler.Severity.good, rows[0].tick_severity);
+
+    try testing.expectEqualStrings("worker_movement", rows[1].name);
+    try testing.expectApproxEqAbs(@as(f32, 0.22), rows[1].tick_ms, 0.001);
+    try testing.expectApproxEqAbs(@as(f32, 0.0), rows[1].aux_ms, 0.001);
+}
+
+test "collectPluginRows: flattens tick + postTick with correct label" {
+    const src = [_]profiler.PluginRow{
+        .{ .name = "box2d", .tick = stat(1_200_000), .post_tick = stat(300_000) },
+        .{ .name = "debug", .tick = stat(6_000_000) },
+    };
+    var dst: [8]profiler.OverlayRow = undefined;
+    const rows = profiler.collectPluginRows(&dst, &src);
+
+    try testing.expectEqual(@as(usize, 2), rows.len);
+    try testing.expectEqualStrings("box2d", rows[0].name);
+    try testing.expectApproxEqAbs(@as(f32, 1.2), rows[0].tick_ms, 0.001);
+    try testing.expectEqual(profiler.Severity.warn, rows[0].tick_severity); // 1.2ms → yellow
+    try testing.expectEqualStrings("postTick", rows[0].aux_label);
+    try testing.expectApproxEqAbs(@as(f32, 0.3), rows[0].aux_ms, 0.001);
+
+    // 6ms tick → red.
+    try testing.expectEqual(profiler.Severity.bad, rows[1].tick_severity);
+}
+
+test "collectScriptRows: respects destination bound" {
+    const src = [_]profiler.ScriptRow{
+        .{ .name = "a", .tick = stat(1) },
+        .{ .name = "b", .tick = stat(2) },
+        .{ .name = "c", .tick = stat(3) },
+    };
+    var dst: [2]profiler.OverlayRow = undefined;
+    const rows = profiler.collectScriptRows(&dst, &src);
+    try testing.expectEqual(@as(usize, 2), rows.len);
+}
+
+test "totalMs: sums primary + secondary phase across rows" {
+    const rows = [_]profiler.OverlayRow{
+        .{ .name = "a", .tick_ms = 0.45, .aux_ms = 0.12 },
+        .{ .name = "b", .tick_ms = 0.22, .aux_ms = 0.0 },
+    };
+    try testing.expectApproxEqAbs(@as(f32, 0.79), profiler.totalMs(&rows), 0.001);
+}
+
+test "game: scriptProfileRows/pluginProfileRows are empty when unwired" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    try testing.expectEqual(@as(usize, 0), game.scriptProfileRows().len);
+    try testing.expectEqual(@as(usize, 0), game.pluginProfileRows().len);
+}
+
+test "game: profile row accessors round-trip the opaque pointer" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const scripts = [_]profiler.ScriptRow{
+        .{ .name = "physics", .tick = stat(450_000) },
+        .{ .name = "needs", .tick = stat(50_000) },
+    };
+    const plugins = [_]profiler.PluginRow{
+        .{ .name = "box2d", .tick = stat(1_200_000), .post_tick = stat(300_000) },
+    };
+
+    // Mirror what the generated `main.zig` does after building the
+    // ScriptRunner / SystemRegistry.
+    game.script_profile_ptr = @ptrCast(&scripts);
+    game.script_profile_count = scripts.len;
+    game.plugin_profile_ptr = @ptrCast(&plugins);
+    game.plugin_profile_count = plugins.len;
+
+    const srows = game.scriptProfileRows();
+    try testing.expectEqual(@as(usize, 2), srows.len);
+    try testing.expectEqualStrings("physics", srows[0].name);
+    try testing.expectEqual(@as(u64, 450_000), srows[0].tick.last_ns);
+
+    const prows = game.pluginProfileRows();
+    try testing.expectEqual(@as(usize, 1), prows.len);
+    try testing.expectEqualStrings("box2d", prows[0].name);
+
+    // End-to-end: the accessor feeds straight into the overlay collector.
+    var buf: [8]profiler.OverlayRow = undefined;
+    const overlay = profiler.collectScriptRows(&buf, srows);
+    try testing.expectEqual(@as(usize, 2), overlay.len);
+    try testing.expectApproxEqAbs(@as(f32, 0.45), overlay[0].tick_ms, 0.001);
+}


### PR DESCRIPTION
Completes the remaining, un-shipped half of **#380**. The per-script / per-plugin **profiler** already shipped (env-gated `LABELLE_PROFILE`, `scene/src/profiler.zig` + `src/script_runner.zig`, v1.6.0). This PR adds the two pieces the issue marked as future work: an **FPS counter** and a **live in-inspector overlay** surface for the already-collected profiler timings.

Everything here is **engine-side, backend-agnostic, and headless-testable** — no GUI/imgui dependency is introduced.

## What's added

**FPS counter — `src/frame_profiler.zig`**
- `FrameProfiler`: rolling 120-frame window + EMA-smoothed FPS, `min/avg/max` frame time, oldest-first `history()` for a mini-graph.
- Ungated (one ring write + EMA update per frame), so the FPS header works even without `LABELLE_PROFILE`. Non-finite / non-positive `dt` samples are dropped so a paused/NaN frame can't poison the average.
- Wired into `Game`: `frame_profiler` field, `record(dt)` at the top of `tick` (real unscaled dt, including paused frames). Accessors: `game.fps()`, `game.frameTimeMs()`, `game.frameStats()`.

**Live overlay data model — `scene/src/profiler.zig`**
- `ScriptRow` / `PluginRow` view structs, now **layout-shared** with `ScriptRunner.ProfileEntry` and `SystemRegistry.PluginProfileEntry`, so `Game`'s opaque `script_profile_ptr` / `plugin_profile_ptr` cast back to a stable, plugin-visible layout.
- `Severity` traffic-light coding per the issue spec (green `<1ms` / yellow `1-5ms` / red `>5ms`).
- `collectScriptRows` / `collectPluginRows` — flatten the live `last_ns` per-frame timings into render-ready `OverlayRow`s; `totalMs` for the footer line.
- `Game.scriptProfileRows()` / `pluginProfileRows()` — typed round-trip of the opaque pointers for the debug plugin to walk.

**Incidental fix**: the `src/scene.zig` re-export layer never forwarded `profiler`, so `engine.profiler` was unreachable (this PR is the first reference). Forwarded it.

## Tests
- `test/frame_profiler_test.zig` — FPS from dt samples, EMA convergence, non-finite/negative filtering, ring wrap, history ordering, Game accessor wiring.
- `test/inspector_overlay_test.zig` — severity buckets, collectors, `totalMs`, and the opaque-pointer round-trip end-to-end into the collector.

`zig build test` → **839/839 passing**, exit 0 (Zig 0.16).

## What remains (not "Closes")
The actual imgui rendering of this data lives in `labelle-cli/plugins/debug` (a separate repo). This PR delivers the engine-side FPS + profiler-data API + headless collector the debug plugin consumes; that UI wiring is the follow-up. Referencing #380 rather than closing it.

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw