### PR TITLE
Sprite-based asset inference: reverse index + AssetManifest (part of #563)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -104,6 +104,12 @@ pub fn build(b: *std.Build) void {
         "test/font_types_test.zig",
         "test/font_loader_test.zig",
         "test/asset_streaming_shim_test.zig",
+        // #563 — sprite-based asset inference: reverse index (sprite/image →
+        // resource bundle) + entity-tree walker that derives the `meta.assets`
+        // set, plus the `AssetManifest` escape hatch. Engine half of the RFC
+        // unification; assembler-side codegen (making `meta.assets` optional)
+        // is the follow-up.
+        "test/asset_manifest_test.zig",
         "test/animation_def_test.zig",
         "test/animation_state_transitions_test.zig",
         "test/animation_def_runtime_test.zig",

--- a/src/asset_manifest.zig
+++ b/src/asset_manifest.zig
@@ -171,6 +171,15 @@ pub const ReverseIndex = struct {
             .object => |frames_obj| {
                 var it = frames_obj.iterator();
                 while (it.next()) |entry| {
+                    // Same validation as the array form below: a hash-form
+                    // frame value must be an object carrying a `frame` rect.
+                    // A malformed value here is the same "this isn't the atlas
+                    // I think it is" signal — reject rather than index a bogus
+                    // sprite key.
+                    if (entry.value_ptr.* != .object) return IndexError.InvalidAtlasJson;
+                    const frame = entry.value_ptr.*.object.get("frame") orelse
+                        return IndexError.InvalidAtlasJson;
+                    if (frame != .object) return IndexError.InvalidAtlasJson;
                     const key = try self.arena.allocator().dupe(u8, entry.key_ptr.*);
                     try self.insert(key, .{ .atlas = owned_bundle });
                 }
@@ -256,21 +265,24 @@ pub const InferredManifest = struct {
 /// bundle. The mobile over-load cost of that is #566's audit, not this
 /// function's concern.
 ///
-/// **Prefab references are NOT followed (yet).** The walk infers only from the
-/// *inline* `Sprite`/`Image` refs (and nested entity-bearing fields) present in
-/// the tree it is given. When an entity references another prefab by name
-/// (`"prefab": "condenser"` / `@ref`), this walker sees only the reference
-/// *string*, not the referenced prefab's tree — resolving it needs the prefab
-/// registry/cache, which lives on the comptime/assembler side, not here. A ref
-/// whose name happens to match an index key is treated as a plain string
-/// (usually a miss). Assets that live *only* inside a referenced prefab must,
-/// for now, be surfaced by the referencing scene either through inference of
-/// that prefab when *it* is loaded as a top-level tree, or via an
-/// `AssetManifest` on the referencing entity.
-/// TODO(#563 follow-up): resolve prefab references against the prefab tree so a
-/// referencing scene pulls in the referenced prefab's assets transitively. This
-/// is part of the same assembler-side wiring (build the reverse index from
-/// `project.labelle` + walk the comptime prefab registry) noted in the PR body.
+/// **Prefab references and scene-includes are NOT followed (yet).** The walk
+/// infers only from the *inline* `Sprite`/`Image` refs (and nested
+/// entity-bearing fields) present in the tree it is given. When an entity
+/// references another prefab by name (`"prefab": "condenser"` / `@ref`), or a
+/// scene pulls in another scene/fragment by an include reference, this walker
+/// sees only the reference *string*, not the referenced tree — resolving it
+/// needs the prefab / scene-include registry/cache, which lives on the
+/// comptime/assembler side, not here. A ref whose name happens to match an
+/// index key is treated as a plain string (usually a miss). Assets that live
+/// *only* inside a referenced prefab/scene must, for now, be surfaced by the
+/// referencing scene either through inference of that prefab/scene when *it*
+/// is loaded as a top-level tree, or via an `AssetManifest` on the referencing
+/// entity.
+/// TODO(#563 follow-up): resolve prefab references AND scene-includes against
+/// their trees so a referencing scene pulls in the referenced assets
+/// transitively. This is part of the same assembler-side wiring (build the
+/// reverse index from `project.labelle` + walk the comptime prefab / scene
+/// registry) noted in the PR body.
 ///
 /// Caller owns the returned `InferredManifest` (call `.deinit()`).
 pub fn inferAssets(
@@ -316,6 +328,14 @@ fn walk(
                     try walkMetaSkippingAssets(out, index, entry.value_ptr.*.object);
                     continue;
                 }
+                // Legacy pre-unification scenes carried the hand-authored
+                // list as a top-level `"assets": [...]` field (before it moved
+                // under `meta`). Skip it for the same reason as `meta.assets`.
+                // Guarded on an array value so a component field that happens
+                // to be named `assets` isn't accidentally dropped.
+                if (std.mem.eql(u8, entry.key_ptr.*, "assets") and entry.value_ptr.* == .array) {
+                    continue;
+                }
                 try walk(out, index, entry.value_ptr.*);
             }
         },
@@ -339,6 +359,13 @@ fn walkMetaSkippingAssets(
 /// Read `{"load":[...]}` out of an `AssetManifest` value node and union every
 /// listed name into the set. Tolerant of a missing/mis-typed `load` (the
 /// generic walk still visits nested strings, so nothing is lost).
+///
+/// Entries are restricted to non-empty strings: an empty `""` name would ask
+/// the catalog to `acquire("")` (a guaranteed miss / no-op) and only bloats
+/// the set, so it's dropped. Fuller validation — that each name is a *known*
+/// resource — needs the resource set, which isn't available at walk time;
+/// TODO(#563 follow-up): validate manifest entries against the built reverse
+/// index / catalog once the assembler wires the real resource list in.
 fn collectManifestLoad(
     out: *InferredManifest,
     manifest: std.json.Value,
@@ -347,7 +374,7 @@ fn collectManifestLoad(
     const load = manifest.object.get("load") orelse return;
     if (load != .array) return;
     for (load.array.items) |item| {
-        if (item == .string) try out.add(item.string);
+        if (item == .string and item.string.len > 0) try out.add(item.string);
     }
 }
 
@@ -377,16 +404,23 @@ pub fn inferAssetsJsonc(
 /// Parse a JSONC scene/prefab source and infer its required resource bundles
 /// in one call — the shape a scene loader wires in. Parses into an internal
 /// arena (freed before return); the returned `InferredManifest` owns its own
-/// name copies. `error.ParseFailed` wraps any JSONC syntax error.
+/// name copies. `error.ParseFailed` wraps a genuine JSONC *syntax* error;
+/// `error.OutOfMemory` propagates distinctly (a transient allocation failure
+/// is not a malformed scene and callers may want to retry, not reject).
 pub fn inferAssetsFromSource(
     gpa: std.mem.Allocator,
     index: *const ReverseIndex,
     source: []const u8,
-) !InferredManifest {
+) (error{ ParseFailed, OutOfMemory })!InferredManifest {
     var arena = std.heap.ArenaAllocator.init(gpa);
     defer arena.deinit();
     var parser = jsonc.JsoncParser.init(arena.allocator(), source);
-    const root = parser.parse() catch return error.ParseFailed;
+    const root = parser.parse() catch |err| switch (err) {
+        // Keep OOM distinct — collapsing it into ParseFailed would make a
+        // recoverable allocation hiccup look like a permanently broken scene.
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.ParseFailed,
+    };
     return inferAssetsJsonc(gpa, index, root);
 }
 
@@ -417,6 +451,11 @@ fn walkJsonc(
                     }
                     continue;
                 }
+                // Legacy top-level `"assets": [...]` list (pre-`meta` move) —
+                // skip for the same reason, guarded on an array value.
+                if (std.mem.eql(u8, entry.key, "assets") and entry.value == .array) {
+                    continue;
+                }
                 try walkJsonc(out, index, entry.value);
             }
         },
@@ -433,6 +472,6 @@ fn collectManifestLoadJsonc(
     const load = manifest.object.get("load") orelse return;
     if (load != .array) return;
     for (load.array.items) |item| {
-        if (item == .string) try out.add(item.string);
+        if (item == .string and item.string.len > 0) try out.add(item.string);
     }
 }

--- a/src/asset_manifest.zig
+++ b/src/asset_manifest.zig
@@ -177,9 +177,19 @@ pub const ReverseIndex = struct {
             },
             .array => |frames_arr| {
                 for (frames_arr.items) |item| {
-                    if (item != .object) continue;
-                    const fname = item.object.get("filename") orelse continue;
-                    if (fname != .string) continue;
+                    // A malformed entry is a real "this isn't the atlas I
+                    // think it is" signal — surface it rather than silently
+                    // skipping (which would drop a sprite from the index and
+                    // reappear later as a mysterious missing-texture bug).
+                    // Expected TexturePacker array shape:
+                    // `{ "filename": "<path>", "frame": { … }, … }`.
+                    if (item != .object) return IndexError.InvalidAtlasJson;
+                    const fname = item.object.get("filename") orelse
+                        return IndexError.InvalidAtlasJson;
+                    if (fname != .string) return IndexError.InvalidAtlasJson;
+                    const frame = item.object.get("frame") orelse
+                        return IndexError.InvalidAtlasJson;
+                    if (frame != .object) return IndexError.InvalidAtlasJson;
                     const key = try self.arena.allocator().dupe(u8, fname.string);
                     try self.insert(key, .{ .atlas = owned_bundle });
                 }
@@ -246,6 +256,22 @@ pub const InferredManifest = struct {
 /// bundle. The mobile over-load cost of that is #566's audit, not this
 /// function's concern.
 ///
+/// **Prefab references are NOT followed (yet).** The walk infers only from the
+/// *inline* `Sprite`/`Image` refs (and nested entity-bearing fields) present in
+/// the tree it is given. When an entity references another prefab by name
+/// (`"prefab": "condenser"` / `@ref`), this walker sees only the reference
+/// *string*, not the referenced prefab's tree — resolving it needs the prefab
+/// registry/cache, which lives on the comptime/assembler side, not here. A ref
+/// whose name happens to match an index key is treated as a plain string
+/// (usually a miss). Assets that live *only* inside a referenced prefab must,
+/// for now, be surfaced by the referencing scene either through inference of
+/// that prefab when *it* is loaded as a top-level tree, or via an
+/// `AssetManifest` on the referencing entity.
+/// TODO(#563 follow-up): resolve prefab references against the prefab tree so a
+/// referencing scene pulls in the referenced prefab's assets transitively. This
+/// is part of the same assembler-side wiring (build the reverse index from
+/// `project.labelle` + walk the comptime prefab registry) noted in the PR body.
+///
 /// Caller owns the returned `InferredManifest` (call `.deinit()`).
 pub fn inferAssets(
     gpa: std.mem.Allocator,
@@ -279,11 +305,34 @@ fn walk(
                 if (std.mem.eql(u8, entry.key_ptr.*, "AssetManifest")) {
                     try collectManifestLoad(out, entry.value_ptr.*);
                 }
+                // Do NOT recurse into the explicit `meta.assets` list. Those
+                // are hand-authored asset KEYS, not sprite-path refs — the
+                // whole point of inference is to derive the set INDEPENDENTLY
+                // so it can validate the explicit list. Walking them would let
+                // a stale explicit entry re-inject itself into the inferred
+                // set (a self-fulfilling, non-validating result). Everything
+                // else under `meta` is still walked.
+                if (std.mem.eql(u8, entry.key_ptr.*, "meta") and entry.value_ptr.* == .object) {
+                    try walkMetaSkippingAssets(out, index, entry.value_ptr.*.object);
+                    continue;
+                }
                 try walk(out, index, entry.value_ptr.*);
             }
         },
         // number / bool / null carry no references.
         else => {},
+    }
+}
+
+fn walkMetaSkippingAssets(
+    out: *InferredManifest,
+    index: *const ReverseIndex,
+    meta: std.json.ObjectMap,
+) std.mem.Allocator.Error!void {
+    var it = meta.iterator();
+    while (it.next()) |entry| {
+        if (std.mem.eql(u8, entry.key_ptr.*, "assets")) continue;
+        try walk(out, index, entry.value_ptr.*);
     }
 }
 
@@ -357,6 +406,16 @@ fn walkJsonc(
             for (obj.entries) |entry| {
                 if (std.mem.eql(u8, entry.key, "AssetManifest")) {
                     try collectManifestLoadJsonc(out, entry.value);
+                }
+                // Skip the explicit `meta.assets` list — see the `walk`
+                // counterpart for the rationale (derive independently to
+                // validate; a stale entry must not re-inject itself).
+                if (std.mem.eql(u8, entry.key, "meta") and entry.value == .object) {
+                    for (entry.value.object.entries) |meta_entry| {
+                        if (std.mem.eql(u8, meta_entry.key, "assets")) continue;
+                        try walkJsonc(out, index, meta_entry.value);
+                    }
+                    continue;
                 }
                 try walkJsonc(out, index, entry.value);
             }

--- a/src/asset_manifest.zig
+++ b/src/asset_manifest.zig
@@ -1,0 +1,379 @@
+//! Sprite-based asset inference — the engine half of RFC-UNIFY-SCENES-AND-PREFABS
+//! §"Assets — inference + lazy fallback over `AssetCatalog`" (labelle-engine#563).
+//!
+//! Today a scene must hand-maintain an explicit `{"meta":{"assets":[...]}}`
+//! list naming every atlas/image bundle it needs (see `SceneEntry.assets`,
+//! threaded by the assembler and gated in `scene_mixin.setScene`). That list
+//! duplicates information already present in the scene: every `Sprite` and
+//! `Image` component already *names* the visual it references. When the two
+//! drift, you get either a silent black sprite (asset missing from the list)
+//! or a wasted atlas load (stale entry). This module makes the list
+//! **derivable** from the entity tree so it no longer has to be authored by
+//! hand.
+//!
+//! Two pieces, matching the RFC's exact shape:
+//!
+//!   1. **Reverse index** (`ReverseIndex`) — maps every *sprite path* /
+//!      *image asset name* to the resource bundle that provides it
+//!      (`ResourceRef`). Built once at engine startup by parsing every entry
+//!      in `project.labelle`'s `.resources`. Atlas entries contribute one key
+//!      per sprite path (extracted from the TexturePacker JSON); standalone
+//!      image entries contribute a single self-keyed entry. Name collisions
+//!      are a load-time error (exact-match, case-sensitive) rather than a
+//!      silent shadow.
+//!
+//!   2. **Walker** (`inferAssets`) — walks a scene/prefab entity tree
+//!      (`std.json.Value`, the universal shape produced by the JSONC bridge)
+//!      and, for every string in component data, looks it up in the reverse
+//!      index. Hits union into the inferred resource set. `AssetManifest.load`
+//!      declarations (the eager escape hatch for assets inference can't see —
+//!      script-computed names, audio banks, runtime overlays) are unioned in
+//!      directly. The result is a deduped, order-stable list of resource
+//!      bundle names — exactly the shape of the current explicit
+//!      `meta.assets` list, so an inferred manifest can *supplement or
+//!      validate* an explicit one without breaking existing scenes.
+//!
+//! **Scope of this module / PR:** the reverse-index + walker *core*. It takes
+//! no gfx dependency, touches no lifecycle, and reuses the existing
+//! `AssetCatalog` for the actual acquire/decode/upload/release (Phase B).
+//! Wiring the walker's output into `setScene`'s acquire gate (replacing the
+//! Debug eager-load fallback) and building the reverse index from the real
+//! `project.labelle` `.resources` at codegen time is assembler-side follow-up
+//! — see the PR body. False-positive over-load auditing is #566.
+
+const std = @import("std");
+const jsonc = @import("jsonc");
+
+/// Where a referenced sprite/image name lives. Unified across atlas-sprites
+/// and standalone images so the walker and the lazy-on-miss path (#568)
+/// consume one index. RFC §"Reverse index".
+pub const ResourceRef = union(enum) {
+    /// The named sprite path is provided by this atlas *bundle* — acquiring
+    /// the bundle loads the whole atlas (and thus the sprite).
+    atlas: []const u8,
+    /// The name *is* a standalone image asset — acquire it directly.
+    image: []const u8,
+
+    /// The `AssetCatalog` resource key to `acquire` for this reference. For
+    /// both variants this is the bundle/asset name (the payload); the tag
+    /// only records *why* it resolves, which the renderer's lazy-on-miss
+    /// path uses to pick `findSprite` vs `findImage`.
+    pub fn resourceName(self: ResourceRef) []const u8 {
+        return switch (self) {
+            .atlas => |name| name,
+            .image => |name| name,
+        };
+    }
+};
+
+/// The `AssetManifest` component (RFC §"`AssetManifest` component"). An eager
+/// escape hatch: any prefab can carry `{"AssetManifest":{"load":[...]}}` on
+/// its root (or any entity) to pre-load resources the walker can't infer from
+/// a `Sprite`/`Image` reference — script-computed sprite names, audio banks,
+/// runtime overlays. The walker unions `load` into the prefab's required set.
+///
+/// This is the *parsed* shape. It is deserialized straight from the component
+/// JSON block; the walker also reads it directly out of the `std.json.Value`
+/// tree (see `inferAssets`) so it works before any component registry mapping.
+pub const AssetManifest = struct {
+    load: []const []const u8 = &.{},
+};
+
+/// Errors surfaced while building the reverse index. A `DuplicateResourceName`
+/// is a load-time error by design (RFC §"Collisions"): two resources claiming
+/// the same sprite/image name would otherwise shadow each other under
+/// load-order-dependent, hard-to-debug conditions.
+pub const IndexError = error{
+    /// Two resources declare the same sprite path / image name.
+    DuplicateResourceName,
+    /// The atlas JSON did not have the expected TexturePacker `frames` shape.
+    InvalidAtlasJson,
+} || std.mem.Allocator.Error || std.json.ParseError(std.json.Scanner);
+
+/// Reverse index: `sprite-path | image-name → ResourceRef`. Owns its own
+/// arena for every duped key and bundle-name payload, so callers can free the
+/// resources/JSON they built it from immediately after. RFC §"Reverse index".
+pub const ReverseIndex = struct {
+    arena: std.heap.ArenaAllocator,
+    map: std.StringHashMapUnmanaged(ResourceRef) = .empty,
+
+    pub fn init(gpa: std.mem.Allocator) ReverseIndex {
+        return .{ .arena = std.heap.ArenaAllocator.init(gpa) };
+    }
+
+    pub fn deinit(self: *ReverseIndex) void {
+        self.arena.deinit();
+        self.* = undefined;
+    }
+
+    pub fn count(self: *const ReverseIndex) usize {
+        return self.map.count();
+    }
+
+    /// Resolve a sprite path / image name to its providing resource, or null
+    /// if no registered resource declares it.
+    pub fn lookup(self: *const ReverseIndex, name: []const u8) ?ResourceRef {
+        return self.map.get(name);
+    }
+
+    /// Register a standalone image resource: the asset name is its own key
+    /// (`name → .{ .image = name }`). RFC §"Reverse index" (entry without
+    /// `.json`).
+    pub fn addImage(self: *ReverseIndex, asset_name: []const u8) IndexError!void {
+        const a = self.arena.allocator();
+        const key = try a.dupe(u8, asset_name);
+        try self.insert(key, .{ .image = key });
+    }
+
+    /// Register an atlas resource from an explicit sprite-path list. Every
+    /// path becomes a key pointing at `bundle_name`. Prefer
+    /// `addAtlasFromJson` when you have the TexturePacker JSON; this overload
+    /// exists for callers that already parsed sprite names (and for tests).
+    pub fn addAtlas(
+        self: *ReverseIndex,
+        bundle_name: []const u8,
+        sprite_paths: []const []const u8,
+    ) IndexError!void {
+        const a = self.arena.allocator();
+        const owned_bundle = try a.dupe(u8, bundle_name);
+        for (sprite_paths) |path| {
+            const key = try a.dupe(u8, path);
+            try self.insert(key, .{ .atlas = owned_bundle });
+        }
+    }
+
+    /// Register an atlas resource by parsing its TexturePacker JSON content
+    /// and extracting every sprite path. Accepts both the hash form
+    /// (`{"frames":{"path":{...}}}`) and the array form
+    /// (`{"frames":[{"filename":"path",...}]}`). RFC §"Reverse index" (entry
+    /// with `.json`).
+    pub fn addAtlasFromJson(
+        self: *ReverseIndex,
+        bundle_name: []const u8,
+        json_content: []const u8,
+    ) IndexError!void {
+        // Parse into the arena's allocator so the transient Value tree is
+        // reclaimed on deinit; the sprite-name keys we keep are re-duped by
+        // `addAtlas` anyway (they alias `parsed`'s buffers otherwise).
+        var parsed = try std.json.parseFromSlice(
+            std.json.Value,
+            self.arena.child_allocator,
+            json_content,
+            .{},
+        );
+        defer parsed.deinit();
+
+        if (parsed.value != .object) return IndexError.InvalidAtlasJson;
+        const frames = parsed.value.object.get("frames") orelse return IndexError.InvalidAtlasJson;
+
+        const owned_bundle = try self.arena.allocator().dupe(u8, bundle_name);
+        switch (frames) {
+            .object => |frames_obj| {
+                var it = frames_obj.iterator();
+                while (it.next()) |entry| {
+                    const key = try self.arena.allocator().dupe(u8, entry.key_ptr.*);
+                    try self.insert(key, .{ .atlas = owned_bundle });
+                }
+            },
+            .array => |frames_arr| {
+                for (frames_arr.items) |item| {
+                    if (item != .object) continue;
+                    const fname = item.object.get("filename") orelse continue;
+                    if (fname != .string) continue;
+                    const key = try self.arena.allocator().dupe(u8, fname.string);
+                    try self.insert(key, .{ .atlas = owned_bundle });
+                }
+            },
+            else => return IndexError.InvalidAtlasJson,
+        }
+    }
+
+    fn insert(self: *ReverseIndex, key: []const u8, ref: ResourceRef) IndexError!void {
+        const gop = try self.map.getOrPut(self.arena.allocator(), key);
+        if (gop.found_existing) return IndexError.DuplicateResourceName;
+        gop.value_ptr.* = ref;
+    }
+};
+
+/// The resource set inferred (and/or declared) for one entity tree. Order is
+/// insertion order (first-seen), which keeps output stable across runs for
+/// diffing against an explicit `meta.assets` list. Names are owned dupes.
+pub const InferredManifest = struct {
+    gpa: std.mem.Allocator,
+    names: std.ArrayListUnmanaged([]const u8) = .empty,
+    seen: std.StringHashMapUnmanaged(void) = .empty,
+
+    pub fn deinit(self: *InferredManifest) void {
+        for (self.names.items) |n| self.gpa.free(n);
+        self.names.deinit(self.gpa);
+        self.seen.deinit(self.gpa);
+        self.* = undefined;
+    }
+
+    /// The inferred resource-bundle names — the exact shape of the explicit
+    /// `meta.assets` list / `SceneEntry.assets`.
+    pub fn slice(self: *const InferredManifest) []const []const u8 {
+        return self.names.items;
+    }
+
+    /// True if `name` is in the inferred set (order-independent membership).
+    pub fn contains(self: *const InferredManifest, name: []const u8) bool {
+        return self.seen.contains(name);
+    }
+
+    fn add(self: *InferredManifest, name: []const u8) std.mem.Allocator.Error!void {
+        const gop = try self.seen.getOrPut(self.gpa, name);
+        if (gop.found_existing) return;
+        // Re-key `seen` onto the owned copy so the borrow can't dangle.
+        const owned = try self.gpa.dupe(u8, name);
+        gop.key_ptr.* = owned;
+        try self.names.append(self.gpa, owned);
+    }
+};
+
+/// Walk an entity tree and infer its required resource bundles. RFC §"Walker".
+///
+/// `scene` is any `std.json.Value` node — a whole scene, a single prefab root,
+/// or a subtree. The walk is recursive and shape-agnostic: it visits every
+/// nested object/array and, for each *string value*, looks it up in `index`.
+/// Hits contribute their `ResourceRef.resourceName()`. `AssetManifest`
+/// component blocks (`{"AssetManifest":{"load":[...]}}`) found anywhere in the
+/// tree contribute every `load` entry directly, whether or not the index
+/// knows them (that's the whole point of the escape hatch).
+///
+/// False positives (a string that happens to match a sprite name but isn't a
+/// visual reference) are *correctness*-harmless — they pre-load an unneeded
+/// bundle. The mobile over-load cost of that is #566's audit, not this
+/// function's concern.
+///
+/// Caller owns the returned `InferredManifest` (call `.deinit()`).
+pub fn inferAssets(
+    gpa: std.mem.Allocator,
+    index: *const ReverseIndex,
+    scene: std.json.Value,
+) std.mem.Allocator.Error!InferredManifest {
+    var out = InferredManifest{ .gpa = gpa };
+    errdefer out.deinit();
+    try walk(&out, index, scene);
+    return out;
+}
+
+fn walk(
+    out: *InferredManifest,
+    index: *const ReverseIndex,
+    node: std.json.Value,
+) std.mem.Allocator.Error!void {
+    switch (node) {
+        .string => |s| {
+            if (index.lookup(s)) |ref| try out.add(ref.resourceName());
+        },
+        .array => |arr| {
+            for (arr.items) |item| try walk(out, index, item);
+        },
+        .object => |obj| {
+            var it = obj.iterator();
+            while (it.next()) |entry| {
+                // Escape hatch: an `AssetManifest` component block declares
+                // resources directly (audio banks, script-loaded overlays)
+                // that no sprite/image reference would surface.
+                if (std.mem.eql(u8, entry.key_ptr.*, "AssetManifest")) {
+                    try collectManifestLoad(out, entry.value_ptr.*);
+                }
+                try walk(out, index, entry.value_ptr.*);
+            }
+        },
+        // number / bool / null carry no references.
+        else => {},
+    }
+}
+
+/// Read `{"load":[...]}` out of an `AssetManifest` value node and union every
+/// listed name into the set. Tolerant of a missing/mis-typed `load` (the
+/// generic walk still visits nested strings, so nothing is lost).
+fn collectManifestLoad(
+    out: *InferredManifest,
+    manifest: std.json.Value,
+) std.mem.Allocator.Error!void {
+    if (manifest != .object) return;
+    const load = manifest.object.get("load") orelse return;
+    if (load != .array) return;
+    for (load.array.items) |item| {
+        if (item == .string) try out.add(item.string);
+    }
+}
+
+// ── `jsonc.Value` overloads (the scene-load wiring shape) ──
+//
+// The JSONC bridge parses scenes/prefabs into `jsonc.Value` (its own
+// format-agnostic tree, distinct from `std.json.Value`), so the walker that
+// actually runs at scene-load time consumes that shape. `inferAssetsFromSource`
+// is the entry a loader calls: parse the scene source once, walk it, get the
+// inferred `meta.assets` list. Structurally identical to the `std.json.Value`
+// walk above.
+
+/// Walk a `jsonc.Value` entity tree and infer its required resource bundles.
+/// The scene-load counterpart to `inferAssets`. Caller owns the returned
+/// `InferredManifest`.
+pub fn inferAssetsJsonc(
+    gpa: std.mem.Allocator,
+    index: *const ReverseIndex,
+    scene: jsonc.Value,
+) std.mem.Allocator.Error!InferredManifest {
+    var out = InferredManifest{ .gpa = gpa };
+    errdefer out.deinit();
+    try walkJsonc(&out, index, scene);
+    return out;
+}
+
+/// Parse a JSONC scene/prefab source and infer its required resource bundles
+/// in one call — the shape a scene loader wires in. Parses into an internal
+/// arena (freed before return); the returned `InferredManifest` owns its own
+/// name copies. `error.ParseFailed` wraps any JSONC syntax error.
+pub fn inferAssetsFromSource(
+    gpa: std.mem.Allocator,
+    index: *const ReverseIndex,
+    source: []const u8,
+) !InferredManifest {
+    var arena = std.heap.ArenaAllocator.init(gpa);
+    defer arena.deinit();
+    var parser = jsonc.JsoncParser.init(arena.allocator(), source);
+    const root = parser.parse() catch return error.ParseFailed;
+    return inferAssetsJsonc(gpa, index, root);
+}
+
+fn walkJsonc(
+    out: *InferredManifest,
+    index: *const ReverseIndex,
+    node: jsonc.Value,
+) std.mem.Allocator.Error!void {
+    switch (node) {
+        .string => |s| {
+            if (index.lookup(s)) |ref| try out.add(ref.resourceName());
+        },
+        .array => |arr| {
+            for (arr.items) |item| try walkJsonc(out, index, item);
+        },
+        .object => |obj| {
+            for (obj.entries) |entry| {
+                if (std.mem.eql(u8, entry.key, "AssetManifest")) {
+                    try collectManifestLoadJsonc(out, entry.value);
+                }
+                try walkJsonc(out, index, entry.value);
+            }
+        },
+        // number / bool / null / enum_literal carry no sprite references.
+        else => {},
+    }
+}
+
+fn collectManifestLoadJsonc(
+    out: *InferredManifest,
+    manifest: jsonc.Value,
+) std.mem.Allocator.Error!void {
+    if (manifest != .object) return;
+    const load = manifest.object.get("load") orelse return;
+    if (load != .array) return;
+    for (load.array.items) |item| {
+        if (item == .string) try out.add(item.string);
+    }
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -98,6 +98,21 @@ pub const Image = @import("image_component.zig").Image;
 /// mirror of gfx's `Pivot`). See `src/image_component.zig`.
 pub const ImagePivot = @import("image_component.zig").Pivot;
 
+// ── Asset inference (sprite-based reverse index + AssetManifest, #563) ──
+/// Sprite/image → resource-bundle reverse index + entity-tree walker that
+/// infers which atlas/image resources a scene needs (making the explicit
+/// `meta.assets` list derivable) plus the `AssetManifest` escape-hatch
+/// component. RFC-UNIFY-SCENES-AND-PREFABS §"Assets — inference". Engine half
+/// of #563; see `src/asset_manifest.zig`.
+pub const asset_manifest_mod = @import("asset_manifest.zig");
+pub const ResourceRef = asset_manifest_mod.ResourceRef;
+pub const AssetManifest = asset_manifest_mod.AssetManifest;
+pub const ReverseIndex = asset_manifest_mod.ReverseIndex;
+pub const InferredManifest = asset_manifest_mod.InferredManifest;
+pub const inferAssets = asset_manifest_mod.inferAssets;
+pub const inferAssetsJsonc = asset_manifest_mod.inferAssetsJsonc;
+pub const inferAssetsFromSource = asset_manifest_mod.inferAssetsFromSource;
+
 // ── Input ──
 pub const InputInterface = input_mod.InputInterface;
 pub const StubInput = input_mod.StubInput;

--- a/test/asset_manifest_test.zig
+++ b/test/asset_manifest_test.zig
@@ -183,6 +183,27 @@ test "walker: explicit meta.assets and inferred set agree" {
     }
 }
 
+test "reverse index: malformed atlas HASH-form entry is rejected" {
+    var idx = ReverseIndex.init(testing.allocator);
+    defer idx.deinit();
+
+    // Hash-form frame value missing the required `frame` rect.
+    const no_frame =
+        \\{ "frames": { "room/floor.png": { "rotated": false } } }
+    ;
+    try testing.expectError(error.InvalidAtlasJson, idx.addAtlasFromJson("a", no_frame));
+
+    // Hash-form frame value is a scalar, not an object.
+    const scalar_value =
+        \\{ "frames": { "room/floor.png": 42 } }
+    ;
+    try testing.expectError(error.InvalidAtlasJson, idx.addAtlasFromJson("b", scalar_value));
+
+    // A well-formed hash atlas still parses (guards against over-strictness).
+    try idx.addAtlasFromJson("rooms", rooms_atlas_json);
+    try testing.expect(idx.lookup("room/floor.png") != null);
+}
+
 test "reverse index: malformed atlas array entry is rejected" {
     var idx = ReverseIndex.init(testing.allocator);
     defer idx.deinit();
@@ -245,6 +266,82 @@ test "walker: explicit meta.assets is NOT re-inferred as sprite refs" {
     try testing.expectEqual(@as(usize, 1), inferred.slice().len);
     try testing.expect(inferred.contains("rooms"));
     try testing.expect(!inferred.contains("logo_splash"));
+}
+
+test "walker: legacy top-level assets list is NOT re-inferred" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var idx = ReverseIndex.init(testing.allocator);
+    defer idx.deinit();
+    try idx.addAtlasFromJson("rooms", rooms_atlas_json);
+    try idx.addImage("logo_splash");
+
+    // Pre-unification scenes carried the hand-authored list at the TOP level
+    // (before it moved under `meta`). A stale "logo_splash" there must not
+    // leak into the derived set; only the real Sprite → rooms is inferred.
+    const scene_src =
+        \\{
+        \\  "assets": ["rooms", "logo_splash"],
+        \\  "root": {
+        \\    "children": [
+        \\      { "components": { "Sprite": { "sprite_name": "room/wall.png" } } }
+        \\    ]
+        \\  }
+        \\}
+    ;
+    const scene = try stdValue(scene_src, arena);
+
+    var inferred = try engine.inferAssets(testing.allocator, &idx, scene);
+    defer inferred.deinit();
+
+    try testing.expectEqual(@as(usize, 1), inferred.slice().len);
+    try testing.expect(inferred.contains("rooms"));
+    try testing.expect(!inferred.contains("logo_splash"));
+}
+
+test "inferAssetsFromSource: OutOfMemory propagates distinctly (not ParseFailed)" {
+    var idx = ReverseIndex.init(testing.allocator);
+    defer idx.deinit();
+    try idx.addAtlasFromJson("rooms", rooms_atlas_json);
+
+    const scene_src =
+        \\{ "root": { "components": { "Sprite": { "sprite_name": "room/floor.png" } } } }
+    ;
+
+    // Fail the very first allocation the JSONC parser makes: the parse must
+    // surface OutOfMemory *as* OutOfMemory, not collapse it into ParseFailed
+    // (a transient alloc failure is not a malformed scene).
+    var failing = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 0 });
+    try testing.expectError(
+        error.OutOfMemory,
+        engine.inferAssetsFromSource(failing.allocator(), &idx, scene_src),
+    );
+}
+
+test "walker: AssetManifest.load skips empty-string entries" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var idx = ReverseIndex.init(testing.allocator);
+    defer idx.deinit();
+
+    const scene_src =
+        \\{ "root": { "components": {
+        \\  "AssetManifest": { "load": ["intro_audio", "", "cinematic_overlay"] }
+        \\} } }
+    ;
+    const scene = try stdValue(scene_src, arena);
+
+    var inferred = try engine.inferAssets(testing.allocator, &idx, scene);
+    defer inferred.deinit();
+
+    // The empty "" name is dropped; the two real ones remain.
+    try testing.expectEqual(@as(usize, 2), inferred.slice().len);
+    try testing.expect(inferred.contains("intro_audio"));
+    try testing.expect(inferred.contains("cinematic_overlay"));
 }
 
 test "walker: AssetManifest.load unions in assets inference can't see" {

--- a/test/asset_manifest_test.zig
+++ b/test/asset_manifest_test.zig
@@ -1,0 +1,273 @@
+//! Sprite-based asset inference — reverse index + walker (labelle-engine#563).
+//!
+//! Proves the engine half of RFC-UNIFY-SCENES-AND-PREFABS §"Assets —
+//! inference": a scene that names sprites/images via `Sprite`/`Image`
+//! components no longer needs a hand-authored `meta.assets` list — the walker
+//! derives the same set from the entity tree. Coverage:
+//!
+//!   1. `ReverseIndex` from a TexturePacker atlas JSON (hash + array forms)
+//!      and from standalone images, with correct `ResourceRef` tags.
+//!   2. Name collisions are a load-time error.
+//!   3. A scene with `Sprite` refs but NO explicit assets list infers the
+//!      correct resource-bundle set.
+//!   4. Explicit `meta.assets` and inferred set agree (the derivability
+//!      guarantee — inferred supplements/validates, doesn't diverge).
+//!   5. The `AssetManifest` escape hatch unions in assets the walker can't
+//!      see from a sprite reference (audio banks, script overlays).
+//!   6. `inferAssetsFromSource` — the JSONC scene-load wiring entry.
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+
+const ReverseIndex = engine.ReverseIndex;
+const ResourceRef = engine.ResourceRef;
+
+// A minimal TexturePacker atlas JSON in the "frames-hash" shape.
+const rooms_atlas_json =
+    \\{
+    \\  "frames": {
+    \\    "room/floor.png":   { "frame": { "x": 0,  "y": 0,  "w": 64, "h": 64 } },
+    \\    "room/wall.png":    { "frame": { "x": 64, "y": 0,  "w": 64, "h": 64 } },
+    \\    "room/door.png":    { "frame": { "x": 0,  "y": 64, "w": 64, "h": 64 } }
+    \\  },
+    \\  "meta": { "size": { "w": 128, "h": 128 } }
+    \\}
+;
+
+// The "frames-array" shape (filename per entry).
+const chars_atlas_json =
+    \\{
+    \\  "frames": [
+    \\    { "filename": "worker/idle.png", "frame": { "x": 0, "y": 0, "w": 32, "h": 32 } },
+    \\    { "filename": "worker/walk.png", "frame": { "x": 32, "y": 0, "w": 32, "h": 32 } }
+    \\  ]
+    \\}
+;
+
+fn stdValue(src: []const u8, arena: std.mem.Allocator) !std.json.Value {
+    const parsed = try std.json.parseFromSlice(std.json.Value, arena, src, .{});
+    return parsed.value; // arena-backed; lives as long as `arena`
+}
+
+test "reverse index: atlas (hash form) maps every sprite path to its bundle" {
+    var idx = ReverseIndex.init(testing.allocator);
+    defer idx.deinit();
+
+    try idx.addAtlasFromJson("rooms", rooms_atlas_json);
+
+    try testing.expectEqual(@as(usize, 3), idx.count());
+    const ref = idx.lookup("room/floor.png") orelse return error.MissingSprite;
+    try testing.expectEqualStrings("rooms", ref.atlas);
+    try testing.expectEqualStrings("rooms", ref.resourceName());
+    try testing.expect(idx.lookup("room/does_not_exist.png") == null);
+}
+
+test "reverse index: atlas (array form) + standalone image" {
+    var idx = ReverseIndex.init(testing.allocator);
+    defer idx.deinit();
+
+    try idx.addAtlasFromJson("characters", chars_atlas_json);
+    try idx.addImage("logo_splash");
+
+    const walk = idx.lookup("worker/walk.png") orelse return error.MissingSprite;
+    try testing.expectEqualStrings("characters", walk.atlas);
+
+    const logo = idx.lookup("logo_splash") orelse return error.MissingImage;
+    try testing.expectEqualStrings("logo_splash", logo.image);
+    try testing.expectEqualStrings("logo_splash", logo.resourceName());
+}
+
+test "reverse index: duplicate sprite path across resources is a load-time error" {
+    var idx = ReverseIndex.init(testing.allocator);
+    defer idx.deinit();
+
+    try idx.addAtlas("atlas_a", &.{ "shared/tile.png", "a/only.png" });
+    try testing.expectError(
+        error.DuplicateResourceName,
+        idx.addAtlas("atlas_b", &.{"shared/tile.png"}),
+    );
+    // Image colliding with a sprite path is equally rejected.
+    try testing.expectError(
+        error.DuplicateResourceName,
+        idx.addImage("a/only.png"),
+    );
+}
+
+test "walker: scene with Sprite refs but NO explicit assets list infers the set" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var idx = ReverseIndex.init(testing.allocator);
+    defer idx.deinit();
+    try idx.addAtlasFromJson("rooms", rooms_atlas_json);
+    try idx.addAtlasFromJson("characters", chars_atlas_json);
+    try idx.addImage("logo_splash");
+
+    // A scene tree with Sprite/Image references but no `meta.assets`.
+    // Includes a ref nested inside an entity-bearing component field
+    // (`Room.workstations[].Sprite`) — the C1 pattern the walker must reach.
+    const scene_src =
+        \\{
+        \\  "root": {
+        \\    "components": {
+        \\      "Image": { "name": "logo_splash", "pivot": "center", "layer": "ui" }
+        \\    },
+        \\    "children": [
+        \\      {
+        \\        "components": {
+        \\          "Sprite": { "sprite_name": "room/floor.png", "pivot": "center" },
+        \\          "Room": {
+        \\            "workstations": [
+        \\              { "components": { "Sprite": { "sprite_name": "worker/idle.png" } } }
+        \\            ]
+        \\          }
+        \\        }
+        \\      }
+        \\    ]
+        \\  }
+        \\}
+    ;
+    const scene = try stdValue(scene_src, arena);
+
+    var inferred = try engine.inferAssets(testing.allocator, &idx, scene);
+    defer inferred.deinit();
+
+    // rooms (floor.png), characters (worker/idle.png), logo_splash (Image).
+    try testing.expectEqual(@as(usize, 3), inferred.slice().len);
+    try testing.expect(inferred.contains("rooms"));
+    try testing.expect(inferred.contains("characters"));
+    try testing.expect(inferred.contains("logo_splash"));
+}
+
+test "walker: explicit meta.assets and inferred set agree" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var idx = ReverseIndex.init(testing.allocator);
+    defer idx.deinit();
+    try idx.addAtlasFromJson("rooms", rooms_atlas_json);
+    try idx.addAtlasFromJson("characters", chars_atlas_json);
+
+    const scene_src =
+        \\{
+        \\  "meta": { "assets": ["rooms", "characters"] },
+        \\  "root": {
+        \\    "children": [
+        \\      { "components": { "Sprite": { "sprite_name": "room/wall.png" } } },
+        \\      { "components": { "Sprite": { "sprite_name": "worker/walk.png" } } }
+        \\    ]
+        \\  }
+        \\}
+    ;
+    const scene = try stdValue(scene_src, arena);
+
+    var inferred = try engine.inferAssets(testing.allocator, &idx, scene);
+    defer inferred.deinit();
+
+    // Read the explicit list back out and prove membership matches exactly.
+    const explicit = scene.object.get("meta").?.object.get("assets").?.array;
+    try testing.expectEqual(explicit.items.len, inferred.slice().len);
+    for (explicit.items) |item| {
+        try testing.expect(inferred.contains(item.string));
+    }
+    // ...and every inferred name appears in the explicit list (no drift either way).
+    for (inferred.slice()) |name| {
+        var found = false;
+        for (explicit.items) |item| {
+            if (std.mem.eql(u8, item.string, name)) found = true;
+        }
+        try testing.expect(found);
+    }
+}
+
+test "walker: AssetManifest.load unions in assets inference can't see" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var idx = ReverseIndex.init(testing.allocator);
+    defer idx.deinit();
+    try idx.addAtlasFromJson("rooms", rooms_atlas_json);
+
+    // The intro audio bank has no sprite/image reference — only the manifest
+    // surfaces it. `cinematic_overlay` likewise (a script-loaded resource).
+    const scene_src =
+        \\{
+        \\  "root": {
+        \\    "components": {
+        \\      "AssetManifest": { "load": ["intro_audio", "cinematic_overlay"] },
+        \\      "Sprite": { "sprite_name": "room/door.png" }
+        \\    }
+        \\  }
+        \\}
+    ;
+    const scene = try stdValue(scene_src, arena);
+
+    var inferred = try engine.inferAssets(testing.allocator, &idx, scene);
+    defer inferred.deinit();
+
+    try testing.expectEqual(@as(usize, 3), inferred.slice().len);
+    try testing.expect(inferred.contains("rooms")); // from the Sprite
+    try testing.expect(inferred.contains("intro_audio")); // manifest-only
+    try testing.expect(inferred.contains("cinematic_overlay")); // manifest-only
+}
+
+test "walker: dedupes repeated references to the same bundle" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var idx = ReverseIndex.init(testing.allocator);
+    defer idx.deinit();
+    try idx.addAtlasFromJson("rooms", rooms_atlas_json);
+
+    // Three different sprites, all from the "rooms" bundle → one entry.
+    const scene_src =
+        \\{
+        \\  "children": [
+        \\    { "Sprite": { "sprite_name": "room/floor.png" } },
+        \\    { "Sprite": { "sprite_name": "room/wall.png" } },
+        \\    { "Sprite": { "sprite_name": "room/door.png" } }
+        \\  ]
+        \\}
+    ;
+    const scene = try stdValue(scene_src, arena);
+
+    var inferred = try engine.inferAssets(testing.allocator, &idx, scene);
+    defer inferred.deinit();
+
+    try testing.expectEqual(@as(usize, 1), inferred.slice().len);
+    try testing.expectEqualStrings("rooms", inferred.slice()[0]);
+}
+
+test "inferAssetsFromSource: JSONC scene source (comments + trailing commas)" {
+    var idx = ReverseIndex.init(testing.allocator);
+    defer idx.deinit();
+    try idx.addAtlasFromJson("rooms", rooms_atlas_json);
+    try idx.addImage("logo_splash");
+
+    // JSONC-specific syntax the raw std.json parser would reject.
+    const scene_src =
+        \\{
+        \\  // a scene authored as JSONC
+        \\  "root": {
+        \\    "components": {
+        \\      "Image": { "name": "logo_splash", "pivot": "center" }, // trailing comma
+        \\    },
+        \\    "children": [
+        \\      { "components": { "Sprite": { "sprite_name": "room/floor.png" } } },
+        \\    ],
+        \\  },
+        \\}
+    ;
+
+    var inferred = try engine.inferAssetsFromSource(testing.allocator, &idx, scene_src);
+    defer inferred.deinit();
+
+    try testing.expectEqual(@as(usize, 2), inferred.slice().len);
+    try testing.expect(inferred.contains("rooms"));
+    try testing.expect(inferred.contains("logo_splash"));
+}

--- a/test/asset_manifest_test.zig
+++ b/test/asset_manifest_test.zig
@@ -183,6 +183,70 @@ test "walker: explicit meta.assets and inferred set agree" {
     }
 }
 
+test "reverse index: malformed atlas array entry is rejected" {
+    var idx = ReverseIndex.init(testing.allocator);
+    defer idx.deinit();
+
+    // Entry missing the required `frame` rect.
+    const no_frame =
+        \\{ "frames": [ { "filename": "worker/idle.png" } ] }
+    ;
+    try testing.expectError(error.InvalidAtlasJson, idx.addAtlasFromJson("a", no_frame));
+
+    // Entry missing `filename`.
+    const no_filename =
+        \\{ "frames": [ { "frame": { "x": 0, "y": 0, "w": 8, "h": 8 } } ] }
+    ;
+    try testing.expectError(error.InvalidAtlasJson, idx.addAtlasFromJson("b", no_filename));
+
+    // Non-object entry.
+    const scalar_entry =
+        \\{ "frames": [ "worker/idle.png" ] }
+    ;
+    try testing.expectError(error.InvalidAtlasJson, idx.addAtlasFromJson("c", scalar_entry));
+
+    // A well-formed array entry still parses (guards against over-strictness).
+    try idx.addAtlasFromJson("characters", chars_atlas_json);
+    try testing.expect(idx.lookup("worker/idle.png") != null);
+}
+
+test "walker: explicit meta.assets is NOT re-inferred as sprite refs" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var idx = ReverseIndex.init(testing.allocator);
+    defer idx.deinit();
+    try idx.addAtlasFromJson("rooms", rooms_atlas_json);
+    // `logo_splash` is a valid index key (a standalone image), so if the
+    // walker recursed into `meta.assets` it would wrongly pick it up.
+    try idx.addImage("logo_splash");
+
+    // `meta.assets` lists BOTH "rooms" and a STALE "logo_splash" — but no
+    // entity actually references logo_splash. Only a Sprite → rooms is used.
+    const scene_src =
+        \\{
+        \\  "meta": { "assets": ["rooms", "logo_splash"] },
+        \\  "root": {
+        \\    "children": [
+        \\      { "components": { "Sprite": { "sprite_name": "room/floor.png" } } }
+        \\    ]
+        \\  }
+        \\}
+    ;
+    const scene = try stdValue(scene_src, arena);
+
+    var inferred = try engine.inferAssets(testing.allocator, &idx, scene);
+    defer inferred.deinit();
+
+    // Only "rooms" is inferred (from the real Sprite ref). The stale
+    // "logo_splash" in the explicit list must NOT leak into the derived set —
+    // otherwise inference could never contradict/validate a stale list.
+    try testing.expectEqual(@as(usize, 1), inferred.slice().len);
+    try testing.expect(inferred.contains("rooms"));
+    try testing.expect(!inferred.contains("logo_splash"));
+}
+
 test "walker: AssetManifest.load unions in assets inference can't see" {
     var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena_state.deinit();


### PR DESCRIPTION
## What

The **engine half** of RFC-UNIFY-SCENES-AND-PREFABS §"Assets — inference + lazy fallback over `AssetCatalog`" (#563): make a scene's asset set **derivable** from its entity tree instead of hand-maintaining `{"meta":{"assets":[...]}}`.

Today `SceneEntry.assets` (threaded by the assembler, gated in `scene_mixin.setScene`) duplicates information already in the scene — every `Sprite`/`Image` names its visual. Drift causes silent black sprites or wasted atlas loads. This PR adds the reverse-index + walker so the list no longer has to be authored by hand.

## API (`src/asset_manifest.zig`, re-exported via `engine.*`)

- **`ResourceRef`** — `union(enum){ atlas: []const u8, image: []const u8 }`, the unified reverse-index value (shared with #568's Image lazy-on-miss path). `.resourceName()` → the `AssetCatalog` key to acquire.
- **`AssetManifest`** — `struct{ load: []const []const u8 }`, the eager escape hatch component for assets inference can't see (audio banks, script-computed names, runtime overlays).
- **`ReverseIndex`** — `sprite-path | image-name → ResourceRef`, arena-owned.
  - `addAtlasFromJson(bundle, json)` — parses TexturePacker JSON (hash **and** array forms), one key per sprite path.
  - `addImage(name)` — standalone image, self-keyed.
  - `addAtlas(bundle, paths)` — pre-parsed convenience.
  - Name **collisions are a load-time error** (`error.DuplicateResourceName`, exact-match, case-sensitive) per the RFC — no silent shadowing.
  - `lookup(name) → ?ResourceRef`.
- **`inferAssets(gpa, *ReverseIndex, std.json.Value) → InferredManifest`** — walks every string in component data, unions hits + `AssetManifest.load`. Reaches refs nested in entity-bearing fields (`Room.workstations[].Sprite`). Output is a deduped, **order-stable** `[]const []const u8` — the exact shape of `meta.assets`.
- **`inferAssetsJsonc` / `inferAssetsFromSource`** — same walk over `jsonc.Value` (the tree the JSONC bridge actually produces at scene load) and straight from a scene source string. This is the scene-load wiring shape.

## Additive / non-breaking

Explicit `meta.assets` still works untouched; the inferred set **supplements/validates** it. No lifecycle, no gfx dependency, reuses the existing `AssetCatalog` for the real acquire/decode/upload/release.

## Tests (8, `zig build test` green on Zig 0.16)

reverse index (both atlas forms + image) · collision error · **scene with `Sprite` refs but no explicit list infers the correct set** · **explicit `meta.assets` ⇔ inferred agree (both directions)** · `AssetManifest.load` union · bundle dedupe · JSONC source path (comments + trailing commas).

## Why "part of #563" — assembler-side follow-up remaining

This lands the engine reverse-index + `AssetManifest` core. To **fully close #563** (removing the hand-authored list) the assembler must:

1. **Build the reverse index from `project.labelle`'s `.resources`** at codegen/startup (this PR builds it from atlas-JSON/image inputs; wiring the real resource descriptors is assembler-side).
2. **Make `meta.assets` optional in codegen** — emit the inferred manifest (or call `inferAssetsFromSource` at load) instead of requiring the authored list, and route its output into `setScene`'s acquire gate (replacing the Debug eager-load fallback).
3. Phase-B acquire/release **lifecycle** at top-level spawn/destroy and lazy-on-miss pop-in wiring (RFC §"acquire/spawn/release", §"lazy on-miss").

False-positive mobile over-load auditing is tracked separately as **#566**.

part of #563

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw