### PR TITLE
feat(engine): standalone Image component for entities — Closes #568

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -94,6 +94,10 @@ pub fn build(b: *std.Build) void {
         // C2 — a project-registered component named `Tilemap` must win over
         // the engine built-in in the scene loader (no silent shadowing).
         "test/jsonc/tilemap_precedence_test.zig",
+        // #568 — standalone `Image` component: scene-loader parse, loader
+        // resolution through AssetCatalog, and registered-vs-built-in
+        // precedence.
+        "test/jsonc/image_component_test.zig",
         "test/scene_ref_test.zig",
         "test/asset_catalog_test.zig",
         "test/audio_loader_test.zig",

--- a/src/game.zig
+++ b/src/game.zig
@@ -62,6 +62,7 @@ const tilemap_mod = @import("tilemap.zig");
 const tilemap_runtime = @import("tilemap_runtime.zig");
 const tilemap_mixin = @import("game/tilemap_mixin.zig");
 const camera_mod = @import("camera.zig");
+const image_component_mod = @import("image_component.zig");
 const camera_mixin = @import("game/camera_mixin.zig");
 const frame_profiler_mod = @import("frame_profiler.zig");
 
@@ -218,6 +219,10 @@ pub fn GameConfigWithYAxis(
         pub const HooksIsMergedExport = HooksIsMerged;
         pub const EcsBackend = EcsImpl;
         pub const SpriteComp = Sprite;
+        /// Engine built-in `Image` component — standalone-PNG entity backed by
+        /// `AssetCatalog` (#568). Distinct from `SpriteComp` (atlas sprites)
+        /// and from the imgui `gui_types.Image`. See `src/image_component.zig`.
+        pub const ImageComp = image_component_mod.Image;
         pub const ShapeComp = Shape;
         pub const TextComp = Text;
         pub const IconComp = Icon;

--- a/src/image_component.zig
+++ b/src/image_component.zig
@@ -1,0 +1,90 @@
+//! Standalone `Image` component (RFC-UNIFY-SCENES-AND-PREFABS §"Standalone
+//! `Image` component", labelle-engine#568).
+//!
+//! An `Image` entity displays a **standalone PNG** — no atlas, no sub-rect —
+//! loaded through the `AssetCatalog` `image` loader (decode-on-worker,
+//! upload-on-main, refcounted). It is the entity-side counterpart to that
+//! loader: today entities can only show images via atlas sprites
+//! (`Sprite.sprite_name` → `TextureManager.findSprite`), and the workaround
+//! for a loose PNG is to wrap it as a 1-sprite atlas. `Image` removes that
+//! workaround.
+//!
+//! **Engine built-in, NOT a `ComponentRegistry` component.** Like `Position`,
+//! `Tilemap` (`src/tilemap.zig`) and `Camera` (`src/camera.zig`), `Image` is
+//! handled by a dedicated built-in channel in the scene loader
+//! (`jsonc/component_apply.zig`). The built-in branch is guarded
+//! `!Components.has("Image")` so a project-registered `Image` still wins. Do
+//! not register it in a game's `ComponentRegistry`.
+//!
+//! **Renderer-agnostic.** The engine takes no gfx dependency, so `pivot` /
+//! `layer` are engine-local (a mirror enum + a layer *name* string) rather
+//! than gfx's `Pivot` / comptime `LayerEnum`. The render seam maps them onto
+//! the backend. The full-texture draw branch lives renderer-side
+//! (labelle-gfx) and is tracked separately — this component + its
+//! scene-loader apply + the `AssetCatalog` resolution path are the engine's
+//! half of the seam.
+//!
+//! **Naming caveat.** There is already a `gui_types.Image` in the imgui GUI
+//! layer. This ECS `Image` component is distinct: different module, different
+//! render path. Reach it as `engine.Image` / `Game.ImageComp`.
+//!
+//! **V1 scope is deliberately narrow** (issue #568): no animation, no dynamic
+//! name swapping, no sub-rect cropping. If any of those is needed, the answer
+//! is "use `Sprite` + an atlas". `Image` is for static single-PNG entities
+//! and nothing else.
+
+const std = @import("std");
+
+/// Pivot anchor for a standalone `Image`. Engine-local MIRROR of gfx's
+/// `Pivot` — the engine takes no gfx dependency, so the render seam maps
+/// these names onto the backend's `Pivot` enum. Member names match gfx's
+/// exactly so a JSONC `"pivot": "bottom_left"` round-trips through
+/// `std.meta.stringToEnum` on both sides.
+pub const Pivot = enum {
+    center,
+    top_left,
+    top_center,
+    top_right,
+    center_left,
+    center_right,
+    bottom_left,
+    bottom_center,
+    bottom_right,
+    custom,
+};
+
+/// The `Image` component — a static single-PNG entity backed by the
+/// `AssetCatalog` `image` loader.
+///
+/// Resolution: `name` is an `AssetCatalog` asset key. The asset is acquired
+/// through `game.assets.acquire(name)`; once `game.assets.isReady(name)`, the
+/// uploaded GPU texture handle is read from `entry.resource.?.image`
+/// (`bridgeImageAssetsToAtlasManager` in `game/scene_mixin.zig` already wires
+/// ready `.image` assets into the renderer). Rendering is skipped while the
+/// asset is not ready (matches the lazy pop-in model).
+pub const Image = struct {
+    /// `AssetCatalog` asset key of the standalone PNG. Borrowed from the
+    /// scene's nested-entity arena (same lifetime as `Sprite.sprite_name`).
+    name: []const u8 = "",
+
+    /// Anchor point — same semantics as `Sprite.pivot`.
+    pivot: Pivot = .center,
+
+    /// Layer *name* — same layering model as `Sprite`, but carried as a
+    /// string because the engine cannot see the project's comptime layer
+    /// enum. The render seam maps it onto the backend layer. Empty = the
+    /// renderer's default layer.
+    layer: []const u8 = "",
+
+    /// Draw order within the layer — same as `Sprite.z_index` (matches gfx's
+    /// `i16` width).
+    z_index: i16 = 0,
+
+    /// Visibility toggle — same as `Sprite.visible`.
+    visible: bool = true,
+};
+
+// Coverage lives in `test/jsonc/image_component_test.zig` — per the engine
+// convention, `src/*.zig` test blocks aren't reached by build.zig's
+// cross-module test import.
+

--- a/src/jsonc/component_apply.zig
+++ b/src/jsonc/component_apply.zig
@@ -24,6 +24,7 @@ const Position = core.Position;
 const deserializer = @import("deserializer.zig");
 const ref_resolver_mod = @import("ref_resolver.zig");
 const uf = @import("unified_format.zig");
+const ImageComp = @import("../image_component.zig").Image;
 
 pub fn ComponentApply(comptime GameType: type, comptime Components: type) type {
     const Entity = GameType.EntityType;
@@ -155,6 +156,30 @@ pub fn ComponentApply(comptime GameType: type, comptime Components: type) type {
                             }
                         }
                         game.addComponent(entity, cam);
+                    }
+                    return;
+                }
+            }
+
+            // Image (standalone-PNG component, #568) — built-in, deserializes
+            // to a plain engine-local POD stored via `addComponent` (like the
+            // `Camera` branch above; unlike `Tilemap` there is no side-table /
+            // asset decode at apply time — the referenced PNG is acquired
+            // through `AssetCatalog` on the scene's asset path). Guarded
+            // `!Components.has("Image")` exactly like `Tilemap` / `Camera` so a
+            // project-registered `Image` still wins (the built-in branch
+            // compiles out, routing `"Image"` to the registered type via the
+            // generic dispatch below).
+            //
+            // `name` / `layer` are `[]const u8` and `pivot` is an enum — the
+            // generic struct deserializer maps all of them from JSONC (strings
+            // land in `comp_alloc` = the nested-entity arena, matching
+            // `Sprite.sprite_name`'s lifetime), so no `Camera`-style inline-tag
+            // special-casing is needed here.
+            if (comptime !Components.has("Image")) {
+                if (std.mem.eql(u8, name, "Image")) {
+                    if (deserializer.deserialize(ImageComp, value, comp_alloc)) |image| {
+                        game.addComponent(entity, image);
                     }
                     return;
                 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -86,6 +86,18 @@ pub const CameraViewport = @import("camera.zig").Viewport;
 /// inline camera-tag buffer (camera-bound layers, #723/#724).
 pub const camera_mod = @import("camera.zig");
 
+// ── Image (standalone-PNG component, #568) ──
+/// Engine built-in `Image` component — displays a standalone PNG loaded
+/// through `AssetCatalog` (no atlas, no sub-rect), the entity-side
+/// counterpart to `Sprite`. Reachable on a configured game as
+/// `Game.ImageComp`. NOTE: distinct from `gui_types.Image` in the imgui
+/// layer — different module, different render path. See
+/// `src/image_component.zig` / RFC-UNIFY-SCENES-AND-PREFABS.md.
+pub const Image = @import("image_component.zig").Image;
+/// Engine-local pivot enum carried by `Image.pivot` (a renderer-agnostic
+/// mirror of gfx's `Pivot`). See `src/image_component.zig`.
+pub const ImagePivot = @import("image_component.zig").Pivot;
+
 // ── Input ──
 pub const InputInterface = input_mod.InputInterface;
 pub const StubInput = input_mod.StubInput;

--- a/test/jsonc/image_component_test.zig
+++ b/test/jsonc/image_component_test.zig
@@ -1,0 +1,254 @@
+//! Standalone `Image` component (labelle-engine#568) — scene-loader + loader
+//! resolution coverage.
+//!
+//! Two things are proven here:
+//!   1. A scene entity with an `"Image"` block parses into the engine
+//!      built-in `Image` component with the RFC field shape
+//!      (`name` / `pivot` / `layer` / `z_index` / `visible`).
+//!   2. The `Image.name` the loader parsed resolves end-to-end through the
+//!      `AssetCatalog` `image` loader — register → acquire → worker-decode →
+//!      upload → `.ready` → GPU texture handle — the same path
+//!      `bridgeImageAssetsToAtlasManager` bridges into the renderer.
+//!
+//! A third test guards the built-in precedence rule: a project-registered
+//! component named `Image` wins over the engine built-in (mirrors the
+//! `Tilemap` / `Camera` precedence contract in `component_apply.zig`).
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+const core = @import("labelle-core");
+
+const image_loader = engine.ImageLoader;
+
+const MockEcs = core.MockEcsBackend(u32);
+
+fn Game(comptime Components: type) type {
+    return engine.game_mod.GameConfig(
+        core.StubRender(MockEcs.Entity),
+        MockEcs,
+        engine.input_mod.StubInput,
+        engine.audio_mod.StubAudio,
+        engine.StubVideo,
+        engine.gui_mod.StubGui,
+        void,
+        core.StubLogSink,
+        Components,
+        &.{},
+        void,
+    );
+}
+
+// No project component named `Image` — the engine built-in is active.
+const BuiltinComponents = engine.ComponentRegistry(.{});
+const BuiltinGame = Game(BuiltinComponents);
+const BuiltinBridge = engine.JsoncSceneBridge(BuiltinGame, BuiltinComponents);
+
+// ---------------------------------------------------------------------
+// Mock image backend — 1×1 RGBA, mirrors asset_catalog_test's shape.
+// ---------------------------------------------------------------------
+
+const Mock = struct {
+    var decode_calls: u32 = 0;
+    var upload_calls: u32 = 0;
+    var next_tex: engine.AssetTexture = 100;
+
+    fn reset() void {
+        decode_calls = 0;
+        upload_calls = 0;
+        next_tex = 100;
+    }
+
+    fn decodeFn(
+        file_type: [:0]const u8,
+        data: []const u8,
+        allocator: std.mem.Allocator,
+    ) anyerror!engine.DecodedImage {
+        _ = file_type;
+        _ = data;
+        decode_calls += 1;
+        const pixels = try allocator.alloc(u8, 4);
+        @memset(pixels, 0x7F);
+        return .{ .pixels = pixels, .width = 1, .height = 1 };
+    }
+
+    fn uploadFn(decoded: engine.DecodedImage) anyerror!engine.AssetTexture {
+        _ = decoded;
+        upload_calls += 1;
+        const t = next_tex;
+        next_tex += 1;
+        return t;
+    }
+
+    fn unloadFn(texture: engine.AssetTexture) void {
+        _ = texture;
+    }
+
+    const backend: engine.ImageBackend = .{
+        .decode = decodeFn,
+        .upload = uploadFn,
+        .unload = unloadFn,
+    };
+};
+
+test "Image: scene entity parses into the engine built-in with the RFC shape" {
+    var game = BuiltinGame.init(testing.allocator);
+    defer game.deinit();
+
+    try BuiltinBridge.loadSceneFromSource(&game,
+        \\{ "entities": [
+        \\  { "components": { "Image": {
+        \\      "name": "logo_splash",
+        \\      "pivot": "bottom_left",
+        \\      "layer": "ui",
+        \\      "z_index": 10,
+        \\      "visible": true
+        \\  } } }
+        \\] }
+    , "/tmp/labelle-nonexistent");
+
+    var view = game.ecs_backend.view(.{engine.Image}, .{});
+    defer view.deinit();
+    const ent = view.next().?;
+
+    const img = game.ecs_backend.getComponent(ent, engine.Image).?;
+    try testing.expectEqualStrings("logo_splash", img.name);
+    try testing.expectEqual(engine.ImagePivot.bottom_left, img.pivot);
+    try testing.expectEqualStrings("ui", img.layer);
+    try testing.expectEqual(@as(i16, 10), img.z_index);
+    try testing.expect(img.visible);
+}
+
+test "Image: defaults land for a minimal block" {
+    var game = BuiltinGame.init(testing.allocator);
+    defer game.deinit();
+
+    try BuiltinBridge.loadSceneFromSource(&game,
+        \\{ "entities": [
+        \\  { "components": { "Image": { "name": "bare" } } }
+        \\] }
+    , "/tmp/labelle-nonexistent");
+
+    var view = game.ecs_backend.view(.{engine.Image}, .{});
+    defer view.deinit();
+    const img = game.ecs_backend.getComponent(view.next().?, engine.Image).?;
+    try testing.expectEqualStrings("bare", img.name);
+    try testing.expectEqual(engine.ImagePivot.center, img.pivot);
+    try testing.expectEqualStrings("", img.layer);
+    try testing.expectEqual(@as(i16, 0), img.z_index);
+    try testing.expect(img.visible);
+}
+
+test "Image: parsed name resolves end-to-end through the AssetCatalog image loader" {
+    Mock.reset();
+    image_loader.setBackend(Mock.backend);
+    defer image_loader.clearBackend();
+
+    var game = BuiltinGame.init(testing.allocator);
+    defer game.deinit();
+
+    // The standalone PNG the scene's `Image` will reference. In a real game
+    // this registration comes from `project.labelle` `.resources` (a
+    // `.texture`-only, `.json`-less entry → the `image` loader). Here we
+    // register it directly on the game's catalog.
+    try game.assets.register("logo_splash", engine.LoaderKind.image, "png", "fake-png-bytes");
+
+    try BuiltinBridge.loadSceneFromSource(&game,
+        \\{ "entities": [
+        \\  { "components": { "Image": { "name": "logo_splash", "pivot": "center" } } }
+        \\] }
+    , "/tmp/labelle-nonexistent");
+
+    // Pull the asset key straight off the loaded component so this test
+    // exercises exactly what the scene loader parsed.
+    var view = game.ecs_backend.view(.{engine.Image}, .{});
+    defer view.deinit();
+    const img = game.ecs_backend.getComponent(view.next().?, engine.Image).?;
+    try testing.expectEqualStrings("logo_splash", img.name);
+
+    // Resolve `img.name` through the image loader.
+    try testing.expect(!game.assets.isReady(img.name));
+    _ = try game.assets.acquire(img.name);
+
+    // Drain the worker's decoded payload (pump() is a no-op until #442, so
+    // finalize by hand — same shape as asset_catalog_test).
+    const deadline_ns: u64 = 200 * std.time.ns_per_ms;
+    var waited_ns: u64 = 0;
+    const step_ns: u64 = 1 * std.time.ns_per_ms;
+    const result = outer: while (waited_ns < deadline_ns) {
+        for (&game.assets.results) |*ring| {
+            if (ring.tryDequeue()) |r| break :outer r;
+        }
+        {
+            var req: std.c.timespec = .{ .sec = (step_ns / std.time.ns_per_s), .nsec = (step_ns % std.time.ns_per_s) };
+            var rem: std.c.timespec = undefined;
+            _ = std.c.nanosleep(&req, &rem);
+        }
+        waited_ns += step_ns;
+    } else {
+        return error.WorkerDidNotRespond;
+    };
+
+    try testing.expectEqualStrings("logo_splash", result.entry_name);
+    try testing.expect(result.err == null);
+    try testing.expect(result.decoded != null);
+    try testing.expectEqual(@as(u32, 1), Mock.decode_calls);
+
+    const entry = game.assets.entries.getPtr(img.name).?;
+    try result.vtable.upload(entry, result.decoded.?, testing.allocator);
+    entry.decoded = null;
+    entry.state = .ready;
+
+    // The Image's asset is now resolved: ready, with an uploaded GPU texture
+    // handle — exactly what `bridgeImageAssetsToAtlasManager` reads to wire
+    // the renderer.
+    try testing.expect(game.assets.isReady(img.name));
+    try testing.expect(entry.resource != null);
+    const tex = switch (entry.resource.?) {
+        .image => |t| t,
+        else => return error.WrongResourceKind,
+    };
+    try testing.expect(tex >= 100);
+    try testing.expectEqual(@as(u32, 1), Mock.upload_calls);
+
+    game.assets.release(img.name);
+}
+
+// ---------------------------------------------------------------------
+// Precedence — a project-registered `Image` wins over the built-in.
+// ---------------------------------------------------------------------
+
+/// A project component that happens to be named `Image`, with a shape
+/// distinct from the engine built-in.
+const ProjectImage = struct {
+    pub const save = core.Saveable(.saveable, @This(), .{});
+    width: i32 = 0,
+    height: i32 = 0,
+};
+
+const OverrideComponents = engine.ComponentRegistry(.{
+    .Image = ProjectImage,
+});
+const OverrideGame = Game(OverrideComponents);
+const OverrideBridge = engine.JsoncSceneBridge(OverrideGame, OverrideComponents);
+
+test "Image: a registered component named Image wins over the engine built-in" {
+    var game = OverrideGame.init(testing.allocator);
+    defer game.deinit();
+
+    try OverrideBridge.loadSceneFromSource(&game,
+        \\{ "entities": [
+        \\  { "components": { "Image": { "width": 320, "height": 240 } } }
+        \\] }
+    , "/tmp/labelle-nonexistent");
+
+    var view = game.ecs_backend.view(.{ProjectImage}, .{});
+    defer view.deinit();
+    const ent = view.next().?;
+    const pimg = game.ecs_backend.getComponent(ent, ProjectImage).?;
+    try testing.expectEqual(@as(i32, 320), pimg.width);
+    try testing.expectEqual(@as(i32, 240), pimg.height);
+
+    // The engine built-in `Image` must NOT have been attached to the entity.
+    try testing.expect(game.getComponent(ent, engine.Image) == null);
+}


### PR DESCRIPTION
Closes #568.

Implements the RFC-UNIFY-SCENES-AND-PREFABS "Standalone `Image` component" subsection: an engine built-in `Image` ECS component so an entity can display a **standalone PNG** loaded through `AssetCatalog`'s `image` loader — the entity-side counterpart to `Sprite` (atlas sprites). Removes the "wrap each loose PNG as a 1-sprite atlas" workaround.

## Component shape (per RFC / issue)

```jsonc
"Image": {
    "name": "logo_splash",   // AssetCatalog asset key
    "pivot": "bottom_left",  // same enum semantics as Sprite
    "layer": "ui",           // same layering as Sprite (carried as a name string)
    "z_index": 10,           // same (i16, matches gfx Sprite)
    "visible": true          // optional, defaults true
}
```

Field types (`src/image_component.zig`): `name: []const u8`, `pivot: Pivot` (engine-local mirror enum), `layer: []const u8`, `z_index: i16 = 0`, `visible: bool = true`. V1 is deliberately narrow: no animation, no dynamic name swapping, no sub-rect cropping (use `Sprite` + an atlas for those).

## What's here

- **`src/image_component.zig`** — the `Image` POD + `Pivot` mirror enum. Renderer-agnostic (the engine takes no gfx dependency): `pivot` is a name-matched mirror of gfx's `Pivot`, `layer` is a name string the render seam maps onto the backend's comptime layer enum.
- **`src/jsonc/component_apply.zig`** — a guarded `!Components.has("Image")` branch that deserializes `"Image": {...}` and attaches via `addComponent`, mirroring the `Tilemap` / `Camera` built-in precedence rule (a project-registered `Image` still wins; the built-in branch compiles out).
- **`src/root.zig` / `src/game.zig`** — re-exported as `engine.Image` / `engine.ImagePivot` and `Game.ImageComp`. Docs note the distinction from the imgui-layer `gui_types.Image`.

## Tests (`test/jsonc/image_component_test.zig`)

- A scene entity with an `Image` block parses into the built-in with the full RFC field shape (name/pivot/layer/z_index/visible), and minimal blocks get the right defaults.
- The parsed `Image.name` resolves **end-to-end through the AssetCatalog image loader** — register → acquire → worker-decode → upload → `.ready` → GPU texture handle (the same path `bridgeImageAssetsToAtlasManager` bridges into the renderer).
- Precedence: a project-registered component named `Image` wins over the built-in.

`zig build test` — exit 0 (Zig 0.16.0).

## Deferred (gfx-side)

The renderer's full-texture `Image` draw branch — a `.image` visual/tracked kind honouring pivot/layer/z_index/visibility — lives in labelle-gfx and is not in this engine PR. The ready `.image` texture is already bridged into the renderer by `bridgeImageAssetsToAtlasManager`; this PR lands the **engine half** of the seam (component type + scene-loader apply + loader resolution). Asset inference of `Image.name` rides on the unified reverse-index walker (#563), which lands separately per the issue's suggested order.

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw