### PR TITLE
feat(#737): Script Runtime Contract v1 — C-ABI surface for language plugins

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -225,6 +225,13 @@ pub fn build(b: *std.Build) void {
         // these cover the FPS counter and the overlay-facing surface.
         "test/frame_profiler_test.zig",
         "test/inspector_overlay_test.zig",
+        // #737 — Script Runtime Contract v1: the `labelle_*` C-ABI
+        // surface language plugins bind (RFC-LANGUAGE-PLUGINS). Covers
+        // pre-bind no-op safety, the bind/vtable dispatch for every op,
+        // component serde round-trips over the registry, name-dispatched
+        // queries, event emit-by-name, and the subscribe/drain/poll FIFO
+        // (incl. the two-arena payload lifetime).
+        "test/script_contract_test.zig",
     };
 
     for (test_files) |test_file| {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -79,5 +79,9 @@
         "codegen",
         "audio_backend",
         "spec",
+        // The Script Runtime Contract header (contract/labelle_script.h)
+        // ships with the package — native-compiled language plugins bind
+        // against it (#737).
+        "contract",
     },
 }

--- a/contract/labelle_script.h
+++ b/contract/labelle_script.h
@@ -21,8 +21,11 @@
  *     nothing written, 0 returned).
  *   - Structured payloads are UTF-8 JSON (encoding v1).
  *   - Components are addressed BY NAME over the game's own component
- *     registry (the same set JSONC scenes author), plus the built-in
- *     "Position" ({"x":…,"y":…}).
+ *     registry plus the engine built-ins JSONC scenes author: "Position"
+ *     ({"x":…,"y":…}) and the five scene built-ins "Sprite", "Shape",
+ *     "Tilemap", "Camera", "Image" — routed through the scene loader's
+ *     own apply machinery (see the support table before
+ *     labelle_component_set).
  *   - Events are addressed by the game's `GameEvents` union tag name
  *     (e.g. "turret__fired", "engine__tick"); payloads are the variant
  *     struct as JSON.
@@ -76,6 +79,40 @@ uint64_t labelle_prefab_spawn(const char *name, size_t name_len,
 
 /* ── Components (by name, JSON payloads) ──────────────────────────── */
 
+/* Built-in component support (write-parity with JSONC scenes — `set`
+ * dispatches through the very apply branches the scene loader uses,
+ * with its precedence: a project-registered component named Tilemap /
+ * Camera / Image WINS and routes through the registry instead; Sprite /
+ * Shape are always the built-ins, in scenes too). All five also
+ * resolve in labelle_query.
+ *
+ *   name      set  get  has  remove   notes
+ *   Position  yes  yes  yes  yes      set routes through setPosition so
+ *                                     render dirty-tracking fires
+ *   Sprite    yes  yes* yes  yes      set/remove register/untrack the
+ *                                     renderer (addSprite/removeSprite)
+ *   Shape     yes  yes* yes  yes      same channel as Sprite
+ *                                     (addShape/removeShape)
+ *   Tilemap   yes  yes  yes  yes      set decodes the referenced .tmx
+ *                                     (where the renderer has the seam);
+ *                                     remove frees the decoded runtime
+ *                                     (removeTilemap)
+ *   Camera    yes  yes  yes  yes      `tag` is carried as a JSON string
+ *                                     both ways; remove drops the
+ *                                     authored seed (the live camera
+ *                                     keeps its last seeded state)
+ *   Image     yes  yes  yes  yes      plain data component
+ *
+ * yes* — get omits fields that are renderer HANDLES rather than
+ * authored data (e.g. gfx Sprite's `texture`); they re-derive from the
+ * authored fields (`sprite_name`) on the next set, so get→set is still
+ * lossless. Camera's get emits {"zoom":…,"viewport":…|null,"tag":"…"}.
+ *
+ * Built-in sets follow the scene loader's LENIENT field semantics: a
+ * wrong-typed field with a declared default falls back to that default;
+ * malformed JSON and non-object payloads are refused with -1 (entity
+ * untouched). */
+
 /* Set component `name` on entity `id` from a JSON object. REPLACE
  * semantics: the JSON is parsed as the whole component struct — absent
  * fields take the component's declared defaults, unknown fields are
@@ -88,7 +125,8 @@ int32_t labelle_component_set(uint64_t id,
 
 /* Serialize component `name` of entity `id` to JSON into `out`
  * (capacity `out_cap`). Returns bytes written; 0 = absent / unknown
- * name / dead entity / doesn't fit. */
+ * name / dead entity / doesn't fit. Scene built-ins serialize as a
+ * scene could have authored them — see the support table above. */
 size_t labelle_component_get(uint64_t id,
                              const char *name, size_t name_len,
                              char *out, size_t out_cap);
@@ -129,10 +167,15 @@ size_t labelle_query(const char *names_json, size_t names_json_len,
 int32_t labelle_event_emit(const char *name, size_t name_len,
                            const char *json, size_t json_len);
 
-/* Declare interest in an event name. From the next frame on, matching
- * events are queued for labelle_event_poll. Duplicates are deduped.
- * Subscribing before the host binds is a no-op (plugin setup always
- * runs after bind in the generated main). */
+/* Declare interest in an event name. A subscription takes effect for
+ * events emitted AFTER the current tick's drain: events already
+ * buffered this tick (e.g. the engine's own emits, which precede
+ * script execution) — or emitted later within this same tick — are
+ * never delivered to it, so subscribing mid-tick cannot replay a past
+ * the script never subscribed to. Delivery starts with the next tick's
+ * events. Duplicates are deduped. Subscribing before the host binds is
+ * a no-op (plugin setup always runs after bind in the generated
+ * main). */
 void labelle_event_subscribe(const char *name, size_t name_len);
 
 /* Drain one pending event: copies the next "<name> <json>" entry

--- a/contract/labelle_script.h
+++ b/contract/labelle_script.h
@@ -13,6 +13,12 @@
  *
  * Conventions
  *   - Strings are (pointer, length) pairs — NOT NUL-terminated.
+ *   - Nullability: required string parameters (component/event/scene/
+ *     prefab names, log messages, the query's names_json) must be
+ *     non-NULL even when their length is 0. Only JSON payloads
+ *     documented "NULL/len 0" may be NULL, and `out` buffers may be
+ *     NULL only together with a 0 capacity (treated as capacity 0:
+ *     nothing written, 0 returned).
  *   - Structured payloads are UTF-8 JSON (encoding v1).
  *   - Components are addressed BY NAME over the game's own component
  *     registry (the same set JSONC scenes author), plus the built-in
@@ -73,7 +79,7 @@ uint64_t labelle_prefab_spawn(const char *name, size_t name_len,
 /* Set component `name` on entity `id` from a JSON object. REPLACE
  * semantics: the JSON is parsed as the whole component struct — absent
  * fields take the component's declared defaults, unknown fields are
- * ignored; there is no merge/patch. Empty json (len 0) means "{}"
+ * ignored; there is no merge/patch. Empty json (NULL/len 0) means "{}"
  * (all defaults). 0 = ok; -1 = unknown component / unknown-or-dead
  * entity / parse error. On -1 the entity is untouched. */
 int32_t labelle_component_set(uint64_t id,
@@ -116,7 +122,7 @@ size_t labelle_query(const char *names_json, size_t names_json_len,
 
 /* Emit a game event by union-tag name into the engine's buffered event
  * path — flows (OnEvent), Zig hooks, and other subscribed scripts all
- * see it at this frame's dispatch. Empty json (len 0) means "{}"
+ * see it at this frame's dispatch. Empty json (NULL/len 0) means "{}"
  * (all-default payload; payload fields without defaults must be
  * present in the JSON). 0 = ok; -1 = unknown event name / parse
  * failure / the game declares no events. */
@@ -132,9 +138,11 @@ void labelle_event_subscribe(const char *name, size_t name_len);
 /* Drain one pending event: copies the next "<name> <json>" entry
  * (FIFO, emission order) into `out` and returns bytes written; 0 =
  * inbox empty. The entry is consumed even when `out_cap` truncates it
- * — size `out` generously. Drain in a while (poll() > 0) loop once per
- * tick. Beyond an internal cap of pending events, further events are
- * dropped newest-first until the script polls. */
+ * — size `out` generously. A NULL or zero-capacity `out` is the one
+ * exception: it reads (and consumes) nothing and returns 0. Drain in a
+ * while (poll() > 0) loop once per tick. Beyond an internal cap of
+ * pending events, further events are dropped newest-first until the
+ * script polls. */
 size_t labelle_event_poll(char *out, size_t out_cap);
 
 /* ── Scene / log / time ───────────────────────────────────────────── */
@@ -148,9 +156,20 @@ int32_t labelle_scene_change(const char *name, size_t name_len);
 void labelle_log(const char *msg, size_t len);
 
 /* The last tick's GAMEPLAY delta-time in seconds — the same scaled dt
- * Zig scripts receive: real frame time × time_scale, 0 while paused
- * (and before the first tick). */
+ * Zig scripts receive: the value stamped for this tick via
+ * labelle_time_dt_stamp when the language plugin stamps, else the
+ * host's own record of the last tick (real frame time × time_scale,
+ * 0 while paused and before the first tick). */
 float labelle_time_dt(void);
+
+/* Stamp the tick's gameplay delta-time. Called once per tick by the
+ * scripting LANGUAGE PLUGIN, with the scaled dt the host handed it,
+ * before it runs the frame's scripts — game scripts must not call it.
+ * Once a session has stamped, labelle_time_dt returns the stamped
+ * value exactly, so every script observes the very dt Zig scripts
+ * received this tick even when a script changes the time scale
+ * mid-tick. Ignored before the host binds. */
+void labelle_time_dt_stamp(float dt);
 
 #ifdef __cplusplus
 }

--- a/contract/labelle_script.h
+++ b/contract/labelle_script.h
@@ -18,7 +18,9 @@
  *     non-NULL even when their length is 0. Only JSON payloads
  *     documented "NULL/len 0" may be NULL, and `out` buffers may be
  *     NULL only together with a 0 capacity (treated as capacity 0:
- *     nothing written, 0 returned).
+ *     nothing written; 0 returned — except labelle_query, whose
+ *     NULL/cap-0 call is a legal sizing probe returning the required
+ *     size).
  *   - Structured payloads are UTF-8 JSON (encoding v1).
  *   - Components are addressed BY NAME over the game's own component
  *     registry plus the engine built-ins JSONC scenes author: "Position"
@@ -38,6 +40,10 @@
  *   - Out-parameter functions return bytes written; 0 = absent /
  *     unknown / empty / doesn't fit. Two-call sizing is deliberately
  *     not offered — script payloads are small, size buffers generously.
+ *     The ONE deliberate exception is labelle_query, the contract's
+ *     only unbounded-cardinality op: it returns the bytes the complete
+ *     result REQUIRES (snprintf-style) while writing at most `out_cap`,
+ *     so callers can detect truncation and retry right-sized.
  *   - Main-thread only; calls are valid during the plugin's tick.
  *   - Before the host binds its game (once, at startup, before plugin
  *     setup), every call is a safe no-op following the same
@@ -145,14 +151,22 @@ int32_t labelle_component_remove(uint64_t id, const char *name, size_t name_len)
 /* Query entity ids by component names. `names_json` is a JSON array of
  * component names (["CloudDrift","Position"]); the host iterates a
  * view on the FIRST name and filters on the rest, writing the matching
- * ids as a JSON array ([3,7,12]) into `out`. Returns bytes written;
+ * ids as a JSON array ([3,7,12]) into `out`. Returns the size the
+ * COMPLETE result requires, snprintf-style — the one written-bytes
+ * exception in the contract, because a query's cardinality (every
+ * matching entity) is the one thing a caller cannot bound up front.
  * 0 = malformed input / not bound. Unknown names yield the valid empty
- * result "[]".
+ * result "[]" (required size 2).
+ *
+ * Writing fills `out` up to `out_cap`, truncated at the last whole id,
+ * so the written prefix is always valid JSON. A return larger than
+ * `out_cap` means the result was truncated — retry with a buffer of
+ * the returned size to get the full set. NULL/cap-0 `out` is a legal
+ * pure sizing probe: nothing written, required size returned.
  *
  * Snapshot semantics: the id list is captured at query time — spawning
  * or destroying entities while walking it is safe (component_get on a
- * since-destroyed id returns 0). If not all ids fit, the list is
- * truncated at the last whole id and stays valid JSON. */
+ * since-destroyed id returns 0). */
 size_t labelle_query(const char *names_json, size_t names_json_len,
                      char *out, size_t out_cap);
 

--- a/contract/labelle_script.h
+++ b/contract/labelle_script.h
@@ -1,0 +1,157 @@
+/* labelle_script.h — Script Runtime Contract v1 (labelle-engine#737,
+ * RFC-LANGUAGE-PLUGINS).
+ *
+ * The one versioned C-ABI surface every scripting language binds. The
+ * host game (assembler-generated, engine `src/script_contract.zig`)
+ * exports these flat symbols; language plugins consume them:
+ *
+ *   - embedded-VM languages (Lua, mruby, QuickJS, CoreCLR) call them
+ *     from binding closures;
+ *   - native-compiled languages (Rust, Crystal, Go) declare them
+ *     `extern "C"` — this header IS the binding — and link against the
+ *     host binary.
+ *
+ * Conventions
+ *   - Strings are (pointer, length) pairs — NOT NUL-terminated.
+ *   - Structured payloads are UTF-8 JSON (encoding v1).
+ *   - Components are addressed BY NAME over the game's own component
+ *     registry (the same set JSONC scenes author), plus the built-in
+ *     "Position" ({"x":…,"y":…}).
+ *   - Events are addressed by the game's `GameEvents` union tag name
+ *     (e.g. "turret__fired", "engine__tick"); payloads are the variant
+ *     struct as JSON.
+ *   - Entity ids are u64; 0 is never a valid id and doubles as the
+ *     failure sentinel.
+ *   - rc convention: functions returning int32_t yield 0 = ok and
+ *     -1 = failure (unknown name / unknown-or-dead entity / parse
+ *     error / host not bound), except `labelle_component_has`, which
+ *     is a boolean 1/0.
+ *   - Out-parameter functions return bytes written; 0 = absent /
+ *     unknown / empty / doesn't fit. Two-call sizing is deliberately
+ *     not offered — script payloads are small, size buffers generously.
+ *   - Main-thread only; calls are valid during the plugin's tick.
+ *   - Before the host binds its game (once, at startup, before plugin
+ *     setup), every call is a safe no-op following the same
+ *     conventions (0 / -1 / no bytes).
+ */
+#pragma once
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* The contract version this header describes. Compare against
+ * labelle_contract_version() at plugin startup and refuse a mismatch. */
+#define LABELLE_CONTRACT_VERSION 1u
+
+/* Contract version the host binary was built with. Pure — callable
+ * before anything else. */
+uint32_t labelle_contract_version(void);
+
+/* ── Entities ─────────────────────────────────────────────────────── */
+
+/* Create an empty entity. Returns its id, or 0 when the host is not
+ * bound. */
+uint64_t labelle_entity_create(void);
+
+/* Destroy an entity (children cascade, same as the engine's
+ * destroyEntity). Unknown / already-dead ids are ignored. */
+void labelle_entity_destroy(uint64_t id);
+
+/* Spawn a named prefab (requires a JSONC scene to have been loaded —
+ * the standard assembled-game boot). `params_json` is optional: pass
+ * NULL/len 0 to spawn at the origin, or a {"x":…,"y":…} object for the
+ * spawn position (unknown keys ignored). Returns the root entity id,
+ * or 0 on failure (unknown prefab, malformed params, not bound). */
+uint64_t labelle_prefab_spawn(const char *name, size_t name_len,
+                              const char *params_json, size_t params_len);
+
+/* ── Components (by name, JSON payloads) ──────────────────────────── */
+
+/* Set component `name` on entity `id` from a JSON object. REPLACE
+ * semantics: the JSON is parsed as the whole component struct — absent
+ * fields take the component's declared defaults, unknown fields are
+ * ignored; there is no merge/patch. Empty json (len 0) means "{}"
+ * (all defaults). 0 = ok; -1 = unknown component / unknown-or-dead
+ * entity / parse error. On -1 the entity is untouched. */
+int32_t labelle_component_set(uint64_t id,
+                              const char *name, size_t name_len,
+                              const char *json, size_t json_len);
+
+/* Serialize component `name` of entity `id` to JSON into `out`
+ * (capacity `out_cap`). Returns bytes written; 0 = absent / unknown
+ * name / dead entity / doesn't fit. */
+size_t labelle_component_get(uint64_t id,
+                             const char *name, size_t name_len,
+                             char *out, size_t out_cap);
+
+/* 1 when the entity carries the component, else 0 (absent, unknown
+ * name, dead entity). */
+int32_t labelle_component_has(uint64_t id, const char *name, size_t name_len);
+
+/* Remove component `name` from entity `id`. Idempotent on the
+ * component (absent-but-known removes return 0). 0 = ok; -1 = unknown
+ * component name / unknown-or-dead entity. */
+int32_t labelle_component_remove(uint64_t id, const char *name, size_t name_len);
+
+/* ── Queries ──────────────────────────────────────────────────────── */
+
+/* Query entity ids by component names. `names_json` is a JSON array of
+ * component names (["CloudDrift","Position"]); the host iterates a
+ * view on the FIRST name and filters on the rest, writing the matching
+ * ids as a JSON array ([3,7,12]) into `out`. Returns bytes written;
+ * 0 = malformed input / not bound. Unknown names yield the valid empty
+ * result "[]".
+ *
+ * Snapshot semantics: the id list is captured at query time — spawning
+ * or destroying entities while walking it is safe (component_get on a
+ * since-destroyed id returns 0). If not all ids fit, the list is
+ * truncated at the last whole id and stays valid JSON. */
+size_t labelle_query(const char *names_json, size_t names_json_len,
+                     char *out, size_t out_cap);
+
+/* ── Events (emit + subscribe/poll drain) ─────────────────────────── */
+
+/* Emit a game event by union-tag name into the engine's buffered event
+ * path — flows (OnEvent), Zig hooks, and other subscribed scripts all
+ * see it at this frame's dispatch. Empty json (len 0) means "{}"
+ * (all-default payload; payload fields without defaults must be
+ * present in the JSON). 0 = ok; -1 = unknown event name / parse
+ * failure / the game declares no events. */
+int32_t labelle_event_emit(const char *name, size_t name_len,
+                           const char *json, size_t json_len);
+
+/* Declare interest in an event name. From the next frame on, matching
+ * events are queued for labelle_event_poll. Duplicates are deduped.
+ * Subscribing before the host binds is a no-op (plugin setup always
+ * runs after bind in the generated main). */
+void labelle_event_subscribe(const char *name, size_t name_len);
+
+/* Drain one pending event: copies the next "<name> <json>" entry
+ * (FIFO, emission order) into `out` and returns bytes written; 0 =
+ * inbox empty. The entry is consumed even when `out_cap` truncates it
+ * — size `out` generously. Drain in a while (poll() > 0) loop once per
+ * tick. Beyond an internal cap of pending events, further events are
+ * dropped newest-first until the script polls. */
+size_t labelle_event_poll(char *out, size_t out_cap);
+
+/* ── Scene / log / time ───────────────────────────────────────────── */
+
+/* Switch to a registered scene by name. 0 = ok (including a swap
+ * deferred on asset streaming — the engine retries it); -1 = unknown
+ * scene (the running scene is untouched) / not bound. */
+int32_t labelle_scene_change(const char *name, size_t name_len);
+
+/* Log through the game's log sink at info level, "[script]"-prefixed. */
+void labelle_log(const char *msg, size_t len);
+
+/* The last tick's GAMEPLAY delta-time in seconds — the same scaled dt
+ * Zig scripts receive: real frame time × time_scale, 0 while paused
+ * (and before the first tick). */
+float labelle_time_dt(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/contract/labelle_script.h
+++ b/contract/labelle_script.h
@@ -17,10 +17,9 @@
  *     prefab names, log messages, the query's names_json) must be
  *     non-NULL even when their length is 0. Only JSON payloads
  *     documented "NULL/len 0" may be NULL, and `out` buffers may be
- *     NULL only together with a 0 capacity (treated as capacity 0:
- *     nothing written; 0 returned — except labelle_query, whose
- *     NULL/cap-0 call is a legal sizing probe returning the required
- *     size).
+ *     NULL only together with a 0 capacity — the NULL/cap-0 call is
+ *     each out-writing function's documented sizing probe (see the
+ *     sizing convention below and the per-function comments).
  *   - Structured payloads are UTF-8 JSON (encoding v1).
  *   - Components are addressed BY NAME over the game's own component
  *     registry plus the engine built-ins JSONC scenes author: "Position"
@@ -37,13 +36,19 @@
  *     -1 = failure (unknown name / unknown-or-dead entity / parse
  *     error / host not bound), except `labelle_component_has`, which
  *     is a boolean 1/0.
- *   - Out-parameter functions return bytes written; 0 = absent /
- *     unknown / empty / doesn't fit. Two-call sizing is deliberately
- *     not offered — script payloads are small, size buffers generously.
- *     The ONE deliberate exception is labelle_query, the contract's
- *     only unbounded-cardinality op: it returns the bytes the complete
- *     result REQUIRES (snprintf-style) while writing at most `out_cap`,
- *     so callers can detect truncation and retry right-sized.
+ *   - Out-parameter sizing: labelle_component_get and labelle_query
+ *     return the bytes the COMPLETE result REQUIRES (snprintf-style;
+ *     required > out_cap is the truncation signal — retry right-sized;
+ *     NULL/cap-0 out is a legal pure sizing probe; 0 keeps its
+ *     sentinel meaning: absent / unknown / dead / malformed). They
+ *     differ in what an under-sized cap writes: the query fills a
+ *     truncated-at-the-last-whole-id prefix that is still valid JSON,
+ *     while component_get writes ALL-OR-NOTHING (a truncated JSON
+ *     object prefix is useless — on overflow the buffer is untouched).
+ *     labelle_event_poll alone returns bytes WRITTEN, because a real
+ *     poll consumes its entry, truncation included; its sizing story
+ *     is the paired NULL/cap-0 probe, which returns the NEXT entry's
+ *     size without consuming — probe, grow, then poll.
  *   - Main-thread only; calls are valid during the plugin's tick.
  *   - Before the host binds its game (once, at startup, before plugin
  *     setup), every call is a safe no-op following the same
@@ -123,16 +128,24 @@ uint64_t labelle_prefab_spawn(const char *name, size_t name_len,
  * semantics: the JSON is parsed as the whole component struct — absent
  * fields take the component's declared defaults, unknown fields are
  * ignored; there is no merge/patch. Empty json (NULL/len 0) means "{}"
- * (all defaults). 0 = ok; -1 = unknown component / unknown-or-dead
- * entity / parse error. On -1 the entity is untouched. */
+ * (all defaults). The payload must be a single JSON document: trailing
+ * bytes after it (beyond whitespace — plus comments for the built-ins,
+ * which parse as JSONC) are a parse error. 0 = ok; -1 = unknown
+ * component / unknown-or-dead entity / parse error. On -1 the entity
+ * is untouched. */
 int32_t labelle_component_set(uint64_t id,
                               const char *name, size_t name_len,
                               const char *json, size_t json_len);
 
 /* Serialize component `name` of entity `id` to JSON into `out`
- * (capacity `out_cap`). Returns bytes written; 0 = absent / unknown
- * name / dead entity / doesn't fit. Scene built-ins serialize as a
- * scene could have authored them — see the support table above. */
+ * (capacity `out_cap`). Returns the bytes the COMPLETE JSON requires
+ * (snprintf-style, like labelle_query); 0 = absent / unknown name /
+ * dead entity. The write is ALL-OR-NOTHING: `out` is filled only when
+ * the whole JSON fits (required <= out_cap) — a truncated JSON object
+ * prefix is useless, so on overflow nothing is written; retry with a
+ * buffer of the returned size. NULL/cap-0 `out` is a legal pure
+ * sizing probe. Scene built-ins serialize as a scene could have
+ * authored them — see the support table above. */
 size_t labelle_component_get(uint64_t id,
                              const char *name, size_t name_len,
                              char *out, size_t out_cap);
@@ -152,11 +165,10 @@ int32_t labelle_component_remove(uint64_t id, const char *name, size_t name_len)
  * component names (["CloudDrift","Position"]); the host iterates a
  * view on the FIRST name and filters on the rest, writing the matching
  * ids as a JSON array ([3,7,12]) into `out`. Returns the size the
- * COMPLETE result requires, snprintf-style — the one written-bytes
- * exception in the contract, because a query's cardinality (every
- * matching entity) is the one thing a caller cannot bound up front.
- * 0 = malformed input / not bound. Unknown names yield the valid empty
- * result "[]" (required size 2).
+ * COMPLETE result requires, snprintf-style (the shared sizing
+ * convention — see the conventions block above). 0 = malformed input /
+ * not bound. Unknown names yield the valid empty result "[]"
+ * (required size 2).
  *
  * Writing fills `out` up to `out_cap`, truncated at the last whole id,
  * so the written prefix is always valid JSON. A return larger than
@@ -176,8 +188,11 @@ size_t labelle_query(const char *names_json, size_t names_json_len,
  * path — flows (OnEvent), Zig hooks, and other subscribed scripts all
  * see it at this frame's dispatch. Empty json (NULL/len 0) means "{}"
  * (all-default payload; payload fields without defaults must be
- * present in the JSON). 0 = ok; -1 = unknown event name / parse
- * failure / the game declares no events. */
+ * present in the JSON). VOID-payload events (the union tag declares no
+ * payload struct) accept exactly: empty (NULL/len 0), the exact bytes
+ * "{}", or the exact bytes "null" — anything else, malformed JSON
+ * included, is a parse failure. 0 = ok; -1 = unknown event name /
+ * parse failure / the game declares no events. */
 int32_t labelle_event_emit(const char *name, size_t name_len,
                            const char *json, size_t json_len);
 
@@ -193,13 +208,16 @@ int32_t labelle_event_emit(const char *name, size_t name_len,
 void labelle_event_subscribe(const char *name, size_t name_len);
 
 /* Drain one pending event: copies the next "<name> <json>" entry
- * (FIFO, emission order) into `out` and returns bytes written; 0 =
- * inbox empty. The entry is consumed even when `out_cap` truncates it
- * — size `out` generously. A NULL or zero-capacity `out` is the one
- * exception: it reads (and consumes) nothing and returns 0. Drain in a
- * while (poll() > 0) loop once per tick. Beyond an internal cap of
- * pending events, further events are dropped newest-first until the
- * script polls. */
+ * (FIFO, emission order) into `out` and returns bytes WRITTEN; 0 =
+ * inbox empty. A real read consumes the entry even when `out_cap`
+ * truncates it — but no caller needs to eat a truncation: a NULL or
+ * zero-capacity `out` is the paired no-consume SIZING PROBE, returning
+ * the NEXT entry's full size (0 = inbox empty) while reading and
+ * consuming nothing — probe, grow the buffer, then poll. An entry is
+ * never empty, so a probe's non-zero return cannot be confused with
+ * inbox-empty. Drain in a while (poll() > 0) loop once per tick.
+ * Beyond an internal cap of pending events, further events are
+ * dropped newest-first until the script polls. */
 size_t labelle_event_poll(char *out, size_t out_cap);
 
 /* ── Scene / log / time ───────────────────────────────────────────── */

--- a/src/jsonc/component_apply.zig
+++ b/src/jsonc/component_apply.zig
@@ -8,6 +8,15 @@
 //! with the two-pass `@ref` resolution flow when a `RefContext` is
 //! active.
 //!
+//! The per-built-in branches are factored into `applySprite` /
+//! `applyShape` / `applyTilemap` / `applyCamera` / `applyImage` so the
+//! Script Runtime Contract (`src/script_contract.zig`, #737) can route
+//! `labelle_component_set` through the IDENTICAL machinery — scripts
+//! get write-parity with scenes by construction. The fns report
+//! whether the deserialize applied; `applyComponent` ignores the
+//! answer (scene loading stays fire-and-forget), the contract maps
+//! `false` to its rc `-1`.
+//!
 //! Allocation lifetime — `deserialize`-side allocations (slices for
 //! `frames` / `entries` / etc.) land in
 //! `active_world.nested_entity_arena` so they share the lifetime of
@@ -99,17 +108,13 @@ pub fn ComponentApply(comptime GameType: type, comptime Components: type) type {
 
             // Sprite — uses addSprite for renderer registration.
             if (std.mem.eql(u8, name, "Sprite")) {
-                if (deserializer.deserialize(Sprite, value, comp_alloc)) |sprite| {
-                    game.addSprite(entity, sprite);
-                }
+                _ = applySprite(game, entity, value);
                 return;
             }
 
             // Shape — uses addShape for renderer registration.
             if (std.mem.eql(u8, name, "Shape")) {
-                if (deserializer.deserialize(Shape, value, comp_alloc)) |shape| {
-                    game.addShape(entity, shape);
-                }
+                _ = applyShape(game, entity, value);
                 return;
             }
 
@@ -126,9 +131,7 @@ pub fn ComponentApply(comptime GameType: type, comptime Components: type) type {
             // tilemap) — silent scene-data loss (C2).
             if (comptime !Components.has("Tilemap")) {
                 if (std.mem.eql(u8, name, "Tilemap")) {
-                    if (deserializer.deserialize(GameType.TilemapComp, value, comp_alloc)) |tilemap| {
-                        game.addTilemap(entity, tilemap);
-                    }
+                    _ = applyTilemap(game, entity, value);
                     return;
                 }
             }
@@ -142,21 +145,7 @@ pub fn ComponentApply(comptime GameType: type, comptime Components: type) type {
             // registered type via the generic dispatch below).
             if (comptime !Components.has("Camera")) {
                 if (std.mem.eql(u8, name, "Camera")) {
-                    if (deserializer.deserialize(GameType.CameraComp, value, comp_alloc)) |camera| {
-                        var cam = camera;
-                        // `tag` is an INLINE bounded buffer (`[16:0]u8`), which
-                        // the generic struct deserializer doesn't map from a
-                        // JSON string — it would silently keep the `"main"`
-                        // default. Apply the authored tag here so the primary
-                        // authoring channel (`{"Camera":{"tag":"sky_parallax"}}`)
-                        // seeds the bounded field. Absent → default `"main"`.
-                        if (value.asObject()) |o| {
-                            if (o.get("tag")) |t| {
-                                if (t.asString()) |s| cam.setTagSlice(s);
-                            }
-                        }
-                        game.addComponent(entity, cam);
-                    }
+                    _ = applyCamera(game, entity, value);
                     return;
                 }
             }
@@ -170,17 +159,9 @@ pub fn ComponentApply(comptime GameType: type, comptime Components: type) type {
             // project-registered `Image` still wins (the built-in branch
             // compiles out, routing `"Image"` to the registered type via the
             // generic dispatch below).
-            //
-            // `name` / `layer` are `[]const u8` and `pivot` is an enum — the
-            // generic struct deserializer maps all of them from JSONC (strings
-            // land in `comp_alloc` = the nested-entity arena, matching
-            // `Sprite.sprite_name`'s lifetime), so no `Camera`-style inline-tag
-            // special-casing is needed here.
             if (comptime !Components.has("Image")) {
                 if (std.mem.eql(u8, name, "Image")) {
-                    if (deserializer.deserialize(ImageComp, value, comp_alloc)) |image| {
-                        game.addComponent(entity, image);
-                    }
+                    _ = applyImage(game, entity, value);
                     return;
                 }
             }
@@ -222,6 +203,74 @@ pub fn ComponentApply(comptime GameType: type, comptime Components: type) type {
             if (uf.isPascalCase(name)) {
                 uf.warnUnknownComponent(game.log, name);
             }
+        }
+
+        // ── Per-built-in apply fns (shared with the script contract) ──
+        //
+        // Each targets the ENGINE built-in type unconditionally; the
+        // registry-precedence gates (`!Components.has("Tilemap")` etc.)
+        // stay at the call sites — `applyComponent` above and the
+        // contract's `builtin_comps` dispatch — so a project-registered
+        // component of the same name never reaches these. The `bool`
+        // return reports whether the deserialize applied: scenes ignore
+        // it, `labelle_component_set` maps `false` to `-1` (the entity
+        // is untouched on failure — the deserialize is all-or-nothing).
+
+        /// `Sprite` → `addSprite`, so renderer entity-tracking fires.
+        pub fn applySprite(game: *GameType, entity: Entity, value: Value) bool {
+            const comp_alloc = game.active_world.nested_entity_arena.allocator();
+            const sprite = deserializer.deserialize(Sprite, value, comp_alloc) orelse return false;
+            game.addSprite(entity, sprite);
+            return true;
+        }
+
+        /// `Shape` → `addShape`, so renderer entity-tracking fires.
+        pub fn applyShape(game: *GameType, entity: Entity, value: Value) bool {
+            const comp_alloc = game.active_world.nested_entity_arena.allocator();
+            const shape = deserializer.deserialize(Shape, value, comp_alloc) orelse return false;
+            game.addShape(entity, shape);
+            return true;
+        }
+
+        /// `Tilemap` → `addTilemap`, so the `.tmx` asset decodes + binds
+        /// a draw-pass renderer (a no-op attach on renderers without the
+        /// tilemap seam — the component still lands).
+        pub fn applyTilemap(game: *GameType, entity: Entity, value: Value) bool {
+            const comp_alloc = game.active_world.nested_entity_arena.allocator();
+            const tilemap = deserializer.deserialize(GameType.TilemapComp, value, comp_alloc) orelse return false;
+            game.addTilemap(entity, tilemap);
+            return true;
+        }
+
+        /// `Camera` → `addComponent` of the engine built-in POD. `tag` is
+        /// an INLINE bounded buffer (`[16:0]u8`), which the generic struct
+        /// deserializer doesn't map from a JSON string — it would silently
+        /// keep the `"main"` default. Apply the authored tag here so the
+        /// primary authoring channel (`{"Camera":{"tag":"sky_parallax"}}`)
+        /// seeds the bounded field. Absent → default `"main"`.
+        pub fn applyCamera(game: *GameType, entity: Entity, value: Value) bool {
+            const comp_alloc = game.active_world.nested_entity_arena.allocator();
+            var cam = deserializer.deserialize(GameType.CameraComp, value, comp_alloc) orelse return false;
+            if (value.asObject()) |o| {
+                if (o.get("tag")) |t| {
+                    if (t.asString()) |s| cam.setTagSlice(s);
+                }
+            }
+            game.addComponent(entity, cam);
+            return true;
+        }
+
+        /// `Image` → `addComponent` of the engine-local POD (#568).
+        /// `name` / `layer` are `[]const u8` and `pivot` is an enum — the
+        /// generic struct deserializer maps all of them from JSONC
+        /// (strings land in the nested-entity arena, matching
+        /// `Sprite.sprite_name`'s lifetime), so no `Camera`-style
+        /// inline-tag special-casing is needed here.
+        pub fn applyImage(game: *GameType, entity: Entity, value: Value) bool {
+            const comp_alloc = game.active_world.nested_entity_arena.allocator();
+            const image = deserializer.deserialize(ImageComp, value, comp_alloc) orelse return false;
+            game.addComponent(entity, image);
+            return true;
         }
 
         /// Strip fields that contain entity-like arrays from a

--- a/src/root.zig
+++ b/src/root.zig
@@ -707,6 +707,17 @@ pub const preview_iosurface_mod = preview_mode_mod.preview_iosurface;
 // so non-preview builds emit no `editor_*` symbols.
 pub const editor_api = @import("editor_api.zig");
 
+// ── Script Runtime Contract v1 (language plugins, #737) ──
+// The flat `export fn labelle_*` C-ABI surface every scripting language
+// binds (RFC-LANGUAGE-PLUGINS; header in `contract/labelle_script.h`),
+// plus the two touchpoints the assembler-generated main splices in when
+// a language plugin is attached (`bind` / `drainEvents`). Deliberately a
+// lazy `pub const` and NOT referenced anywhere else in the engine: a
+// build that never references `engine.script_contract` never analyzes
+// the file, so script-less builds emit no `labelle_*` symbols — the
+// same zero-cost gate as `editor_api` above.
+pub const script_contract = @import("script_contract.zig");
+
 // ── Out-of-band screenshot request (labelle-cli#227) ──
 // Read by the assembler-generated `main.zig`'s frame loop after the
 // game enters its main loop — when `LABELLE_SCREENSHOT_PATH` is set

--- a/src/script_contract.zig
+++ b/src/script_contract.zig
@@ -73,6 +73,15 @@
 //! own `labelle_event_emit` alike. `emitSync` bypasses the buffer and is
 //! therefore NOT tappable, mirroring how it also skips flow `OnEvent`s.
 //!
+//! Subscriptions activate at DRAIN boundaries: `labelle_event_subscribe`
+//! parks the name in a PENDING set, and `drainEvents` filters the
+//! frame's buffer against the ACTIVE set only, absorbing the pending
+//! set at the end — a subscription takes effect for events emitted
+//! after the current tick's drain. Without the boundary, a script
+//! subscribing mid-tick would be handed events buffered EARLIER in
+//! that same tick (`engine__tick` fires before scripts run) — a replay
+//! of a past the script never subscribed to.
+//!
 //! ## Payload memory (`labelle_event_emit`)
 //!
 //! Emitted payloads are parsed from JSON into the typed variant struct;
@@ -94,11 +103,31 @@
 //! Pointer-free components (the per-tick hot path, e.g. `Position`)
 //! parse without allocating at all.
 //!
+//! ## Component name space (registry + scene built-ins)
+//!
+//! Component names resolve over the game's own `ComponentRegistry` PLUS
+//! everything JSONC scenes can author: `Position`, and the five
+//! `jsonc/component_apply.zig` special-cases — `Sprite`, `Shape`,
+//! `Tilemap`, `Camera`, `Image`. The built-ins are not merely
+//! name-aliased: `set` routes through the scene loader's OWN apply fns
+//! (`applySprite` → `addSprite` renderer tracking, `applyCamera`'s
+//! inline-tag mapping, `applyTilemap`'s asset decode), and `remove`
+//! through the engine's typed teardown channels (`removeSprite` /
+//! `removeShape` / `removeTilemap`), so a script write is
+//! indistinguishable from a scene author. The loader's registry-
+//! precedence gates carry over too — `Tilemap`/`Camera`/`Image` defer
+//! to a project-registered component of the same name, `Sprite`/`Shape`
+//! stay built-in — and `contract/labelle_script.h` tabulates the
+//! per-name `get` caveats (renderer-handle fields are omitted; `Camera`
+//! serializes `tag` as a string).
+//!
 //! Single-threaded by design (main thread, during the plugin's tick);
 //! no atomics.
 
 const std = @import("std");
 const core = @import("labelle-core");
+const jsonc = @import("jsonc");
+const component_apply = @import("jsonc/component_apply.zig");
 
 /// Contract version consumers compile against. Bump on any ABI or
 /// semantic change; language plugins check it via
@@ -125,8 +154,15 @@ var vtable: ?*const VTable = null;
 /// The bound game's allocator — owns `subs`/`inbox` entries and the
 /// emit arena. `null` = not bound.
 var bound_allocator: ?std.mem.Allocator = null;
-/// Subscribed event names (deduped, owned copies).
+/// ACTIVE subscribed event names (deduped, owned copies) — the set
+/// `drainEvents` filters against.
 var subs: std.ArrayList([]u8) = .empty;
+/// PENDING subscriptions (deduped against both sets, owned copies):
+/// names subscribed since the last drain. `drainEvents` absorbs them
+/// into `subs` at the END of the drain, so a subscription made
+/// mid-tick can never match events buffered earlier that same tick
+/// (effective-next-drain semantics — see the module doc).
+var pending_subs: std.ArrayList([]u8) = .empty;
 /// FIFO inbox of pending `"<name> <json>"` entries (owned). Popped from
 /// `inbox_head` so a drain-heavy frame is O(1) per poll; the backing
 /// list is compacted whenever it runs empty, or in place once the dead
@@ -206,6 +242,9 @@ pub fn unbind() void {
         for (subs.items) |s| alloc.free(s);
         subs.deinit(alloc);
         subs = .empty;
+        for (pending_subs.items) |s| alloc.free(s);
+        pending_subs.deinit(alloc);
+        pending_subs = .empty;
         // Entries before `inbox_head` were already freed by poll.
         for (inbox.items[inbox_head..]) |e| alloc.free(e);
         inbox.deinit(alloc);
@@ -225,8 +264,13 @@ pub fn unbind() void {
 /// and BEFORE `g.dispatchEvents()` — see the module doc for why that
 /// ordering is load-bearing (dispatch consumes the buffer; the tap only
 /// reads it). Walks the frame's buffered `GameEvents`, serializes each
-/// SUBSCRIBED one to `"<name> <json>"` (name = union tag, payload via
-/// `std.json` reflection), and appends it to the poll FIFO.
+/// event whose name is in the ACTIVE subscription set to
+/// `"<name> <json>"` (name = union tag, payload via `std.json`
+/// reflection), and appends it to the poll FIFO. Subscriptions made
+/// since the last drain are PENDING and do not match this walk; they
+/// activate at the end of it (effective-next-drain — the module doc's
+/// "Event tap semantics" section), so a mid-tick subscribe never
+/// replays events buffered earlier in the same tick.
 ///
 /// Also the once-per-frame maintenance point: flips the double-buffered
 /// `labelle_event_emit` payload arenas and recycles the one holding the
@@ -236,8 +280,8 @@ pub fn unbind() void {
 /// dance).
 ///
 /// A comptime no-op for games without a `GameEvents` union, and an
-/// early-out when nothing is subscribed — an unused tap costs one
-/// branch per frame.
+/// early-out (past pending-subscription activation) when nothing is
+/// subscribed — an unused tap costs one branch per frame.
 pub fn drainEvents(g: anytype) void {
     const GP = @TypeOf(g);
     comptime {
@@ -256,6 +300,10 @@ pub fn drainEvents(g: anytype) void {
     if (comptime !gameHasEventsUnion(G)) return;
     if (vtable == null) return;
     const alloc = bound_allocator orelse return;
+    // Pending subscriptions activate at the END of the drain — the
+    // defer covers the no-active-subs early-out below, so a session's
+    // FIRST subscription still becomes active for the next drain.
+    defer activatePendingSubs(alloc);
     if (subs.items.len == 0) return;
 
     for (g.event_buffer.items) |ev| {
@@ -266,6 +314,19 @@ pub fn drainEvents(g: anytype) void {
             },
         }
     }
+}
+
+/// Absorb the pending subscription set into the active one — the tail
+/// end of `drainEvents`. Entries MOVE (same allocator owns them);
+/// dedupe already happened at subscribe time, against both sets. The
+/// OOM policy matches subscribe's: a name that can't be recorded is
+/// dropped silently rather than taking the frame down.
+fn activatePendingSubs(alloc: std.mem.Allocator) void {
+    if (pending_subs.items.len == 0) return;
+    for (pending_subs.items) |s| {
+        subs.append(alloc, s) catch alloc.free(s);
+    }
+    pending_subs.clearRetainingCapacity();
 }
 
 // ── Exports (plain, non-generic; dispatch through the vtable) ───────
@@ -312,12 +373,15 @@ pub export fn labelle_prefab_spawn(
 }
 
 /// Set component `name` on entity `id` from a JSON object — the general
-/// serde seam over the game's OWN `ComponentRegistry` (plus the built-in
-/// `Position`, which routes through `setPosition` so render dirty-
-/// tracking fires). Unlike `editor_set_component` — deliberately
-/// allowlisted to the vetted `"Camera"` — this dispatch is open: the
-/// contract is the game's own code calling itself, so it gets the full
-/// registry, exactly like the JSONC scene loader.
+/// serde seam over the game's OWN `ComponentRegistry`, plus everything
+/// scenes can author: the built-in `Position` (routed through
+/// `setPosition` so render dirty-tracking fires) and the five scene
+/// built-ins `Sprite`/`Shape`/`Tilemap`/`Camera`/`Image`, dispatched
+/// through the scene loader's own apply fns with its registry-
+/// precedence gates (module doc, "Component name space"). Unlike
+/// `editor_set_component` — deliberately allowlisted to the vetted
+/// `"Camera"` — this dispatch is open: the contract is the game's own
+/// code calling itself, so it gets the full scene-authoring surface.
 ///
 /// REPLACE semantics: the JSON is parsed as the whole component struct
 /// (absent fields take the struct's defaults, unknown fields are
@@ -325,7 +389,9 @@ pub export fn labelle_prefab_spawn(
 /// (`len == 0`), meaning `"{}"` — all defaults. Returns 0 = ok; -1 =
 /// unknown component name / unknown-or-dead entity / parse failure /
 /// not bound. On -1 the entity is untouched (the parse runs before any
-/// mutation).
+/// mutation). The built-ins follow the scene loader's LENIENT field
+/// semantics (a wrong-typed field with a default falls back to that
+/// default; malformed JSON and non-object payloads are still -1).
 pub export fn labelle_component_set(
     id: u64,
     name_ptr: [*]const u8,
@@ -348,6 +414,13 @@ pub export fn labelle_component_set(
 /// fit. A NULL `out` is treated as capacity 0 (nothing written, 0
 /// returned). Two-call sizing is deliberately avoided (POC decision):
 /// script payloads are small — size `out` generously.
+///
+/// Scene built-ins serialize as a scene could have AUTHORED them: any
+/// field that is a renderer handle rather than authored data (the
+/// non-exhaustive-enum idiom, e.g. gfx `Sprite.texture`) is omitted —
+/// it re-derives on the next set — and `Camera.tag` serializes as a
+/// string (the inline `[16:0]u8` would emit as a NUL-padded array).
+/// The output feeds back through `labelle_component_set` losslessly.
 pub export fn labelle_component_get(
     id: u64,
     name_ptr: [*]const u8,
@@ -372,7 +445,10 @@ pub export fn labelle_component_has(id: u64, name_ptr: [*]const u8, name_len: us
 /// Remove component `name` from entity `id`. Idempotent on the
 /// component (removing an absent-but-known component is 0). Returns
 /// 0 = ok; -1 = unknown component name / unknown-or-dead entity / not
-/// bound.
+/// bound. Scene built-ins tear down through the engine's typed
+/// channels — `removeSprite`/`removeShape` (renderer untrack),
+/// `removeTilemap` (frees the decoded side-table runtime) — so a
+/// script remove can't strand renderer state.
 pub export fn labelle_component_remove(id: u64, name_ptr: [*]const u8, name_len: usize) i32 {
     const vt = vtable orelse return -1;
     if (name_len == 0) return -1;
@@ -384,7 +460,10 @@ pub export fn labelle_component_remove(id: u64, name_ptr: [*]const u8, name_len:
 /// view on the FIRST name and filters the rest, writing the matching ids
 /// as a JSON array (`[3,7,12]`) into `out`. Returns bytes written; 0 =
 /// malformed names / not bound / `out_cap` too small for even `[]`.
-/// An unknown component name yields the valid empty result `[]`.
+/// An unknown component name yields the valid empty result `[]`. Names
+/// resolve over the same space as the component ops — the registry,
+/// `Position`, and the scene built-ins (`Sprite`/`Shape`/`Tilemap`/
+/// `Camera`/`Image`, with the same registry-precedence gates).
 ///
 /// Snapshot semantics: the id list is captured at query time, so
 /// spawn/destroy while the script walks it is safe (a per-id
@@ -425,20 +504,27 @@ pub export fn labelle_event_emit(
     );
 }
 
-/// Declare interest in event `name` (a `GameEvents` union tag). From the
-/// next `drainEvents` on, matching events are queued for
-/// `labelle_event_poll`. Duplicate subscriptions are deduped. Pre-bind:
-/// a safe no-op (the generated main binds before plugin setup, so no
-/// real subscriber exists earlier).
+/// Declare interest in event `name` (a `GameEvents` union tag). The
+/// subscription lands in the PENDING set and takes effect for events
+/// emitted after the current tick's drain: `drainEvents` filters
+/// against the ACTIVE set only and absorbs pending names at its end.
+/// So events already buffered this tick — or emitted later this same
+/// tick — are NOT delivered; the next tick's are (no same-tick replay:
+/// `engine__tick` fires before scripts run, and a mid-tick subscriber
+/// must not receive a past it never subscribed to). Duplicate
+/// subscriptions are deduped across both sets. Pre-bind: a safe no-op
+/// (the generated main binds before plugin setup, so no real
+/// subscriber exists earlier).
 pub export fn labelle_event_subscribe(name_ptr: [*]const u8, name_len: usize) void {
     const alloc = bound_allocator orelse return;
     if (name_len == 0) return;
     const name = name_ptr[0..name_len];
-    for (subs.items) |s| {
-        if (std.mem.eql(u8, s, name)) return;
+    if (isSubscribed(name)) return; // already active
+    for (pending_subs.items) |s| {
+        if (std.mem.eql(u8, s, name)) return; // already pending
     }
     const copy = alloc.dupe(u8, name) catch return;
-    subs.append(alloc, copy) catch {
+    pending_subs.append(alloc, copy) catch {
         alloc.free(copy);
     };
 }
@@ -567,6 +653,39 @@ fn isSubscribed(name: []const u8) bool {
     return false;
 }
 
+/// Comptime: does `T` serialize through `std.json` as AUTHORED data —
+/// i.e. would `labelle_component_set`'s deserialize path accept the
+/// emitted shape back? Non-exhaustive enums are the renderer-handle
+/// idiom (gfx `TextureId`): unnamed values emit as raw integers and are
+/// not scene-authorable, so component GET omits such fields — they
+/// re-derive from the authored fields on the next set, exactly as the
+/// scene loader relies on. Everything else the engine built-ins carry
+/// (scalars, strings, exhaustive enums, optionals, tagged unions,
+/// nested structs, slices/arrays thereof) round-trips.
+fn jsonRoundTrips(comptime T: type) bool {
+    return switch (@typeInfo(T)) {
+        .bool, .int, .float, .void => true,
+        .@"enum" => |e| e.is_exhaustive,
+        .optional => |o| jsonRoundTrips(o.child),
+        .array => |a| jsonRoundTrips(a.child),
+        .pointer => |p| p.size == .slice and jsonRoundTrips(p.child),
+        .@"struct" => |s| blk: {
+            for (s.fields) |f| {
+                if (!jsonRoundTrips(f.type)) break :blk false;
+            }
+            break :blk true;
+        },
+        .@"union" => |u| blk: {
+            if (u.tag_type == null) break :blk false;
+            for (u.fields) |f| {
+                if (f.type != void and !jsonRoundTrips(f.type)) break :blk false;
+            }
+            break :blk true;
+        },
+        else => false,
+    };
+}
+
 /// Serialize + queue one tapped event. Drop-newest past the cap (see
 /// `max_pending_events`); allocation failures drop silently — an event
 /// tap must never take the frame down.
@@ -597,12 +716,47 @@ fn Holder(comptime GP: type) type {
         /// The game's own registry — the same `names()`/`getType()`
         /// surface the JSONC scene bridge dispatches over, so the
         /// contract resolves exactly the set of components scenes can
-        /// author (plus the built-in `Position`, which the bridge also
+        /// author (plus the built-ins below, which the bridge also
         /// special-cases). Registries without `getType` (the minimal
         /// `GameWith` shape) are fine: `names()` is empty there, so the
         /// `inline for` bodies that reference `getType` never
         /// instantiate.
         const Components = G.ComponentRegistry;
+        /// The scene loader's component-apply machinery, instantiated
+        /// for this Game — built-in `set`s reuse its per-name apply fns
+        /// VERBATIM (`applySprite`/…), so a script's `Sprite` write is
+        /// the scene loader's own code path, not a reimplementation.
+        const Apply = component_apply.ComponentApply(G, Components);
+
+        /// `true` when the game's registry claims `comp_name` for
+        /// itself. The `@hasDecl` belt mirrors `game.zig`'s
+        /// `camera_is_builtin`, keeping registry shapes that predate a
+        /// `has` decl compiling (they can't shadow built-ins either
+        /// way).
+        fn registryHas(comptime comp_name: []const u8) bool {
+            return @hasDecl(Components, "has") and Components.has(comp_name);
+        }
+
+        const BuiltinComp = struct { name: []const u8, T: type };
+        /// The five scene BUILT-INS (`jsonc/component_apply.zig`'s
+        /// dedicated branches), with the scene loader's exact
+        /// precedence: `Sprite`/`Shape` are unconditional (they shadow
+        /// a same-named registry entry in the scene path too);
+        /// `Tilemap`/`Camera`/`Image` are compiled out when the project
+        /// registered its own component of that name — the mirror of
+        /// the loader's `!Components.has(…)` gates (and game.zig's
+        /// `camera_is_builtin`), so the registry loop below owns the
+        /// name exactly when the scene's generic dispatch would.
+        const builtin_comps: []const BuiltinComp = blk: {
+            var list: []const BuiltinComp = &.{
+                .{ .name = "Sprite", .T = G.SpriteComp },
+                .{ .name = "Shape", .T = G.ShapeComp },
+            };
+            if (!registryHas("Tilemap")) list = list ++ &[_]BuiltinComp{.{ .name = "Tilemap", .T = G.TilemapComp }};
+            if (!registryHas("Camera")) list = list ++ &[_]BuiltinComp{.{ .name = "Camera", .T = G.CameraComp }};
+            if (!registryHas("Image")) list = list ++ &[_]BuiltinComp{.{ .name = "Image", .T = G.ImageComp }};
+            break :blk list;
+        };
 
         var game: GP = undefined;
 
@@ -682,6 +836,16 @@ fn Holder(comptime GP: type) type {
                 game.setPosition(ent, pos);
                 return 0;
             }
+            // Scene built-ins — dispatched BEFORE the registry loop so
+            // the contract matches the scene loader's precedence
+            // (`builtin_comps`), and through its very apply fns so a
+            // script's `Sprite`/`Camera`/… write is indistinguishable
+            // from a scene author's.
+            inline for (builtin_comps) |spec| {
+                if (std.mem.eql(u8, name, spec.name)) {
+                    return setBuiltinComponent(spec.name, ent, json);
+                }
+            }
             const comp_names = comptime Components.names();
             inline for (comp_names) |comp_name| {
                 if (std.mem.eql(u8, name, comp_name)) {
@@ -706,11 +870,60 @@ fn Holder(comptime GP: type) type {
             return -1;
         }
 
+        /// Set one scene built-in by routing the payload through the
+        /// scene loader's own apply fn. The apply fns consume a parsed
+        /// JSONC `Value`; the tree is parsed with a call-scoped arena —
+        /// `deserialize` copies everything it keeps (strings intern,
+        /// other slices land in `componentAlloc()`), so nothing escapes
+        /// it. -1 on parse/deserialize failure leaves the entity
+        /// untouched: the apply is all-or-nothing.
+        fn setBuiltinComponent(comptime comp_name: []const u8, ent: Entity, json: []const u8) i32 {
+            var arena = std.heap.ArenaAllocator.init(game.allocator);
+            defer arena.deinit();
+            var parser = jsonc.JsoncParser.init(arena.allocator(), json);
+            const value = parser.parse() catch return -1;
+            const applied = if (comptime std.mem.eql(u8, comp_name, "Sprite"))
+                Apply.applySprite(game, ent, value)
+            else if (comptime std.mem.eql(u8, comp_name, "Shape"))
+                Apply.applyShape(game, ent, value)
+            else if (comptime std.mem.eql(u8, comp_name, "Tilemap"))
+                Apply.applyTilemap(game, ent, value)
+            else if (comptime std.mem.eql(u8, comp_name, "Camera"))
+                Apply.applyCamera(game, ent, value)
+            else
+                Apply.applyImage(game, ent, value);
+            return if (applied) 0 else -1;
+        }
+
         fn componentGetImpl(id: u64, name: []const u8, out: []u8) usize {
             const ent = castEntity(id) orelse return 0;
+            // Liveness guard, same as set/remove: `getComponent` is a
+            // raw sparse lookup on real backends, so a stale script id
+            // held past `labelle_entity_destroy` could otherwise read a
+            // dead — or recycled — entity's row. Dead → 0 (absent).
+            if (!game.ecs_backend.entityExists(ent)) return 0;
             if (std.mem.eql(u8, name, "Position")) {
                 const pos = game.getComponent(ent, core.Position) orelse return 0;
                 return stringifyInto(pos.*, out);
+            }
+            inline for (builtin_comps) |spec| {
+                if (std.mem.eql(u8, name, spec.name)) {
+                    const comp = game.getComponent(ent, spec.T) orelse return 0;
+                    if (comptime std.mem.eql(u8, spec.name, "Camera")) {
+                        // `tag` is an inline `[16:0]u8`; serialize the
+                        // STRING view so the output round-trips through
+                        // the apply branch's `setTagSlice` (the generic
+                        // path would emit a NUL-padded byte array).
+                        return stringifyInto(.{
+                            .zoom = comp.zoom,
+                            .viewport = comp.viewport,
+                            .tag = comp.tagSlice(),
+                        }, out);
+                    }
+                    // Omit renderer-handle fields (gfx `Sprite.texture`)
+                    // — GET mirrors what a scene could have authored.
+                    return stringifyFilteredInto(comp.*, out);
+                }
             }
             const comp_names = comptime Components.names();
             inline for (comp_names) |comp_name| {
@@ -725,8 +938,15 @@ fn Holder(comptime GP: type) type {
 
         fn componentHasImpl(id: u64, name: []const u8) i32 {
             const ent = castEntity(id) orelse return 0;
+            // Liveness guard — see componentGetImpl. Dead → 0 (absent).
+            if (!game.ecs_backend.entityExists(ent)) return 0;
             if (std.mem.eql(u8, name, "Position")) {
                 return @intFromBool(game.hasComponent(ent, core.Position));
+            }
+            inline for (builtin_comps) |spec| {
+                if (std.mem.eql(u8, name, spec.name)) {
+                    return @intFromBool(game.hasComponent(ent, spec.T));
+                }
             }
             const comp_names = comptime Components.names();
             inline for (comp_names) |comp_name| {
@@ -749,6 +969,30 @@ fn Holder(comptime GP: type) type {
                 if (!game.hasComponent(ent, core.Position)) return 0;
                 game.removeComponent(ent, core.Position);
                 return 0;
+            }
+            // Scene built-ins tear down through the engine's TYPED
+            // channels, not bare `removeComponent`: `removeSprite` /
+            // `removeShape` untrack the renderer, `removeTilemap` frees
+            // the decoded side-table runtime. Same absent-but-known
+            // idempotence guard as the registry path (and those typed
+            // removes would untrack/backend-remove unconditionally).
+            inline for (builtin_comps) |spec| {
+                if (std.mem.eql(u8, name, spec.name)) {
+                    if (!game.hasComponent(ent, spec.T)) return 0;
+                    if (comptime std.mem.eql(u8, spec.name, "Sprite")) {
+                        game.removeSprite(ent);
+                    } else if (comptime std.mem.eql(u8, spec.name, "Shape")) {
+                        game.removeShape(ent);
+                    } else if (comptime std.mem.eql(u8, spec.name, "Tilemap")) {
+                        game.removeTilemap(ent);
+                    } else {
+                        // Camera / Image are plain data components; the
+                        // generic remove (with its onRemove gate) is the
+                        // whole teardown.
+                        game.removeComponent(ent, spec.T);
+                    }
+                    return 0;
+                }
             }
             const comp_names = comptime Components.names();
             inline for (comp_names) |comp_name| {
@@ -777,9 +1021,17 @@ fn Holder(comptime GP: type) type {
             const names = parsed.value;
             if (names.len == 0) return writeEmptyArray(out);
             // Comptime-dispatch the FIRST name to a typed view; the
-            // rest filter per-entity by name below.
+            // rest filter per-entity by name below. Scene built-ins
+            // resolve here too (before the registry, same precedence
+            // as the component ops) so `has`/`query` agree on the
+            // name space.
             if (std.mem.eql(u8, names[0], "Position")) {
                 return runQuery(core.Position, names[1..], out);
+            }
+            inline for (builtin_comps) |spec| {
+                if (std.mem.eql(u8, names[0], spec.name)) {
+                    return runQuery(spec.T, names[1..], out);
+                }
             }
             const comp_names = comptime Components.names();
             inline for (comp_names) |comp_name| {
@@ -839,6 +1091,9 @@ fn Holder(comptime GP: type) type {
         /// Runtime component name → "is it dispatchable at all".
         fn nameResolvable(name: []const u8) bool {
             if (std.mem.eql(u8, name, "Position")) return true;
+            inline for (builtin_comps) |spec| {
+                if (std.mem.eql(u8, name, spec.name)) return true;
+            }
             const comp_names = comptime Components.names();
             inline for (comp_names) |comp_name| {
                 if (std.mem.eql(u8, name, comp_name)) return true;
@@ -850,6 +1105,11 @@ fn Holder(comptime GP: type) type {
         fn hasByName(ent: Entity, name: []const u8) bool {
             if (std.mem.eql(u8, name, "Position")) {
                 return game.hasComponent(ent, core.Position);
+            }
+            inline for (builtin_comps) |spec| {
+                if (std.mem.eql(u8, name, spec.name)) {
+                    return game.hasComponent(ent, spec.T);
+                }
             }
             const comp_names = comptime Components.names();
             inline for (comp_names) |comp_name| {
@@ -943,6 +1203,27 @@ fn Holder(comptime GP: type) type {
             var w = std.Io.Writer.fixed(out);
             // WriteFailed = doesn't fit → 0, per the export's contract.
             std.json.Stringify.value(value, .{}, &w) catch return 0;
+            return w.buffered().len;
+        }
+
+        /// `stringifyInto` for the scene built-ins: streams the struct
+        /// as a JSON object, omitting fields `std.json` can't round-trip
+        /// as AUTHORED data (see `jsonRoundTrips` — e.g. gfx
+        /// `Sprite.texture`, a renderer handle the next set re-derives
+        /// from `sprite_name`). The registry path keeps whole-struct
+        /// `stringifyInto`; only built-ins carry renderer handles.
+        fn stringifyFilteredInto(comp: anytype, out: []u8) usize {
+            var w = std.Io.Writer.fixed(out);
+            var jw: std.json.Stringify = .{ .writer = &w };
+            // WriteFailed = doesn't fit → 0, per the export's contract.
+            jw.beginObject() catch return 0;
+            inline for (@typeInfo(@TypeOf(comp)).@"struct".fields) |f| {
+                if (comptime jsonRoundTrips(f.type)) {
+                    jw.objectField(f.name) catch return 0;
+                    jw.write(@field(comp, f.name)) catch return 0;
+                }
+            }
+            jw.endObject() catch return 0;
             return w.buffered().len;
         }
 

--- a/src/script_contract.zig
+++ b/src/script_contract.zig
@@ -103,18 +103,24 @@
 //! Pointer-free components (the per-tick hot path, e.g. `Position`)
 //! parse without allocating at all.
 //!
-//! ## Out-buffer sizing (one deliberate asymmetry)
+//! ## Out-buffer sizing (required-size vs written-bytes)
 //!
-//! `labelle_component_get` and `labelle_event_poll` return bytes
-//! WRITTEN (0 = absent / empty / doesn't fit): their payloads are
-//! single structs — bounded in practice — so two-call sizing would buy
-//! nothing (POC decision). `labelle_query` is the contract's only
-//! UNBOUNDED-cardinality op (every matching entity), so it alone sizes
-//! snprintf-style: the return is the bytes the COMPLETE result
-//! requires, while writing still fills only up to the cap, truncated
-//! at the last whole id and always valid JSON. `required > cap` is the
-//! caller's truncation signal — retry with a `required`-sized buffer;
-//! NULL/cap-0 is a legal pure sizing probe.
+//! `labelle_query` and `labelle_component_get` size snprintf-style:
+//! the return is the bytes the COMPLETE result requires, `required >
+//! cap` is the caller's truncation signal (retry right-sized), and a
+//! NULL/cap-0 `out` is a legal pure sizing probe. 0 keeps its
+//! sentinel meaning (malformed names for the query; absent / unknown
+//! / dead for the get). They differ in what an under-sized cap
+//! WRITES: the query fills `out` up to the cap, truncated at the
+//! last whole id and always valid JSON — a prefix of independent ids
+//! has value — while the get writes ALL-OR-NOTHING (only when
+//! `required <= cap`): a truncated JSON object prefix is useless, so
+//! on overflow the buffer is untouched. `labelle_event_poll` alone
+//! returns bytes WRITTEN, because a poll CONSUMES its entry
+//! (truncation included) and a required-size return after the copy
+//! could not be retried; its sizing story is the paired NULL/cap-0
+//! probe instead — the NEXT entry's size, nothing read or consumed —
+//! so a sizing caller probes, grows its buffer, then polls.
 //!
 //! ## Component name space (registry + scene built-ins)
 //!
@@ -405,6 +411,9 @@ pub export fn labelle_prefab_spawn(
 /// mutation). The built-ins follow the scene loader's LENIENT field
 /// semantics (a wrong-typed field with a default falls back to that
 /// default; malformed JSON and non-object payloads are still -1).
+/// On EVERY path the payload must be a single JSON document: trailing
+/// bytes after it (beyond whitespace — plus comments on the built-in
+/// path, which is JSONC) are malformed JSON, refused with -1.
 pub export fn labelle_component_set(
     id: u64,
     name_ptr: [*]const u8,
@@ -422,11 +431,16 @@ pub export fn labelle_component_set(
 }
 
 /// Serialize component `name` of entity `id` to JSON into `out`
-/// (capacity `out_cap`) and return the number of bytes written. 0 =
-/// absent component / unknown name / dead entity / not bound / doesn't
-/// fit. A NULL `out` is treated as capacity 0 (nothing written, 0
-/// returned). Two-call sizing is deliberately avoided (POC decision):
-/// script payloads are small — size `out` generously.
+/// (capacity `out_cap`) and return the bytes the COMPLETE JSON
+/// requires (snprintf-style sizing, like `labelle_query`). 0 keeps
+/// its sentinel meaning: absent component / unknown name / dead
+/// entity / not bound. The write is ALL-OR-NOTHING: `out` is filled
+/// only when the whole JSON fits (`required <= out_cap`) — a
+/// truncated JSON object prefix is useless, unlike the query's
+/// still-valid id prefix — so on overflow the buffer is untouched
+/// and `required > out_cap` is the caller's signal to retry with a
+/// `required`-sized buffer. A NULL or zero-capacity `out` is a legal
+/// pure sizing probe: nothing written, the required size returned.
 ///
 /// Scene built-ins serialize as a scene could have AUTHORED them: any
 /// field that is a renderer handle rather than authored data (the
@@ -442,9 +456,12 @@ pub export fn labelle_component_get(
     out_cap: usize,
 ) usize {
     const vt = vtable orelse return 0;
-    if (name_len == 0 or out_cap == 0) return 0;
-    const buf = out orelse return 0;
-    return vt.component_get(id, name_ptr[0..name_len], buf[0..out_cap]);
+    if (name_len == 0) return 0;
+    // NULL (legal only alongside cap 0, but tolerated regardless) is
+    // the documented sizing probe: an empty destination — required-size
+    // computation runs, nothing is written. Same shape as the query's.
+    const buf: []u8 = if (out) |p| p[0..out_cap] else &.{};
+    return vt.component_get(id, name_ptr[0..name_len], buf);
 }
 
 /// 1 when entity `id` carries component `name`; 0 otherwise (absent,
@@ -511,7 +528,10 @@ pub export fn labelle_query(
 /// other subscribed scripts all see it at this frame's
 /// `dispatchEvents`. `name` must be a `GameEvents` union tag; `json` is
 /// the variant's payload struct (NULL or empty → `{}`, i.e. all-default
-/// fields). Returns 0 = ok; -1 = unknown event name / parse failure /
+/// fields). VOID-payload variants (the tag declares no payload struct)
+/// accept exactly: empty (NULL/len 0), the bytes `{}`, or the bytes
+/// `null` — anything else, malformed JSON included, is a parse
+/// failure. Returns 0 = ok; -1 = unknown event name / parse failure /
 /// the game declares no `GameEvents` union / not bound.
 pub export fn labelle_event_emit(
     name_ptr: [*]const u8,
@@ -554,17 +574,23 @@ pub export fn labelle_event_subscribe(name_ptr: [*]const u8, name_len: usize) vo
 
 /// Drain one pending event: copies the next `"<name> <json>"` entry
 /// (FIFO — emission order within and across frames) into `out` and
-/// returns bytes written; 0 = inbox empty. The entry is consumed even
-/// when `out_cap` truncates it (POC-pinned behavior) — size `out`
-/// generously. A NULL or zero-capacity `out` is the one exception: it
-/// reads (and consumes) nothing and returns 0. Scripts drain in a
-/// `while (poll() > 0)` loop once per tick.
+/// returns bytes WRITTEN; 0 = inbox empty. A real read consumes the
+/// entry even when `out_cap` truncates it (POC-pinned behavior) — but
+/// no caller ever needs to eat a truncation, because a NULL or
+/// zero-capacity `out` is the paired no-consume SIZING PROBE: it
+/// returns the NEXT entry's full size (0 = inbox empty) while reading
+/// and consuming nothing, so a sizing caller probes, grows its
+/// buffer, then polls. An entry is never empty (`"<name> <json>"`
+/// carries at least the name), so a probe's non-zero return cannot be
+/// confused with inbox-empty. Scripts drain in a `while (poll() > 0)`
+/// loop once per tick.
 pub export fn labelle_event_poll(out: ?[*]u8, out_cap: usize) usize {
     if (inbox_head >= inbox.items.len) return 0;
     const alloc = bound_allocator orelse return 0;
-    const buf = out orelse return 0;
-    if (out_cap == 0) return 0;
     const entry = inbox.items[inbox_head];
+    // The probe leg: report the pending entry's size, touch nothing.
+    const buf = out orelse return entry.len;
+    if (out_cap == 0) return entry.len;
     inbox_head += 1;
     const len = @min(entry.len, out_cap);
     @memcpy(buf[0..len], entry[0..len]);
@@ -876,11 +902,16 @@ fn Holder(comptime GP: type) type {
                     // Slice-bearing fields land in the nested-entity
                     // arena — the scene bridge's exact lifetime
                     // convention (freed atomically on scene change).
+                    // `alloc_always`, never the slice default
+                    // alloc_if_needed: an unescaped string field would
+                    // otherwise BORROW the caller's json — a buffer
+                    // valid only during this call — and the stored
+                    // component's slices would dangle on return.
                     const comp = std.json.parseFromSliceLeaky(
                         T,
                         componentAlloc(),
                         json,
-                        .{ .ignore_unknown_fields = true },
+                        .{ .ignore_unknown_fields = true, .allocate = .alloc_always },
                     ) catch return -1;
                     // `setComponent`, not the backend add: it fires
                     // onSet/onAdd, roster invalidation, and preview
@@ -905,6 +936,14 @@ fn Holder(comptime GP: type) type {
             defer arena.deinit();
             var parser = jsonc.JsoncParser.init(arena.allocator(), json);
             const value = parser.parse() catch return -1;
+            // The JSONC parser stops after ONE value (consuming any
+            // trailing whitespace/comments — JSONC trivia); bytes left
+            // past it mean the payload wasn't a single JSON document.
+            // That is the contract's malformed-JSON -1, decided BEFORE
+            // the apply so the entity stays untouched — std.json's
+            // end-of-document check refuses the same shapes on the
+            // registry path by itself.
+            if (parser.pos != json.len) return -1;
             const applied = if (comptime std.mem.eql(u8, comp_name, "Sprite"))
                 Apply.applySprite(game, ent, value)
             else if (comptime std.mem.eql(u8, comp_name, "Shape"))
@@ -1176,19 +1215,34 @@ fn Holder(comptime GP: type) type {
             inline for (fields) |f| {
                 if (std.mem.eql(u8, name, f.name)) {
                     if (comptime f.type == void) {
+                        // No payload struct exists for std.json to
+                        // validate against, so the accept set is pinned
+                        // explicitly (and documented in the export doc
+                        // + header): empty — NULL/len-0 arrives here as
+                        // "{}" via the export's default — or the exact
+                        // bytes "{}" or "null". Anything else is the
+                        // contract's parse failure: -1, nothing
+                        // buffered.
+                        if (!std.mem.eql(u8, json, "{}") and !std.mem.eql(u8, json, "null"))
+                            return -1;
                         game.emit(@unionInit(G.GameEvents, f.name, {}));
                         return 0;
                     }
                     // Payload slices live in the ACTIVE emit arena,
                     // which stays untouched through this frame's
                     // dispatch and is recycled one flip later (module
-                    // doc, "Payload memory").
+                    // doc, "Payload memory"). `alloc_always`, never the
+                    // slice default alloc_if_needed: the event sits
+                    // buffered until dispatchEvents long after this
+                    // call returns, so an unescaped string field must
+                    // be COPIED into the arena, not borrowed from the
+                    // caller's transient json.
                     const arena = if (emit_arenas[emit_active]) |*a| a.allocator() else return -1;
                     const payload = std.json.parseFromSliceLeaky(
                         f.type,
                         arena,
                         json,
-                        .{ .ignore_unknown_fields = true },
+                        .{ .ignore_unknown_fields = true, .allocate = .alloc_always },
                     ) catch return -1;
                     game.emit(@unionInit(G.GameEvents, f.name, payload));
                     return 0;
@@ -1245,11 +1299,26 @@ fn Holder(comptime GP: type) type {
             return game.active_world.nested_entity_arena.allocator();
         }
 
+        /// Serialize `value` with the get's required-size semantics:
+        /// the return is the bytes the COMPLETE JSON needs, and `out`
+        /// is written only when all of it fits — ALL-OR-NOTHING, a
+        /// truncated JSON object prefix being useless (unlike the
+        /// query's id-list prefix). A counting pass sizes first so an
+        /// over-cap value never scribbles a partial write into `out`
+        /// (the canary the contract tests pin); gets are game-logic
+        /// scale, so the doubled serialization is irrelevant.
         fn stringifyInto(value: anytype, out: []u8) usize {
-            var w = std.Io.Writer.fixed(out);
-            // WriteFailed = doesn't fit → 0, per the export's contract.
-            std.json.Stringify.value(value, .{}, &w) catch return 0;
-            return w.buffered().len;
+            var counting: std.Io.Writer.Discarding = .init(&.{});
+            // A discarding writer cannot fail; catch is belt.
+            std.json.Stringify.value(value, .{}, &counting.writer) catch return 0;
+            const required: usize = @intCast(counting.fullCount());
+            if (required <= out.len) {
+                var w = std.Io.Writer.fixed(out);
+                // Counted to fit — unreachable, but 0 (absent) beats a
+                // lying required if it ever fires.
+                std.json.Stringify.value(value, .{}, &w) catch return 0;
+            }
+            return required;
         }
 
         /// `stringifyInto` for the scene built-ins: streams the struct
@@ -1258,19 +1327,28 @@ fn Holder(comptime GP: type) type {
         /// `Sprite.texture`, a renderer handle the next set re-derives
         /// from `sprite_name`). The registry path keeps whole-struct
         /// `stringifyInto`; only built-ins carry renderer handles.
+        /// Same required-size / all-or-nothing semantics.
         fn stringifyFilteredInto(comp: anytype, out: []u8) usize {
-            var w = std.Io.Writer.fixed(out);
-            var jw: std.json.Stringify = .{ .writer = &w };
-            // WriteFailed = doesn't fit → 0, per the export's contract.
-            jw.beginObject() catch return 0;
+            var counting: std.Io.Writer.Discarding = .init(&.{});
+            writeFilteredJson(comp, &counting.writer) catch return 0;
+            const required: usize = @intCast(counting.fullCount());
+            if (required <= out.len) {
+                var w = std.Io.Writer.fixed(out);
+                writeFilteredJson(comp, &w) catch return 0;
+            }
+            return required;
+        }
+
+        fn writeFilteredJson(comp: anytype, w: *std.Io.Writer) std.Io.Writer.Error!void {
+            var jw: std.json.Stringify = .{ .writer = w };
+            try jw.beginObject();
             inline for (@typeInfo(@TypeOf(comp)).@"struct".fields) |f| {
                 if (comptime jsonRoundTrips(f.type)) {
-                    jw.objectField(f.name) catch return 0;
-                    jw.write(@field(comp, f.name)) catch return 0;
+                    try jw.objectField(f.name);
+                    try jw.write(@field(comp, f.name));
                 }
             }
-            jw.endObject() catch return 0;
-            return w.buffered().len;
+            try jw.endObject();
         }
 
         fn castEntity(id: u64) ?Entity {

--- a/src/script_contract.zig
+++ b/src/script_contract.zig
@@ -129,9 +129,20 @@ var bound_allocator: ?std.mem.Allocator = null;
 var subs: std.ArrayList([]u8) = .empty;
 /// FIFO inbox of pending `"<name> <json>"` entries (owned). Popped from
 /// `inbox_head` so a drain-heavy frame is O(1) per poll; the backing
-/// list is compacted whenever it runs empty.
+/// list is compacted whenever it runs empty, or in place once the dead
+/// prefix passes `inbox_compact_threshold` (see `compactInbox` — a
+/// budgeted poller that always leaves a backlog never runs it empty).
 var inbox: std.ArrayList([]u8) = .empty;
 var inbox_head: usize = 0;
+/// Dead-slot count past which `compactInbox` slides the pending tail
+/// to the front instead of waiting for the inbox to run empty.
+const inbox_compact_threshold: usize = 16;
+/// The tick's scaled (gameplay) dt as stamped by the language plugin
+/// via `labelle_time_dt_stamp`; `null` = never stamped this session,
+/// so `labelle_time_dt` reconstructs the value from the frame-profiler
+/// ring instead. Reset on bind/unbind — the stamp belongs to the
+/// plugin session, exactly like `subs`/`inbox`.
+var stamped_dt: ?f32 = null;
 /// Double-buffered arenas for `labelle_event_emit` payloads — see the
 /// module doc's "Payload memory" section for why one arena would UAF.
 /// `emit_active` indexes the arena current emits parse into; it flips
@@ -181,6 +192,7 @@ pub fn bind(g: anytype) void {
         std.heap.ArenaAllocator.init(g.allocator),
     };
     emit_active = 0;
+    stamped_dt = null;
 }
 
 /// Drop the bound game and reset all contract state (subscriptions,
@@ -205,6 +217,7 @@ pub fn unbind() void {
         slot.* = null;
     }
     emit_active = 0;
+    stamped_dt = null;
     bound_allocator = null;
 }
 
@@ -279,22 +292,22 @@ pub export fn labelle_entity_destroy(id: u64) void {
     vt.entity_destroy(id);
 }
 
-/// Spawn a named prefab. `params_json` is optional: empty (`len == 0`)
-/// spawns at the origin; otherwise it is a `{"x":…,"y":…}` object giving
-/// the spawn position (unknown keys ignored; malformed JSON fails the
-/// spawn). Returns the root entity id, or 0 on failure (unknown prefab,
-/// no JSONC scene loaded yet, bad params, not bound).
+/// Spawn a named prefab. `params_json` is optional: NULL or empty
+/// (`len == 0`) spawns at the origin; otherwise it is a `{"x":…,"y":…}`
+/// object giving the spawn position (unknown keys ignored; malformed
+/// JSON fails the spawn). Returns the root entity id, or 0 on failure
+/// (unknown prefab, no JSONC scene loaded yet, bad params, not bound).
 pub export fn labelle_prefab_spawn(
     name_ptr: [*]const u8,
     name_len: usize,
-    json_ptr: [*]const u8,
+    json_ptr: ?[*]const u8,
     json_len: usize,
 ) u64 {
     const vt = vtable orelse return 0;
     if (name_len == 0) return 0;
     return vt.prefab_spawn(
         name_ptr[0..name_len],
-        if (json_len == 0) "" else json_ptr[0..json_len],
+        optionalJson(json_ptr, json_len, ""),
     );
 }
 
@@ -308,14 +321,16 @@ pub export fn labelle_prefab_spawn(
 ///
 /// REPLACE semantics: the JSON is parsed as the whole component struct
 /// (absent fields take the struct's defaults, unknown fields are
-/// ignored); there is no merge/patch. Returns 0 = ok; -1 = unknown
-/// component name / unknown-or-dead entity / parse failure / not bound.
-/// On -1 the entity is untouched (the parse runs before any mutation).
+/// ignored); there is no merge/patch. `json` may be NULL or empty
+/// (`len == 0`), meaning `"{}"` — all defaults. Returns 0 = ok; -1 =
+/// unknown component name / unknown-or-dead entity / parse failure /
+/// not bound. On -1 the entity is untouched (the parse runs before any
+/// mutation).
 pub export fn labelle_component_set(
     id: u64,
     name_ptr: [*]const u8,
     name_len: usize,
-    json_ptr: [*]const u8,
+    json_ptr: ?[*]const u8,
     json_len: usize,
 ) i32 {
     const vt = vtable orelse return -1;
@@ -323,25 +338,27 @@ pub export fn labelle_component_set(
     return vt.component_set(
         id,
         name_ptr[0..name_len],
-        if (json_len == 0) "{}" else json_ptr[0..json_len],
+        optionalJson(json_ptr, json_len, "{}"),
     );
 }
 
 /// Serialize component `name` of entity `id` to JSON into `out`
 /// (capacity `out_cap`) and return the number of bytes written. 0 =
 /// absent component / unknown name / dead entity / not bound / doesn't
-/// fit. Two-call sizing is deliberately avoided (POC decision): script
-/// payloads are small — size `out` generously.
+/// fit. A NULL `out` is treated as capacity 0 (nothing written, 0
+/// returned). Two-call sizing is deliberately avoided (POC decision):
+/// script payloads are small — size `out` generously.
 pub export fn labelle_component_get(
     id: u64,
     name_ptr: [*]const u8,
     name_len: usize,
-    out: [*]u8,
+    out: ?[*]u8,
     out_cap: usize,
 ) usize {
     const vt = vtable orelse return 0;
     if (name_len == 0 or out_cap == 0) return 0;
-    return vt.component_get(id, name_ptr[0..name_len], out[0..out_cap]);
+    const buf = out orelse return 0;
+    return vt.component_get(id, name_ptr[0..name_len], buf[0..out_cap]);
 }
 
 /// 1 when entity `id` carries component `name`; 0 otherwise (absent,
@@ -374,36 +391,37 @@ pub export fn labelle_component_remove(id: u64, name_ptr: [*]const u8, name_len:
 /// `labelle_component_get` on a since-destroyed entity returns 0). When
 /// the ids don't all fit, the list is truncated at the last whole id —
 /// the output is always valid JSON (same contract as
-/// `editor_scene_digest`).
+/// `editor_scene_digest`). A NULL `out` is treated as capacity 0.
 pub export fn labelle_query(
     names_json_ptr: [*]const u8,
     names_json_len: usize,
-    out: [*]u8,
+    out: ?[*]u8,
     out_cap: usize,
 ) usize {
     const vt = vtable orelse return 0;
     if (names_json_len == 0 or out_cap == 0) return 0;
-    return vt.query(names_json_ptr[0..names_json_len], out[0..out_cap]);
+    const buf = out orelse return 0;
+    return vt.query(names_json_ptr[0..names_json_len], buf[0..out_cap]);
 }
 
 /// Emit a game event by name into the buffered event path — the same
 /// `game.emit` every Zig script uses, so flows (`OnEvent`), hooks, and
 /// other subscribed scripts all see it at this frame's
 /// `dispatchEvents`. `name` must be a `GameEvents` union tag; `json` is
-/// the variant's payload struct (empty → `{}`, i.e. all-default
+/// the variant's payload struct (NULL or empty → `{}`, i.e. all-default
 /// fields). Returns 0 = ok; -1 = unknown event name / parse failure /
 /// the game declares no `GameEvents` union / not bound.
 pub export fn labelle_event_emit(
     name_ptr: [*]const u8,
     name_len: usize,
-    json_ptr: [*]const u8,
+    json_ptr: ?[*]const u8,
     json_len: usize,
 ) i32 {
     const vt = vtable orelse return -1;
     if (name_len == 0) return -1;
     return vt.event_emit(
         name_ptr[0..name_len],
-        if (json_len == 0) "{}" else json_ptr[0..json_len],
+        optionalJson(json_ptr, json_len, "{}"),
     );
 }
 
@@ -429,23 +447,50 @@ pub export fn labelle_event_subscribe(name_ptr: [*]const u8, name_len: usize) vo
 /// (FIFO — emission order within and across frames) into `out` and
 /// returns bytes written; 0 = inbox empty. The entry is consumed even
 /// when `out_cap` truncates it (POC-pinned behavior) — size `out`
-/// generously. Scripts drain in a `while (poll() > 0)` loop once per
-/// tick.
-pub export fn labelle_event_poll(out: [*]u8, out_cap: usize) usize {
+/// generously. A NULL or zero-capacity `out` is the one exception: it
+/// reads (and consumes) nothing and returns 0. Scripts drain in a
+/// `while (poll() > 0)` loop once per tick.
+pub export fn labelle_event_poll(out: ?[*]u8, out_cap: usize) usize {
     if (inbox_head >= inbox.items.len) return 0;
     const alloc = bound_allocator orelse return 0;
+    const buf = out orelse return 0;
+    if (out_cap == 0) return 0;
     const entry = inbox.items[inbox_head];
     inbox_head += 1;
     const len = @min(entry.len, out_cap);
-    if (len > 0) @memcpy(out[0..len], entry[0..len]);
+    @memcpy(buf[0..len], entry[0..len]);
     alloc.free(entry);
-    // Compact once drained so the list never grows past one frame's
-    // backlog (head-index popping leaves freed slots behind otherwise).
+    compactInbox();
+    return len;
+}
+
+/// Reclaim the freed slots head-index popping leaves behind. Fully
+/// drained → plain reset; otherwise slide the pending tail to the
+/// front once the dead prefix is worth the copy. The in-place slide is
+/// what keeps a BUDGETED poller bounded: a script that always leaves a
+/// backlog never runs the inbox empty, and without it the backing
+/// array would grow every frame even at matched emit/poll throughput.
+/// Amortized O(1) per poll — a slide of `pending` entries only happens
+/// after at least `pending` (or `inbox_compact_threshold`) dead slots
+/// accumulated, and `max_pending_events` caps the slide size anyway.
+fn compactInbox() void {
     if (inbox_head == inbox.items.len) {
         inbox.clearRetainingCapacity();
         inbox_head = 0;
+        return;
     }
-    return len;
+    if (inbox_head < inbox_compact_threshold and inbox_head * 2 < inbox.items.len) return;
+    const pending = inbox.items.len - inbox_head;
+    std.mem.copyForwards([]u8, inbox.items[0..pending], inbox.items[inbox_head..]);
+    inbox.shrinkRetainingCapacity(pending);
+    inbox_head = 0;
+}
+
+/// Backing capacity of the poll inbox — a test seam (asserts budgeted
+/// polling can't grow the storage unboundedly), not part of the C
+/// surface.
+pub fn inboxCapacity() usize {
+    return inbox.capacity;
 }
 
 /// Switch to scene `name`. 0 = ok (including a swap deferred on the
@@ -468,14 +513,30 @@ pub export fn labelle_log(msg_ptr: [*]const u8, len: usize) void {
 }
 
 /// The last tick's GAMEPLAY delta-time in seconds — the same scaled dt
-/// Zig scripts receive (`engine__tick`'s `.dt`): the real frame time ×
-/// `time_scale`, and 0 while paused. Reads the game's own record of the
-/// last tick (the `frame_profiler` ring `tick()` feeds every frame), so
-/// no extra generated-main touchpoint is needed. 0 before the first
-/// tick / pre-bind.
+/// Zig scripts receive (`engine__tick`'s `.dt`). When the language
+/// plugin has stamped the tick (`labelle_time_dt_stamp`), the stamped
+/// value is returned verbatim; otherwise — pre-plugin, or a plugin
+/// that never stamps — it is reconstructed from the game's own record
+/// of the last tick (the `frame_profiler` ring `tick()` feeds every
+/// frame): the real frame time × `time_scale`, and 0 while paused. 0
+/// before the first tick / pre-bind.
 pub export fn labelle_time_dt() f32 {
     const vt = vtable orelse return 0;
-    return vt.time_dt();
+    return stamped_dt orelse vt.time_dt();
+}
+
+/// Stamp the tick's gameplay delta-time. Called once per tick by the
+/// scripting LANGUAGE PLUGIN, with the scaled dt the host handed it,
+/// before it runs the frame's scripts — game scripts should not call
+/// it. Once a session has stamped, `labelle_time_dt` returns the
+/// stamped value exactly, so every script observes the very dt Zig
+/// scripts received this tick even when a script changes `time_scale`
+/// mid-tick (the profiler reconstruction reads the CURRENT scale and
+/// would drift). Pre-bind: silently ignored; bind/unbind reset the
+/// stamp with the rest of the session state.
+pub export fn labelle_time_dt_stamp(dt: f32) void {
+    if (vtable == null) return;
+    stamped_dt = dt;
 }
 
 // ── Implementation ──────────────────────────────────────────────────
@@ -486,6 +547,17 @@ pub export fn labelle_time_dt() f32 {
 fn gameHasEventsUnion(comptime G: type) bool {
     if (!@hasDecl(G, "GameEvents")) return false;
     return @typeInfo(G.GameEvents) == .@"union";
+}
+
+/// Normalize an optional (documented "NULL/len 0") JSON parameter to a
+/// slice: NULL or empty selects `default`, the export's documented
+/// stand-in payload. NULL must be handled BEFORE any slicing — a null
+/// non-optional `[*]const u8` is an invalid ABI value in its own
+/// right, len check or no.
+fn optionalJson(ptr: ?[*]const u8, len: usize, default: []const u8) []const u8 {
+    const p = ptr orelse return default;
+    if (len == 0) return default;
+    return p[0..len];
 }
 
 fn isSubscribed(name: []const u8) bool {
@@ -669,7 +741,12 @@ fn Holder(comptime GP: type) type {
         fn componentRemoveImpl(id: u64, name: []const u8) i32 {
             const ent = castEntity(id) orelse return -1;
             if (!game.ecs_backend.entityExists(ent)) return -1;
+            // Absent-but-known is the documented idempotent 0 — and it
+            // must return WITHOUT calling `removeComponent`, which
+            // fires `T.onRemove` unconditionally: a remove the entity
+            // never had would leak a false hook side effect.
             if (std.mem.eql(u8, name, "Position")) {
+                if (!game.hasComponent(ent, core.Position)) return 0;
                 game.removeComponent(ent, core.Position);
                 return 0;
             }
@@ -677,6 +754,7 @@ fn Holder(comptime GP: type) type {
             inline for (comp_names) |comp_name| {
                 if (std.mem.eql(u8, name, comp_name)) {
                     const T = Components.getType(comp_name);
+                    if (!game.hasComponent(ent, T)) return 0;
                     game.removeComponent(ent, T);
                     return 0;
                 }

--- a/src/script_contract.zig
+++ b/src/script_contract.zig
@@ -1,0 +1,902 @@
+//! script_contract — the Script Runtime Contract v1 (RFC-LANGUAGE-PLUGINS,
+//! labelle-engine#737).
+//!
+//! The one versioned C-ABI surface every scripting language binds: flat
+//! `export fn labelle_*` symbols, strings as ptr+len, payloads as JSON.
+//! Embedded-VM languages (Lua, mruby) call these from binding closures;
+//! native-compiled languages (Rust, Crystal) declare them `extern "C"`
+//! against `contract/labelle_script.h` and link into the host. Both
+//! families consume the IDENTICAL surface — proven by the POC in
+//! `spike/language-plugins/` (PR #734), whose subscribe/poll-drain event
+//! semantics are pinned here verbatim.
+//!
+//! ## Bind pattern
+//!
+//! Module-scope `g` in the assembler-generated `main.zig` is not visible
+//! to a sibling module, so the generated main hands it to `bind(&g)` once,
+//! right after `Game.init`. `bind` is comptime-generic: it instantiates a
+//! `Holder` for the concrete Game type, stores the pointer in that
+//! instantiation's container-level `var`, and publishes a vtable of plain
+//! (non-generic) function pointers. The `export fn`s dispatch through that
+//! vtable — they carry no comptime type information themselves.
+//!
+//! Before `bind` runs, every export is a safe no-op: id-returning ops
+//! return 0, rc-returning ops return -1, `labelle_component_get` /
+//! `labelle_query` / `labelle_event_poll` write nothing and return 0, and
+//! the void ops silently ignore. `labelle_contract_version` is pure and
+//! works even before `bind`.
+//!
+//! ## No symbols in script-less builds
+//!
+//! This file is reachable from the engine root only through
+//! `root.script_contract`, a lazily-analyzed `pub const`. The generated
+//! main `@import`s/binds it only when a language plugin is attached; a
+//! build that never references the module never semantically analyzes this
+//! file, so none of the `labelle_*` exports are emitted — the same
+//! zero-cost gate `editor_api` uses for its `editor_*` symbols.
+//!
+//! ## Generated-main touchpoints (the assembler splices exactly these)
+//!
+//! ```zig
+//! script_contract.bind(&g);            // once, after Game init
+//! // per frame:
+//! g.tick(dt);                          // plugin tick runs the scripts
+//! script_contract.drainEvents(&g);     // AFTER tick, BEFORE dispatchEvents
+//! g.dispatchEvents();
+//! ```
+//!
+//! The tick → drainEvents → dispatchEvents ordering is load-bearing:
+//! `drainEvents` walks the frame's buffered events (`game.event_buffer`)
+//! and copies the subscribed ones into the poll FIFO, WITHOUT consuming
+//! the buffer — `dispatchEvents` then drains it to Zig hooks as always.
+//! Running the tap after `dispatchEvents` would see an already-emptied
+//! buffer (dispatch swaps it out), so scripts would never receive a
+//! single event. Call `drainEvents` exactly once per frame: it is also
+//! the maintenance point that recycles the `labelle_event_emit` payload
+//! arenas (see "Payload memory" below) — skipping it grows them
+//! unboundedly, and a second call in one frame would both double-deliver
+//! the frame's events and recycle payloads that are still awaiting
+//! dispatch.
+//!
+//! ## Event tap semantics (the POC's subscribe/poll model)
+//!
+//! A script declares interest with `labelle_event_subscribe(name)` (the
+//! `GameEvents` union tag, e.g. `"turret__fired"` or `"engine__tick"`),
+//! then DRAINS its inbox once per tick: each `labelle_event_poll` copies
+//! the next pending event as `"<name> <json>"` into `out` and returns
+//! bytes written; 0 = inbox empty. Dispatch-to-handlers is language-
+//! plugin sugar over this drain loop (Lua callbacks, Rust match, Ruby
+//! blocks). The event name is the union tag name; the payload is the
+//! variant struct serialized through `std.json` reflection. Every event
+//! flowing through the buffered path this frame is visible — engine
+//! `engine__*` dual-emits, game scripts' `game.emit`, and the script's
+//! own `labelle_event_emit` alike. `emitSync` bypasses the buffer and is
+//! therefore NOT tappable, mirroring how it also skips flow `OnEvent`s.
+//!
+//! ## Payload memory (`labelle_event_emit`)
+//!
+//! Emitted payloads are parsed from JSON into the typed variant struct;
+//! slice-bearing fields land in one of TWO module-owned arenas that
+//! alternate per frame. `drainEvents` flips the active arena and resets
+//! the newly-active one — which holds only the PREVIOUS frame's
+//! payloads, already delivered by that frame's `dispatchEvents`. The
+//! frame's own emits (made during the tick, dispatched after the drain)
+//! sit untouched in the other arena until the NEXT flip. Two arenas
+//! rather than one because a single reset-at-drain would recycle
+//! this-frame payloads BEFORE their end-of-frame dispatch — a
+//! use-after-free for any slice-bearing event payload. Steady-state
+//! memory is bounded by two frames' worth of emitted payloads.
+//!
+//! Component-set payloads use a different lifetime: slices parsed for a
+//! component land in `active_world.nested_entity_arena`, the exact
+//! allocator the JSONC scene bridge uses for deserialized components, so
+//! they share the entity's lifetime and free atomically on scene change.
+//! Pointer-free components (the per-tick hot path, e.g. `Position`)
+//! parse without allocating at all.
+//!
+//! Single-threaded by design (main thread, during the plugin's tick);
+//! no atomics.
+
+const std = @import("std");
+const core = @import("labelle-core");
+
+/// Contract version consumers compile against. Bump on any ABI or
+/// semantic change; language plugins check it via
+/// `labelle_contract_version()` at startup and refuse a mismatch.
+pub const CONTRACT_VERSION: u32 = 1;
+
+/// Inbox back-pressure cap: pending (drained-but-unpolled) events beyond
+/// this are dropped NEWEST-first, matching the POC's fixed-ring behavior.
+/// A script that subscribes but never polls can't grow the heap
+/// unboundedly; a script that drains each tick never comes near it.
+pub const max_pending_events: usize = 256;
+
+// ── Contract-local state (module scope, shared by every Holder) ─────
+//
+// The subscribe/poll machinery is deliberately NOT per-Game state: like
+// `editor_api`'s pause/step counters it belongs to the module, because
+// the exports that manipulate it are plain C symbols with no game
+// context. All of it needs the bound game's allocator, so unlike
+// `editor_pause` it only becomes functional after `bind` (subscribe is
+// a documented pre-bind no-op — the generated main binds before the
+// language plugin's setup runs, so no real subscriber exists earlier).
+
+var vtable: ?*const VTable = null;
+/// The bound game's allocator — owns `subs`/`inbox` entries and the
+/// emit arena. `null` = not bound.
+var bound_allocator: ?std.mem.Allocator = null;
+/// Subscribed event names (deduped, owned copies).
+var subs: std.ArrayList([]u8) = .empty;
+/// FIFO inbox of pending `"<name> <json>"` entries (owned). Popped from
+/// `inbox_head` so a drain-heavy frame is O(1) per poll; the backing
+/// list is compacted whenever it runs empty.
+var inbox: std.ArrayList([]u8) = .empty;
+var inbox_head: usize = 0;
+/// Double-buffered arenas for `labelle_event_emit` payloads — see the
+/// module doc's "Payload memory" section for why one arena would UAF.
+/// `emit_active` indexes the arena current emits parse into; it flips
+/// at every `drainEvents`.
+var emit_arenas: [2]?std.heap.ArenaAllocator = .{ null, null };
+var emit_active: u1 = 0;
+
+// ── Type-erased dispatch ────────────────────────────────────────────
+
+const VTable = struct {
+    entity_create: *const fn () u64,
+    entity_destroy: *const fn (id: u64) void,
+    prefab_spawn: *const fn (name: []const u8, params_json: []const u8) u64,
+    component_set: *const fn (id: u64, name: []const u8, json: []const u8) i32,
+    component_get: *const fn (id: u64, name: []const u8, out: []u8) usize,
+    component_has: *const fn (id: u64, name: []const u8) i32,
+    component_remove: *const fn (id: u64, name: []const u8) i32,
+    query: *const fn (names_json: []const u8, out: []u8) usize,
+    event_emit: *const fn (name: []const u8, json: []const u8) i32,
+    scene_change: *const fn (name: []const u8) i32,
+    log: *const fn (msg: []const u8) void,
+    time_dt: *const fn () f32,
+};
+
+// ── Generated-main API (non-export) ─────────────────────────────────
+
+/// Store the concrete Game behind the type-erased vtable. Called once by
+/// the generated main, after `Game.init` (and scene registration) and
+/// before the language plugin's `setup` runs. `g` must be a stable
+/// `*Game` pointer. Re-binding tears the previous session down first
+/// (subscriptions and pending events belong to the plugin session, not
+/// the process), so a bind-after-bind never leaks or cross-delivers.
+pub fn bind(g: anytype) void {
+    const GP = @TypeOf(g);
+    comptime {
+        const info = @typeInfo(GP);
+        if (info != .pointer or @typeInfo(info.pointer.child) != .@"struct")
+            @compileError("script_contract.bind expects a *Game pointer, got " ++ @typeName(GP));
+    }
+    if (vtable != null) unbind();
+    const H = Holder(GP);
+    H.game = g;
+    vtable = &H.vtable_impl;
+    bound_allocator = g.allocator;
+    emit_arenas = .{
+        std.heap.ArenaAllocator.init(g.allocator),
+        std.heap.ArenaAllocator.init(g.allocator),
+    };
+    emit_active = 0;
+}
+
+/// Drop the bound game and reset all contract state (subscriptions,
+/// pending inbox entries, the emit arena). Exports revert to their
+/// pre-bind no-op behavior. Call before the Game is deinitialized if
+/// the module outlives it; tests use it to isolate the module-level
+/// state.
+pub fn unbind() void {
+    vtable = null;
+    if (bound_allocator) |alloc| {
+        for (subs.items) |s| alloc.free(s);
+        subs.deinit(alloc);
+        subs = .empty;
+        // Entries before `inbox_head` were already freed by poll.
+        for (inbox.items[inbox_head..]) |e| alloc.free(e);
+        inbox.deinit(alloc);
+        inbox = .empty;
+        inbox_head = 0;
+    }
+    for (&emit_arenas) |*slot| {
+        if (slot.*) |*a| a.deinit();
+        slot.* = null;
+    }
+    emit_active = 0;
+    bound_allocator = null;
+}
+
+/// Per-frame event tap, called by the generated main AFTER `g.tick(dt)`
+/// and BEFORE `g.dispatchEvents()` — see the module doc for why that
+/// ordering is load-bearing (dispatch consumes the buffer; the tap only
+/// reads it). Walks the frame's buffered `GameEvents`, serializes each
+/// SUBSCRIBED one to `"<name> <json>"` (name = union tag, payload via
+/// `std.json` reflection), and appends it to the poll FIFO.
+///
+/// Also the once-per-frame maintenance point: flips the double-buffered
+/// `labelle_event_emit` payload arenas and recycles the one holding the
+/// PREVIOUS frame's payloads (safe precisely because that frame's
+/// `dispatchEvents` already delivered everything referencing it — the
+/// module doc's "Payload memory" section spells out the two-arena
+/// dance).
+///
+/// A comptime no-op for games without a `GameEvents` union, and an
+/// early-out when nothing is subscribed — an unused tap costs one
+/// branch per frame.
+pub fn drainEvents(g: anytype) void {
+    const GP = @TypeOf(g);
+    comptime {
+        const info = @typeInfo(GP);
+        if (info != .pointer or @typeInfo(info.pointer.child) != .@"struct")
+            @compileError("script_contract.drainEvents expects a *Game pointer, got " ++ @typeName(GP));
+    }
+    const G = @typeInfo(GP).pointer.child;
+    // Flip + recycle BEFORE the events gate: even a game that never
+    // subscribes still routes `labelle_event_emit` payloads through the
+    // arenas. The newly-active arena held the previous frame's
+    // (already-dispatched) payloads; this frame's own emits stay valid
+    // in the other one until the next flip.
+    emit_active +%= 1;
+    if (emit_arenas[emit_active]) |*a| _ = a.reset(.retain_capacity);
+    if (comptime !gameHasEventsUnion(G)) return;
+    if (vtable == null) return;
+    const alloc = bound_allocator orelse return;
+    if (subs.items.len == 0) return;
+
+    for (g.event_buffer.items) |ev| {
+        switch (ev) {
+            inline else => |data, tag| {
+                if (!isSubscribed(@tagName(tag))) continue;
+                enqueueEvent(alloc, @tagName(tag), data);
+            },
+        }
+    }
+}
+
+// ── Exports (plain, non-generic; dispatch through the vtable) ───────
+
+/// The contract version this binary was built with. Pure — works before
+/// `bind`, so a plugin can version-check first thing.
+pub export fn labelle_contract_version() u32 {
+    return CONTRACT_VERSION;
+}
+
+/// Create an empty entity. Returns its id, or 0 when not bound (entity
+/// ids are never 0 — every ECS backend starts at 1, and the JSONC
+/// bridge relies on the same sentinel).
+pub export fn labelle_entity_create() u64 {
+    const vt = vtable orelse return 0;
+    return vt.entity_create();
+}
+
+/// Destroy entity `id` (children cascade, exactly like a Zig script's
+/// `game.destroyEntity`). Unknown/dead/overflowing ids are ignored, not
+/// crashes — mirrors `editor_set_entity_position`'s tolerance.
+pub export fn labelle_entity_destroy(id: u64) void {
+    const vt = vtable orelse return;
+    vt.entity_destroy(id);
+}
+
+/// Spawn a named prefab. `params_json` is optional: empty (`len == 0`)
+/// spawns at the origin; otherwise it is a `{"x":…,"y":…}` object giving
+/// the spawn position (unknown keys ignored; malformed JSON fails the
+/// spawn). Returns the root entity id, or 0 on failure (unknown prefab,
+/// no JSONC scene loaded yet, bad params, not bound).
+pub export fn labelle_prefab_spawn(
+    name_ptr: [*]const u8,
+    name_len: usize,
+    json_ptr: [*]const u8,
+    json_len: usize,
+) u64 {
+    const vt = vtable orelse return 0;
+    if (name_len == 0) return 0;
+    return vt.prefab_spawn(
+        name_ptr[0..name_len],
+        if (json_len == 0) "" else json_ptr[0..json_len],
+    );
+}
+
+/// Set component `name` on entity `id` from a JSON object — the general
+/// serde seam over the game's OWN `ComponentRegistry` (plus the built-in
+/// `Position`, which routes through `setPosition` so render dirty-
+/// tracking fires). Unlike `editor_set_component` — deliberately
+/// allowlisted to the vetted `"Camera"` — this dispatch is open: the
+/// contract is the game's own code calling itself, so it gets the full
+/// registry, exactly like the JSONC scene loader.
+///
+/// REPLACE semantics: the JSON is parsed as the whole component struct
+/// (absent fields take the struct's defaults, unknown fields are
+/// ignored); there is no merge/patch. Returns 0 = ok; -1 = unknown
+/// component name / unknown-or-dead entity / parse failure / not bound.
+/// On -1 the entity is untouched (the parse runs before any mutation).
+pub export fn labelle_component_set(
+    id: u64,
+    name_ptr: [*]const u8,
+    name_len: usize,
+    json_ptr: [*]const u8,
+    json_len: usize,
+) i32 {
+    const vt = vtable orelse return -1;
+    if (name_len == 0) return -1;
+    return vt.component_set(
+        id,
+        name_ptr[0..name_len],
+        if (json_len == 0) "{}" else json_ptr[0..json_len],
+    );
+}
+
+/// Serialize component `name` of entity `id` to JSON into `out`
+/// (capacity `out_cap`) and return the number of bytes written. 0 =
+/// absent component / unknown name / dead entity / not bound / doesn't
+/// fit. Two-call sizing is deliberately avoided (POC decision): script
+/// payloads are small — size `out` generously.
+pub export fn labelle_component_get(
+    id: u64,
+    name_ptr: [*]const u8,
+    name_len: usize,
+    out: [*]u8,
+    out_cap: usize,
+) usize {
+    const vt = vtable orelse return 0;
+    if (name_len == 0 or out_cap == 0) return 0;
+    return vt.component_get(id, name_ptr[0..name_len], out[0..out_cap]);
+}
+
+/// 1 when entity `id` carries component `name`; 0 otherwise (absent,
+/// unknown name, dead entity, not bound).
+pub export fn labelle_component_has(id: u64, name_ptr: [*]const u8, name_len: usize) i32 {
+    const vt = vtable orelse return 0;
+    if (name_len == 0) return 0;
+    return vt.component_has(id, name_ptr[0..name_len]);
+}
+
+/// Remove component `name` from entity `id`. Idempotent on the
+/// component (removing an absent-but-known component is 0). Returns
+/// 0 = ok; -1 = unknown component name / unknown-or-dead entity / not
+/// bound.
+pub export fn labelle_component_remove(id: u64, name_ptr: [*]const u8, name_len: usize) i32 {
+    const vt = vtable orelse return -1;
+    if (name_len == 0) return -1;
+    return vt.component_remove(id, name_ptr[0..name_len]);
+}
+
+/// Query entity ids by component names. `names_json` is a JSON array of
+/// component names (`["CloudDrift","Position"]`); the engine iterates a
+/// view on the FIRST name and filters the rest, writing the matching ids
+/// as a JSON array (`[3,7,12]`) into `out`. Returns bytes written; 0 =
+/// malformed names / not bound / `out_cap` too small for even `[]`.
+/// An unknown component name yields the valid empty result `[]`.
+///
+/// Snapshot semantics: the id list is captured at query time, so
+/// spawn/destroy while the script walks it is safe (a per-id
+/// `labelle_component_get` on a since-destroyed entity returns 0). When
+/// the ids don't all fit, the list is truncated at the last whole id —
+/// the output is always valid JSON (same contract as
+/// `editor_scene_digest`).
+pub export fn labelle_query(
+    names_json_ptr: [*]const u8,
+    names_json_len: usize,
+    out: [*]u8,
+    out_cap: usize,
+) usize {
+    const vt = vtable orelse return 0;
+    if (names_json_len == 0 or out_cap == 0) return 0;
+    return vt.query(names_json_ptr[0..names_json_len], out[0..out_cap]);
+}
+
+/// Emit a game event by name into the buffered event path — the same
+/// `game.emit` every Zig script uses, so flows (`OnEvent`), hooks, and
+/// other subscribed scripts all see it at this frame's
+/// `dispatchEvents`. `name` must be a `GameEvents` union tag; `json` is
+/// the variant's payload struct (empty → `{}`, i.e. all-default
+/// fields). Returns 0 = ok; -1 = unknown event name / parse failure /
+/// the game declares no `GameEvents` union / not bound.
+pub export fn labelle_event_emit(
+    name_ptr: [*]const u8,
+    name_len: usize,
+    json_ptr: [*]const u8,
+    json_len: usize,
+) i32 {
+    const vt = vtable orelse return -1;
+    if (name_len == 0) return -1;
+    return vt.event_emit(
+        name_ptr[0..name_len],
+        if (json_len == 0) "{}" else json_ptr[0..json_len],
+    );
+}
+
+/// Declare interest in event `name` (a `GameEvents` union tag). From the
+/// next `drainEvents` on, matching events are queued for
+/// `labelle_event_poll`. Duplicate subscriptions are deduped. Pre-bind:
+/// a safe no-op (the generated main binds before plugin setup, so no
+/// real subscriber exists earlier).
+pub export fn labelle_event_subscribe(name_ptr: [*]const u8, name_len: usize) void {
+    const alloc = bound_allocator orelse return;
+    if (name_len == 0) return;
+    const name = name_ptr[0..name_len];
+    for (subs.items) |s| {
+        if (std.mem.eql(u8, s, name)) return;
+    }
+    const copy = alloc.dupe(u8, name) catch return;
+    subs.append(alloc, copy) catch {
+        alloc.free(copy);
+    };
+}
+
+/// Drain one pending event: copies the next `"<name> <json>"` entry
+/// (FIFO — emission order within and across frames) into `out` and
+/// returns bytes written; 0 = inbox empty. The entry is consumed even
+/// when `out_cap` truncates it (POC-pinned behavior) — size `out`
+/// generously. Scripts drain in a `while (poll() > 0)` loop once per
+/// tick.
+pub export fn labelle_event_poll(out: [*]u8, out_cap: usize) usize {
+    if (inbox_head >= inbox.items.len) return 0;
+    const alloc = bound_allocator orelse return 0;
+    const entry = inbox.items[inbox_head];
+    inbox_head += 1;
+    const len = @min(entry.len, out_cap);
+    if (len > 0) @memcpy(out[0..len], entry[0..len]);
+    alloc.free(entry);
+    // Compact once drained so the list never grows past one frame's
+    // backlog (head-index popping leaves freed slots behind otherwise).
+    if (inbox_head == inbox.items.len) {
+        inbox.clearRetainingCapacity();
+        inbox_head = 0;
+    }
+    return len;
+}
+
+/// Switch to scene `name`. 0 = ok (including a swap deferred on the
+/// asset gate — a retry is queued, mirroring `editor_set_scene`),
+/// -1 = unknown scene / error / not bound. Validated BEFORE calling
+/// `setScene` so a typo'd script request never tears the running scene
+/// down.
+pub export fn labelle_scene_change(name_ptr: [*]const u8, name_len: usize) i32 {
+    const vt = vtable orelse return -1;
+    if (name_len == 0) return -1;
+    return vt.scene_change(name_ptr[0..name_len]);
+}
+
+/// Log through the game's log sink (info level, `[script]`-prefixed so
+/// game logs attribute the line). Pre-bind: silently ignored.
+pub export fn labelle_log(msg_ptr: [*]const u8, len: usize) void {
+    const vt = vtable orelse return;
+    if (len == 0) return;
+    vt.log(msg_ptr[0..len]);
+}
+
+/// The last tick's GAMEPLAY delta-time in seconds — the same scaled dt
+/// Zig scripts receive (`engine__tick`'s `.dt`): the real frame time ×
+/// `time_scale`, and 0 while paused. Reads the game's own record of the
+/// last tick (the `frame_profiler` ring `tick()` feeds every frame), so
+/// no extra generated-main touchpoint is needed. 0 before the first
+/// tick / pre-bind.
+pub export fn labelle_time_dt() f32 {
+    const vt = vtable orelse return 0;
+    return vt.time_dt();
+}
+
+// ── Implementation ──────────────────────────────────────────────────
+
+/// The documented consumer gate for `Game.GameEvents` (see game.zig):
+/// the decl always exists but is `void` for event-less games, so the
+/// union check — not `@hasDecl` alone — is what discriminates.
+fn gameHasEventsUnion(comptime G: type) bool {
+    if (!@hasDecl(G, "GameEvents")) return false;
+    return @typeInfo(G.GameEvents) == .@"union";
+}
+
+fn isSubscribed(name: []const u8) bool {
+    for (subs.items) |s| {
+        if (std.mem.eql(u8, s, name)) return true;
+    }
+    return false;
+}
+
+/// Serialize + queue one tapped event. Drop-newest past the cap (see
+/// `max_pending_events`); allocation failures drop silently — an event
+/// tap must never take the frame down.
+fn enqueueEvent(alloc: std.mem.Allocator, name: []const u8, data: anytype) void {
+    if (inbox.items.len - inbox_head >= max_pending_events) return;
+    if (comptime @TypeOf(data) == void) {
+        appendInboxEntry(alloc, name, "{}");
+    } else {
+        const payload = std.json.Stringify.valueAlloc(alloc, data, .{}) catch return;
+        defer alloc.free(payload);
+        appendInboxEntry(alloc, name, payload);
+    }
+}
+
+fn appendInboxEntry(alloc: std.mem.Allocator, name: []const u8, payload: []const u8) void {
+    const entry = std.fmt.allocPrint(alloc, "{s} {s}", .{ name, payload }) catch return;
+    inbox.append(alloc, entry) catch alloc.free(entry);
+}
+
+/// One instantiation per concrete Game-pointer type. The container-level
+/// `var` gives the plain vtable fns a place to find the typed pointer
+/// without any runtime type erasure gymnastics — same shape as
+/// `editor_api.Holder`.
+fn Holder(comptime GP: type) type {
+    return struct {
+        const G = @typeInfo(GP).pointer.child;
+        const Entity = G.EntityType;
+        /// The game's own registry — the same `names()`/`getType()`
+        /// surface the JSONC scene bridge dispatches over, so the
+        /// contract resolves exactly the set of components scenes can
+        /// author (plus the built-in `Position`, which the bridge also
+        /// special-cases). Registries without `getType` (the minimal
+        /// `GameWith` shape) are fine: `names()` is empty there, so the
+        /// `inline for` bodies that reference `getType` never
+        /// instantiate.
+        const Components = G.ComponentRegistry;
+
+        var game: GP = undefined;
+
+        const vtable_impl = VTable{
+            .entity_create = &entityCreateImpl,
+            .entity_destroy = &entityDestroyImpl,
+            .prefab_spawn = &prefabSpawnImpl,
+            .component_set = &componentSetImpl,
+            .component_get = &componentGetImpl,
+            .component_has = &componentHasImpl,
+            .component_remove = &componentRemoveImpl,
+            .query = &queryImpl,
+            .event_emit = &eventEmitImpl,
+            .scene_change = &sceneChangeImpl,
+            .log = &logImpl,
+            .time_dt = &timeDtImpl,
+        };
+
+        // ── Entities ─────────────────────────────────────────────
+
+        fn entityCreateImpl() u64 {
+            return entityId(game.createEntity());
+        }
+
+        fn entityDestroyImpl(id: u64) void {
+            const ent = castEntity(id) orelse return;
+            // Liveness-check first: `destroyEntity` runs the full
+            // cascade (hooks, tombstones) and debug builds assert on
+            // already-dead ids — a script's stale handle must be a
+            // no-op, not a panic.
+            if (!game.ecs_backend.entityExists(ent)) return;
+            game.destroyEntity(ent);
+        }
+
+        // ── Prefabs ──────────────────────────────────────────────
+
+        fn prefabSpawnImpl(name: []const u8, params_json: []const u8) u64 {
+            var pos = core.Position{};
+            if (params_json.len != 0) {
+                // Positional params only in v1. Parsed with the game
+                // allocator and freed immediately — the struct is
+                // pointer-free, so nothing escapes the Parsed arena.
+                const SpawnParams = struct { x: f32 = 0, y: f32 = 0 };
+                const parsed = std.json.parseFromSlice(
+                    SpawnParams,
+                    game.allocator,
+                    params_json,
+                    .{ .ignore_unknown_fields = true },
+                ) catch return 0;
+                defer parsed.deinit();
+                pos = .{ .x = parsed.value.x, .y = parsed.value.y };
+            }
+            // `spawnPrefab` resolves through the prefab cache the JSONC
+            // scene bridge attached (spawn_prefab_fn); before any JSONC
+            // scene load it logs + returns null, which maps to 0 here.
+            const ent = game.spawnPrefab(name, pos) orelse return 0;
+            return entityId(ent);
+        }
+
+        // ── Components (serde dispatch over the registry) ────────
+
+        fn componentSetImpl(id: u64, name: []const u8, json: []const u8) i32 {
+            const ent = castEntity(id) orelse return -1;
+            if (!game.ecs_backend.entityExists(ent)) return -1;
+            // Position — built-in for every game (the RFC's own query/
+            // set examples use it). Routed through `setPosition` so the
+            // render pipeline's dirty-tracking fires, exactly like
+            // `editor_set_entity_position`. Pointer-free: parses with
+            // no allocation.
+            if (std.mem.eql(u8, name, "Position")) {
+                const pos = std.json.parseFromSliceLeaky(
+                    core.Position,
+                    componentAlloc(),
+                    json,
+                    .{ .ignore_unknown_fields = true },
+                ) catch return -1;
+                game.setPosition(ent, pos);
+                return 0;
+            }
+            const comp_names = comptime Components.names();
+            inline for (comp_names) |comp_name| {
+                if (std.mem.eql(u8, name, comp_name)) {
+                    const T = Components.getType(comp_name);
+                    // Slice-bearing fields land in the nested-entity
+                    // arena — the scene bridge's exact lifetime
+                    // convention (freed atomically on scene change).
+                    const comp = std.json.parseFromSliceLeaky(
+                        T,
+                        componentAlloc(),
+                        json,
+                        .{ .ignore_unknown_fields = true },
+                    ) catch return -1;
+                    // `setComponent`, not the backend add: it fires
+                    // onSet/onAdd, roster invalidation, and preview
+                    // telemetry — a script write must be
+                    // indistinguishable from a Zig script's.
+                    game.setComponent(ent, comp);
+                    return 0;
+                }
+            }
+            return -1;
+        }
+
+        fn componentGetImpl(id: u64, name: []const u8, out: []u8) usize {
+            const ent = castEntity(id) orelse return 0;
+            if (std.mem.eql(u8, name, "Position")) {
+                const pos = game.getComponent(ent, core.Position) orelse return 0;
+                return stringifyInto(pos.*, out);
+            }
+            const comp_names = comptime Components.names();
+            inline for (comp_names) |comp_name| {
+                if (std.mem.eql(u8, name, comp_name)) {
+                    const T = Components.getType(comp_name);
+                    const comp = game.getComponent(ent, T) orelse return 0;
+                    return stringifyInto(comp.*, out);
+                }
+            }
+            return 0;
+        }
+
+        fn componentHasImpl(id: u64, name: []const u8) i32 {
+            const ent = castEntity(id) orelse return 0;
+            if (std.mem.eql(u8, name, "Position")) {
+                return @intFromBool(game.hasComponent(ent, core.Position));
+            }
+            const comp_names = comptime Components.names();
+            inline for (comp_names) |comp_name| {
+                if (std.mem.eql(u8, name, comp_name)) {
+                    const T = Components.getType(comp_name);
+                    return @intFromBool(game.hasComponent(ent, T));
+                }
+            }
+            return 0;
+        }
+
+        fn componentRemoveImpl(id: u64, name: []const u8) i32 {
+            const ent = castEntity(id) orelse return -1;
+            if (!game.ecs_backend.entityExists(ent)) return -1;
+            if (std.mem.eql(u8, name, "Position")) {
+                game.removeComponent(ent, core.Position);
+                return 0;
+            }
+            const comp_names = comptime Components.names();
+            inline for (comp_names) |comp_name| {
+                if (std.mem.eql(u8, name, comp_name)) {
+                    const T = Components.getType(comp_name);
+                    game.removeComponent(ent, T);
+                    return 0;
+                }
+            }
+            return -1;
+        }
+
+        // ── Query ────────────────────────────────────────────────
+
+        fn queryImpl(names_json: []const u8, out: []u8) usize {
+            // The names array is transient: parse with the game
+            // allocator, freed on return.
+            const parsed = std.json.parseFromSlice(
+                []const []const u8,
+                game.allocator,
+                names_json,
+                .{},
+            ) catch return 0;
+            defer parsed.deinit();
+            const names = parsed.value;
+            if (names.len == 0) return writeEmptyArray(out);
+            // Comptime-dispatch the FIRST name to a typed view; the
+            // rest filter per-entity by name below.
+            if (std.mem.eql(u8, names[0], "Position")) {
+                return runQuery(core.Position, names[1..], out);
+            }
+            const comp_names = comptime Components.names();
+            inline for (comp_names) |comp_name| {
+                if (std.mem.eql(u8, names[0], comp_name)) {
+                    return runQuery(Components.getType(comp_name), names[1..], out);
+                }
+            }
+            // Unknown first name: a valid, empty result — not an error.
+            // Matches `labelle_component_has`'s "unknown = absent" read
+            // of names that simply aren't in this game's registry.
+            return writeEmptyArray(out);
+        }
+
+        fn runQuery(comptime T: type, rest: []const []const u8, out: []u8) usize {
+            // An unknown FILTER name can never match — same empty
+            // result as an unknown first name, decided up front so the
+            // view isn't walked for nothing.
+            for (rest) |rn| {
+                if (!nameResolvable(rn)) return writeEmptyArray(out);
+            }
+            if (out.len < 2) return 0;
+            // Reserve the closing `]` so id truncation can never eat
+            // the byte that keeps the JSON valid (digest pattern).
+            const body = out[0 .. out.len - 1];
+            var cur: usize = 0;
+            appendLit(body, &cur, "[") catch return 0;
+            var first = true;
+            var v = game.ecs_backend.view(.{T}, .{});
+            defer v.deinit();
+            while (v.next()) |ent| {
+                const matches = blk: {
+                    for (rest) |rn| {
+                        if (!hasByName(ent, rn)) break :blk false;
+                    }
+                    break :blk true;
+                };
+                if (!matches) continue;
+                const mark = cur;
+                writeIdJson(body, &cur, entityId(ent), first) catch {
+                    // Doesn't fit — roll back this id (and its comma)
+                    // and stop; the `]` below keeps the truncated list
+                    // valid JSON.
+                    cur = mark;
+                    break;
+                };
+                first = false;
+            }
+            out[cur] = ']';
+            return cur + 1;
+        }
+
+        fn writeIdJson(buf: []u8, cur: *usize, id: u64, first: bool) error{NoSpace}!void {
+            if (!first) try appendLit(buf, cur, ",");
+            try appendFmt(buf, cur, "{d}", .{id});
+        }
+
+        /// Runtime component name → "is it dispatchable at all".
+        fn nameResolvable(name: []const u8) bool {
+            if (std.mem.eql(u8, name, "Position")) return true;
+            const comp_names = comptime Components.names();
+            inline for (comp_names) |comp_name| {
+                if (std.mem.eql(u8, name, comp_name)) return true;
+            }
+            return false;
+        }
+
+        /// Runtime component name → hasComponent on the resolved type.
+        fn hasByName(ent: Entity, name: []const u8) bool {
+            if (std.mem.eql(u8, name, "Position")) {
+                return game.hasComponent(ent, core.Position);
+            }
+            const comp_names = comptime Components.names();
+            inline for (comp_names) |comp_name| {
+                if (std.mem.eql(u8, name, comp_name)) {
+                    return game.hasComponent(ent, Components.getType(comp_name));
+                }
+            }
+            return false;
+        }
+
+        // ── Events ───────────────────────────────────────────────
+
+        fn eventEmitImpl(name: []const u8, json: []const u8) i32 {
+            // Event-less game: the union check folds the whole body to
+            // `-1` at comptime (the documented `GameEvents` gate).
+            if (comptime !gameHasEventsUnion(G)) return -1;
+            const fields = comptime @typeInfo(G.GameEvents).@"union".fields;
+            inline for (fields) |f| {
+                if (std.mem.eql(u8, name, f.name)) {
+                    if (comptime f.type == void) {
+                        game.emit(@unionInit(G.GameEvents, f.name, {}));
+                        return 0;
+                    }
+                    // Payload slices live in the ACTIVE emit arena,
+                    // which stays untouched through this frame's
+                    // dispatch and is recycled one flip later (module
+                    // doc, "Payload memory").
+                    const arena = if (emit_arenas[emit_active]) |*a| a.allocator() else return -1;
+                    const payload = std.json.parseFromSliceLeaky(
+                        f.type,
+                        arena,
+                        json,
+                        .{ .ignore_unknown_fields = true },
+                    ) catch return -1;
+                    game.emit(@unionInit(G.GameEvents, f.name, payload));
+                    return 0;
+                }
+            }
+            return -1;
+        }
+
+        // ── Scene / log / time ───────────────────────────────────
+
+        fn sceneChangeImpl(name: []const u8) i32 {
+            // Validate BEFORE calling setScene: the engine tears the
+            // current scene down before it discovers an unknown target
+            // (mirrors editor_api.setSceneImpl — a typo'd script
+            // request must not nuke the running scene).
+            if (game.scenes.get(name) == null and game.jsonc_scenes.get(name) == null)
+                return -1;
+            game.setScene(name) catch return -1;
+            // `setScene` DEFERS while the target's asset manifest is
+            // still loading; queue the change so the game loop's
+            // retrier commits it once the assets are ready.
+            if (game.pending_scene_assets != null) game.queueSceneChange(name);
+            return 0;
+        }
+
+        fn logImpl(msg: []const u8) void {
+            game.log.info("[script] {s}", .{msg});
+        }
+
+        fn timeDtImpl() f32 {
+            // Reconstruct the tick's scaled dt from state the game
+            // already keeps: `tick()` records the REAL dt into the
+            // frame_profiler ring every frame (newest at index-1) and
+            // scales by `time_scale` for scripts; a paused game skips
+            // script work entirely, so scripts observe dt 0.
+            if (game.isPaused()) return 0;
+            const fp = &game.frame_profiler;
+            if (fp.count == 0) return 0;
+            const n = fp.frame_times.len;
+            const last = fp.frame_times[(fp.index + n - 1) % n];
+            return last * game.time_scale;
+        }
+
+        // ── Helpers ──────────────────────────────────────────────
+
+        /// Deserialize-side allocations for components (slice fields)
+        /// share the spawned data's lifetime: the nested-entity arena,
+        /// freed atomically on scene change — the identical convention
+        /// `jsonc/component_apply.zig` documents. Pointer-free
+        /// components never touch it (std.json allocates nothing for
+        /// scalar/enum/bool fields), keeping per-tick `Position` sets
+        /// allocation-free.
+        fn componentAlloc() std.mem.Allocator {
+            return game.active_world.nested_entity_arena.allocator();
+        }
+
+        fn stringifyInto(value: anytype, out: []u8) usize {
+            var w = std.Io.Writer.fixed(out);
+            // WriteFailed = doesn't fit → 0, per the export's contract.
+            std.json.Stringify.value(value, .{}, &w) catch return 0;
+            return w.buffered().len;
+        }
+
+        fn castEntity(id: u64) ?Entity {
+            if (comptime @typeInfo(Entity) != .int) return null;
+            return std.math.cast(Entity, id);
+        }
+
+        fn entityId(ent: Entity) u64 {
+            const info = @typeInfo(Entity);
+            if (comptime info == .int and info.int.signedness == .unsigned and info.int.bits <= 64) {
+                return @intCast(ent);
+            }
+            return 0;
+        }
+    };
+}
+
+fn writeEmptyArray(out: []u8) usize {
+    if (out.len < 2) return 0;
+    out[0] = '[';
+    out[1] = ']';
+    return 2;
+}
+
+fn appendLit(buf: []u8, cur: *usize, lit: []const u8) error{NoSpace}!void {
+    if (buf.len - cur.* < lit.len) return error.NoSpace;
+    @memcpy(buf[cur.*..][0..lit.len], lit);
+    cur.* += lit.len;
+}
+
+fn appendFmt(buf: []u8, cur: *usize, comptime fmt: []const u8, args: anytype) error{NoSpace}!void {
+    const written = std.fmt.bufPrint(buf[cur.*..], fmt, args) catch return error.NoSpace;
+    cur.* += written.len;
+}

--- a/src/script_contract.zig
+++ b/src/script_contract.zig
@@ -103,6 +103,19 @@
 //! Pointer-free components (the per-tick hot path, e.g. `Position`)
 //! parse without allocating at all.
 //!
+//! ## Out-buffer sizing (one deliberate asymmetry)
+//!
+//! `labelle_component_get` and `labelle_event_poll` return bytes
+//! WRITTEN (0 = absent / empty / doesn't fit): their payloads are
+//! single structs — bounded in practice — so two-call sizing would buy
+//! nothing (POC decision). `labelle_query` is the contract's only
+//! UNBOUNDED-cardinality op (every matching entity), so it alone sizes
+//! snprintf-style: the return is the bytes the COMPLETE result
+//! requires, while writing still fills only up to the cap, truncated
+//! at the last whole id and always valid JSON. `required > cap` is the
+//! caller's truncation signal — retry with a `required`-sized buffer;
+//! NULL/cap-0 is a legal pure sizing probe.
+//!
 //! ## Component name space (registry + scene built-ins)
 //!
 //! Component names resolve over the game's own `ComponentRegistry` PLUS
@@ -458,19 +471,26 @@ pub export fn labelle_component_remove(id: u64, name_ptr: [*]const u8, name_len:
 /// Query entity ids by component names. `names_json` is a JSON array of
 /// component names (`["CloudDrift","Position"]`); the engine iterates a
 /// view on the FIRST name and filters the rest, writing the matching ids
-/// as a JSON array (`[3,7,12]`) into `out`. Returns bytes written; 0 =
-/// malformed names / not bound / `out_cap` too small for even `[]`.
-/// An unknown component name yields the valid empty result `[]`. Names
-/// resolve over the same space as the component ops — the registry,
-/// `Position`, and the scene built-ins (`Sprite`/`Shape`/`Tilemap`/
-/// `Camera`/`Image`, with the same registry-precedence gates).
+/// as a JSON array (`[3,7,12]`) into `out`. Returns the bytes the
+/// COMPLETE result requires (snprintf-style sizing — the one deliberate
+/// exception to the contract's written-bytes convention, because a query
+/// is its only unbounded-cardinality op); 0 = malformed names / not
+/// bound. An unknown component name yields the valid empty result `[]`
+/// (required = 2). Names resolve over the same space as the component
+/// ops — the registry, `Position`, and the scene built-ins (`Sprite`/
+/// `Shape`/`Tilemap`/`Camera`/`Image`, with the same registry-precedence
+/// gates).
+///
+/// Writing fills `out` up to `out_cap`, ending at the last whole id, so
+/// the written prefix is always valid JSON (same shape as
+/// `editor_scene_digest`); a return larger than `out_cap` is how the
+/// caller DETECTS truncation — retry with a `required`-sized buffer for
+/// the full set. A NULL or zero-capacity `out` is a legal pure sizing
+/// probe: nothing is written, the required size still returns.
 ///
 /// Snapshot semantics: the id list is captured at query time, so
 /// spawn/destroy while the script walks it is safe (a per-id
-/// `labelle_component_get` on a since-destroyed entity returns 0). When
-/// the ids don't all fit, the list is truncated at the last whole id —
-/// the output is always valid JSON (same contract as
-/// `editor_scene_digest`). A NULL `out` is treated as capacity 0.
+/// `labelle_component_get` on a since-destroyed entity returns 0).
 pub export fn labelle_query(
     names_json_ptr: [*]const u8,
     names_json_len: usize,
@@ -478,9 +498,12 @@ pub export fn labelle_query(
     out_cap: usize,
 ) usize {
     const vt = vtable orelse return 0;
-    if (names_json_len == 0 or out_cap == 0) return 0;
-    const buf = out orelse return 0;
-    return vt.query(names_json_ptr[0..names_json_len], buf[0..out_cap]);
+    if (names_json_len == 0) return 0;
+    // NULL (legal only alongside cap 0, but tolerated regardless) is the
+    // documented sizing probe: an empty destination — required-size
+    // computation runs, nothing is written.
+    const buf: []u8 = if (out) |p| p[0..out_cap] else &.{};
+    return vt.query(names_json_ptr[0..names_json_len], buf);
 }
 
 /// Emit a game event by name into the buffered event path — the same
@@ -1052,12 +1075,17 @@ fn Holder(comptime GP: type) type {
             for (rest) |rn| {
                 if (!nameResolvable(rn)) return writeEmptyArray(out);
             }
-            if (out.len < 2) return 0;
+            // snprintf-style: write up to the cap, RETURN the bytes the
+            // complete result requires. A cap under 2 can't hold even
+            // `[]`, so it degrades to a pure sizing pass (writes
+            // nothing) — the NULL/cap-0 probe the export documents.
+            var writing = out.len >= 2;
             // Reserve the closing `]` so id truncation can never eat
             // the byte that keeps the JSON valid (digest pattern).
-            const body = out[0 .. out.len - 1];
+            const body = if (writing) out[0 .. out.len - 1] else out;
             var cur: usize = 0;
-            appendLit(body, &cur, "[") catch return 0;
+            if (writing) appendLit(body, &cur, "[") catch unreachable;
+            var required: usize = 2; // the brackets, matches present or not
             var first = true;
             var v = game.ecs_backend.view(.{T}, .{});
             defer v.deinit();
@@ -1069,18 +1097,36 @@ fn Holder(comptime GP: type) type {
                     break :blk true;
                 };
                 if (!matches) continue;
-                const mark = cur;
-                writeIdJson(body, &cur, entityId(ent), first) catch {
-                    // Doesn't fit — roll back this id (and its comma)
-                    // and stop; the `]` below keeps the truncated list
-                    // valid JSON.
-                    cur = mark;
-                    break;
-                };
+                const id = entityId(ent);
+                required += idJsonLen(id, first);
+                if (writing) {
+                    const mark = cur;
+                    writeIdJson(body, &cur, id, first) catch {
+                        // Doesn't fit — roll back this id (and its
+                        // comma); the `]` below keeps the truncated
+                        // list valid JSON. Keep ITERATING though: the
+                        // remaining ids still count toward `required`,
+                        // which is what lets the caller detect the
+                        // truncation and retry right-sized.
+                        cur = mark;
+                        writing = false;
+                    };
+                }
                 first = false;
             }
-            out[cur] = ']';
-            return cur + 1;
+            if (out.len >= 2) out[cur] = ']';
+            return required;
+        }
+
+        /// Serialized length of one id in the result array — its digits
+        /// plus the separating comma — WITHOUT writing it: this is how
+        /// the past-the-cap ids contribute to the required size
+        /// cheaply.
+        fn idJsonLen(id: u64, first: bool) usize {
+            var digits: usize = 1;
+            var v = id;
+            while (v >= 10) : (v /= 10) digits += 1;
+            return digits + @intFromBool(!first);
         }
 
         fn writeIdJson(buf: []u8, cur: *usize, id: u64, first: bool) error{NoSpace}!void {
@@ -1242,10 +1288,13 @@ fn Holder(comptime GP: type) type {
     };
 }
 
+/// Empty query result: `[]` requires 2 bytes (the return, per the
+/// query's snprintf-style sizing) and is written only when it fits.
 fn writeEmptyArray(out: []u8) usize {
-    if (out.len < 2) return 0;
-    out[0] = '[';
-    out[1] = ']';
+    if (out.len >= 2) {
+        out[0] = '[';
+        out[1] = ']';
+    }
     return 2;
 }
 

--- a/test/script_contract_test.zig
+++ b/test/script_contract_test.zig
@@ -1,0 +1,685 @@
+//! Script Runtime Contract v1 (#737) — labelle_* C-ABI surface tests.
+//!
+//! The module keeps its dispatch state (vtable, subscriptions, poll
+//! FIFO, emit arenas) in module-scope vars, so every test starts and
+//! ends with `contract.unbind()` to stay isolated — same discipline as
+//! editor_api_test.zig.
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+const core = @import("labelle-core");
+
+const contract = engine.script_contract;
+
+// ── Test game: two registered components + a GameEvents union ───────
+//
+// The assembler-shaped instantiation: a ComponentRegistry the contract
+// dispatches over, and a custom `GameEvents` union for emit/subscribe.
+// StubRender/MockEcs keep it headless (the editor_api tests' shape).
+
+const Health = struct { hp: i32 = 100, regen: f32 = 0 };
+const Velocity = struct { dx: f32 = 0, dy: f32 = 0 };
+
+const TestComponents = engine.ComponentRegistry(.{
+    .Health = Health,
+    .Velocity = Velocity,
+});
+
+const TestEvents = union(enum) {
+    turret__fired: struct { turret: u32 = 0, heat: f32 = 0 },
+    wave__started: struct { index: u32 = 0 },
+    // Slice-bearing payload — pins the emit-arena lifetime contract
+    // (parsed name must survive from emit through dispatch).
+    state__renamed: struct { name: []const u8 = "" },
+};
+
+const MockEcs = core.MockEcsBackend(u32);
+const ContractGame = engine.GameConfig(
+    core.StubRender(MockEcs.Entity),
+    MockEcs,
+    engine.StubInput,
+    engine.StubAudio,
+    engine.StubVideo,
+    engine.StubGui,
+    void, // no hooks — dispatchEvents just drains the buffer
+    core.StubLogSink,
+    TestComponents,
+    &.{},
+    TestEvents,
+);
+
+// ── ptr+len call helpers (the C shapes are noisy in Zig) ────────────
+
+fn setComp(id: u64, name: []const u8, json: []const u8) i32 {
+    return contract.labelle_component_set(id, name.ptr, name.len, json.ptr, json.len);
+}
+
+fn getComp(id: u64, name: []const u8, buf: []u8) []const u8 {
+    const n = contract.labelle_component_get(id, name.ptr, name.len, buf.ptr, buf.len);
+    return buf[0..n];
+}
+
+fn hasComp(id: u64, name: []const u8) i32 {
+    return contract.labelle_component_has(id, name.ptr, name.len);
+}
+
+fn removeComp(id: u64, name: []const u8) i32 {
+    return contract.labelle_component_remove(id, name.ptr, name.len);
+}
+
+fn query(names_json: []const u8, buf: []u8) []const u8 {
+    const n = contract.labelle_query(names_json.ptr, names_json.len, buf.ptr, buf.len);
+    return buf[0..n];
+}
+
+fn emitEvent(name: []const u8, json: []const u8) i32 {
+    return contract.labelle_event_emit(name.ptr, name.len, json.ptr, json.len);
+}
+
+fn subscribe(name: []const u8) void {
+    contract.labelle_event_subscribe(name.ptr, name.len);
+}
+
+fn poll(buf: []u8) []const u8 {
+    const n = contract.labelle_event_poll(buf.ptr, buf.len);
+    return buf[0..n];
+}
+
+fn spawnPrefab(name: []const u8, json: []const u8) u64 {
+    return contract.labelle_prefab_spawn(name.ptr, name.len, json.ptr, json.len);
+}
+
+/// Parse a query result (`[3,7]`) and check it equals `expected` as a
+/// SET — the mock backend iterates a hash map, so id order is
+/// unspecified.
+fn expectQueryIds(result: []const u8, expected: []const u64) !void {
+    const parsed = try std.json.parseFromSlice([]u64, testing.allocator, result, .{});
+    defer parsed.deinit();
+    try testing.expectEqual(expected.len, parsed.value.len);
+    for (expected) |want| {
+        var found = false;
+        for (parsed.value) |got| {
+            if (got == want) found = true;
+        }
+        try testing.expect(found);
+    }
+}
+
+// ── Version ─────────────────────────────────────────────────────────
+
+test "labelle_contract_version: pure, works pre-bind, matches the decl" {
+    contract.unbind();
+    defer contract.unbind();
+
+    try testing.expectEqual(@as(u32, 1), contract.labelle_contract_version());
+    try testing.expectEqual(contract.CONTRACT_VERSION, contract.labelle_contract_version());
+}
+
+// ── Pre-bind no-op safety ───────────────────────────────────────────
+
+test "pre-bind: every export is a safe no-op" {
+    contract.unbind();
+    defer contract.unbind();
+
+    // Id-returning ops: 0 (never a valid entity id).
+    try testing.expectEqual(@as(u64, 0), contract.labelle_entity_create());
+    try testing.expectEqual(@as(u64, 0), spawnPrefab("turret", ""));
+
+    // Void ops silently ignore.
+    contract.labelle_entity_destroy(42);
+    contract.labelle_log("hello", 5);
+    subscribe("turret__fired");
+
+    // rc ops report failure.
+    try testing.expectEqual(@as(i32, -1), setComp(1, "Health", "{\"hp\":1}"));
+    try testing.expectEqual(@as(i32, -1), removeComp(1, "Health"));
+    try testing.expectEqual(@as(i32, -1), emitEvent("turret__fired", "{}"));
+    try testing.expectEqual(@as(i32, -1), contract.labelle_scene_change("main", 4));
+
+    // Boolean / out-writing ops: 0 bytes, 0 answer.
+    try testing.expectEqual(@as(i32, 0), hasComp(1, "Health"));
+    var buf: [128]u8 = undefined;
+    try testing.expectEqual(@as(usize, 0), getComp(1, "Health", &buf).len);
+    try testing.expectEqual(@as(usize, 0), query("[\"Health\"]", &buf).len);
+    try testing.expectEqual(@as(usize, 0), poll(&buf).len);
+
+    // Time: no game, no dt.
+    try testing.expectEqual(@as(f32, 0), contract.labelle_time_dt());
+}
+
+// ── Entities ────────────────────────────────────────────────────────
+
+test "entity create/destroy: real ECS lifecycle through the vtable" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+    try testing.expect(id != 0);
+    const ent: u32 = @intCast(id);
+    try testing.expect(game.ecs_backend.entityExists(ent));
+
+    contract.labelle_entity_destroy(id);
+    try testing.expect(!game.ecs_backend.entityExists(ent));
+
+    // Stale/dead/overflowing ids are ignored, not crashes (debug builds
+    // assert inside destroyEntity — the contract liveness-checks first).
+    contract.labelle_entity_destroy(id);
+    contract.labelle_entity_destroy(999_999);
+    contract.labelle_entity_destroy(std.math.maxInt(u64));
+}
+
+// ── Components: set / get / has / remove ────────────────────────────
+
+test "component set/get: JSON round-trip over the registry" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+    const ent: u32 = @intCast(id);
+
+    // Set: parsed to the typed struct, applied via setComponent.
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Health", "{\"hp\":42,\"regen\":1.5}"));
+    const h = game.getComponent(ent, Health).?;
+    try testing.expectEqual(@as(i32, 42), h.hp);
+    try testing.expectEqual(@as(f32, 1.5), h.regen);
+
+    // Absent fields take struct defaults (REPLACE, not merge): a second
+    // set with only `hp` resets `regen` to its default.
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Health", "{\"hp\":7}"));
+    try testing.expectEqual(@as(f32, 0), game.getComponent(ent, Health).?.regen);
+
+    // Unknown JSON keys are tolerated.
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Health", "{\"hp\":9,\"bogus\":true}"));
+
+    // Get: serialize back and parse to verify the round-trip.
+    var buf: [256]u8 = undefined;
+    const json = getComp(id, "Health", &buf);
+    try testing.expect(json.len > 0);
+    const parsed = try std.json.parseFromSlice(Health, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqual(@as(i32, 9), parsed.value.hp);
+
+    // Failure modes, all -1 with the entity untouched:
+    try testing.expectEqual(@as(i32, -1), setComp(id, "Mana", "{\"points\":3}")); // unknown name
+    try testing.expectEqual(@as(i32, -1), setComp(id, "Health", "{\"hp\":")); // parse error
+    try testing.expectEqual(@as(i32, -1), setComp(999_999, "Health", "{\"hp\":1}")); // dead entity
+    try testing.expectEqual(@as(i32, 9), game.getComponent(ent, Health).?.hp);
+
+    // Get failure modes: 0 bytes.
+    try testing.expectEqual(@as(usize, 0), getComp(id, "Mana", &buf).len); // unknown name
+    try testing.expectEqual(@as(usize, 0), getComp(id, "Velocity", &buf).len); // absent component
+    try testing.expectEqual(@as(usize, 0), getComp(999_999, "Health", &buf).len); // dead entity
+    var tiny: [2]u8 = undefined;
+    try testing.expectEqual(@as(usize, 0), getComp(id, "Health", &tiny).len); // doesn't fit
+}
+
+test "component set/get: the built-in Position routes through setPosition" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+    const ent: u32 = @intCast(id);
+
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Position", "{\"x\":320,\"y\":240}"));
+    const pos = game.getComponent(ent, core.Position).?;
+    try testing.expectEqual(@as(f32, 320), pos.x);
+    try testing.expectEqual(@as(f32, 240), pos.y);
+
+    var buf: [128]u8 = undefined;
+    const json = getComp(id, "Position", &buf);
+    const parsed = try std.json.parseFromSlice(core.Position, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqual(@as(f32, 320), parsed.value.x);
+    try testing.expectEqual(@as(f32, 240), parsed.value.y);
+
+    try testing.expectEqual(@as(i32, 1), hasComp(id, "Position"));
+}
+
+test "component has/remove: presence flips, unknown names refuse" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+
+    try testing.expectEqual(@as(i32, 0), hasComp(id, "Velocity"));
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Velocity", "{\"dx\":1}"));
+    try testing.expectEqual(@as(i32, 1), hasComp(id, "Velocity"));
+
+    try testing.expectEqual(@as(i32, 0), removeComp(id, "Velocity"));
+    try testing.expectEqual(@as(i32, 0), hasComp(id, "Velocity"));
+    // Removing an absent-but-known component is idempotent 0.
+    try testing.expectEqual(@as(i32, 0), removeComp(id, "Velocity"));
+
+    // Unknown name / dead entity: -1 (remove), 0 (has).
+    try testing.expectEqual(@as(i32, -1), removeComp(id, "Mana"));
+    try testing.expectEqual(@as(i32, -1), removeComp(999_999, "Velocity"));
+    try testing.expectEqual(@as(i32, 0), hasComp(999_999, "Velocity"));
+}
+
+// ── Query ───────────────────────────────────────────────────────────
+
+test "query: view on the first name, filter on the rest" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    // e1: Health+Velocity; e2: Health; e3: Velocity.
+    const e1 = contract.labelle_entity_create();
+    try testing.expectEqual(@as(i32, 0), setComp(e1, "Health", "{}"));
+    try testing.expectEqual(@as(i32, 0), setComp(e1, "Velocity", "{}"));
+    const e2 = contract.labelle_entity_create();
+    try testing.expectEqual(@as(i32, 0), setComp(e2, "Health", "{}"));
+    const e3 = contract.labelle_entity_create();
+    try testing.expectEqual(@as(i32, 0), setComp(e3, "Velocity", "{}"));
+
+    var buf: [256]u8 = undefined;
+
+    // Single name: every Health carrier.
+    try expectQueryIds(query("[\"Health\"]", &buf), &.{ e1, e2 });
+
+    // Two names: the filter narrows to the intersection.
+    try expectQueryIds(query("[\"Health\",\"Velocity\"]", &buf), &.{e1});
+    try expectQueryIds(query("[\"Velocity\",\"Health\"]", &buf), &.{e1});
+
+    // Built-in Position participates on both sides of the dispatch.
+    try testing.expectEqual(@as(i32, 0), setComp(e2, "Position", "{\"x\":1,\"y\":2}"));
+    try expectQueryIds(query("[\"Position\"]", &buf), &.{e2});
+    try expectQueryIds(query("[\"Health\",\"Position\"]", &buf), &.{e2});
+
+    // Unknown names — first or filter — yield the valid empty result.
+    try testing.expectEqualStrings("[]", query("[\"Mana\"]", &buf));
+    try testing.expectEqualStrings("[]", query("[\"Health\",\"Mana\"]", &buf));
+    try testing.expectEqualStrings("[]", query("[]", &buf));
+
+    // Malformed names JSON: 0 bytes (an error, not an empty result).
+    try testing.expectEqual(@as(usize, 0), query("[\"Health\"", &buf).len);
+    try testing.expectEqual(@as(usize, 0), query("{\"not\":\"array\"}", &buf).len);
+}
+
+test "query: id list truncates at the last whole id and stays valid JSON" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    var i: usize = 0;
+    while (i < 50) : (i += 1) {
+        _ = setComp(contract.labelle_entity_create(), "Health", "{}");
+    }
+
+    // Full result parses.
+    var big: [1024]u8 = undefined;
+    const full = query("[\"Health\"]", &big);
+    var parsed = try std.json.parseFromSlice([]u64, testing.allocator, full, .{});
+    const total = parsed.value.len;
+    parsed.deinit();
+    try testing.expectEqual(@as(usize, 50), total);
+
+    // Every cap must yield valid JSON — truncated, never torn.
+    var cap: usize = 2;
+    while (cap <= 64) : (cap += 3) {
+        const out = query("[\"Health\"]", big[0..cap]);
+        var p = try std.json.parseFromSlice([]u64, testing.allocator, out, .{});
+        try testing.expect(p.value.len <= total);
+        p.deinit();
+    }
+}
+
+// ── Events: emit by name ────────────────────────────────────────────
+
+test "event emit: named union variant parsed from JSON into the game buffer" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    try testing.expectEqual(@as(i32, 0), emitEvent("turret__fired", "{\"turret\":7,\"heat\":0.5}"));
+    try testing.expectEqual(@as(usize, 1), game.event_buffer.items.len);
+    switch (game.event_buffer.items[0]) {
+        .turret__fired => |p| {
+            try testing.expectEqual(@as(u32, 7), p.turret);
+            try testing.expectApproxEqAbs(@as(f32, 0.5), p.heat, 0.0001);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+
+    // Empty payload = all-default fields.
+    try testing.expectEqual(@as(i32, 0), emitEvent("wave__started", ""));
+    switch (game.event_buffer.items[1]) {
+        .wave__started => |p| try testing.expectEqual(@as(u32, 0), p.index),
+        else => return error.TestUnexpectedResult,
+    }
+
+    // Unknown event name / malformed payload: -1, nothing buffered.
+    try testing.expectEqual(@as(i32, -1), emitEvent("nope__event", "{}"));
+    try testing.expectEqual(@as(i32, -1), emitEvent("turret__fired", "{\"turret\":"));
+    try testing.expectEqual(@as(usize, 2), game.event_buffer.items.len);
+}
+
+test "event emit: a game without a GameEvents union refuses with -1" {
+    contract.unbind();
+    defer contract.unbind();
+
+    // engine.Game is the GameWith(void) shape: `GameEvents = void`, and
+    // its EmptyComponents registry has no getType — binding it also
+    // proves the registry loops fold away safely on the minimal shape.
+    var game = engine.Game.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    try testing.expectEqual(@as(i32, -1), emitEvent("turret__fired", "{}"));
+    // The tap is a comptime no-op — must compile and do nothing.
+    contract.drainEvents(&game);
+
+    // Registry ops on the registry-less game: only Position resolves.
+    const id = contract.labelle_entity_create();
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Position", "{\"x\":5,\"y\":6}"));
+    try testing.expectEqual(@as(i32, -1), setComp(id, "Health", "{\"hp\":1}"));
+}
+
+// ── Events: subscribe / drain / poll FIFO ───────────────────────────
+
+test "subscribe/poll: name-filtered FIFO in emission order; the tap does not consume the buffer" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    subscribe("turret__fired");
+    subscribe("turret__fired"); // deduped — no double delivery
+
+    // Mixed emitters, one frame: contract-side and Zig-side (game.emit)
+    // both flow through the buffered path the tap walks.
+    try testing.expectEqual(@as(i32, 0), emitEvent("turret__fired", "{\"turret\":1,\"heat\":0.25}"));
+    game.emit(.{ .wave__started = .{ .index = 3 } }); // not subscribed
+    game.emit(.{ .turret__fired = .{ .turret = 2, .heat = 0.75 } });
+
+    contract.drainEvents(&game);
+
+    // The tap COPIES; dispatch still sees all three events.
+    try testing.expectEqual(@as(usize, 3), game.event_buffer.items.len);
+    game.dispatchEvents();
+    try testing.expectEqual(@as(usize, 0), game.event_buffer.items.len);
+
+    // FIFO: subscribed events in emission order, `<name> <json>` shape.
+    var buf: [256]u8 = undefined;
+    const first = poll(&buf);
+    try testing.expect(std.mem.startsWith(u8, first, "turret__fired "));
+    {
+        const payload = first["turret__fired ".len..];
+        const p = try std.json.parseFromSlice(
+            @FieldType(TestEvents, "turret__fired"),
+            testing.allocator,
+            payload,
+            .{},
+        );
+        defer p.deinit();
+        try testing.expectEqual(@as(u32, 1), p.value.turret);
+    }
+    const second = poll(&buf);
+    try testing.expect(std.mem.startsWith(u8, second, "turret__fired "));
+    {
+        const payload = second["turret__fired ".len..];
+        const p = try std.json.parseFromSlice(
+            @FieldType(TestEvents, "turret__fired"),
+            testing.allocator,
+            payload,
+            .{},
+        );
+        defer p.deinit();
+        try testing.expectEqual(@as(u32, 2), p.value.turret);
+    }
+
+    // wave__started was filtered out; the inbox is now empty.
+    try testing.expectEqual(@as(usize, 0), poll(&buf).len);
+    try testing.expectEqual(@as(usize, 0), poll(&buf).len);
+
+    // A fresh frame with no subscribed events queues nothing.
+    game.emit(.{ .wave__started = .{ .index = 4 } });
+    contract.drainEvents(&game);
+    game.dispatchEvents();
+    try testing.expectEqual(@as(usize, 0), poll(&buf).len);
+}
+
+test "subscribe/poll: slice-bearing payload survives emit → drain → dispatch (two-arena lifetime)" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    subscribe("state__renamed");
+
+    // Frame 1: emit with a string payload. The parsed slice lives in
+    // the ACTIVE emit arena.
+    try testing.expectEqual(@as(i32, 0), emitEvent("state__renamed", "{\"name\":\"combat\"}"));
+    contract.drainEvents(&game); // flips arenas — must NOT recycle this frame's payload
+    switch (game.event_buffer.items[0]) {
+        .state__renamed => |p| try testing.expectEqualStrings("combat", p.name),
+        else => return error.TestUnexpectedResult,
+    }
+    game.dispatchEvents();
+
+    var buf: [256]u8 = undefined;
+    try testing.expectEqualStrings("state__renamed {\"name\":\"combat\"}", poll(&buf));
+
+    // Frames 2 + 3: both arenas recycle; nothing dangles, nothing polls.
+    contract.drainEvents(&game);
+    game.dispatchEvents();
+    contract.drainEvents(&game);
+    try testing.expectEqual(@as(usize, 0), poll(&buf).len);
+}
+
+test "subscribe pre-bind is a no-op; unpolled inbox entries free on unbind" {
+    contract.unbind();
+    defer contract.unbind();
+
+    // Pre-bind subscribe records nothing (the generated main always
+    // binds before plugin setup).
+    subscribe("turret__fired");
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    game.emit(.{ .turret__fired = .{} });
+    contract.drainEvents(&game);
+    game.dispatchEvents();
+    var buf: [128]u8 = undefined;
+    try testing.expectEqual(@as(usize, 0), poll(&buf).len); // pre-bind sub didn't stick
+
+    // Now a real subscription; leave an entry UNPOLLED at unbind — the
+    // testing allocator flags it if unbind doesn't free.
+    subscribe("turret__fired");
+    game.emit(.{ .turret__fired = .{ .turret = 9 } });
+    game.emit(.{ .turret__fired = .{ .turret = 10 } });
+    contract.drainEvents(&game);
+    game.dispatchEvents();
+    _ = poll(&buf); // consume one, leave one pending
+}
+
+// ── Scene change ────────────────────────────────────────────────────
+
+test "scene_change: 0 on a known scene, -1 leaves the running scene alone" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const loader = struct {
+        fn load(g: *ContractGame) anyerror!void {
+            const e = g.createEntity();
+            g.setPosition(e, .{ .x = 0, .y = 0 });
+            g.trackSceneEntity(e);
+        }
+    }.load;
+    game.registerSceneSimple("arena", loader);
+
+    try testing.expectEqual(@as(i32, 0), contract.labelle_scene_change("arena", 5));
+    try testing.expectEqualStrings("arena", game.getCurrentSceneName().?);
+    try testing.expectEqual(@as(usize, 1), game.entityCount());
+
+    // Unknown scene: refused up front — nothing torn down.
+    try testing.expectEqual(@as(i32, -1), contract.labelle_scene_change("nope", 4));
+    try testing.expectEqualStrings("arena", game.getCurrentSceneName().?);
+    try testing.expectEqual(@as(usize, 1), game.entityCount());
+}
+
+// ── Prefab spawn ────────────────────────────────────────────────────
+
+const PrefabBridge = engine.JsoncSceneBridge(ContractGame, TestComponents);
+
+const TURRET_PREFAB =
+    \\{ "components": { "Health": { "hp": 55 } } }
+;
+
+/// Boot the assembler's wasm sequence: embedded prefab registration,
+/// then a scene load (which attaches the prefab cache to the game and
+/// enables `spawnPrefab`) — the editor_api_test bootPrefabGame shape.
+fn bootPrefabGame(game: *ContractGame) !void {
+    try PrefabBridge.addEmbeddedPrefab(game, "turret", TURRET_PREFAB, "prefabs");
+    try PrefabBridge.loadSceneFromSource(game,
+        \\{ "entities": [] }
+    , "prefabs");
+}
+
+test "prefab_spawn: positions from params JSON; empty params spawn at origin" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    try bootPrefabGame(&game);
+    contract.bind(&game);
+
+    // Positioned spawn.
+    const id = spawnPrefab("turret", "{\"x\":30,\"y\":40}");
+    try testing.expect(id != 0);
+    const ent: u32 = @intCast(id);
+    try testing.expectEqual(@as(i32, 55), game.getComponent(ent, Health).?.hp);
+    const pos = game.getComponent(ent, core.Position).?;
+    try testing.expectEqual(@as(f32, 30), pos.x);
+    try testing.expectEqual(@as(f32, 40), pos.y);
+
+    // Empty params: origin. Unknown params keys: ignored.
+    const id2 = spawnPrefab("turret", "");
+    try testing.expect(id2 != 0);
+    const pos2 = game.getComponent(@as(u32, @intCast(id2)), core.Position).?;
+    try testing.expectEqual(@as(f32, 0), pos2.x);
+    const id3 = spawnPrefab("turret", "{\"x\":1,\"facing\":\"left\"}");
+    try testing.expect(id3 != 0);
+
+    // Failure modes: unknown prefab / malformed params → 0.
+    try testing.expectEqual(@as(u64, 0), spawnPrefab("ghost", ""));
+    try testing.expectEqual(@as(u64, 0), spawnPrefab("turret", "{\"x\":"));
+}
+
+test "prefab_spawn: 0 before any JSONC scene attached the prefab cache" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    try testing.expectEqual(@as(u64, 0), spawnPrefab("turret", ""));
+}
+
+// ── Time / log ──────────────────────────────────────────────────────
+
+test "time_dt: last tick's scaled dt; 0 while paused and before the first tick" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    // No tick yet.
+    try testing.expectEqual(@as(f32, 0), contract.labelle_time_dt());
+
+    game.tick(0.016);
+    try testing.expectApproxEqAbs(@as(f32, 0.016), contract.labelle_time_dt(), 0.0001);
+
+    // Scripts observe the GAMEPLAY dt: real dt × time_scale.
+    game.setTimeScale(0.5);
+    game.tick(0.016);
+    try testing.expectApproxEqAbs(@as(f32, 0.008), contract.labelle_time_dt(), 0.0001);
+    game.setTimeScale(1.0);
+
+    // Paused: scripts don't advance, dt reads 0; resume restores.
+    game.setPaused(true);
+    try testing.expectEqual(@as(f32, 0), contract.labelle_time_dt());
+    game.setPaused(false);
+    game.tick(0.020);
+    try testing.expectApproxEqAbs(@as(f32, 0.020), contract.labelle_time_dt(), 0.0001);
+}
+
+test "log: routes through the game log sink without crashing" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    contract.labelle_log("hello from a script", 19);
+    contract.labelle_log("x", 0); // empty: ignored
+}
+
+// ── Rebind ──────────────────────────────────────────────────────────
+
+test "bind twice: the second bind starts a fresh session (no leaks, no stale subscriptions)" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    subscribe("turret__fired");
+    game.emit(.{ .turret__fired = .{} });
+    contract.drainEvents(&game);
+
+    // Re-bind (e.g. a restarted plugin session): pending entries and
+    // subscriptions from the first session are torn down.
+    contract.bind(&game);
+    var buf: [128]u8 = undefined;
+    try testing.expectEqual(@as(usize, 0), poll(&buf).len);
+
+    // The first session's subscription is gone too: fresh emits don't
+    // queue until this session subscribes again.
+    game.emit(.{ .turret__fired = .{} });
+    contract.drainEvents(&game);
+    game.dispatchEvents();
+    try testing.expectEqual(@as(usize, 0), poll(&buf).len);
+}

--- a/test/script_contract_test.zig
+++ b/test/script_contract_test.zig
@@ -265,6 +265,280 @@ test "component set/get: the built-in Position routes through setPosition" {
     try testing.expectEqual(@as(i32, 1), hasComp(id, "Position"));
 }
 
+// ── Components: scene built-ins (JSONC write-parity, #749) ──────────
+//
+// `Sprite`/`Shape`/`Tilemap`/`Camera`/`Image` dispatch through the
+// scene loader's OWN apply fns (`jsonc/component_apply.zig`) with its
+// registry-precedence gates — whatever a scene can author, a script
+// can set/get/has/remove. The support matrix lives in
+// `contract/labelle_script.h`.
+
+test "built-ins: set routes through the scene apply machinery" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+    const ent: u32 = @intCast(id);
+
+    // Sprite — lands as the renderer's component AND registers with
+    // the renderer (addSprite entity-tracking), exactly like a scene.
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Sprite", "{\"sprite_name\":\"hero\",\"z_index\":3}"));
+    const sp = game.getComponent(ent, ContractGame.SpriteComp).?;
+    try testing.expectEqualStrings("hero", sp.sprite_name);
+    try testing.expectEqual(@as(i16, 3), sp.z_index);
+    try testing.expectEqual(@as(usize, 1), game.renderer.tracked_count);
+
+    // Shape — addShape, tracked too.
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Shape", "{\"shape\":{\"circle\":{\"radius\":7}},\"visible\":false}"));
+    const sh = game.getComponent(ent, ContractGame.ShapeComp).?;
+    try testing.expectEqual(@as(f32, 7), sh.shape.circle.radius);
+    try testing.expect(!sh.visible);
+    try testing.expectEqual(@as(usize, 2), game.renderer.tracked_count);
+
+    // Tilemap — attaches the component (StubRender has no tilemap
+    // seam, so no decode side-table — same as a scene on a stub).
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Tilemap", "{\"asset_name\":\"dungeon.tmx\"}"));
+    try testing.expectEqualStrings("dungeon.tmx", game.getComponent(ent, ContractGame.TilemapComp).?.asset_name);
+
+    // Camera — built-in here (no registry "Camera"): the authored tag
+    // string routes through `setTagSlice` onto the inline `[16:0]u8`,
+    // the scene branch's special case.
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Camera", "{\"zoom\":2,\"tag\":\"minimap\"}"));
+    const cam = game.getComponent(ent, ContractGame.CameraComp).?;
+    try testing.expectEqual(@as(f32, 2), cam.zoom);
+    try testing.expectEqualStrings("minimap", cam.tagSlice());
+
+    // Image — plain engine POD; the enum pivot maps from its name.
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Image", "{\"name\":\"logo.png\",\"pivot\":\"bottom_center\",\"z_index\":2}"));
+    const img = game.getComponent(ent, ContractGame.ImageComp).?;
+    try testing.expectEqualStrings("logo.png", img.name);
+    try testing.expect(img.pivot == .bottom_center);
+    try testing.expectEqual(@as(i16, 2), img.z_index);
+
+    // Failure modes, -1 with the entity untouched: malformed JSON and
+    // non-object payloads (the apply is all-or-nothing).
+    try testing.expectEqual(@as(i32, -1), setComp(id, "Sprite", "{\"sprite_name\":"));
+    try testing.expectEqual(@as(i32, -1), setComp(id, "Sprite", "5"));
+    try testing.expectEqualStrings("hero", game.getComponent(ent, ContractGame.SpriteComp).?.sprite_name);
+
+    // Dead entity → -1 (the same liveness gate as the registry path).
+    try testing.expectEqual(@as(i32, -1), setComp(999_999, "Sprite", "{}"));
+}
+
+test "built-ins: get serializes what a scene could author, and feeds back through set" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+    const id2 = contract.labelle_entity_create();
+    const ent2: u32 = @intCast(id2);
+    var buf: [512]u8 = undefined;
+
+    // Absent built-in: 0 bytes, per the get contract.
+    try testing.expectEqual(@as(usize, 0), getComp(id, "Sprite", &buf).len);
+
+    // Sprite round-trip: get's output applies cleanly to a fresh
+    // entity and reproduces the component (StubRender's Sprite has no
+    // handle fields; on gfx `texture` would be omitted and re-derived).
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Sprite", "{\"sprite_name\":\"hero\",\"z_index\":3}"));
+    const sprite_json = getComp(id, "Sprite", &buf);
+    try testing.expect(sprite_json.len > 0);
+    try testing.expectEqual(@as(i32, 0), setComp(id2, "Sprite", sprite_json));
+    const sp2 = game.getComponent(ent2, ContractGame.SpriteComp).?;
+    try testing.expectEqualStrings("hero", sp2.sprite_name);
+    try testing.expectEqual(@as(i16, 3), sp2.z_index);
+
+    // Shape round-trip (tagged union payload).
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Shape", "{\"shape\":{\"rectangle\":{\"width\":4,\"height\":5}}}"));
+    const shape_json = getComp(id, "Shape", &buf);
+    try testing.expectEqual(@as(i32, 0), setComp(id2, "Shape", shape_json));
+    try testing.expectEqual(@as(f32, 4), game.getComponent(ent2, ContractGame.ShapeComp).?.shape.rectangle.width);
+
+    // Camera: `tag` serializes as a STRING (the component stores an
+    // inline `[16:0]u8`), and the whole shape feeds back through the
+    // apply branch's `setTagSlice`.
+    try testing.expectEqual(@as(i32, 0), setComp(
+        id,
+        "Camera",
+        "{\"zoom\":2,\"tag\":\"minimap\",\"viewport\":{\"x\":0,\"y\":0,\"width\":320,\"height\":180}}",
+    ));
+    var cam_buf: [512]u8 = undefined;
+    const cam_json = getComp(id, "Camera", &cam_buf);
+    const cam_parsed = try std.json.parseFromSlice(struct {
+        zoom: f32,
+        viewport: ?struct { x: i32, y: i32, width: i32, height: i32 },
+        tag: []const u8,
+    }, testing.allocator, cam_json, .{});
+    defer cam_parsed.deinit();
+    try testing.expectEqual(@as(f32, 2), cam_parsed.value.zoom);
+    try testing.expectEqualStrings("minimap", cam_parsed.value.tag);
+    try testing.expectEqual(@as(i32, 180), cam_parsed.value.viewport.?.height);
+    try testing.expectEqual(@as(i32, 0), setComp(id2, "Camera", cam_json));
+    const cam2 = game.getComponent(ent2, ContractGame.CameraComp).?;
+    try testing.expectEqualStrings("minimap", cam2.tagSlice());
+    try testing.expectEqual(@as(i32, 320), cam2.viewport.?.width);
+
+    // Tilemap round-trips including layer bindings (slice of structs).
+    try testing.expectEqual(@as(i32, 0), setComp(
+        id,
+        "Tilemap",
+        "{\"asset_name\":\"a.tmx\",\"layer_bindings\":[{\"tmx_layer\":\"bg\",\"engine_layer\":\"world\"}]}",
+    ));
+    const tm_json = getComp(id, "Tilemap", &buf);
+    try testing.expectEqual(@as(i32, 0), setComp(id2, "Tilemap", tm_json));
+    const tm2 = game.getComponent(ent2, ContractGame.TilemapComp).?;
+    try testing.expectEqualStrings("a.tmx", tm2.asset_name);
+    try testing.expectEqualStrings("bg", tm2.layer_bindings.?[0].tmx_layer);
+    try testing.expectEqualStrings("world", tm2.layer_bindings.?[0].engine_layer);
+
+    // Image round-trip (string / enum / int / bool fields).
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Image", "{\"name\":\"logo.png\",\"pivot\":\"bottom_center\"}"));
+    const img_json = getComp(id, "Image", &buf);
+    try testing.expectEqual(@as(i32, 0), setComp(id2, "Image", img_json));
+    const img2 = game.getComponent(ent2, ContractGame.ImageComp).?;
+    try testing.expectEqualStrings("logo.png", img2.name);
+    try testing.expect(img2.pivot == .bottom_center);
+}
+
+test "built-ins: has/remove — typed teardown channels with the idempotence guard" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+
+    // Sprite: remove goes through removeSprite — the renderer is
+    // untracked, not just the ECS row dropped.
+    try testing.expectEqual(@as(i32, 0), hasComp(id, "Sprite"));
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Sprite", "{\"sprite_name\":\"hero\"}"));
+    try testing.expectEqual(@as(i32, 1), hasComp(id, "Sprite"));
+    try testing.expectEqual(@as(usize, 1), game.renderer.tracked_count);
+    try testing.expectEqual(@as(i32, 0), removeComp(id, "Sprite"));
+    try testing.expectEqual(@as(i32, 0), hasComp(id, "Sprite"));
+    try testing.expectEqual(@as(usize, 0), game.renderer.tracked_count);
+    // Absent-but-known: idempotent 0, and NO second renderer untrack.
+    try testing.expectEqual(@as(i32, 0), removeComp(id, "Sprite"));
+    try testing.expectEqual(@as(usize, 0), game.renderer.tracked_count);
+
+    // Shape mirrors Sprite (removeShape).
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Shape", "{}"));
+    try testing.expectEqual(@as(i32, 1), hasComp(id, "Shape"));
+    try testing.expectEqual(@as(i32, 0), removeComp(id, "Shape"));
+    try testing.expectEqual(@as(i32, 0), hasComp(id, "Shape"));
+
+    // Tilemap: removeTilemap — the full teardown channel (frees the
+    // decoded side-table runtime where a renderer has the seam).
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Tilemap", "{\"asset_name\":\"a.tmx\"}"));
+    try testing.expectEqual(@as(i32, 1), hasComp(id, "Tilemap"));
+    try testing.expectEqual(@as(i32, 0), removeComp(id, "Tilemap"));
+    try testing.expectEqual(@as(i32, 0), hasComp(id, "Tilemap"));
+    try testing.expectEqual(@as(i32, 0), removeComp(id, "Tilemap")); // idempotent
+
+    // Camera / Image: plain data components, generic remove.
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Camera", "{}"));
+    try testing.expectEqual(@as(i32, 1), hasComp(id, "Camera"));
+    try testing.expectEqual(@as(i32, 0), removeComp(id, "Camera"));
+    try testing.expectEqual(@as(i32, 0), hasComp(id, "Camera"));
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Image", "{}"));
+    try testing.expectEqual(@as(i32, 1), hasComp(id, "Image"));
+    try testing.expectEqual(@as(i32, 0), removeComp(id, "Image"));
+    try testing.expectEqual(@as(i32, 0), hasComp(id, "Image"));
+
+    // Dead entity: -1 (remove), 0 (has) — the liveness gates.
+    try testing.expectEqual(@as(i32, -1), removeComp(999_999, "Sprite"));
+    try testing.expectEqual(@as(i32, 0), hasComp(999_999, "Sprite"));
+}
+
+// A project that registers its OWN `Camera`: the built-in channel is
+// compiled out (`camera_is_builtin == false`) and the name routes
+// through the registry — the scene loader's exact precedence.
+const RegisteredCamera = struct { fov: f32 = 90 };
+const RegisteredCameraComponents = engine.ComponentRegistry(.{
+    .Health = Health,
+    .Camera = RegisteredCamera,
+});
+const RegisteredCameraGame = engine.GameConfig(
+    core.StubRender(MockEcs.Entity),
+    MockEcs,
+    engine.StubInput,
+    engine.StubAudio,
+    engine.StubVideo,
+    engine.StubGui,
+    void,
+    core.StubLogSink,
+    RegisteredCameraComponents,
+    &.{},
+    void,
+);
+
+test "built-ins: a project-registered Camera wins over the built-in (scene precedence)" {
+    contract.unbind();
+    defer contract.unbind();
+
+    // The same comptime gate every built-in Camera channel keys on.
+    try testing.expect(ContractGame.camera_is_builtin);
+    try testing.expect(!RegisteredCameraGame.camera_is_builtin);
+
+    var game = RegisteredCameraGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+    const ent: u32 = @intCast(id);
+
+    // "Camera" resolves through the REGISTRY (setComponent): the
+    // project's type lands, the engine built-in never materializes.
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Camera", "{\"fov\":45}"));
+    try testing.expectEqual(@as(f32, 45), game.getComponent(ent, RegisteredCamera).?.fov);
+    try testing.expect(game.getComponent(ent, RegisteredCameraGame.CameraComp) == null);
+
+    // get / has / remove route to the registry type too.
+    try testing.expectEqual(@as(i32, 1), hasComp(id, "Camera"));
+    var buf: [128]u8 = undefined;
+    const json = getComp(id, "Camera", &buf);
+    const parsed = try std.json.parseFromSlice(RegisteredCamera, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqual(@as(f32, 45), parsed.value.fov);
+    try testing.expectEqual(@as(i32, 0), removeComp(id, "Camera"));
+    try testing.expectEqual(@as(i32, 0), hasComp(id, "Camera"));
+
+    // Sprite/Shape stay built-in even here — they are unconditional in
+    // the scene path too.
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Sprite", "{\"sprite_name\":\"x\"}"));
+    try testing.expectEqual(@as(i32, 1), hasComp(id, "Sprite"));
+}
+
+test "built-ins: query resolves them on both sides of the dispatch" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const e1 = contract.labelle_entity_create();
+    try testing.expectEqual(@as(i32, 0), setComp(e1, "Sprite", "{\"sprite_name\":\"a\"}"));
+    try testing.expectEqual(@as(i32, 0), setComp(e1, "Health", "{}"));
+    const e2 = contract.labelle_entity_create();
+    try testing.expectEqual(@as(i32, 0), setComp(e2, "Sprite", "{\"sprite_name\":\"b\"}"));
+
+    var buf: [256]u8 = undefined;
+    try expectQueryIds(query("[\"Sprite\"]", &buf), &.{ e1, e2 });
+    try expectQueryIds(query("[\"Sprite\",\"Health\"]", &buf), &.{e1});
+    try expectQueryIds(query("[\"Health\",\"Sprite\"]", &buf), &.{e1});
+}
+
 test "component has/remove: presence flips, unknown names refuse" {
     contract.unbind();
     defer contract.unbind();
@@ -322,6 +596,195 @@ test "component remove: an absent component never false-fires onRemove" {
     // The built-in Position takes the same guard (absent → 0, no-op).
     try testing.expectEqual(@as(i32, 0), removeComp(id, "Position"));
     try testing.expectEqual(@as(i32, 5), game.getComponent(@as(u32, @intCast(id)), Health).?.hp);
+}
+
+// ── Stale-id liveness (reads must guard entityExists) ───────────────
+//
+// core's MockEcsBackend liveness-checks INSIDE getComponent /
+// hasComponent, which would mask the very hazard the contract guards
+// against: on a real sparse-set backend (zig_ecs) a component read is a
+// raw index lookup, so a stale id held by a script past
+// `labelle_entity_destroy` can still hit the dead entity's row — or a
+// recycled one. LeakyReadEcs models that backend: the MockEcs surface,
+// but component reads skip the alive gate and `destroyEntity` only
+// drops the id from `alive`, leaving rows readable. With it, ONLY the
+// contract-level `entityExists` guard keeps get/has at 0.
+
+const LeakyReadEcs = struct {
+    pub const Entity = u32;
+
+    const CleanupFn = *const fn (*Self) void;
+
+    next_id: u32 = 1,
+    alive: std.AutoHashMap(u32, void),
+    storages: std.AutoHashMap(usize, *anyopaque),
+    cleanups: std.ArrayListUnmanaged(CleanupFn) = .empty,
+    allocator: std.mem.Allocator,
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator) Self {
+        return .{
+            .alive = std.AutoHashMap(u32, void).init(allocator),
+            .storages = std.AutoHashMap(usize, *anyopaque).init(allocator),
+            .allocator = allocator,
+        };
+    }
+
+    pub fn deinit(self: *Self) void {
+        for (self.cleanups.items) |cleanup| cleanup(self);
+        self.cleanups.deinit(self.allocator);
+        self.storages.deinit();
+        self.alive.deinit();
+    }
+
+    pub fn createEntity(self: *Self) u32 {
+        const id = self.next_id;
+        self.next_id += 1;
+        self.alive.put(id, {}) catch @panic("OOM");
+        return id;
+    }
+
+    pub fn destroyEntity(self: *Self, entity: u32) void {
+        // Deliberately NO storage scrub — stale rows stay readable.
+        _ = self.alive.remove(entity);
+    }
+
+    pub fn entityExists(self: *Self, entity: u32) bool {
+        return self.alive.contains(entity);
+    }
+
+    pub fn entityCount(self: *Self) usize {
+        return self.alive.count();
+    }
+
+    pub fn addComponent(self: *Self, entity: u32, component: anytype) void {
+        self.getOrCreateStorage(@TypeOf(component)).put(entity, component) catch @panic("OOM");
+    }
+
+    /// Raw lookup — no alive gate (the point of this fixture).
+    pub fn getComponent(self: *Self, entity: u32, comptime T: type) ?*T {
+        const storage = self.getStorage(T) orelse return null;
+        return storage.getPtr(entity);
+    }
+
+    /// Raw lookup — no alive gate (the point of this fixture).
+    pub fn hasComponent(self: *Self, entity: u32, comptime T: type) bool {
+        const storage = self.getStorage(T) orelse return false;
+        return storage.contains(entity);
+    }
+
+    pub fn removeComponent(self: *Self, entity: u32, comptime T: type) void {
+        const storage = self.getStorage(T) orelse return;
+        _ = storage.remove(entity);
+    }
+
+    // The iteration shape is liveness-agnostic — reuse MockEcs's View
+    // type; only entities in `alive` are collected, like any backend.
+    pub fn View(comptime includes: anytype, comptime excludes: anytype) type {
+        return MockEcs.View(includes, excludes);
+    }
+
+    pub fn view(self: *Self, comptime includes: anytype, comptime excludes: anytype) View(includes, excludes) {
+        var result: std.ArrayListUnmanaged(u32) = .empty;
+        var it = self.alive.keyIterator();
+        while (it.next()) |key_ptr| {
+            const entity = key_ptr.*;
+            const matches = blk: {
+                inline for (includes) |T| {
+                    if (!self.hasComponent(entity, T)) break :blk false;
+                }
+                inline for (excludes) |T| {
+                    if (self.hasComponent(entity, T)) break :blk false;
+                }
+                break :blk true;
+            };
+            if (matches) result.append(self.allocator, entity) catch @panic("OOM");
+        }
+        return .{
+            .entities = result.toOwnedSlice(self.allocator) catch @panic("OOM"),
+            .allocator = self.allocator,
+        };
+    }
+
+    fn getOrCreateStorage(self: *Self, comptime T: type) *std.AutoHashMap(u32, T) {
+        const tid = typeId(T);
+        if (self.storages.get(tid)) |raw| return @ptrCast(@alignCast(raw));
+        const storage = self.allocator.create(std.AutoHashMap(u32, T)) catch @panic("OOM");
+        storage.* = std.AutoHashMap(u32, T).init(self.allocator);
+        self.storages.put(tid, @ptrCast(storage)) catch @panic("OOM");
+        self.cleanups.append(self.allocator, &struct {
+            fn cleanup(s: *Self) void {
+                if (s.storages.get(typeId(T))) |raw| {
+                    const typed: *std.AutoHashMap(u32, T) = @ptrCast(@alignCast(raw));
+                    typed.deinit();
+                    s.allocator.destroy(typed);
+                }
+            }
+        }.cleanup) catch @panic("OOM");
+        return storage;
+    }
+
+    fn getStorage(self: *Self, comptime T: type) ?*std.AutoHashMap(u32, T) {
+        const raw = self.storages.get(typeId(T)) orelse return null;
+        return @ptrCast(@alignCast(raw));
+    }
+
+    fn typeId(comptime T: type) usize {
+        return @intFromPtr(&struct {
+            comptime {
+                _ = T;
+            }
+            var x: u8 = 0;
+        }.x);
+    }
+};
+
+const LeakyGame = engine.GameConfig(
+    core.StubRender(u32),
+    LeakyReadEcs,
+    engine.StubInput,
+    engine.StubAudio,
+    engine.StubVideo,
+    engine.StubGui,
+    void,
+    core.StubLogSink,
+    TestComponents,
+    &.{},
+    void, // no events — the fixture pins component reads only
+);
+
+test "component get/has: a stale id after entity_destroy reads as absent (liveness guard)" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = LeakyGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Health", "{\"hp\":31}"));
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Position", "{\"x\":1,\"y\":2}"));
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Sprite", "{\"sprite_name\":\"husk\"}"));
+    var buf: [256]u8 = undefined;
+    try testing.expect(getComp(id, "Health", &buf).len > 0);
+
+    contract.labelle_entity_destroy(id);
+
+    // The backend itself still serves the dead rows — proving the
+    // assertions below pin the CONTRACT's guard, not backend charity.
+    const ent: u32 = @intCast(id);
+    try testing.expect(game.ecs_backend.getComponent(ent, Health) != null);
+    try testing.expect(game.ecs_backend.hasComponent(ent, Health));
+
+    // Through the exports the stale id reads as ABSENT: registry name,
+    // built-in Position, and scene built-in alike (get 0 bytes, has 0).
+    try testing.expectEqual(@as(usize, 0), getComp(id, "Health", &buf).len);
+    try testing.expectEqual(@as(i32, 0), hasComp(id, "Health"));
+    try testing.expectEqual(@as(usize, 0), getComp(id, "Position", &buf).len);
+    try testing.expectEqual(@as(i32, 0), hasComp(id, "Position"));
+    try testing.expectEqual(@as(usize, 0), getComp(id, "Sprite", &buf).len);
+    try testing.expectEqual(@as(i32, 0), hasComp(id, "Sprite"));
 }
 
 // ── Query ───────────────────────────────────────────────────────────
@@ -463,7 +926,11 @@ test "subscribe/poll: name-filtered FIFO in emission order; the tap does not con
     contract.bind(&game);
 
     subscribe("turret__fired");
-    subscribe("turret__fired"); // deduped — no double delivery
+    subscribe("turret__fired"); // deduped (while still pending) — no double delivery
+    // A subscription activates at the END of a drain (effective-next-
+    // drain, no same-tick replay) — run the subscribe tick's drain
+    // before emitting so the next frame's events match.
+    contract.drainEvents(&game);
 
     // Mixed emitters, one frame: contract-side and Zig-side (game.emit)
     // both flow through the buffered path the tap walks.
@@ -518,6 +985,48 @@ test "subscribe/poll: name-filtered FIFO in emission order; the tap does not con
     try testing.expectEqual(@as(usize, 0), poll(&buf).len);
 }
 
+test "subscribe mid-tick: effective-next-drain — no same-tick replay, next tick delivers" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    // Tick N, the engine__tick shape: an event is buffered BEFORE the
+    // script subscribes (engine emits precede script execution), and
+    // another lands after the subscribe, still in the same tick.
+    game.emit(.{ .turret__fired = .{ .turret = 1 } });
+    subscribe("turret__fired");
+    game.emit(.{ .turret__fired = .{ .turret = 2 } });
+    contract.drainEvents(&game); // the same tick's drain
+    game.dispatchEvents();
+
+    // Neither event is delivered: the subscription was PENDING for the
+    // whole of tick N's drain — a mid-tick subscribe must not replay a
+    // past it never subscribed to (and activation is a drain boundary,
+    // not a mid-buffer split).
+    var buf: [256]u8 = undefined;
+    try testing.expectEqual(@as(usize, 0), poll(&buf).len);
+
+    // Tick N+1: the subscription is active now — delivery starts here,
+    // and it is the NEW emit, not a replay of tick N's.
+    game.emit(.{ .turret__fired = .{ .turret = 3 } });
+    contract.drainEvents(&game);
+    game.dispatchEvents();
+    const entry = poll(&buf);
+    try testing.expect(std.mem.startsWith(u8, entry, "turret__fired "));
+    const p = try std.json.parseFromSlice(
+        @FieldType(TestEvents, "turret__fired"),
+        testing.allocator,
+        entry["turret__fired ".len..],
+        .{},
+    );
+    defer p.deinit();
+    try testing.expectEqual(@as(u32, 3), p.value.turret);
+    try testing.expectEqual(@as(usize, 0), poll(&buf).len);
+}
+
 test "subscribe/poll: slice-bearing payload survives emit → drain → dispatch (two-arena lifetime)" {
     contract.unbind();
     defer contract.unbind();
@@ -527,6 +1036,7 @@ test "subscribe/poll: slice-bearing payload survives emit → drain → dispatch
     contract.bind(&game);
 
     subscribe("state__renamed");
+    contract.drainEvents(&game); // activate the subscription (next-drain semantics)
 
     // Frame 1: emit with a string payload. The parsed slice lives in
     // the ACTIVE emit arena.
@@ -566,9 +1076,11 @@ test "subscribe pre-bind is a no-op; unpolled inbox entries free on unbind" {
     var buf: [128]u8 = undefined;
     try testing.expectEqual(@as(usize, 0), poll(&buf).len); // pre-bind sub didn't stick
 
-    // Now a real subscription; leave an entry UNPOLLED at unbind — the
-    // testing allocator flags it if unbind doesn't free.
+    // Now a real subscription (activated by a drain — next-drain
+    // semantics); leave an entry UNPOLLED at unbind — the testing
+    // allocator flags it if unbind doesn't free.
     subscribe("turret__fired");
+    contract.drainEvents(&game);
     game.emit(.{ .turret__fired = .{ .turret = 9 } });
     game.emit(.{ .turret__fired = .{ .turret = 10 } });
     contract.drainEvents(&game);
@@ -585,6 +1097,7 @@ test "poll: budgeted polling (a backlog always left pending) keeps the inbox sto
     contract.bind(&game);
 
     subscribe("turret__fired");
+    contract.drainEvents(&game); // activate the subscription (next-drain semantics)
 
     // Frame 0 polls one FEWER than arrived; every later frame polls at
     // matched throughput — so the inbox carries a standing backlog and
@@ -730,7 +1243,12 @@ test "NULL C-ABI shapes: NULL/len-0 payloads take defaults; NULL out buffers pro
     );
     try testing.expectEqual(@as(i32, 100), game.getComponent(@as(u32, @intCast(id)), Health).?.hp);
 
-    // event_emit with NULL json = "{}" (all-default payload).
+    // event_emit with NULL json = "{}" (all-default payload). Subscribe
+    // FIRST and run a drain so the subscription is active when the
+    // NULL-emitted event is tapped below (next-drain semantics — a
+    // subscribe after the emit would see nothing this tick).
+    subscribe("wave__started");
+    contract.drainEvents(&game);
     const wave = "wave__started";
     try testing.expectEqual(
         @as(i32, 0),
@@ -751,7 +1269,6 @@ test "NULL C-ABI shapes: NULL/len-0 payloads take defaults; NULL out buffers pro
 
     // poll with a NULL out reads NOTHING and consumes NOTHING: the
     // pending entry survives for the next real poll.
-    subscribe("wave__started");
     contract.drainEvents(&game); // taps the NULL-emitted wave event above
     game.dispatchEvents();
     try testing.expectEqual(@as(usize, 0), contract.labelle_event_poll(null, 0));
@@ -860,11 +1377,16 @@ test "bind twice: the second bind starts a fresh session (no leaks, no stale sub
     contract.bind(&game);
 
     subscribe("turret__fired");
+    contract.drainEvents(&game); // activate (next-drain semantics)
     game.emit(.{ .turret__fired = .{} });
-    contract.drainEvents(&game);
+    contract.drainEvents(&game); // tap: one inbox entry now pending
+    // A second, NOT-yet-activated subscription: rebind must free the
+    // pending-subscription set too, not just the active one.
+    subscribe("wave__started");
 
     // Re-bind (e.g. a restarted plugin session): pending entries and
-    // subscriptions from the first session are torn down.
+    // subscriptions (active AND pending) from the first session are
+    // torn down.
     contract.bind(&game);
     var buf: [128]u8 = undefined;
     try testing.expectEqual(@as(usize, 0), poll(&buf).len);

--- a/test/script_contract_test.zig
+++ b/test/script_contract_test.zig
@@ -84,8 +84,12 @@ fn removeComp(id: u64, name: []const u8) i32 {
     return contract.labelle_component_remove(id, name.ptr, name.len);
 }
 
+/// Call the query with a buffer known to FIT the result — the return is
+/// the required size (snprintf-style), which then equals bytes written.
+/// The truncation test drives `labelle_query` directly instead.
 fn query(names_json: []const u8, buf: []u8) []const u8 {
     const n = contract.labelle_query(names_json.ptr, names_json.len, buf.ptr, buf.len);
+    std.debug.assert(n <= buf.len);
     return buf[0..n];
 }
 
@@ -830,7 +834,7 @@ test "query: view on the first name, filter on the rest" {
     try testing.expectEqual(@as(usize, 0), query("{\"not\":\"array\"}", &buf).len);
 }
 
-test "query: id list truncates at the last whole id and stays valid JSON" {
+test "query: snprintf sizing — truncation detectable, writes stay valid JSON, retry yields all" {
     contract.unbind();
     defer contract.unbind();
 
@@ -843,21 +847,42 @@ test "query: id list truncates at the last whole id and stays valid JSON" {
         _ = setComp(contract.labelle_entity_create(), "Health", "{}");
     }
 
-    // Full result parses.
+    const names = "[\"Health\"]";
+
+    // NULL/cap-0 is the pure sizing probe: required size back, nothing
+    // written.
+    const required = contract.labelle_query(names.ptr, names.len, null, 0);
+    try testing.expect(required > 2);
+
+    // A retry at exactly `required` holds the COMPLETE result: the
+    // return equals the cap and every id parses out.
     var big: [1024]u8 = undefined;
-    const full = query("[\"Health\"]", &big);
-    var parsed = try std.json.parseFromSlice([]u64, testing.allocator, full, .{});
+    try testing.expect(required <= big.len);
+    const n_full = contract.labelle_query(names.ptr, names.len, &big, required);
+    try testing.expectEqual(required, n_full);
+    var parsed = try std.json.parseFromSlice([]u64, testing.allocator, big[0..n_full], .{});
     const total = parsed.value.len;
     parsed.deinit();
     try testing.expectEqual(@as(usize, 50), total);
 
-    // Every cap must yield valid JSON — truncated, never torn.
+    // Every under-sized cap: the return is STILL the full required size
+    // — exceeding the cap, which is exactly how a caller detects the
+    // silent truncation the old written-bytes return hid — while the
+    // written prefix truncates at the last whole id and parses as valid
+    // JSON. Bytes past the cap are never touched.
     var cap: usize = 2;
-    while (cap <= 64) : (cap += 3) {
-        const out = query("[\"Health\"]", big[0..cap]);
-        var p = try std.json.parseFromSlice([]u64, testing.allocator, out, .{});
-        try testing.expect(p.value.len <= total);
+    while (cap < required) : (cap += 3) {
+        @memset(&big, 0xAA);
+        const ret = contract.labelle_query(names.ptr, names.len, &big, cap);
+        try testing.expectEqual(required, ret);
+        try testing.expect(ret > cap);
+        // Ids carry no `]`, so the first `]` ends the written region.
+        const end = std.mem.indexOfScalar(u8, big[0..cap], ']') orelse
+            return error.TestUnexpectedResult;
+        var p = try std.json.parseFromSlice([]u64, testing.allocator, big[0 .. end + 1], .{});
+        try testing.expect(p.value.len < total);
         p.deinit();
+        try testing.expectEqual(@as(u8, 0xAA), big[cap]);
     }
 }
 
@@ -1259,13 +1284,22 @@ test "NULL C-ABI shapes: NULL/len-0 payloads take defaults; NULL out buffers pro
         else => return error.TestUnexpectedResult,
     }
 
-    // NULL out buffers: 0 bytes, nothing written.
+    // NULL out buffers: component_get reports 0 bytes, nothing written…
     try testing.expectEqual(
         @as(usize, 0),
         contract.labelle_component_get(id, health.ptr, health.len, null, 0),
     );
+    // …while query treats NULL/cap-0 as the pure SIZING PROBE (its
+    // documented asymmetry): the required size of the one-carrier
+    // result comes back, and a right-sized call returns the same.
     const names = "[\"Health\"]";
-    try testing.expectEqual(@as(usize, 0), contract.labelle_query(names.ptr, names.len, null, 0));
+    const probe = contract.labelle_query(names.ptr, names.len, null, 0);
+    try testing.expect(probe > 2);
+    var qbuf: [64]u8 = undefined;
+    try testing.expectEqual(
+        probe,
+        contract.labelle_query(names.ptr, names.len, &qbuf, qbuf.len),
+    );
 
     // poll with a NULL out reads NOTHING and consumes NOTHING: the
     // pending entry survives for the next real poll.

--- a/test/script_contract_test.zig
+++ b/test/script_contract_test.zig
@@ -1415,7 +1415,7 @@ const TURRET_PREFAB =
 fn bootPrefabGame(game: *ContractGame) !void {
     try PrefabBridge.addEmbeddedPrefab(game, "turret", TURRET_PREFAB, "prefabs");
     try PrefabBridge.loadSceneFromSource(game,
-        \\{ "entities": [] }
+        \\{ "root": { "children": [] } }
     , "prefabs");
 }
 

--- a/test/script_contract_test.zig
+++ b/test/script_contract_test.zig
@@ -36,10 +36,16 @@ const Doomed = struct {
     }
 };
 
+/// String-bearing component — pins the copy-out-of-the-caller's-buffer
+/// contract (a borrowed slice would dangle the moment the C call
+/// returns).
+const Label = struct { text: []const u8 = "" };
+
 const TestComponents = engine.ComponentRegistry(.{
     .Health = Health,
     .Velocity = Velocity,
     .Doomed = Doomed,
+    .Label = Label,
 });
 
 const TestEvents = union(enum) {
@@ -48,6 +54,8 @@ const TestEvents = union(enum) {
     // Slice-bearing payload — pins the emit-arena lifetime contract
     // (parsed name must survive from emit through dispatch).
     state__renamed: struct { name: []const u8 = "" },
+    // Void payload — pins the emit accept set (empty / "{}" / "null").
+    game__paused,
 };
 
 const MockEcs = core.MockEcsBackend(u32);
@@ -71,8 +79,13 @@ fn setComp(id: u64, name: []const u8, json: []const u8) i32 {
     return contract.labelle_component_set(id, name.ptr, name.len, json.ptr, json.len);
 }
 
+/// Call component_get with a buffer known to FIT the component — the
+/// return is the required size (snprintf-style), which then equals
+/// bytes written. The sizing test drives `labelle_component_get`
+/// directly instead.
 fn getComp(id: u64, name: []const u8, buf: []u8) []const u8 {
     const n = contract.labelle_component_get(id, name.ptr, name.len, buf.ptr, buf.len);
+    std.debug.assert(n <= buf.len);
     return buf[0..n];
 }
 
@@ -239,8 +252,169 @@ test "component set/get: JSON round-trip over the registry" {
     try testing.expectEqual(@as(usize, 0), getComp(id, "Mana", &buf).len); // unknown name
     try testing.expectEqual(@as(usize, 0), getComp(id, "Velocity", &buf).len); // absent component
     try testing.expectEqual(@as(usize, 0), getComp(999_999, "Health", &buf).len); // dead entity
+
+    // Doesn't fit is NOT a failure mode anymore: an under-sized cap
+    // returns the required size (> cap = the truncation signal) — the
+    // dedicated sizing test below pins the all-or-nothing write.
+    const health = "Health";
     var tiny: [2]u8 = undefined;
-    try testing.expectEqual(@as(usize, 0), getComp(id, "Health", &tiny).len); // doesn't fit
+    try testing.expect(contract.labelle_component_get(id, health.ptr, health.len, &tiny, tiny.len) > tiny.len);
+}
+
+test "component_get: required-size sizing — probe, all-or-nothing write, exact cap" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+    const name = "Health";
+    try testing.expectEqual(@as(i32, 0), setComp(id, name, "{\"hp\":1234,\"regen\":2.5}"));
+
+    // NULL/cap-0 is the pure sizing probe: the required size of the
+    // complete JSON, nothing written.
+    const required = contract.labelle_component_get(id, name.ptr, name.len, null, 0);
+    try testing.expect(required > 0);
+
+    // A call at exactly `required` writes the FULL JSON, returns the
+    // same size the probe promised, and never touches a byte past the
+    // cap.
+    var buf: [256]u8 = undefined;
+    try testing.expect(required < buf.len);
+    @memset(&buf, 0xAA);
+    const n = contract.labelle_component_get(id, name.ptr, name.len, &buf, required);
+    try testing.expectEqual(required, n);
+    const parsed = try std.json.parseFromSlice(Health, testing.allocator, buf[0..n], .{});
+    defer parsed.deinit();
+    try testing.expectEqual(@as(i32, 1234), parsed.value.hp);
+    try testing.expectEqual(@as(u8, 0xAA), buf[required]);
+
+    // EVERY under-sized cap (cap-1 included — the canary case): the
+    // required size still returns, and NOTHING is written — a truncated
+    // JSON object prefix is useless, so the write is all-or-nothing
+    // (unlike the query's still-valid id-list prefix).
+    var cap: usize = 0;
+    while (cap < required) : (cap += 1) {
+        @memset(&buf, 0xAA);
+        try testing.expectEqual(
+            required,
+            contract.labelle_component_get(id, name.ptr, name.len, &buf, cap),
+        );
+        for (buf) |b| try testing.expectEqual(@as(u8, 0xAA), b); // canary intact
+    }
+
+    // Absent / unknown / dead keep the 0 sentinel — even as a probe.
+    const velocity = "Velocity";
+    const mana = "Mana";
+    try testing.expectEqual(@as(usize, 0), contract.labelle_component_get(id, velocity.ptr, velocity.len, null, 0));
+    try testing.expectEqual(@as(usize, 0), contract.labelle_component_get(id, mana.ptr, mana.len, null, 0));
+    try testing.expectEqual(@as(usize, 0), contract.labelle_component_get(999_999, name.ptr, name.len, null, 0));
+
+    // The built-in and filtered paths size the same way: probe ==
+    // sized call, for Position and a scene built-in alike.
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Position", "{\"x\":12.5,\"y\":-3}"));
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Sprite", "{\"sprite_name\":\"hero\",\"z_index\":3}"));
+    inline for (.{ "Position", "Sprite" }) |comp_name| {
+        const probe = contract.labelle_component_get(id, comp_name.ptr, comp_name.len, null, 0);
+        try testing.expect(probe > 0);
+        var out: [512]u8 = undefined;
+        try testing.expectEqual(
+            probe,
+            contract.labelle_component_get(id, comp_name.ptr, comp_name.len, &out, out.len),
+        );
+        // And an under-sized cap writes nothing on these paths too.
+        @memset(&out, 0xAA);
+        try testing.expectEqual(
+            probe,
+            contract.labelle_component_get(id, comp_name.ptr, comp_name.len, &out, probe - 1),
+        );
+        for (out) |b| try testing.expectEqual(@as(u8, 0xAA), b);
+    }
+}
+
+test "component set: string fields are COPIED out of the caller's buffer" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+    const ent: u32 = @intCast(id);
+
+    // The C caller's json is only valid DURING the call — a native
+    // plugin passes a stack or reused buffer. "hello world" needs no
+    // unescaping, which is exactly the case where a default
+    // (alloc_if_needed) parse BORROWS the input instead of copying
+    // into the component arena; the contract must copy always.
+    var jsonbuf: [64]u8 = undefined;
+    const src = "{\"text\":\"hello world\"}";
+    @memcpy(jsonbuf[0..src.len], src);
+    const name = "Label";
+    try testing.expectEqual(
+        @as(i32, 0),
+        contract.labelle_component_set(id, name.ptr, name.len, &jsonbuf, src.len),
+    );
+    @memset(&jsonbuf, 0xAA); // the buffer dies/reuses after the call
+
+    const label = game.getComponent(ent, Label).?;
+    try testing.expectEqualStrings("hello world", label.text);
+    // Structural proof, not just value luck: the stored slice lives
+    // OUTSIDE the caller's buffer (the arena copy).
+    const lo = @intFromPtr(&jsonbuf);
+    const hi = lo + jsonbuf.len;
+    const p = @intFromPtr(label.text.ptr);
+    try testing.expect(p < lo or p >= hi);
+}
+
+test "component set: trailing garbage after the JSON document refuses with -1" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+    const ent: u32 = @intCast(id);
+
+    // Seed known-good values on both dispatch paths.
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Sprite", "{\"sprite_name\":\"hero\"}"));
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Health", "{\"hp\":7}"));
+
+    // Built-in path (the JSONC parser stops after ONE value): any
+    // trailing garbage — a second document included — is malformed
+    // JSON, refused BEFORE the apply, entity untouched.
+    inline for (.{
+        "{\"sprite_name\":\"evil\"}garbage",
+        "{\"sprite_name\":\"evil\"}{}",
+        "{\"sprite_name\":\"evil\"}]",
+    }) |payload| {
+        try testing.expectEqual(@as(i32, -1), setComp(id, "Sprite", payload));
+    }
+    try testing.expectEqualStrings("hero", game.getComponent(ent, ContractGame.SpriteComp).?.sprite_name);
+
+    // Registry path: std.json's end-of-document check refuses the same
+    // shapes by itself — pinned here so a parser swap can't quietly
+    // open the hole the built-in path had.
+    inline for (.{
+        "{\"hp\":9}garbage",
+        "{\"hp\":9}{\"hp\":10}",
+        "{\"hp\":9}}",
+    }) |payload| {
+        try testing.expectEqual(@as(i32, -1), setComp(id, "Health", payload));
+    }
+    try testing.expectEqual(@as(i32, 7), game.getComponent(ent, Health).?.hp);
+
+    // Whitespace-only tails stay legal on both paths — and the
+    // built-in path, being JSONC, treats a trailing comment as trivia.
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Health", "{\"hp\":8} \n"));
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Sprite", "{\"sprite_name\":\"neo\"} // done\n"));
+    try testing.expectEqual(@as(i32, 8), game.getComponent(ent, Health).?.hp);
+    try testing.expectEqualStrings("neo", game.getComponent(ent, ContractGame.SpriteComp).?.sprite_name);
 }
 
 test "component set/get: the built-in Position routes through setPosition" {
@@ -919,6 +1093,42 @@ test "event emit: named union variant parsed from JSON into the game buffer" {
     try testing.expectEqual(@as(usize, 2), game.event_buffer.items.len);
 }
 
+test "event emit: void payloads accept exactly empty, {} and null" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    // A void variant has no payload struct for std.json to validate
+    // against, so the accept set is pinned explicitly (module doc +
+    // header): anything outside it — malformed bytes included — is the
+    // contract's parse failure, -1 with nothing buffered.
+    try testing.expectEqual(@as(i32, -1), emitEvent("game__paused", "{"));
+    try testing.expectEqual(@as(i32, -1), emitEvent("game__paused", "{\"x\":1}"));
+    try testing.expectEqual(@as(i32, -1), emitEvent("game__paused", "garbage"));
+    try testing.expectEqual(@as(i32, -1), emitEvent("game__paused", " {} ")); // exact bytes only
+    try testing.expectEqual(@as(usize, 0), game.event_buffer.items.len);
+
+    // The accept set: empty (len 0), NULL (a C caller's natural "no
+    // payload"), the exact "{}", and the exact "null".
+    try testing.expectEqual(@as(i32, 0), emitEvent("game__paused", ""));
+    const name = "game__paused";
+    try testing.expectEqual(@as(i32, 0), contract.labelle_event_emit(name.ptr, name.len, null, 0));
+    try testing.expectEqual(@as(i32, 0), emitEvent("game__paused", "{}"));
+    try testing.expectEqual(@as(i32, 0), emitEvent("game__paused", "null"));
+    try testing.expectEqual(@as(usize, 4), game.event_buffer.items.len);
+    for (game.event_buffer.items) |ev| {
+        try testing.expect(ev == .game__paused);
+    }
+
+    // Struct-payload variants keep std.json's whole-document check:
+    // trailing garbage after the JSON is a parse failure there too.
+    try testing.expectEqual(@as(i32, -1), emitEvent("turret__fired", "{\"turret\":1}garbage"));
+    try testing.expectEqual(@as(usize, 4), game.event_buffer.items.len);
+}
+
 test "event emit: a game without a GameEvents union refuses with -1" {
     contract.unbind();
     defer contract.unbind();
@@ -1063,9 +1273,21 @@ test "subscribe/poll: slice-bearing payload survives emit → drain → dispatch
     subscribe("state__renamed");
     contract.drainEvents(&game); // activate the subscription (next-drain semantics)
 
-    // Frame 1: emit with a string payload. The parsed slice lives in
-    // the ACTIVE emit arena.
-    try testing.expectEqual(@as(i32, 0), emitEvent("state__renamed", "{\"name\":\"combat\"}"));
+    // Frame 1: emit with a string payload FROM A TRANSIENT BUFFER —
+    // the plugin's json is only valid during the call — and poison it
+    // the moment the call returns. The parsed slice must be a COPY in
+    // the ACTIVE emit arena, never a borrow of the caller's bytes
+    // ("combat" needs no unescaping, the exact case alloc_if_needed
+    // would alias).
+    var jsonbuf: [32]u8 = undefined;
+    const src = "{\"name\":\"combat\"}";
+    @memcpy(jsonbuf[0..src.len], src);
+    const ev_name = "state__renamed";
+    try testing.expectEqual(
+        @as(i32, 0),
+        contract.labelle_event_emit(ev_name.ptr, ev_name.len, &jsonbuf, src.len),
+    );
+    @memset(&jsonbuf, 0xAA); // the buffer dies/reuses after the call
     contract.drainEvents(&game); // flips arenas — must NOT recycle this frame's payload
     switch (game.event_buffer.items[0]) {
         .state__renamed => |p| try testing.expectEqualStrings("combat", p.name),
@@ -1284,14 +1506,17 @@ test "NULL C-ABI shapes: NULL/len-0 payloads take defaults; NULL out buffers pro
         else => return error.TestUnexpectedResult,
     }
 
-    // NULL out buffers: component_get reports 0 bytes, nothing written…
+    // NULL out buffers are pure SIZING PROBES: component_get returns
+    // the required size of the complete JSON (nothing written) and a
+    // right-sized call returns the same…
+    const get_required = contract.labelle_component_get(id, health.ptr, health.len, null, 0);
+    try testing.expect(get_required > 0);
+    var gbuf: [128]u8 = undefined;
     try testing.expectEqual(
-        @as(usize, 0),
-        contract.labelle_component_get(id, health.ptr, health.len, null, 0),
+        get_required,
+        contract.labelle_component_get(id, health.ptr, health.len, &gbuf, gbuf.len),
     );
-    // …while query treats NULL/cap-0 as the pure SIZING PROBE (its
-    // documented asymmetry): the required size of the one-carrier
-    // result comes back, and a right-sized call returns the same.
+    // …query probes identically (the shared snprintf-style sizing)…
     const names = "[\"Health\"]";
     const probe = contract.labelle_query(names.ptr, names.len, null, 0);
     try testing.expect(probe > 2);
@@ -1301,13 +1526,17 @@ test "NULL C-ABI shapes: NULL/len-0 payloads take defaults; NULL out buffers pro
         contract.labelle_query(names.ptr, names.len, &qbuf, qbuf.len),
     );
 
-    // poll with a NULL out reads NOTHING and consumes NOTHING: the
-    // pending entry survives for the next real poll.
+    // …and poll's NULL probe reports the NEXT entry's size while
+    // consuming NOTHING: the entry survives — repeatedly — until the
+    // real poll reads it, after which the probe is back to 0 (empty).
     contract.drainEvents(&game); // taps the NULL-emitted wave event above
     game.dispatchEvents();
-    try testing.expectEqual(@as(usize, 0), contract.labelle_event_poll(null, 0));
+    const entry = "wave__started {\"index\":0}";
+    try testing.expectEqual(entry.len, contract.labelle_event_poll(null, 0));
+    try testing.expectEqual(entry.len, contract.labelle_event_poll(null, 0));
     var buf: [128]u8 = undefined;
-    try testing.expectEqualStrings("wave__started {\"index\":0}", poll(&buf));
+    try testing.expectEqualStrings(entry, poll(&buf));
+    try testing.expectEqual(@as(usize, 0), contract.labelle_event_poll(null, 0));
 }
 
 // ── Time / log ──────────────────────────────────────────────────────

--- a/test/script_contract_test.zig
+++ b/test/script_contract_test.zig
@@ -21,9 +21,25 @@ const contract = engine.script_contract;
 const Health = struct { hp: i32 = 100, regen: f32 = 0 };
 const Velocity = struct { dx: f32 = 0, dy: f32 = 0 };
 
+/// `Doomed.onRemove` is a static method — no instance to mutate. A
+/// module-scope counter (reset at the start of the relevant test, the
+/// nested_lifecycle_test pattern) pins that `labelle_component_remove`
+/// on an ABSENT component never false-fires the hook.
+var doomed_on_remove_calls: u32 = 0;
+
+const Doomed = struct {
+    tag: u8 = 0,
+
+    pub fn onRemove(payload: engine.ComponentPayload) void {
+        _ = payload;
+        doomed_on_remove_calls += 1;
+    }
+};
+
 const TestComponents = engine.ComponentRegistry(.{
     .Health = Health,
     .Velocity = Velocity,
+    .Doomed = Doomed,
 });
 
 const TestEvents = union(enum) {
@@ -129,6 +145,7 @@ test "pre-bind: every export is a safe no-op" {
     // Void ops silently ignore.
     contract.labelle_entity_destroy(42);
     contract.labelle_log("hello", 5);
+    contract.labelle_time_dt_stamp(0.033);
     subscribe("turret__fired");
 
     // rc ops report failure.
@@ -271,6 +288,40 @@ test "component has/remove: presence flips, unknown names refuse" {
     try testing.expectEqual(@as(i32, -1), removeComp(id, "Mana"));
     try testing.expectEqual(@as(i32, -1), removeComp(999_999, "Velocity"));
     try testing.expectEqual(@as(i32, 0), hasComp(999_999, "Velocity"));
+}
+
+test "component remove: an absent component never false-fires onRemove" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    doomed_on_remove_calls = 0;
+    const id = contract.labelle_entity_create();
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Health", "{\"hp\":5}"));
+
+    // Absent-but-known: idempotent 0, and the hook must NOT fire —
+    // `game.removeComponent` runs `T.onRemove` unconditionally, so the
+    // contract has to gate on presence first.
+    try testing.expectEqual(@as(i32, 0), removeComp(id, "Doomed"));
+    try testing.expectEqual(@as(u32, 0), doomed_on_remove_calls);
+    // Sibling components are untouched by the no-op remove.
+    try testing.expectEqual(@as(i32, 5), game.getComponent(@as(u32, @intCast(id)), Health).?.hp);
+
+    // Present: the hook fires exactly once per real removal.
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Doomed", "{}"));
+    try testing.expectEqual(@as(i32, 0), removeComp(id, "Doomed"));
+    try testing.expectEqual(@as(u32, 1), doomed_on_remove_calls);
+
+    // And the remove made it absent again: back to the silent path.
+    try testing.expectEqual(@as(i32, 0), removeComp(id, "Doomed"));
+    try testing.expectEqual(@as(u32, 1), doomed_on_remove_calls);
+
+    // The built-in Position takes the same guard (absent → 0, no-op).
+    try testing.expectEqual(@as(i32, 0), removeComp(id, "Position"));
+    try testing.expectEqual(@as(i32, 5), game.getComponent(@as(u32, @intCast(id)), Health).?.hp);
 }
 
 // ── Query ───────────────────────────────────────────────────────────
@@ -525,6 +576,42 @@ test "subscribe pre-bind is a no-op; unpolled inbox entries free on unbind" {
     _ = poll(&buf); // consume one, leave one pending
 }
 
+test "poll: budgeted polling (a backlog always left pending) keeps the inbox storage bounded" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    subscribe("turret__fired");
+
+    // Frame 0 polls one FEWER than arrived; every later frame polls at
+    // matched throughput — so the inbox carries a standing backlog and
+    // never runs empty. The compact-only-when-empty scheme never fired
+    // here: `inbox_head` advanced forever while appends landed at
+    // `items.len`, growing the backing array every frame even though
+    // the pending count stayed at ~1. The threshold compaction slides
+    // the pending tail back to index 0 instead.
+    var buf: [128]u8 = undefined;
+    var settled: usize = 0;
+    var frame: usize = 0;
+    while (frame < 100) : (frame += 1) {
+        game.emit(.{ .turret__fired = .{ .turret = 1 } });
+        game.emit(.{ .turret__fired = .{ .turret = 2 } });
+        contract.drainEvents(&game);
+        game.dispatchEvents();
+        try testing.expect(poll(&buf).len > 0);
+        if (frame > 0) try testing.expect(poll(&buf).len > 0);
+        // A few frames in the capacity must have settled for good:
+        // pending stays at one carried entry + the frame's traffic.
+        if (frame == 10) settled = contract.inboxCapacity();
+        if (frame > 10) try testing.expect(contract.inboxCapacity() <= settled);
+    }
+    // The standing backlog entry is still pending here; the deferred
+    // unbind frees it (proven leak-free by the test above).
+}
+
 // ── Scene change ────────────────────────────────────────────────────
 
 test "scene_change: 0 on a known scene, -1 leaves the running scene alone" {
@@ -614,6 +701,64 @@ test "prefab_spawn: 0 before any JSONC scene attached the prefab cache" {
     try testing.expectEqual(@as(u64, 0), spawnPrefab("turret", ""));
 }
 
+// ── NULL-pointer ABI shapes ─────────────────────────────────────────
+
+test "NULL C-ABI shapes: NULL/len-0 payloads take defaults; NULL out buffers probe safely" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    try bootPrefabGame(&game);
+    contract.bind(&game);
+
+    // prefab_spawn with params_json = NULL/0 — the header's documented
+    // origin-spawn shape (a C caller's natural "no params").
+    const name = "turret";
+    const id = contract.labelle_prefab_spawn(name.ptr, name.len, null, 0);
+    try testing.expect(id != 0);
+    const pos = game.getComponent(@as(u32, @intCast(id)), core.Position).?;
+    try testing.expectEqual(@as(f32, 0), pos.x);
+    try testing.expectEqual(@as(f32, 0), pos.y);
+
+    // component_set with NULL json = "{}": the whole struct resets to
+    // its declared defaults (hp 100, not the prefab's 55).
+    const health = "Health";
+    try testing.expectEqual(
+        @as(i32, 0),
+        contract.labelle_component_set(id, health.ptr, health.len, null, 0),
+    );
+    try testing.expectEqual(@as(i32, 100), game.getComponent(@as(u32, @intCast(id)), Health).?.hp);
+
+    // event_emit with NULL json = "{}" (all-default payload).
+    const wave = "wave__started";
+    try testing.expectEqual(
+        @as(i32, 0),
+        contract.labelle_event_emit(wave.ptr, wave.len, null, 0),
+    );
+    switch (game.event_buffer.items[game.event_buffer.items.len - 1]) {
+        .wave__started => |p| try testing.expectEqual(@as(u32, 0), p.index),
+        else => return error.TestUnexpectedResult,
+    }
+
+    // NULL out buffers: 0 bytes, nothing written.
+    try testing.expectEqual(
+        @as(usize, 0),
+        contract.labelle_component_get(id, health.ptr, health.len, null, 0),
+    );
+    const names = "[\"Health\"]";
+    try testing.expectEqual(@as(usize, 0), contract.labelle_query(names.ptr, names.len, null, 0));
+
+    // poll with a NULL out reads NOTHING and consumes NOTHING: the
+    // pending entry survives for the next real poll.
+    subscribe("wave__started");
+    contract.drainEvents(&game); // taps the NULL-emitted wave event above
+    game.dispatchEvents();
+    try testing.expectEqual(@as(usize, 0), contract.labelle_event_poll(null, 0));
+    var buf: [128]u8 = undefined;
+    try testing.expectEqualStrings("wave__started {\"index\":0}", poll(&buf));
+}
+
 // ── Time / log ──────────────────────────────────────────────────────
 
 test "time_dt: last tick's scaled dt; 0 while paused and before the first tick" {
@@ -642,6 +787,54 @@ test "time_dt: last tick's scaled dt; 0 while paused and before the first tick" 
     game.setPaused(false);
     game.tick(0.020);
     try testing.expectApproxEqAbs(@as(f32, 0.020), contract.labelle_time_dt(), 0.0001);
+}
+
+test "time_dt: the plugin's stamped dt wins over the profiler reconstruction" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    // Unstamped session: the profiler fallback (the pre-plugin path).
+    game.tick(0.016);
+    try testing.expectApproxEqAbs(@as(f32, 0.016), contract.labelle_time_dt(), 0.0001);
+
+    // The plugin stamps the scaled dt it was handed; a script then
+    // changes time_scale MID-TICK. Scripts must still observe the dt
+    // this frame's Zig scripts got — the profiler reconstruction would
+    // report last-real-dt × the NEW scale instead.
+    contract.labelle_time_dt_stamp(0.016);
+    game.setTimeScale(0.25);
+    try testing.expectEqual(@as(f32, 0.016), contract.labelle_time_dt());
+    game.setTimeScale(1.0);
+
+    // Exactness: the stamp is returned verbatim, not recomputed.
+    contract.labelle_time_dt_stamp(0.125);
+    try testing.expectEqual(@as(f32, 0.125), contract.labelle_time_dt());
+
+    // Rebind = a fresh plugin session: the stamp resets, the fallback
+    // takes over again.
+    contract.bind(&game);
+    try testing.expectApproxEqAbs(@as(f32, 0.016), contract.labelle_time_dt(), 0.0001);
+    game.tick(0.020);
+    try testing.expectApproxEqAbs(@as(f32, 0.020), contract.labelle_time_dt(), 0.0001);
+}
+
+test "time_dt_stamp: pre-bind stamps are ignored and never leak into a session" {
+    contract.unbind();
+    defer contract.unbind();
+
+    contract.labelle_time_dt_stamp(0.5);
+    try testing.expectEqual(@as(f32, 0), contract.labelle_time_dt());
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    // No tick yet and no session stamp: the fallback's 0, not 0.5.
+    try testing.expectEqual(@as(f32, 0), contract.labelle_time_dt());
 }
 
 test "log: routes through the game log sink without crashing" {


### PR DESCRIPTION
**Script Runtime Contract v1** — the C-ABI surface every scripting language binds. Closes #737 (Phase 1 core of the language-plugins epic #237; design: `RFC-LANGUAGE-PLUGINS.md` #730; shapes proven by the POC #734).

## Architecture (editor_api-mirrored)

- `bind(&g)` once from the generated main → comptime `Holder` publishes a **type-erased vtable**; the 15 `export fn labelle_*` symbols carry no comptime types. Pre-bind, every export is a safe no-op.
- **Zero cost when unused**: reachable only through the lazily-analyzed `root.script_contract` — a build that never references it emits no symbols (the same `nm`-verified gate `editor_api` uses).
- Generated-main touchpoints documented for the assembler: `bind(&g)` after init; `drainEvents(&g)` **after tick, before `dispatchEvents`** (dispatch swaps the event buffer out — tapping after it always sees an empty list; the ordering is load-bearing and documented).

## Surface

`contract_version · entity_create/destroy · prefab_spawn · component_set/get/has/remove · query · event_emit/subscribe/poll · scene_change · log · time_dt` — consumer header at `contract/labelle_script.h` (`LABELLE_CONTRACT_VERSION 1`).

Notable implementation decisions (all documented in-file):
- **Components by name** over the registered set via the scene-bridge dispatch (not editor_api's Camera allowlist — scripts are the game's own code); `Position` included and routed through `setPosition` so render dirty-tracking fires; slice fields use the scene bridge's `nested_entity_arena` lifetime convention; visual built-ins with renderer side-tables (Sprite/Shape/Camera/…) are explicitly out of v1.
- **Double-buffered emit arenas**: JSON-parsed event payloads with slice fields must survive until end-of-frame dispatch; a single reset-at-drain arena would UAF them. Two arenas flip per drain; pinned by a slice-bearing-payload test.
- **Poll semantics POC-pinned**: `"<name> <json>"` FIFO, truncated entry still consumed, 256-cap drop-newest, subscribe dedupes, rebind = fresh session.
- `time_dt` reads the frame-profiler ring × `time_scale` (no extra generated-main splice); `query` writes always-valid JSON with truncation rollback.

## Verification

**904/904 tests, 170/170 steps** (baseline 885/885) — 19 new tests: pre-bind no-ops, component round-trips incl. unknown-name, 2-component query + filter, emit-by-name into the real buffer, subscribe/poll FIFO + filtering, slice-payload lifetime, `GameEvents = void` and empty-registry (`engine.Game`) compile-and-degrade paths.

Epic: #237 · next consumer: labelle-scripting bootstrap (#738)

https://claude.ai/code/session_01P7YLw4hXFCCaY2LAUt4G1j
