### PR TITLE
POC: language-plugins spike — one contract, three languages, identical worlds (#237)

### DIFF
--- a/spike/language-plugins/.gitignore
+++ b/spike/language-plugins/.gitignore
@@ -1,0 +1,2 @@
+.zig-cache/
+zig-out/

--- a/spike/language-plugins/README.md
+++ b/spike/language-plugins/README.md
@@ -1,0 +1,100 @@
+# Language-plugins spike (RFC-LANGUAGE-PLUGINS, #237)
+
+Proof that **one Script Runtime Contract serves every language family**: the
+same behavior script, written in three languages across both integration
+families, drives the same C-ABI surface and produces **byte-identical world
+state** — asserted by the host, not eyeballed.
+
+```
+== verdict ==
+FAMILIES AGREE: one contract, three languages (Lua VM, Rust, Crystal), identical world state.
+```
+
+Run it (macOS; needs brew `lua`, `cargo`, `crystal`):
+
+```sh
+zig build run    # Zig 0.16
+```
+
+## What each run proves
+
+Every language: creates an entity, sets `Position` by name as JSON, reads it
+back each tick, moves +10/tick for 5 ticks, spawns a bullet on tick 3,
+**emits** `bullet_spawned` — and on the receive side **subscribes** to
+`tick_started` in `init`, **drains a poll loop** each tick, and reacts to
+tick 4 by writing a `TickLog` component. Snapshots (entities + components +
+events) must match exactly across languages.
+
+| | family | mechanism | file |
+|---|---|---|---|
+| **Lua 5.4** | embedded VM | brew `liblua.a` + ~20 hand-declared C externs (no `@cImport`), binding shims → `labelle.*` table | `scripts/behavior.lua`, `main.zig` |
+| **Rust** | native-compiled | zero-dep `staticlib` via cargo, `extern "C"` against the contract, linked into the host | `rust/src/lib.rs` |
+| **Crystal** | native-compiled | `--cross-compile` object, `ld -r` localizes its `main`, boot via `Crystal.init_runtime` | `crystal/script.cr` |
+
+## The event system across languages
+
+The contract's receive side is deliberately minimal — **subscribe + poll**:
+
+```c
+void   labelle_event_subscribe(const char *name, size_t name_len);
+size_t labelle_event_poll(char *out, size_t out_cap); /* "<name> <json>", 0 = empty */
+```
+
+- The host queues events into a per-script FIFO inbox **only for subscribed
+  names** (the engine analog: `GameEvents` dispatch fanning out to
+  language-plugin subscribers, exactly like hook consumption folds events in
+  today — the zero-cost gate flips on per subscription).
+- Scripts **drain the inbox at the top of their tick** — one `while`/`loop`
+  in every language, no callbacks in the ABI. Callback dispatch is
+  *language-plugin sugar built over the drain loop*: labelle-lua registers
+  Lua functions per event name and calls them from the drain; labelle-rust
+  exposes a match/handler trait; labelle-csharp maps to C# events. The ABI
+  stays one function.
+- Emit (script→host) is symmetric (`labelle_event_emit`) and feeds the same
+  engine event bus; both directions are proven here in all three languages.
+- Ordering: the host emits before the tick's `update`; scripts observe a
+  deterministic FIFO. Payloads are JSON (encoding v1), names are the
+  subscription key — same identity model as the engine's event tags.
+
+## Findings (the "clear path" part)
+
+1. **The contract is small and sufficient.** Entities + components-by-name
+   (JSON) + events + log covered the whole behavior; nothing language-specific
+   leaked into the ABI. `component_set` is the runtime generalization of the
+   engine's existing `editor_set_component` — the engine-side work is a
+   surface, not a rewrite.
+2. **Lua is as easy as advertised** (#237 stands): ~20 extern declarations,
+   five shim closures, done. LuaJIT is a link-time swap later.
+3. **Rust needs no bindings work at all** — the contract header *is* the
+   binding. A real labelle-rust is mostly build integration (cargo → staticlib
+   → link) plus ergonomic wrappers.
+4. **Crystal works but has real sharp edges** (all solved here, all must be
+   institutionalized by labelle-crystal):
+   - no `--no-main`: localize the object's `main` via
+     `ld -r -exported_symbols_list` (see `build.zig`);
+   - boot via **`Crystal.init_runtime`** (`Crystal.main_user_code` segfaults
+     under a foreign stack);
+   - **raising APIs segfault**: Crystal's `raise` captures a backtrace by
+     walking the stack, and foreign (host) frames break the walk — the POC's
+     `to_i64?(strict: false)` (raise-and-rescue inside) crashed at 0x2c until
+     replaced with a non-raising parse. The real plugin must wrap script
+     entry points non-raising and/or disable callstack capture;
+   - GC ran with `GC.disable` here; the plugin's first work item is
+     registering the host stack bounds with bdw-gc properly.
+5. **C# (documented, not coded — dotnet 8 present, heaviest lift):** host
+   `hostfxr` (`hostfxr_initialize_for_runtime_config` →
+   `load_assembly_and_get_function_pointer`), script entry points as
+   `[UnmanagedCallersOnly]` static methods, contract consumed via
+   `[LibraryImport]` resolved against the host process (`dlopen(NULL)`
+   resolution). Desktop-first; mobile AOT constraints per the RFC.
+6. **mruby (documented, not coded — not installed here):** same shape as the
+   Lua half verbatim (`mrb_open`, `mrb_define_module_function`, drain loop).
+7. **Zig 0.16 host notes:** `link_libc`/`addObjectFile` moved to the module;
+   `std.Io.Writer.fixed` replaces `std.io`; hand-declared externs beat
+   `@cImport` for stable C APIs.
+
+## What this deliberately does not prove
+
+The real engine integration (the comptime-gated contract surface over the
+serde-reflection registry), hot reload, sandboxing profiles, GC pressure, and
+performance — all Phase 1+ work in the RFC, none of them boundary risks.

--- a/spike/language-plugins/build.zig
+++ b/spike/language-plugins/build.zig
@@ -1,0 +1,55 @@
+//! Spike build: Zig host + system Lua 5.4 (static) + Rust staticlib.
+//! macOS/homebrew POC — paths overridable via -Dlua-lib=... .
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+    const lua_lib = b.option([]const u8, "lua-lib", "path to liblua static archive") orelse
+        "/opt/homebrew/lib/liblua.a";
+
+    const exe = b.addExecutable(.{
+        .name = "lang-spike",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("main.zig"),
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        }),
+    });
+    exe.root_module.addObjectFile(.{ .cwd_relative = lua_lib });
+
+    // Rust staticlib: cargo build, then link the archive.
+    const cargo = b.addSystemCommand(&.{
+        "cargo", "build", "--release", "--quiet",
+        "--manifest-path",
+    });
+    cargo.addFileArg(b.path("rust/Cargo.toml"));
+    exe.step.dependOn(&cargo.step);
+    exe.root_module.addObjectFile(b.path("rust/target/release/liblabelle_rust_script.a"));
+
+    // Crystal object: cross-compile to a .o, then `ld -r` with an
+    // exported-symbols list to LOCALIZE the object's own `main` (Crystal
+    // has no --no-main; the script exports `crystal_script_boot` — GC.init
+    // + Crystal.main_user_code — as the embed seam instead).
+    const crystal = b.addSystemCommand(&.{
+        "crystal", "build", "--cross-compile",
+        "--target", "aarch64-apple-darwin",
+        "crystal/script.cr", "-o", "crystal/crystal_script",
+    });
+    const localize = b.addSystemCommand(&.{
+        "ld", "-r", "crystal/crystal_script.o",
+        "-o", "crystal/crystal_script_lib.o",
+        "-exported_symbols_list", "crystal/exported_symbols.txt",
+    });
+    localize.step.dependOn(&crystal.step);
+    exe.step.dependOn(&localize.step);
+    exe.root_module.addObjectFile(b.path("crystal/crystal_script_lib.o"));
+    exe.root_module.addLibraryPath(.{ .cwd_relative = "/opt/homebrew/lib" });
+    exe.root_module.linkSystemLibrary("gc", .{});
+    exe.root_module.linkSystemLibrary("iconv", .{});
+
+    b.installArtifact(exe);
+    const run = b.addRunArtifact(exe);
+    b.step("run", "run the spike").dependOn(&run.step);
+}

--- a/spike/language-plugins/contract/contract.h
+++ b/spike/language-plugins/contract/contract.h
@@ -1,0 +1,57 @@
+/* Script Runtime Contract — v0 POC surface (RFC-LANGUAGE-PLUGINS).
+ *
+ * The one shared piece every language plugin binds: a flat C-ABI symbol
+ * namespace the host game exports. Components are addressed BY NAME with
+ * JSON payloads (encoding v1) — the same serde-reflection dispatch the
+ * engine's `editor_set_component` bridge already proves at runtime.
+ *
+ * Embedded-VM languages (Lua, mruby, CoreCLR) call these from binding
+ * closures; native-compiled languages (Rust, Crystal) declare them
+ * `extern "C"` and link against the host. Both families consume the
+ * IDENTICAL surface — that equivalence is what this spike demonstrates.
+ *
+ * v0 scope: entities, components, events, time, log. The full v1 adds
+ * queries, input, prefab spawn, scene change (see the RFC).
+ */
+#pragma once
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+uint64_t labelle_entity_create(void);
+void     labelle_entity_destroy(uint64_t id);
+
+/* JSON in; the host validates + stores (real engine: serde dispatch). */
+void labelle_component_set(uint64_t id,
+                           const char *name, size_t name_len,
+                           const char *json, size_t json_len);
+
+/* Copies the component JSON into `out` (cap `out_cap`); returns bytes
+ * written, 0 when absent. Two-call sizing is deliberately avoided in v0
+ * — script payloads are small. */
+size_t labelle_component_get(uint64_t id,
+                             const char *name, size_t name_len,
+                             char *out, size_t out_cap);
+
+int  labelle_component_has(uint64_t id, const char *name, size_t name_len);
+
+void labelle_event_emit(const char *name, size_t name_len,
+                        const char *json, size_t json_len);
+
+/* Receive side (the RFC's subscribe/poll model): a script declares
+ * interest, then DRAINS its inbox once per tick. Each poll copies the
+ * next pending event as "<name> <json>" into `out` and returns bytes
+ * written; 0 = inbox empty. Dispatch-to-handlers is language-plugin
+ * sugar over this drain loop (Lua callbacks, Rust match, C# events). */
+void   labelle_event_subscribe(const char *name, size_t name_len);
+size_t labelle_event_poll(char *out, size_t out_cap);
+
+float labelle_time_dt(void);
+void  labelle_log(const char *msg, size_t len);
+
+#ifdef __cplusplus
+}
+#endif

--- a/spike/language-plugins/crystal/.gitignore
+++ b/spike/language-plugins/crystal/.gitignore
@@ -1,0 +1,3 @@
+crystal_script.o
+crystal_script_lib.o
+crystal_script

--- a/spike/language-plugins/crystal/exported_symbols.txt
+++ b/spike/language-plugins/crystal/exported_symbols.txt
@@ -1,0 +1,3 @@
+_crystal_script_boot
+_crystal_script_init
+_crystal_script_update

--- a/spike/language-plugins/crystal/script.cr
+++ b/spike/language-plugins/crystal/script.cr
@@ -1,0 +1,96 @@
+# The spike behavior, Crystal edition (native-compiled family — Rust's
+# sibling). Same shape: extern C declarations against contract.h, exported
+# `fun`s the host calls. Mirrors behavior.lua / lib.rs exactly.
+
+lib LibLabelle
+  fun labelle_entity_create : UInt64
+  fun labelle_component_set(id : UInt64, name : UInt8*, name_len : LibC::SizeT, json : UInt8*, json_len : LibC::SizeT)
+  fun labelle_component_get(id : UInt64, name : UInt8*, name_len : LibC::SizeT, out : UInt8*, out_cap : LibC::SizeT) : LibC::SizeT
+  fun labelle_event_emit(name : UInt8*, name_len : LibC::SizeT, json : UInt8*, json_len : LibC::SizeT)
+  fun labelle_log(msg : UInt8*, len : LibC::SizeT)
+  fun labelle_event_subscribe(name : UInt8*, name_len : LibC::SizeT)
+  fun labelle_event_poll(out : UInt8*, out_cap : LibC::SizeT) : LibC::SizeT
+end
+
+module Script
+  @@player : UInt64 = 0_u64
+
+  def self.set(id : UInt64, name : String, json : String)
+    LibLabelle.labelle_component_set(id, name.to_unsafe, name.bytesize, json.to_unsafe, json.bytesize)
+  end
+
+  def self.get(id : UInt64, name : String) : String
+    buf = Bytes.new(192)
+    len = LibLabelle.labelle_component_get(id, name.to_unsafe, name.bytesize, buf.to_unsafe, buf.size)
+    String.new(buf[0, len])
+  end
+
+  def self.init
+    @@player = LibLabelle.labelle_entity_create
+    set(@@player, "Position", %({"x":0,"y":0}))
+    LibLabelle.labelle_event_subscribe("tick_started".to_unsafe, "tick_started".bytesize)
+    msg = "crystal: player #{@@player} ready"
+    LibLabelle.labelle_log(msg.to_unsafe, msg.bytesize)
+  end
+
+  def self.update(_dt : Float32)
+    # Receive side: drain the inbox the host filled before this tick.
+    loop do
+      buf = uninitialized UInt8[224]
+      len = LibLabelle.labelle_event_poll(buf.to_unsafe, 224)
+      break if len == 0
+      ev = String.new(buf.to_unsafe, len)
+      if ev.includes?(%("n":4))
+        set(@@player, "TickLog", %({"last":4}))
+        msg = "crystal: saw tick 4"
+        LibLabelle.labelle_log(msg.to_unsafe, msg.bytesize)
+      end
+    end
+
+    json = get(@@player, "Position")
+    # Parse `"x":<n>` manually. POC FINDING: `to_i64?(strict: false)`
+    # raises-and-rescues internally, and Crystal's raise captures a
+    # backtrace by walking the stack — including the host's foreign Zig
+    # frames — which segfaults under embedding. Script entry points must
+    # avoid raising APIs (or the plugin compiles with callstack capture
+    # disabled); see the README's Crystal notes.
+    tail = json.split(%("x":))[1]? || "0"
+    x = 0_i64
+    tail.each_char do |c|
+      break unless c.ascii_number?
+      x = x * 10 + (c.ord - 48)
+    end
+    x += 10
+    set(@@player, "Position", %({"x":#{x},"y":0}))
+    if x == 30
+      bullet = LibLabelle.labelle_entity_create
+      set(bullet, "Bullet", %({"vx":0,"vy":-500}))
+      ev = %({"owner":#{@@player}})
+      LibLabelle.labelle_event_emit("bullet_spawned".to_unsafe, "bullet_spawned".bytesize, ev.to_unsafe, ev.bytesize)
+      msg = "crystal: bullet away"
+      LibLabelle.labelle_log(msg.to_unsafe, msg.bytesize)
+    end
+  end
+end
+
+fun crystal_script_init : Void
+  Script.init
+end
+
+fun crystal_script_update(dt : Float32) : Void
+  Script.update(dt)
+end
+
+# Embedding seam: the host calls this ONCE before any script fn — it
+# initializes the GC and runs Crystal's top-level (the documented
+# embed-Crystal-as-a-library pattern), replacing the `main` the object
+# file ships (which the build localizes away).
+fun crystal_script_boot : Void
+  Crystal.init_runtime
+  # Embedded-mode mitigation for the POC: the host owns the stack, and
+  # bdw-gc's first collection under a foreign stack is the known sharp
+  # edge — disabling collection sidesteps it here. The real labelle-crystal
+  # registers the host stack bounds with the GC instead (documented in
+  # the README as the plugin's first work item).
+  GC.disable
+end

--- a/spike/language-plugins/main.zig
+++ b/spike/language-plugins/main.zig
@@ -1,0 +1,396 @@
+//! Language-plugins spike host (RFC-LANGUAGE-PLUGINS, engine#237).
+//!
+//! One toy world behind the Script Runtime Contract (contract/contract.h,
+//! exported below as flat C symbols), driven by the SAME behavior script
+//! written in two languages from the two integration families:
+//!
+//!   - Lua  (embedded-VM family)     — scripts/behavior.lua in a Lua 5.4
+//!     VM embedded here via hand-declared C externs (no @cImport).
+//!   - Rust (native-compiled family) — rust/src/lib.rs built as a
+//!     staticlib and linked into this binary, calling the same symbols.
+//!
+//! Each language runs init + 5 ticks against a fresh world; the host
+//! snapshots both worlds and REQUIRES them identical. That equivalence —
+//! one contract, two families, same result — is the spike's claim.
+//!
+//! POC shortcuts (fine here, not for the real plugin): fixed-size world
+//! arrays, JSON stored as opaque strings, main-thread only, no queries.
+
+const std = @import("std");
+
+// ── Toy world ───────────────────────────────────────────────────────────
+
+const MAX_ENTITIES = 64;
+const MAX_COMPONENTS = 8;
+const NAME_CAP = 32;
+const JSON_CAP = 192;
+const MAX_EVENTS = 32;
+
+const Component = struct {
+    name: [NAME_CAP]u8 = undefined,
+    name_len: usize = 0,
+    json: [JSON_CAP]u8 = undefined,
+    json_len: usize = 0,
+};
+
+const Entity = struct {
+    id: u64 = 0,
+    alive: bool = false,
+    comps: [MAX_COMPONENTS]Component = undefined,
+    comp_count: usize = 0,
+};
+
+const Event = struct {
+    text: [NAME_CAP + JSON_CAP]u8 = undefined,
+    len: usize = 0,
+};
+
+const World = struct {
+    next_id: u64 = 1,
+    entities: [MAX_ENTITIES]Entity = undefined,
+    entity_count: usize = 0,
+    events: [MAX_EVENTS]Event = undefined,
+    event_count: usize = 0,
+    // Receive side: the script's subscriptions + FIFO inbox it drains
+    // via labelle_event_poll (one script per world in this POC).
+    subs: [8]Event = undefined,
+    sub_count: usize = 0,
+    inbox: [MAX_EVENTS]Event = undefined,
+    inbox_head: usize = 0,
+    inbox_count: usize = 0,
+    dt: f32 = 1.0 / 60.0,
+
+    fn reset(self: *World) void {
+        self.* = .{};
+    }
+
+    fn find(self: *World, id: u64) ?*Entity {
+        for (self.entities[0..self.entity_count]) |*e| {
+            if (e.alive and e.id == id) return e;
+        }
+        return null;
+    }
+
+    /// Deterministic dump for cross-language comparison: entities in id
+    /// order, components in insertion order (both scripts insert in the
+    /// same order by construction).
+    fn snapshot(self: *World, buf: []u8) []const u8 {
+        var w = std.Io.Writer.fixed(buf);
+        for (self.entities[0..self.entity_count]) |*e| {
+            if (!e.alive) continue;
+            w.print("entity {d}:", .{e.id}) catch break;
+            for (e.comps[0..e.comp_count]) |*c| {
+                w.print(" {s}={s}", .{ c.name[0..c.name_len], c.json[0..c.json_len] }) catch break;
+            }
+            w.print("\n", .{}) catch break;
+        }
+        for (self.events[0..self.event_count]) |*ev| {
+            w.print("event {s}\n", .{ev.text[0..ev.len]}) catch break;
+        }
+        return w.buffered();
+    }
+};
+
+var world: World = .{};
+
+// ── Contract exports (contract/contract.h) ─────────────────────────────
+
+export fn labelle_entity_create() u64 {
+    if (world.entity_count >= MAX_ENTITIES) return 0;
+    const e = &world.entities[world.entity_count];
+    e.* = .{ .id = world.next_id, .alive = true };
+    world.next_id += 1;
+    world.entity_count += 1;
+    return e.id;
+}
+
+export fn labelle_entity_destroy(id: u64) void {
+    if (world.find(id)) |e| e.alive = false;
+}
+
+export fn labelle_component_set(id: u64, name: [*]const u8, name_len: usize, json: [*]const u8, json_len: usize) void {
+    const e = world.find(id) orelse return;
+    const n = name[0..@min(name_len, NAME_CAP)];
+    const j = json[0..@min(json_len, JSON_CAP)];
+    // Update-in-place when the component exists (the common per-tick path).
+    for (e.comps[0..e.comp_count]) |*c| {
+        if (std.mem.eql(u8, c.name[0..c.name_len], n)) {
+            @memcpy(c.json[0..j.len], j);
+            c.json_len = j.len;
+            return;
+        }
+    }
+    if (e.comp_count >= MAX_COMPONENTS) return;
+    const c = &e.comps[e.comp_count];
+    @memcpy(c.name[0..n.len], n);
+    c.name_len = n.len;
+    @memcpy(c.json[0..j.len], j);
+    c.json_len = j.len;
+    e.comp_count += 1;
+}
+
+export fn labelle_component_get(id: u64, name: [*]const u8, name_len: usize, out: [*]u8, out_cap: usize) usize {
+    const e = world.find(id) orelse return 0;
+    const n = name[0..@min(name_len, NAME_CAP)];
+    for (e.comps[0..e.comp_count]) |*c| {
+        if (std.mem.eql(u8, c.name[0..c.name_len], n)) {
+            const len = @min(c.json_len, out_cap);
+            @memcpy(out[0..len], c.json[0..len]);
+            return len;
+        }
+    }
+    return 0;
+}
+
+export fn labelle_component_has(id: u64, name: [*]const u8, name_len: usize) c_int {
+    const e = world.find(id) orelse return 0;
+    const n = name[0..@min(name_len, NAME_CAP)];
+    for (e.comps[0..e.comp_count]) |*c| {
+        if (std.mem.eql(u8, c.name[0..c.name_len], n)) return 1;
+    }
+    return 0;
+}
+
+export fn labelle_event_emit(name: [*]const u8, name_len: usize, json: [*]const u8, json_len: usize) void {
+    if (world.event_count >= MAX_EVENTS) return;
+    const ev = &world.events[world.event_count];
+    var w = std.Io.Writer.fixed(&ev.text);
+    w.print("{s} {s}", .{ name[0..name_len], json[0..json_len] }) catch {};
+    ev.len = w.buffered().len;
+    world.event_count += 1;
+}
+
+export fn labelle_event_subscribe(name: [*]const u8, name_len: usize) void {
+    if (world.sub_count >= world.subs.len) return;
+    const s = &world.subs[world.sub_count];
+    const n = name[0..@min(name_len, s.text.len)];
+    @memcpy(s.text[0..n.len], n);
+    s.len = n.len;
+    world.sub_count += 1;
+}
+
+export fn labelle_event_poll(out: [*]u8, out_cap: usize) usize {
+    if (world.inbox_count == 0) return 0;
+    const ev = &world.inbox[world.inbox_head];
+    world.inbox_head = (world.inbox_head + 1) % MAX_EVENTS;
+    world.inbox_count -= 1;
+    const len = @min(ev.len, out_cap);
+    @memcpy(out[0..len], ev.text[0..len]);
+    return len;
+}
+
+export fn labelle_time_dt() f32 {
+    return world.dt;
+}
+
+/// Host-side emit toward scripts: queued into the inbox only when the
+/// script subscribed to the event name (the engine analog: GameEvents
+/// dispatch fanning out to language-plugin subscribers).
+fn hostEmit(name: []const u8, json: []const u8) void {
+    var subscribed = false;
+    for (world.subs[0..world.sub_count]) |*s| {
+        if (std.mem.eql(u8, s.text[0..s.len], name)) subscribed = true;
+    }
+    if (!subscribed or world.inbox_count >= MAX_EVENTS) return;
+    const slot = (world.inbox_head + world.inbox_count) % MAX_EVENTS;
+    const ev = &world.inbox[slot];
+    var w = std.Io.Writer.fixed(&ev.text);
+    w.print("{s} {s}", .{ name, json }) catch {};
+    ev.len = w.buffered().len;
+    world.inbox_count += 1;
+}
+
+export fn labelle_log(msg: [*]const u8, len: usize) void {
+    std.debug.print("  [script] {s}\n", .{msg[0..len]});
+}
+
+// ── Lua 5.4 embedding (hand-declared C API — no @cImport) ──────────────
+
+const lua = struct {
+    const State = opaque {};
+    const CFn = *const fn (?*State) callconv(.c) c_int;
+    const MULTRET: c_int = -1;
+    // lua_pcall(L,n,r,f) is a macro over lua_pcallk in 5.4.
+    extern fn luaL_newstate() ?*State;
+    extern fn luaL_openlibs(L: ?*State) void;
+    extern fn luaL_loadstring(L: ?*State, s: [*:0]const u8) c_int;
+    extern fn lua_pcallk(L: ?*State, nargs: c_int, nresults: c_int, errfunc: c_int, ctx: isize, k: ?*anyopaque) c_int;
+    extern fn lua_close(L: ?*State) void;
+    extern fn lua_createtable(L: ?*State, narr: c_int, nrec: c_int) void;
+    extern fn lua_pushcclosure(L: ?*State, f: CFn, n: c_int) void;
+    extern fn lua_setfield(L: ?*State, idx: c_int, k: [*:0]const u8) void;
+    extern fn lua_setglobal(L: ?*State, name: [*:0]const u8) void;
+    extern fn lua_getglobal(L: ?*State, name: [*:0]const u8) c_int;
+    extern fn lua_pushnumber(L: ?*State, n: f64) void;
+    extern fn lua_pushinteger(L: ?*State, n: i64) void;
+    extern fn lua_pushlstring(L: ?*State, s: [*]const u8, len: usize) void;
+    extern fn lua_tonumberx(L: ?*State, idx: c_int, isnum: ?*c_int) f64;
+    extern fn lua_tointegerx(L: ?*State, idx: c_int, isnum: ?*c_int) i64;
+    extern fn lua_tolstring(L: ?*State, idx: c_int, len: ?*usize) ?[*]const u8;
+    extern fn lua_settop(L: ?*State, idx: c_int) void;
+
+    fn pcall(L: ?*State, nargs: c_int, nresults: c_int) c_int {
+        return lua_pcallk(L, nargs, nresults, 0, 0, null);
+    }
+};
+
+// Binding shims: Lua closures → contract symbols. A real labelle-lua
+// wraps these in idiomatic sugar (entity:get/set); the spike keeps the
+// raw contract visible on purpose.
+fn l_entity_create(L: ?*lua.State) callconv(.c) c_int {
+    lua.lua_pushinteger(L, @intCast(labelle_entity_create()));
+    return 1;
+}
+fn l_component_set(L: ?*lua.State) callconv(.c) c_int {
+    const id: u64 = @intCast(lua.lua_tointegerx(L, 1, null));
+    var nlen: usize = 0;
+    const n = lua.lua_tolstring(L, 2, &nlen) orelse return 0;
+    var jlen: usize = 0;
+    const j = lua.lua_tolstring(L, 3, &jlen) orelse return 0;
+    labelle_component_set(id, n, nlen, j, jlen);
+    return 0;
+}
+fn l_component_get(L: ?*lua.State) callconv(.c) c_int {
+    const id: u64 = @intCast(lua.lua_tointegerx(L, 1, null));
+    var nlen: usize = 0;
+    const n = lua.lua_tolstring(L, 2, &nlen) orelse return 0;
+    var buf: [JSON_CAP]u8 = undefined;
+    const len = labelle_component_get(id, n, nlen, &buf, buf.len);
+    lua.lua_pushlstring(L, &buf, len);
+    return 1;
+}
+fn l_event_emit(L: ?*lua.State) callconv(.c) c_int {
+    var nlen: usize = 0;
+    const n = lua.lua_tolstring(L, 1, &nlen) orelse return 0;
+    var jlen: usize = 0;
+    const j = lua.lua_tolstring(L, 2, &jlen) orelse return 0;
+    labelle_event_emit(n, nlen, j, jlen);
+    return 0;
+}
+fn l_log(L: ?*lua.State) callconv(.c) c_int {
+    var len: usize = 0;
+    const s = lua.lua_tolstring(L, 1, &len) orelse return 0;
+    labelle_log(s, len);
+    return 0;
+}
+fn l_event_subscribe(L: ?*lua.State) callconv(.c) c_int {
+    var nlen: usize = 0;
+    const n = lua.lua_tolstring(L, 1, &nlen) orelse return 0;
+    labelle_event_subscribe(n, nlen);
+    return 0;
+}
+fn l_event_poll(L: ?*lua.State) callconv(.c) c_int {
+    var buf: [NAME_CAP + JSON_CAP]u8 = undefined;
+    const len = labelle_event_poll(&buf, buf.len);
+    lua.lua_pushlstring(L, &buf, len); // "" when the inbox is empty
+    return 1;
+}
+
+fn runLua(script: [*:0]const u8) !void {
+    const L = lua.luaL_newstate() orelse return error.LuaInit;
+    defer lua.lua_close(L);
+    lua.luaL_openlibs(L);
+
+    // The `labelle` binding table.
+    lua.lua_createtable(L, 0, 5);
+    lua.lua_pushcclosure(L, l_entity_create, 0);
+    lua.lua_setfield(L, -2, "entity_create");
+    lua.lua_pushcclosure(L, l_component_set, 0);
+    lua.lua_setfield(L, -2, "component_set");
+    lua.lua_pushcclosure(L, l_component_get, 0);
+    lua.lua_setfield(L, -2, "component_get");
+    lua.lua_pushcclosure(L, l_event_emit, 0);
+    lua.lua_setfield(L, -2, "event_emit");
+    lua.lua_pushcclosure(L, l_log, 0);
+    lua.lua_setfield(L, -2, "log");
+    lua.lua_pushcclosure(L, l_event_subscribe, 0);
+    lua.lua_setfield(L, -2, "event_subscribe");
+    lua.lua_pushcclosure(L, l_event_poll, 0);
+    lua.lua_setfield(L, -2, "event_poll");
+    lua.lua_setglobal(L, "labelle");
+
+    if (lua.luaL_loadstring(L, script) != 0 or lua.pcall(L, 0, lua.MULTRET) != 0) {
+        var len: usize = 0;
+        const err = lua.lua_tolstring(L, -1, &len);
+        std.debug.print("lua error: {s}\n", .{if (err) |e| e[0..len] else "?"});
+        return error.LuaScript;
+    }
+
+    _ = lua.lua_getglobal(L, "init");
+    if (lua.pcall(L, 0, 0) != 0) return error.LuaScript;
+    for (0..5) |i| {
+        emitTick(i + 1);
+        _ = lua.lua_getglobal(L, "update");
+        lua.lua_pushnumber(L, world.dt);
+        if (lua.pcall(L, 1, 0) != 0) return error.LuaScript;
+    }
+}
+
+// ── Rust staticlib entry points (rust/src/lib.rs) ──────────────────────
+
+extern fn rust_script_init() void;
+extern fn rust_script_update(dt: f32) void;
+
+// ── Crystal object entry points (crystal/script.cr) ────────────────────
+// boot = GC.init + Crystal.main_user_code (the embed-as-library seam);
+// the object's own `main` is localized away by `ld -r` in build.zig.
+
+extern fn crystal_script_boot() void;
+extern fn crystal_script_init() void;
+extern fn crystal_script_update(dt: f32) void;
+
+// ── Driver ──────────────────────────────────────────────────────────────
+
+const behavior_lua = @embedFile("scripts/behavior.lua");
+
+/// The host-side event the scripts subscribe to (one per tick).
+fn emitTick(n: usize) void {
+    var buf: [32]u8 = undefined;
+    const json = std.fmt.bufPrint(&buf, "{{\"n\":{d}}}", .{n}) catch return;
+    hostEmit("tick_started", json);
+}
+
+pub fn main() !void {
+    var lua_snap_buf: [4096]u8 = undefined;
+    var rust_snap_buf: [4096]u8 = undefined;
+
+    std.debug.print("== Lua (embedded-VM family) ==\n", .{});
+    world.reset();
+    // Null-terminate the embedded script for luaL_loadstring.
+    var script_z: [behavior_lua.len + 1]u8 = undefined;
+    @memcpy(script_z[0..behavior_lua.len], behavior_lua);
+    script_z[behavior_lua.len] = 0;
+    try runLua(@ptrCast(&script_z));
+    const lua_snap = world.snapshot(&lua_snap_buf);
+    std.debug.print("{s}", .{lua_snap});
+
+    std.debug.print("\n== Rust (native-compiled family) ==\n", .{});
+    world.reset();
+    rust_script_init();
+    for (0..5) |i| {
+        emitTick(i + 1);
+        rust_script_update(world.dt);
+    }
+    const rust_snap = world.snapshot(&rust_snap_buf);
+    std.debug.print("{s}", .{rust_snap});
+
+    std.debug.print("\n== Crystal (native-compiled family) ==\n", .{});
+    var crystal_snap_buf: [4096]u8 = undefined;
+    crystal_script_boot(); // one-time runtime init (GC + top-level)
+    world.reset();
+    crystal_script_init();
+    for (0..5) |i| {
+        emitTick(i + 1);
+        crystal_script_update(world.dt);
+    }
+    const crystal_snap = world.snapshot(&crystal_snap_buf);
+    std.debug.print("{s}", .{crystal_snap});
+
+    std.debug.print("\n== verdict ==\n", .{});
+    if (std.mem.eql(u8, lua_snap, rust_snap) and std.mem.eql(u8, lua_snap, crystal_snap)) {
+        std.debug.print("FAMILIES AGREE: one contract, three languages (Lua VM, Rust, Crystal), identical world state.\n", .{});
+    } else {
+        std.debug.print("MISMATCH — POC FAILED\n", .{});
+        return error.SnapshotMismatch;
+    }
+}

--- a/spike/language-plugins/rust/.gitignore
+++ b/spike/language-plugins/rust/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/spike/language-plugins/rust/Cargo.toml
+++ b/spike/language-plugins/rust/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "labelle_rust_script"
+version = "0.0.1"
+edition = "2021"
+
+[lib]
+crate-type = ["staticlib"]
+
+[profile.release]
+panic = "abort"

--- a/spike/language-plugins/rust/src/lib.rs
+++ b/spike/language-plugins/rust/src/lib.rs
@@ -1,0 +1,115 @@
+//! The spike behavior, Rust edition (native-compiled family).
+//!
+//! Mirrors scripts/behavior.lua exactly — the host asserts both worlds
+//! end identical. Zero crates: the point is the raw C-ABI contract
+//! (contract/contract.h) consumed as plain `extern "C"` declarations, the
+//! way a real labelle-rust build integration would generate them.
+
+use std::os::raw::c_char;
+
+extern "C" {
+    fn labelle_entity_create() -> u64;
+    fn labelle_component_set(id: u64, name: *const c_char, name_len: usize, json: *const c_char, json_len: usize);
+    fn labelle_component_get(id: u64, name: *const c_char, name_len: usize, out: *mut c_char, out_cap: usize) -> usize;
+    fn labelle_event_emit(name: *const c_char, name_len: usize, json: *const c_char, json_len: usize);
+    fn labelle_log(msg: *const c_char, len: usize);
+    fn labelle_event_subscribe(name: *const c_char, name_len: usize);
+    fn labelle_event_poll(out: *mut c_char, out_cap: usize) -> usize;
+}
+
+fn set(id: u64, name: &str, json: &str) {
+    unsafe {
+        labelle_component_set(
+            id,
+            name.as_ptr() as *const c_char,
+            name.len(),
+            json.as_ptr() as *const c_char,
+            json.len(),
+        )
+    }
+}
+
+fn get(id: u64, name: &str) -> String {
+    let mut buf = [0u8; 192];
+    let len = unsafe {
+        labelle_component_get(
+            id,
+            name.as_ptr() as *const c_char,
+            name.len(),
+            buf.as_mut_ptr() as *mut c_char,
+            buf.len(),
+        )
+    };
+    String::from_utf8_lossy(&buf[..len]).into_owned()
+}
+
+fn emit(name: &str, json: &str) {
+    unsafe {
+        labelle_event_emit(
+            name.as_ptr() as *const c_char,
+            name.len(),
+            json.as_ptr() as *const c_char,
+            json.len(),
+        )
+    }
+}
+
+fn log(msg: &str) {
+    unsafe { labelle_log(msg.as_ptr() as *const c_char, msg.len()) }
+}
+
+// POC-only global; a real labelle-rust hands scripts a context struct.
+static mut PLAYER: u64 = 0;
+
+#[no_mangle]
+pub extern "C" fn rust_script_init() {
+    let player = unsafe { labelle_entity_create() };
+    unsafe { PLAYER = player };
+    set(player, "Position", "{\"x\":0,\"y\":0}");
+    unsafe {
+        labelle_event_subscribe("tick_started".as_ptr() as *const c_char, "tick_started".len())
+    };
+    log(&format!("rust: player {} ready", player));
+}
+
+#[no_mangle]
+pub extern "C" fn rust_script_update(_dt: f32) {
+    let player = unsafe { PLAYER };
+    // Receive side: drain the inbox the host filled before this tick.
+    loop {
+        let mut buf = [0u8; 224];
+        let len = unsafe { labelle_event_poll(buf.as_mut_ptr() as *mut c_char, buf.len()) };
+        if len == 0 {
+            break;
+        }
+        let ev = String::from_utf8_lossy(&buf[..len]).into_owned();
+        if ev.contains("\"n\":4") {
+            set(player, "TickLog", "{\"last\":4}");
+            log("rust: saw tick 4");
+        }
+    }
+    let json = get(player, "Position");
+    // Parse `"x":<n>` without a JSON crate — mirrors the Lua string.match.
+    let x: i64 = json
+        .split("\"x\":")
+        .nth(1)
+        .and_then(|s| {
+            s.chars()
+                .take_while(|c| c.is_ascii_digit() || *c == '-')
+                .collect::<String>()
+                .parse()
+                .ok()
+        })
+        .unwrap_or(0);
+    let x = x + 10;
+    set(player, "Position", &format!("{{\"x\":{},\"y\":0}}", x));
+
+    if x == 30 {
+        unsafe {
+            let bullet = labelle_entity_create();
+            set(bullet, "Bullet", "{\"vx\":0,\"vy\":-500}");
+            emit("bullet_spawned", &format!("{{\"owner\":{}}}", player));
+            log("rust: bullet away");
+        }
+    }
+}

--- a/spike/language-plugins/scripts/behavior.lua
+++ b/spike/language-plugins/scripts/behavior.lua
@@ -1,0 +1,39 @@
+-- The spike behavior, Lua edition (embedded-VM family).
+-- Mirrors rust/src/lib.rs exactly: the host asserts both worlds end
+-- identical. Raw contract calls on purpose — a real labelle-lua wraps
+-- these in `entity:get/set` sugar (see #237's reference API).
+
+local player
+
+function init()
+    player = labelle.entity_create()
+    labelle.component_set(player, "Position", '{"x":0,"y":0}')
+    labelle.event_subscribe("tick_started")
+    labelle.log("lua: player " .. player .. " ready")
+end
+
+function update(dt)
+    -- Receive side: drain the inbox the host filled before this tick.
+    while true do
+        local ev = labelle.event_poll()
+        if ev == "" then break end
+        local n = tonumber(string.match(ev, '"n":(%d+)'))
+        if n == 4 then
+            labelle.component_set(player, "TickLog", '{"last":4}')
+            labelle.log("lua: saw tick 4")
+        end
+    end
+
+    local json = labelle.component_get(player, "Position")
+    local x = tonumber(string.match(json, '"x":(-?%d+)'))
+    x = x + 10
+    labelle.component_set(player, "Position", string.format('{"x":%d,"y":0}', x))
+
+    -- On the third tick: spawn a bullet and tell the world about it.
+    if x == 30 then
+        local bullet = labelle.entity_create()
+        labelle.component_set(bullet, "Bullet", '{"vx":0,"vy":-500}')
+        labelle.event_emit("bullet_spawned", string.format('{"owner":%d}', player))
+        labelle.log("lua: bullet away")
+    end
+end


### PR DESCRIPTION
**POC** (draft, spike-only — `spike/language-plugins/`) validating [RFC-LANGUAGE-PLUGINS](https://github.com/labelle-toolkit/labelle-engine/pull/730) / #237: **one Script Runtime Contract serves every language family.**

```
== verdict ==
FAMILIES AGREE: one contract, three languages (Lua VM, Rust, Crystal), identical world state.
```

The same behavior — entity + components-by-name (JSON), move per tick, bullet on tick 3, **event emit**, **event subscribe + poll-drain** reacting to tick 4 — written in **Lua** (embedded-VM family), **Rust** and **Crystal** (native-compiled family), all driving the identical flat C-ABI surface (`contract/contract.h`). The host asserts the three world snapshots **byte-identical** — not eyeballed.

## The event system, verified in all three

`labelle_event_subscribe(name)` + `labelle_event_poll(out) → "<name> <json>"` — the host queues subscribed events into a per-script FIFO; scripts drain at tick start (a plain loop in every language). Callback dispatch is language-plugin *sugar over the drain loop* (Lua function registry, Rust handler match, C# events) — the ABI stays one function. Emit is symmetric and feeds the same bus. Both directions proven in Lua, Rust, and Crystal.

## Findings → clear implementation path

- **Lua**: as easy as #237 promised — ~20 externs + 5 shims. LuaJIT = link-time swap.
- **Rust**: the contract header **is** the binding; labelle-rust is mostly build integration.
- **Crystal**: works, with sharp edges all solved and documented — `ld -r` main-localization (no `--no-main` exists), boot via `Crystal.init_runtime` (`main_user_code` segfaults), and the big one: **raising APIs segfault under foreign stacks** (backtrace capture walks host frames — bisected to `to_i64?(strict: false)`); plugin rule = non-raising entry points + GC stack registration as the first work item.
- **C# / mruby**: paths documented in the README (hostfxr + `UnmanagedCallersOnly` / mruby mirrors the Lua half); not coded — the two families are already both proven.

Run: `zig build run` in the spike dir (macOS: brew lua + cargo + crystal). Not wired into the engine build — deletable, self-contained, same draft-PR pattern as the studio-panels POC (labelle-studio#73).

Issue: #237 · RFC: #730

https://claude.ai/code/session_01P7YLw4hXFCCaY2LAUt4G1j
