### PR TITLE
feat(editor): _editor_plugin_command bridge export (Asset Plugins P3, #729)

### DIFF
--- a/src/editor_api.zig
+++ b/src/editor_api.zig
@@ -79,6 +79,7 @@ const VTable = struct {
     reload_prefab: *const fn (name: []const u8, src: []const u8) i32,
     set_entity_position: *const fn (id: u64, x: f32, y: f32) void,
     set_component: *const fn (id: u64, name: []const u8, json: []const u8) i32,
+    plugin_command: *const fn (plugin: []const u8, command: []const u8, params_json: []const u8) i32,
     scene_digest: *const fn (out: []u8) usize,
     apply_camera: *const fn (x: f32, y: f32, zoom: f32) void,
 };
@@ -336,6 +337,39 @@ pub export fn editor_set_component(
     return vt.set_component(id, name_ptr[0..name_len], json_ptr[0..json_len]);
 }
 
+/// Dispatch a studio-issued play-time PLUGIN command into the running
+/// preview — the play-time action channel for labelle-studio's declarative
+/// plugin panels (editor-bridge contract **v1.7**, Asset Plugins Phase 3,
+/// #729 / assembler #577). The studio calls this (as `_editor_plugin_command`
+/// on the wasm side, the emcc C-ABI underscore) when a panel action whose
+/// `"target"` is `"preview"` is clicked, carrying the panel's dispatch payload
+/// `{plugin_panel, command, params}`: `plugin` is the panel id, `command` the
+/// action's command, and `params_json` the field values as a JSON object.
+///
+/// Routed to the plugin's declared handler — a subscriber to the
+/// `engine__editor_plugin_command` engine event (comptime hook registration;
+/// see `game/editor_command_mixin.zig`). Dispatch is SYNCHRONOUS, so the three
+/// studio-owned buffers may be freed right after the call.
+///
+/// Returns 0 = dispatched; -1 = not bound / empty name / no plugin subscribed
+/// (the graceful-degrade path a v1.1–v1.6 studio also hits by finding no
+/// export at all — it then disables preview-target actions).
+pub export fn editor_plugin_command(
+    plugin_ptr: [*]const u8,
+    plugin_len: usize,
+    command_ptr: [*]const u8,
+    command_len: usize,
+    params_ptr: [*]const u8,
+    params_len: usize,
+) i32 {
+    const vt = vtable orelse return -1;
+    return vt.plugin_command(
+        plugin_ptr[0..plugin_len],
+        command_ptr[0..command_len],
+        params_ptr[0..params_len],
+    );
+}
+
 /// v1: always -1 — the studio picks client-side from the scene digest.
 pub export fn editor_pick(x: f32, y: f32) i64 {
     _ = x;
@@ -434,6 +468,7 @@ fn Holder(comptime GP: type, comptime RP: type) type {
             .reload_prefab = &reloadPrefabImpl,
             .set_entity_position = &setEntityPositionImpl,
             .set_component = &setComponentImpl,
+            .plugin_command = &pluginCommandImpl,
             .scene_digest = &sceneDigestImpl,
             .apply_camera = &applyCameraImpl,
         };
@@ -578,6 +613,16 @@ fn Holder(comptime GP: type, comptime RP: type) type {
             // parse/validation failure (-2) leaves the entity untouched.
             game.applyCameraComponentJson(ent, json) catch return -2;
             return 0;
+        }
+
+        fn pluginCommandImpl(plugin: []const u8, command: []const u8, params_json: []const u8) i32 {
+            // Every assembler-built Game carries `editorPluginCommand` (the
+            // engine mixin), but a minimal duck-typed test/tooling stand-in
+            // may not — gate so binding one still compiles, degrading to the
+            // graceful -1. The routing/handler-channel decision lives in
+            // `game/editor_command_mixin.zig`.
+            if (comptime !@hasDecl(G, "editorPluginCommand")) return -1;
+            return game.editorPluginCommand(plugin, command, params_json);
         }
 
         fn applyCameraImpl(x: f32, y: f32, zoom: f32) void {

--- a/src/game.zig
+++ b/src/game.zig
@@ -51,6 +51,7 @@ const entity_mixin = @import("game/entity_mixin.zig");
 const scene_runtime_mixin = @import("game/scene_runtime_mixin.zig");
 const input_events_mixin = @import("game/input_events_mixin.zig");
 const events_mixin = @import("game/events_mixin.zig");
+const editor_command_mixin = @import("game/editor_command_mixin.zig");
 const loop_mixin = @import("game/loop_mixin.zig");
 const misc_mixin = @import("game/misc_mixin.zig");
 const animation_runtime_mixin = @import("game/animation_runtime_mixin.zig");
@@ -380,6 +381,7 @@ pub fn GameConfigWithYAxis(
         const SceneRuntimeMixin = scene_runtime_mixin.Mixin(Self);
         const InputEventsMixin = input_events_mixin.Mixin(Self);
         const EventsMixin = events_mixin.Mixin(Self);
+        const EditorCommandMixin = editor_command_mixin.Mixin(Self);
         const LoopMixin = loop_mixin.Mixin(Self);
         const MiscMixin = misc_mixin.Mixin(Self);
         const AnimationRuntimeMixin = animation_runtime_mixin.Mixin(Self);
@@ -921,6 +923,11 @@ pub fn GameConfigWithYAxis(
 
         /// Deliver buffered game events to hooks. Called at end of frame.
         pub const dispatchEvents = EventsMixin.dispatchEvents;
+
+        /// Route a studio-issued play-time plugin editor command (the
+        /// `editor_plugin_command` bridge export, editor-contract v1.7) to its
+        /// declared handler. See `game/editor_command_mixin.zig`.
+        pub const editorPluginCommand = EditorCommandMixin.editorPluginCommand;
 
         // ── Debug entity guards (#419, #420) ─────────────────────
 

--- a/src/game/editor_command_mixin.zig
+++ b/src/game/editor_command_mixin.zig
@@ -1,0 +1,89 @@
+//! Editor-command mixin — the play-time action channel for labelle-studio's
+//! plugin panels (Asset Plugins Phase 3, RFC-ASSET-PLUGINS rev 4,
+//! labelle-engine#729 / labelle-assembler#577).
+//!
+//! A plugin ships a declarative `studio/*.panel.jsonc` describing a small
+//! form; the studio renders it with its own kit and, on an action whose
+//! `"target"` is `"preview"`, dispatches the command into the running wasm
+//! preview through the `editor_plugin_command` bridge export (editor-contract
+//! **v1.7**). This mixin is where that command lands on the engine side: it
+//! routes `{plugin, command, params}` to the plugin's declared handler.
+//!
+//! ## Handler declaration (the RFC's open question, resolved)
+//!
+//! rev 4 left "comptime hook registration vs a manifest list" open. This
+//! picks **comptime hook registration via the existing engine-event channel**:
+//! a plugin declares its editor handler by subscribing to the
+//! `engine__editor_plugin_command` event (`engine.Events.editor_plugin_command`,
+//! surfaced in `root.zig`), exactly like input plugins subscribe to
+//! `engine__key_pressed` (#606). Consuming the event flips the variant onto
+//! the project's merged `GameEvents`, which is the zero-cost gate here: when
+//! NO plugin subscribes the variant is absent, this whole path folds to a
+//! `-1`, and an older/handler-less build "degrades gracefully" (the studio
+//! disables preview-target actions on the missing export or the -1 result).
+//!
+//! ## Why synchronous
+//!
+//! Dispatch is SYNCHRONOUS (`emitSync`, not the buffered `emit`): the handler
+//! runs before `editorPluginCommand` returns, so the studio's wasm-owned
+//! `command`/`params` buffers — freed right after the bridge call — stay valid
+//! for the handler with no copy, and the bridge can hand the studio a real
+//! result code. The trade-off (re-entrancy / buffered-event ordering) is
+//! irrelevant for this leaf, host-initiated action channel.
+
+const std = @import("std");
+
+/// Returns the editor-command mixin for a given Game type.
+pub fn Mixin(comptime Game: type) type {
+    const GameEvents = Game.GameEvents;
+    const has_events = Game.has_events_export;
+
+    // The project carries a plugin-editor-command handler channel iff a
+    // plugin/flow subscribed to `engine__editor_plugin_command` (which folds
+    // the variant onto the merged `GameEvents`). Absent → `editorPluginCommand`
+    // returns -1 and never references the union variant, so an event-less game
+    // (`GameEvents = void`) compiles fine and the path folds away entirely —
+    // mirrors the input-events scan's `@hasField` gate.
+    const has_channel = has_events and blk: {
+        const info = @typeInfo(GameEvents);
+        if (info != .@"union") break :blk false;
+        break :blk @hasField(GameEvents, "engine__editor_plugin_command");
+    };
+
+    return struct {
+        /// Route a studio-issued play-time plugin command to its declared
+        /// handler (the `editor_plugin_command` bridge export's engine end).
+        ///
+        /// `plugin` is the panel id (the dispatch payload's `plugin_panel`),
+        /// `command` the action's `command`, and `params_json` the field
+        /// values as a JSON object. All three borrow the caller's buffers for
+        /// the duration of the call only.
+        ///
+        /// Returns 0 when the command was dispatched to a subscriber, or -1
+        /// when unroutable: an empty `plugin`/`command` (most likely a
+        /// host-side length bug, mirrors `setStateImpl`), or no plugin
+        /// subscribed to `engine__editor_plugin_command` (the graceful-degrade
+        /// path). The handler's own success/failure is out of band — a
+        /// play-time action is fire-and-forward, like an input event.
+        pub fn editorPluginCommand(
+            self: *Game,
+            plugin: []const u8,
+            command: []const u8,
+            params_json: []const u8,
+        ) i32 {
+            if (plugin.len == 0 or command.len == 0) return -1;
+            if (comptime !has_channel) return -1;
+            // Synchronous dispatch so studio-owned buffers stay valid and the
+            // handler runs before we return. The payload type is the merged
+            // union's declared shape (`engine.Events.editor_plugin_command`);
+            // its `[]const u8` fields borrow the caller's slices for the call.
+            const Payload = @FieldType(GameEvents, "engine__editor_plugin_command");
+            self.emitSync(@unionInit(GameEvents, "engine__editor_plugin_command", Payload{
+                .plugin = plugin,
+                .command = command,
+                .params = params_json,
+            }));
+            return 0;
+        }
+    };
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -526,6 +526,32 @@ pub const Events = struct {
     /// re-enqueued its GPU-resident assets, and the first frame has been
     /// pumped back to `.ready`.
     pub const surface_restored = struct {};
+
+    // ── Studio plugin panels: play-time action channel (Asset Plugins ──
+    //    Phase 3, RFC-ASSET-PLUGINS rev 4, #729 / assembler #577) ────────
+    //
+    // Fired by the `editor_plugin_command` bridge export (editor-contract
+    // **v1.7**) when the studio dispatches a panel action whose
+    // `"target"` is `"preview"`. A plugin declares its editor handler by
+    // subscribing to this event — comptime hook registration, the same
+    // channel input plugins use for `engine__key_pressed` (#606). Like the
+    // input/anim events, it has NO `HookPayload` mirror: the bridge emits
+    // it directly (synchronously — see `game/editor_command_mixin.zig`),
+    // not the in-process lifecycle path. Zero-cost when no plugin
+    // subscribes: the variant never lands on the merged `GameEvents`, the
+    // bridge folds to a -1, and an older/handler-less build degrades
+    // gracefully.
+
+    /// Fired for one studio play-time plugin command. `plugin` is the panel
+    /// id (the dispatch payload's `plugin_panel`), `command` the action's
+    /// `command`, and `params` the field values as a JSON object. All three
+    /// are borrowed from the studio's wasm buffers for the SYNCHRONOUS
+    /// dispatch only — a handler that retains them must copy.
+    pub const editor_plugin_command = struct {
+        plugin: []const u8,
+        command: []const u8,
+        params: []const u8,
+    };
 };
 
 // ── Hook Types ──

--- a/test/editor_api_test.zig
+++ b/test/editor_api_test.zig
@@ -84,6 +84,9 @@ test "pre-bind: every export is a safe no-op" {
     // Generic per-component edit (v1.5) reports "not bound" pre-bind.
     try testing.expectEqual(@as(i32, -1), editor_api.editor_set_component(42, "Camera", 6, "{\"zoom\":1}", 10));
 
+    // Play-time plugin command (v1.7) reports "not bound" pre-bind.
+    try testing.expectEqual(@as(i32, -1), editor_api.editor_plugin_command("dungeon", 7, "generate", 8, "{}", 2));
+
     // Pick is the documented v1 stub.
     try testing.expectEqual(@as(i64, -1), editor_api.editor_pick(10.0, 20.0));
 
@@ -2024,4 +2027,156 @@ test "camera seed: an OLD non-tagged manager falls back to the single-camera see
     // getCameraByTag is a comptime no-op (null) on a non-tagged manager.
     try testing.expect(game.getCameraByTag("old_ignored") == null);
     try testing.expect(game.getCameraByTag("main") == null);
+}
+
+// ── editor_plugin_command: play-time plugin command channel (v1.7, #729) ──
+//
+// The studio dispatches a panel action whose `"target"` is `"preview"`
+// through `editor_plugin_command`; the engine routes it to the plugin's
+// declared handler — a subscriber to the `engine__editor_plugin_command`
+// engine event. These tests wire a recorder hook + a GameEvents union that
+// carries the channel and assert the export ROUTES, plus the graceful-degrade
+// path when no plugin subscribes.
+
+const PluginCmdEvents = union(enum) {
+    engine__editor_plugin_command: engine.Events.editor_plugin_command,
+};
+
+const PluginCmdRecorder = struct {
+    count: usize = 0,
+    last_plugin_buf: [64]u8 = undefined,
+    last_plugin_len: usize = 0,
+    last_command_buf: [64]u8 = undefined,
+    last_command_len: usize = 0,
+    last_params_buf: [128]u8 = undefined,
+    last_params_len: usize = 0,
+
+    // Dispatch is SYNCHRONOUS, so the borrowed studio-owned slices are valid
+    // here; copy them out because the assertions read after the call returns.
+    pub fn engine__editor_plugin_command(self: *PluginCmdRecorder, info: anytype) void {
+        self.count += 1;
+        @memcpy(self.last_plugin_buf[0..info.plugin.len], info.plugin);
+        self.last_plugin_len = info.plugin.len;
+        @memcpy(self.last_command_buf[0..info.command.len], info.command);
+        self.last_command_len = info.command.len;
+        @memcpy(self.last_params_buf[0..info.params.len], info.params);
+        self.last_params_len = info.params.len;
+    }
+    fn lastPlugin(self: *const PluginCmdRecorder) []const u8 {
+        return self.last_plugin_buf[0..self.last_plugin_len];
+    }
+    fn lastCommand(self: *const PluginCmdRecorder) []const u8 {
+        return self.last_command_buf[0..self.last_command_len];
+    }
+    fn lastParams(self: *const PluginCmdRecorder) []const u8 {
+        return self.last_params_buf[0..self.last_params_len];
+    }
+};
+
+const PluginCmdComponents = struct {
+    pub fn has(comptime _: []const u8) bool {
+        return false;
+    }
+    pub fn names() []const []const u8 {
+        return &.{};
+    }
+};
+
+const PluginCmdMockEcs = core.MockEcsBackend(u32);
+
+/// A project whose merged `GameEvents` DOES carry the editor-command channel
+/// (a plugin subscribed) — the wired-up path.
+const PluginCmdGame = engine.game_mod.GameConfig(
+    core.StubRender(PluginCmdMockEcs.Entity),
+    PluginCmdMockEcs,
+    engine.input_mod.StubInput,
+    engine.audio_mod.StubAudio,
+    engine.StubVideo,
+    engine.gui_mod.StubGui,
+    *PluginCmdRecorder,
+    core.StubLogSink,
+    PluginCmdComponents,
+    &.{},
+    PluginCmdEvents,
+);
+
+/// A project with NO editor-command channel (no plugin subscribed) — the
+/// graceful-degrade path: `editorPluginCommand` folds to a -1.
+const PluginCmdNoChannelGame = engine.game_mod.GameConfig(
+    core.StubRender(PluginCmdMockEcs.Entity),
+    PluginCmdMockEcs,
+    engine.input_mod.StubInput,
+    engine.audio_mod.StubAudio,
+    engine.StubVideo,
+    engine.gui_mod.StubGui,
+    void,
+    core.StubLogSink,
+    PluginCmdComponents,
+    &.{},
+    void,
+);
+
+test "editor_plugin_command: routes to the plugin's engine__editor_plugin_command subscriber" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var recorder = PluginCmdRecorder{};
+    var game = PluginCmdGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&recorder);
+    game.dispatchEvents(); // drain any buffered game_init
+    recorder = .{};
+
+    var runner = DummyRunner{};
+    editor_api.bind(&game, &runner);
+
+    // The exact payload the studio POC emits: {plugin_panel, command, params}.
+    const rc = editor_api.editor_plugin_command(
+        "dungeon_generator",
+        17,
+        "generate",
+        8,
+        "{\"seed\":42}",
+        11,
+    );
+    try testing.expectEqual(@as(i32, 0), rc);
+    try testing.expectEqual(@as(usize, 1), recorder.count);
+    try testing.expectEqualStrings("dungeon_generator", recorder.lastPlugin());
+    try testing.expectEqualStrings("generate", recorder.lastCommand());
+    try testing.expectEqualStrings("{\"seed\":42}", recorder.lastParams());
+}
+
+test "editor_plugin_command: -1 pre-bind, with no subscriber (graceful), and on empty name" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    // Pre-bind: not bound → -1 (mirrors the other export's no-op contract).
+    try testing.expectEqual(@as(i32, -1), editor_api.editor_plugin_command("p", 1, "c", 1, "{}", 2));
+
+    // Bound to a project with no editor-command channel — the RFC's
+    // graceful-degrade path (an older / handler-less build). Routes to -1
+    // without ever touching a subscriber.
+    {
+        var game = PluginCmdNoChannelGame.init(testing.allocator);
+        defer game.deinit();
+        var runner = DummyRunner{};
+        editor_api.bind(&game, &runner);
+        try testing.expectEqual(
+            @as(i32, -1),
+            editor_api.editor_plugin_command("dungeon", 7, "generate", 8, "{}", 2),
+        );
+    }
+
+    // Bound WITH a channel but an empty plugin/command → -1 (a host-side
+    // length bug, never a meaningful dispatch); the subscriber never fires.
+    editor_api.unbind();
+    var recorder = PluginCmdRecorder{};
+    var game2 = PluginCmdGame.init(testing.allocator);
+    defer game2.deinit();
+    game2.setHooks(&recorder);
+    var runner2 = DummyRunner{};
+    editor_api.bind(&game2, &runner2);
+    try testing.expectEqual(@as(i32, -1), editor_api.editor_plugin_command("", 0, "generate", 8, "{}", 2));
+    try testing.expectEqual(@as(i32, -1), editor_api.editor_plugin_command("dungeon", 7, "", 0, "{}", 2));
+    try testing.expectEqual(@as(usize, 0), recorder.count);
 }


### PR DESCRIPTION
Phase 3 of the asset-plugins epic. Design: labelle-toolkit/labelle-engine#725 · RFC `RFC-ASSET-PLUGINS.md` rev 4.

Adds the **play-time action channel** for labelle-studio's declarative plugin panels: a new `editor_plugin_command(plugin_ptr, len, command_ptr, len, params_ptr, len)` WASM export (editor-bridge contract **v1.6 → v1.7**), the same channel family as `editor_set_component`. The studio calls it (as `_editor_plugin_command`, the emcc C-ABI underscore) when a panel action whose `"target"` is `"preview"` is clicked, carrying the dispatch payload `{plugin_panel, command, params}` the studio POC (#73) already emits.

## What it does
- **`src/editor_api.zig`** — `editor_plugin_command` export + `plugin_command` vtable entry + `pluginCommandImpl`, mirroring the existing `editor_*` ptr+len→slice dispatch. Returns `0` = dispatched, `-1` = not bound / empty name / no subscriber.
- **`src/game/editor_command_mixin.zig`** (new) — `editorPluginCommand` routes `{plugin, command, params}` to the plugin's declared handler, gated on a comptime **has-channel** check; wired into `game.zig`.
- **`src/root.zig`** — `engine.Events` gains `editor_plugin_command`.

## Handler declaration (the RFC rev-4 open question — resolved)
"comptime hook registration vs a manifest list" → **comptime hook registration via the existing engine-event channel**. A plugin declares its editor handler by subscribing to the new `engine__editor_plugin_command` event, exactly like input plugins subscribe to `engine__key_pressed` (#606). Consuming the event folds the variant onto the project's merged `GameEvents` — the **zero-cost gate**: no subscriber → variant absent → the bridge folds to `-1` → an older/handler-less build **degrades gracefully** (studio disables preview-target actions on the missing export or the `-1`).

Dispatch is **synchronous** (`emitSync`), so the studio's wasm-owned `command`/`params` buffers stay valid for the handler with no copy and the bridge hands back a real result code.

## Tests (`test/editor_api_test.zig`)
- routes to the plugin's `engine__editor_plugin_command` subscriber (asserts the exact `{plugin, command, params}` payload lands);
- graceful-degrade: bound to a project with no channel → `-1`, subscriber never fires;
- empty plugin/command → `-1`; pre-bind → `-1`.

`zig build test` → **exit 0**.

Studio-side consumption (labelle-studio #74/#75) is a separate parallel effort.

Closes #729

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw