### PR TITLE
feat(engine): default Camera entity at root-only instantiation (Closes #564)

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -1350,6 +1350,12 @@ pub fn GameConfigWithYAxis(
         /// MERGE a JSON patch into an entity's `Camera` component and re-seed.
         /// Backs the `editor_set_component("Camera", …)` bridge export.
         pub const applyCameraComponentJson = CameraMixin.applyCameraComponentJson;
+        /// Insert a default `Camera` entity into the just-instantiated ROOT
+        /// tree when it declares none (labelle-engine#564). The assembler
+        /// emits a call to this at the root-instantiation site only; the
+        /// engine decides *whether* a camera is needed at runtime. See
+        /// `game/camera_mixin.zig` / RFC-CAMERA-PREFABS §"How this subsumes #564".
+        pub const ensureDefaultCamera = CameraMixin.ensureDefaultCamera;
 
         // ── Atlas ─────────────────────────────────────────────────
 

--- a/src/game/camera_mixin.zig
+++ b/src/game/camera_mixin.zig
@@ -275,5 +275,76 @@ pub fn Mixin(comptime Game: type) type {
                 else => error.InvalidCameraComponentJson,
             };
         }
+
+        /// labelle-engine#564 — insert a default `Camera` ENTITY into the
+        /// just-instantiated ROOT tree when it declares none.
+        ///
+        /// The engine owns *whether* a camera is needed — "an explicit
+        /// `Camera` anywhere in the tree wins" is a property of the
+        /// *instantiated* tree (nested-prefab contents, overrides, runtime
+        /// spawns), NOT of the static scene source, so it cannot be evaluated
+        /// by the assembler at comptime. The assembler owns *where* the call
+        /// goes: the root-instantiation site only, never nested-prefab spawns
+        /// — which is what keeps "no two cameras when you nest a scene inside a
+        /// scene" true. See RFC-CAMERA-PREFABS §"How this subsumes #564".
+        ///
+        /// Rules (the three from #564, verbatim):
+        ///   1. Scans the subtree rooted at `root` for ANY entity carrying a
+        ///      `Camera` component. If one exists — anywhere in the tree — the
+        ///      tree is left UNTOUCHED (the authored / explicit camera wins).
+        ///   2. Otherwise materializes exactly ONE default camera: a fresh
+        ///      entity with a default `Position` + default `Camera`, PARENTED
+        ///      under `root` (so the `Parent` cascade groups it with the scene)
+        ///      and tracked as a scene entity (so the scene-unload drain —
+        ///      which pops tracked entities via `destroyEntityOnly`, NOT a
+        ///      single root cascade — tears it down too).
+        ///   3. Because the assembler emits this call at the root only, nested
+        ///      prefabs never each get one, and a tree with several camera-less
+        ///      nested subtrees still receives exactly one default at root.
+        ///
+        /// Returns the entity governing the tree — the pre-existing camera when
+        /// found, else the freshly inserted default. Defers entirely (no-op,
+        /// returns `null`) for a project that registered its OWN `Camera` in
+        /// its `ComponentRegistry` (`camera_is_builtin == false`), mirroring
+        /// every other built-in Camera channel (save/load, digest). Independent
+        /// of whether the renderer has a settable camera: the inserted entity
+        /// exists for the studio (inspector / gizmo / save-load); the render
+        /// seed (`seedCameraFromComponent`) still comptime-folds away on a
+        /// camera-less renderer, leaving the renderer's slot-0 fallback intact.
+        pub fn ensureDefaultCamera(self: *Game, root: Entity) ?Entity {
+            if (comptime !Game.camera_is_builtin) return null;
+
+            // "Explicit Camera anywhere in the tree wins": scan every Camera
+            // entity, keeping the first that belongs to `root`'s subtree.
+            var v = self.ecs_backend.view(.{CameraComp}, .{});
+            defer v.deinit();
+            while (v.next()) |ent| {
+                if (entityInTree(self, ent, root)) return ent;
+            }
+
+            // None found — materialize a default at root scope.
+            const cam = self.createEntity();
+            self.setComponent(cam, Position{});
+            self.setComponent(cam, CameraComp{});
+            self.setParent(cam, root, .{});
+            self.trackSceneEntity(cam);
+            return cam;
+        }
+
+        /// True when `ent` is `root` or a (transitive) descendant of `root`,
+        /// walking the `Parent` chain upward. Depth-capped like
+        /// `hierarchy.wouldCreateCycle` so a malformed cycle can't spin.
+        fn entityInTree(self: *Game, ent: Entity, root: Entity) bool {
+            const Parent = Game.ParentComp;
+            var current = ent;
+            var depth: u8 = 0;
+            while (depth < 33) : (depth += 1) {
+                if (current == root) return true;
+                if (self.ecs_backend.getComponent(current, Parent)) |p| {
+                    current = p.entity;
+                } else return false;
+            }
+            return false;
+        }
     };
 }

--- a/test/editor_api_test.zig
+++ b/test/editor_api_test.zig
@@ -1445,6 +1445,113 @@ test "camera built-in DEFERS to a project's own registered Camera (finding #1)" 
     try testing.expect(game.getComponent(e, engine.Camera) == null);
 }
 
+// ── Default camera at root-only instantiation (labelle-engine#564) ──────
+
+/// Count the entities carrying a built-in `Camera` component in `game`'s
+/// world — the assertion `ensureDefaultCamera` is really about ("exactly one").
+fn countCameraEntities(game: *CameraTestGame) usize {
+    var n: usize = 0;
+    var v = game.ecs_backend.view(.{engine.Camera}, .{});
+    defer v.deinit();
+    while (v.next()) |_| n += 1;
+    return n;
+}
+
+test "ensureDefaultCamera: a root with NO Camera gets exactly one default Camera at root scope" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = CameraTestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const root = game.createEntity();
+    game.setPosition(root, .{ .x = 0, .y = 0 });
+    try testing.expectEqual(@as(usize, 0), countCameraEntities(&game));
+
+    const cam = game.ensureDefaultCamera(root).?;
+
+    // Exactly ONE camera, it carries a default Camera component, and it is
+    // parented under the root (so the scene cascade / hierarchy groups it).
+    try testing.expectEqual(@as(usize, 1), countCameraEntities(&game));
+    const comp = game.getComponent(cam, engine.Camera).?;
+    try testing.expectEqual(@as(f32, 1.0), comp.zoom); // default
+    try testing.expectEqual(root, game.getParent(cam).?);
+
+    // Idempotent: a second call finds the just-inserted camera and inserts
+    // nothing new (the mechanic never stacks cameras).
+    const cam2 = game.ensureDefaultCamera(root).?;
+    try testing.expectEqual(cam, cam2);
+    try testing.expectEqual(@as(usize, 1), countCameraEntities(&game));
+}
+
+test "ensureDefaultCamera: a root WITH a Camera anywhere in the tree is left untouched (authored wins)" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = CameraTestGame.init(testing.allocator);
+    defer game.deinit();
+
+    // Authored camera sits on a CHILD of the root, not the root itself —
+    // "explicit Camera *anywhere* in the tree wins."
+    const root = game.createEntity();
+    game.setPosition(root, .{ .x = 0, .y = 0 });
+    const child = game.createEntity();
+    game.setPosition(child, .{ .x = 10, .y = 20 });
+    game.setParent(child, root, .{});
+    game.addComponent(child, engine.Camera{ .zoom = 3.0 });
+
+    try testing.expectEqual(@as(usize, 1), countCameraEntities(&game));
+
+    const got = game.ensureDefaultCamera(root).?;
+
+    // No new entity: it returned the authored camera and inserted nothing.
+    try testing.expectEqual(child, got);
+    try testing.expectEqual(@as(usize, 1), countCameraEntities(&game));
+    try testing.expectEqual(@as(f32, 3.0), game.getComponent(child, engine.Camera).?.zoom);
+}
+
+test "ensureDefaultCamera: nested camera-less prefabs get ONE default at root, not one each" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = CameraTestGame.init(testing.allocator);
+    defer game.deinit();
+
+    // A root with two nested camera-less subtrees (as if two scenes were
+    // nested inside a scene): root → childA → grandchild, and root → childB.
+    const root = game.createEntity();
+    game.setPosition(root, .{ .x = 0, .y = 0 });
+    const child_a = game.createEntity();
+    game.setParent(child_a, root, .{});
+    const grandchild = game.createEntity();
+    game.setParent(grandchild, child_a, .{});
+    const child_b = game.createEntity();
+    game.setParent(child_b, root, .{});
+
+    // The helper fires ONCE at the root (the assembler's job is to place it
+    // there, never per nested spawn) → exactly one camera for the whole tree.
+    const cam = game.ensureDefaultCamera(root).?;
+    try testing.expectEqual(@as(usize, 1), countCameraEntities(&game));
+    // It is parented directly under the root, not under a nested subtree.
+    try testing.expectEqual(root, game.getParent(cam).?);
+}
+
+test "ensureDefaultCamera: defers (no insert) for a project that registered its own Camera" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var game = RegisteredCameraGame.init(testing.allocator);
+    defer game.deinit();
+
+    const root = game.createEntity();
+    game.setPosition(root, .{ .x = 0, .y = 0 });
+
+    // camera_is_builtin is off → the engine does not materialize a built-in
+    // Camera entity (the project owns the "Camera" name).
+    try testing.expect(game.ensureDefaultCamera(root) == null);
+    try testing.expect(game.getComponent(root, engine.Camera) == null);
+}
+
 test "camera apply-while-paused: a STEPPED frame keeps the ticked camera (single-step debug, finding #2)" {
     editor_api.unbind();
     defer editor_api.unbind();


### PR DESCRIPTION
Closes #564.

Implements the #564 mechanic ("default Camera at root-only instantiation") as reframed under **RFC-CAMERA-PREFABS §"How this subsumes #564"**. With the `Camera` component now shipped (#714/#723), "default-camera insertion" becomes "insert a default `Camera` ENTITY when the root-instantiated tree declares none."

## What this adds

`Game.ensureDefaultCamera(root: Entity) ?Entity` (in `src/game/camera_mixin.zig`, re-exported on `Game`):

1. Scans the subtree rooted at `root` for ANY entity carrying a `Camera` component. If one exists — anywhere in the tree — returns it and leaves the tree **untouched** (authored / explicit camera wins).
2. Otherwise materializes exactly **one** default camera: a fresh entity with a default `Position` + default `Camera`, **parented under `root`** (Parent cascade groups it with the scene) and **tracked as a scene entity** (the scene-unload drain pops tracked entities via `destroyEntityOnly`, not a single root cascade, so parenting alone would leak it).
3. Returns the governing camera entity (pre-existing or freshly inserted).

## Design (per the RFC)

The **engine owns *whether*** a camera is needed — "an explicit `Camera` anywhere wins" is a property of the *instantiated* tree (nested-prefab contents, overrides, runtime spawns), which the assembler cannot evaluate at comptime. The **assembler owns *where*** the call goes: the root-instantiation site only, never nested-prefab spawns. That call-site placement is what makes #564's three rules hold — root-only, nested-excluded, explicit-override-wins.

- **Defers** (no-op, returns `null`) when a project registered its own `Camera` in its `ComponentRegistry` (`camera_is_builtin == false`), mirroring every other built-in Camera channel (save/load, digest).
- **Zero behavior change** for scenes that author a Camera; the renderer slot-0 fallback and the comptime-folded seed path (`seedCameraFromComponent`) are untouched.

## Assembler follow-up required to *fire* in real projects

This PR is the **engine-side runtime primitive**. For it to actually run at scene load in shipped games, **labelle-assembler#569** must emit a call to `game.ensureDefaultCamera(root)` at the root-instantiation site (it owns the single state-root entity and the root-only placement). The engine deliberately does not auto-fire on `setScene`, because the current loader produces a forest with no single designated state root, and auto-firing would be a behavior change for every game rather than an opt-in codegen decision — exactly the split the RFC prescribes.

## Tests (`test/editor_api_test.zig`, `zig build test` green)

- root with no Camera → exactly one default at root scope (parented under root, default zoom), and idempotent on a second call;
- root WITH a Camera on a *child* → untouched, returns the authored camera;
- root with two nested camera-less subtrees → ONE default at root, not one per subtree;
- project-registered Camera → defers (returns null, no insert).

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw