### PR TITLE
Remove legacy unified-format aliases (engine v2.0 breaking change)

### DIFF
--- a/spec/unified_format_spec.zig
+++ b/spec/unified_format_spec.zig
@@ -9,8 +9,8 @@
 //!  - prefab references nested inside entity-bearing component
 //!    fields (the `Room.movement_nodes` pattern) under the unified
 //!    format,
-//!  - a reference entry carrying both `overrides` and a legacy
-//!    `components` key.
+//!  - a reference entry carrying the removed legacy `components`
+//!    key is rejected (engine v2.0, #592).
 
 const std = @import("std");
 const zspec = @import("zspec");
@@ -181,38 +181,39 @@ pub const UnifiedFormatSpec = struct {
             try expect.toBeNull(findMarker(&game, 500));
         }
 
-        test "legacy components on a nested reference still resolves" {
-            try Bridge.loadSceneFromSource(&game,
+        test "legacy components on a nested reference is a load-time error" {
+            // A nested prefab reference patches via `overrides` (or
+            // flat PascalCase keys); the pre-#560 `components`
+            // wrapper on a reference is rejected in v2.0 (#592).
+            try std.testing.expectError(error.InvalidFormat, Bridge.loadSceneFromSource(&game,
                 \\{ "root": { "children": [
                 \\  { "components": { "Container": { "slots": [
                 \\    { "prefab": "nested_item", "components": { "Marker": { "id": 8 } } }
                 \\  ] } } }
                 \\] } }
-            , PREFAB_DIR);
-
-            try expect.notToBeNull(findMarker(&game, 8));
+            , PREFAB_DIR));
         }
     };
 
-    // ── reference entry: overrides vs. legacy components ────────
+    // ── reference entry: legacy components rejected (#592) ──────
 
-    pub const @"a reference carrying both overrides and components" = struct {
+    pub const @"a reference carrying a legacy components key" = struct {
         test "tests:before" {
             const src = Corpus.create(.{});
             try Bridge.addEmbeddedPrefab(&game, "base", src.base, PREFAB_DIR);
         }
 
-        test "overrides wins over a legacy components key on the same entry" {
-            try Bridge.loadSceneFromSource(&game,
+        test "a components key on a prefab reference is a load-time error" {
+            // Even alongside a valid `overrides`, a `components`
+            // wrapper on a reference is the removed legacy alias and
+            // is rejected outright (#592).
+            try std.testing.expectError(error.InvalidFormat, Bridge.loadSceneFromSource(&game,
                 \\{ "root": { "children": [
                 \\  { "prefab": "base",
                 \\    "overrides":  { "Marker": { "id": 9  } },
                 \\    "components": { "Marker": { "id": 99 } } }
                 \\] } }
-            , PREFAB_DIR);
-
-            try expect.notToBeNull(findMarker(&game, 9));
-            try expect.toBeNull(findMarker(&game, 99));
+            , PREFAB_DIR));
         }
     };
 };

--- a/src/jsonc/scene_loader/scene_process.zig
+++ b/src/jsonc/scene_loader/scene_process.zig
@@ -284,16 +284,19 @@ pub fn SceneProcess(comptime GameType: type, comptime Components: type, comptime
                             try loadSceneFile(game, include_path, prefab_cache, include_depth + 1);
                         }
                     }
-                    uf.warnLegacyAssets(scene_obj, game.log);
+                    // Reject the pre-#560 legacy file-level aliases
+                    // (top-level `"entities"` / `"assets"`); removed
+                    // in engine v2.0 (#592).
+                    try uf.rejectLegacyAliases(scene_obj, game.log);
                     // RFC #560 §B2 at the file root: a reference-mode
                     // root may not declare `"children"`.
                     // `uf.rootObject` returns the explicit `"root"`
-                    // block when present (root-wrapped legacy v1.x
-                    // shape) and the file object itself otherwise
-                    // (flat top-level entity, RFC #594), so the
-                    // gate fires for either shape.
+                    // block when present (root-wrapped v1.x shape) and
+                    // the file object itself otherwise (flat top-level
+                    // entity, RFC #594), so the gate fires for either
+                    // shape.
                     try uf.rejectB2Violation(uf.rootObject(scene_obj), game.log, "reference-mode root");
-                    if (uf.fileChildren(scene_obj, game.log)) |entities_arr| {
+                    if (uf.fileChildren(scene_obj)) |entities_arr| {
                         var ref_ctx = RefContext.init(game.allocator, null);
                         defer ref_ctx.deinit();
                         try processEntities(game, entities_arr, prefab_cache, &ref_ctx);
@@ -337,9 +340,9 @@ pub fn SceneProcess(comptime GameType: type, comptime Components: type, comptime
                             try loadSceneFile(game, include_path, prefab_cache, 1);
                         }
                     }
-                    uf.warnLegacyAssets(scene_obj, game.log);
+                    try uf.rejectLegacyAliases(scene_obj, game.log);
                     try uf.rejectB2Violation(uf.rootObject(scene_obj), game.log, "reference-mode root");
-                    if (uf.fileChildren(scene_obj, game.log)) |entities_arr| {
+                    if (uf.fileChildren(scene_obj)) |entities_arr| {
                         var ref_ctx = RefContext.init(game.allocator, null);
                         defer ref_ctx.deinit();
                         try processEntities(game, entities_arr, prefab_cache, &ref_ctx);

--- a/src/jsonc/tree_walker.zig
+++ b/src/jsonc/tree_walker.zig
@@ -290,7 +290,15 @@ fn walkEntry(
         // effective component tree the loader will instantiate.
         const prefab_components: ?Value.Object =
             if (prefab_root) |proot| try uf.prefabComponents(proot, merge_arena.allocator(), NoopLog{}) else null;
-        const patch = try uf.entityPatch(obj, merge_arena.allocator(), NoopLog{});
+        // This is the cycle-detection pre-pass, not the loader. A
+        // legacy `"components"`-on-reference form (rejected in v2.0,
+        // #592) surfaces its `error.InvalidFormat` from the real
+        // loader; here we treat it as "no patch" so cycle detection
+        // still runs over the rest of the tree.
+        const patch = uf.entityPatch(obj, merge_arena.allocator(), NoopLog{}) catch |e| switch (e) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.InvalidFormat => null,
+        };
         if (try effectiveComponents(merge_arena, prefab_components, patch)) |eff| {
             try walkComponentFields(ctx, merge_arena, resolver, eff, depth, visitor);
         }

--- a/src/jsonc/unified_format.zig
+++ b/src/jsonc/unified_format.zig
@@ -22,17 +22,20 @@
 //!   - **Unknown PascalCase → warn-once.** Forward-compat with
 //!     cross-repo plugin authoring; typos still surface visibly.
 //!
-//! Pre-#560 legacy spellings are still accepted during the
-//! migration window and each logs a one-time deprecation warning so
-//! the #572 migrator has a checklist.
+//! Pre-#560 legacy spellings — a top-level `"entities"` array, a
+//! `"components"` wrapper on a prefab reference, and a top-level
+//! `"assets"` array — are NO LONGER accepted as of engine v2.0
+//! (#592). The loader rejects each with an actionable
+//! `error.InvalidFormat` that points at the `labelle migrate
+//! unified` CLI migrator (which rewrites legacy files to the
+//! unified/flat form).
 //!
 //! These accessors are the single place that bridges the shapes —
 //! the loader calls them instead of reading raw keys, so flat,
-//! `"root"`-wrapped, bundle, and legacy files all walk the exact
-//! same code path. Per RFC #594 "Loader changes", during v1.x
-//! every shape is first-class and warning-free (only outright
-//! legacy patterns warn); v2.0 drops the wrapper / root-wrapped /
-//! file-object-no-root paths.
+//! `"root"`-wrapped, and bundle files all walk the exact same code
+//! path. Per RFC #594 "Loader changes", every current shape is
+//! first-class and warning-free; the pre-#560 legacy aliases were
+//! removed in the v2.0 major bump (#592).
 //!
 //! See RFC-UNIFY-SCENES-AND-PREFABS.md, RFC-FLATTEN-ROOT.md, and
 //! RFC-FLATTEN-WRAPPERS-AND-BUNDLES.md.
@@ -56,11 +59,14 @@ const warned_allocator: std.mem.Allocator = if (builtin.target.os.tag == .emscri
 else
     std.heap.page_allocator;
 
-// One-time deprecation-warning dedup, keyed by the comptime message
-// literal. A legacy prefab spawned N times — or a scene with N
-// legacy references — then warns once, not N times. Never freed
-// (process-lifetime set); keys are string literals so there is
-// nothing to dupe.
+// One-time warning dedup, keyed by the comptime message literal.
+// The pre-#560 legacy deprecation warnings were removed in v2.0
+// (#592); the remaining callers are RFC #596 forward-compat
+// diagnostics — the defense-in-depth "mixed wrapper + flat
+// PascalCase shapes" warnings on inline entities, prefab references,
+// and prefab roots. A scene that trips one of these N times then
+// warns once, not N times. Never freed (process-lifetime set); keys
+// are string literals so there is nothing to dupe.
 //
 // Unguarded on purpose. Gemini-review on #573 asked why this isn't
 // behind a `std.Thread.Mutex` — the answer is two-fold:
@@ -161,11 +167,6 @@ pub fn warnUnknownComponent(log: anytype, name: []const u8) void {
 ///    sets are closed and disjoint (RFC #594 §"Key sets are closed
 ///    and disjoint").
 ///
-/// Pre-#594 legacy scenes (those without any `"root"` wrapper and
-/// still using a top-level `"entities"` array) ride the same flat
-/// path here — `entityPatch`/`fileChildren` continue to honor the
-/// legacy keys at top level, warning once.
-///
 /// Returns the object that carries the root entity content either
 /// way: the explicit `"root"` block when present, the file object
 /// itself otherwise.
@@ -173,28 +174,53 @@ pub fn rootObject(file_obj: Value.Object) Value.Object {
     return file_obj.getObject("root") orelse file_obj;
 }
 
-/// The file-level entity list for a scene file. Three shapes ride
-/// the same accessor:
+/// Reject the pre-#560 legacy file-level aliases. As of engine v2.0
+/// (#592) the loader accepts only the unified/flat form, so a scene
+/// file that still carries either:
+///
+///  - a top-level `"entities"` array (the pre-#560 wrapper; the
+///    unified form lists file-level entities under `"children"`, or
+///    directly as a top-level bundle Array), or
+///  - a top-level `"assets"` array (assets are inferred from sprite
+///    references — RFC #563),
+///
+/// is rejected with `error.InvalidFormat` and an actionable message
+/// pointing at the `labelle migrate unified` CLI migrator. Callers
+/// invoke this before `fileChildren` so a legacy file fails loudly
+/// instead of silently loading as empty.
+pub fn rejectLegacyAliases(file_obj: Value.Object, log: anytype) error{InvalidFormat}!void {
+    if (file_obj.get("entities") != null) {
+        log.err(
+            "[unified-format] legacy \"entities\" key is no longer accepted (removed in engine v2.0, #592): list file-level entities under \"children\", or as a top-level bundle Array. Run `labelle migrate unified` to convert this file.",
+            .{},
+        );
+        return error.InvalidFormat;
+    }
+    if (file_obj.get("assets") != null) {
+        log.err(
+            "[unified-format] legacy \"assets\" key is no longer accepted (removed in engine v2.0, #592): assets are inferred from sprite references (RFC #563). Run `labelle migrate unified` to convert this file.",
+            .{},
+        );
+        return error.InvalidFormat;
+    }
+}
+
+/// The file-level entity list for a scene file. Two shapes ride the
+/// same accessor:
 ///
 ///  - **Root-wrapped (v1.0 — v1.x):** `root.children`.
-///  - **Flat (RFC #594, v1.47+):** top-level `"children"` array
-///    sitting alongside `"name"` / future metadata.
-///  - **Legacy pre-RFC-#560:** a top-level `"entities"` array (warned).
+///  - **Flat (RFC #594):** top-level `"children"` array sitting
+///    alongside `"name"` / future metadata.
 ///
-/// Partial-migration safety: if `"root"` is present but carries no
-/// `"children"` array, we still consult the legacy top-level
-/// `"entities"` / `"children"` keys before giving up — otherwise a
-/// scene that adds the `"root"` wrapper before moving its entity
-/// list silently loads as empty (#573).
-pub fn fileChildren(file_obj: Value.Object, log: anytype) ?Value.Array {
+/// The pre-#560 legacy top-level `"entities"` array is no longer
+/// honored (removed in v2.0, #592) — `rejectLegacyAliases` fails such
+/// a file before this is reached.
+pub fn fileChildren(file_obj: Value.Object) ?Value.Array {
     if (file_obj.getObject("root")) |root| {
         if (root.getArray("children")) |children| return children;
-        // `root` is present but empty — fall through to legacy keys
-        // (warned) so a half-migrated file still loads its entities.
-    }
-    if (file_obj.getArray("entities")) |entities| {
-        warnOnce(log, "[unified-format] legacy \"entities\" key: wrap the entity array in a \"root\" block and rename it to \"children\" (RFC #560)");
-        return entities;
+        // `root` is present but empty — fall through to a top-level
+        // `"children"` so a half-migrated file still loads its
+        // entities.
     }
     return file_obj.getArray("children");
 }
@@ -287,15 +313,14 @@ fn isFileHeader(obj: Value.Object) bool {
     return true;
 }
 
-/// The component patch for an entity entry. Three shapes ride this
+/// The component patch for an entity entry. Two shapes ride this
 /// accessor (RFC #560 / #594 / #596):
 ///
-///   - **Wrapped (v1.0 — v1.x):** inline entries carry
-///     `"components": { ... }`; reference entries carry
-///     `"overrides": { ... }`. A legacy `"components"` on a
-///     reference is accepted as a synonym and warned. When
-///     `"overrides"` and `"components"` both appear on a reference,
-///     `"overrides"` wins.
+///   - **Wrapped:** inline entries carry `"components": { ... }`;
+///     reference entries carry `"overrides": { ... }`. As of engine
+///     v2.0 (#592) the pre-#560 `"components"` wrapper on a *prefab
+///     reference* is rejected with `error.InvalidFormat` (it must be
+///     `"overrides"`); an inline entity still uses `"components"`.
 ///   - **Flat (RFC #596 Axis 2):** PascalCase keys at the entity
 ///     scope are the components directly — no `overrides:` /
 ///     `components:` wrapper. Lowercase keys (`prefab`, `children`,
@@ -313,27 +338,27 @@ fn isFileHeader(obj: Value.Object) bool {
 /// Object verbatim). Callers pass their per-scene arena; the
 /// synthesized Object's `entries` slice lives in that arena and
 /// must not outlive it. Leaf values are shared with `entity_obj`.
-pub fn entityPatch(entity_obj: Value.Object, allocator: std.mem.Allocator, log: anytype) error{OutOfMemory}!?Value.Object {
+pub fn entityPatch(entity_obj: Value.Object, allocator: std.mem.Allocator, log: anytype) error{ OutOfMemory, InvalidFormat }!?Value.Object {
     const is_reference = entity_obj.getString("prefab") != null;
 
-    // Wrapped form takes precedence — back-compat for v1.x and the
-    // dual-accept matrix during the deprecation window.
     if (is_reference) {
+        // A prefab reference patches via `"overrides"` (or flat
+        // PascalCase keys, RFC #596). The pre-#560 `"components"`
+        // wrapper on a reference is no longer accepted (removed in
+        // v2.0, #592) — reject it loudly instead of silently
+        // ignoring the patch.
+        if (entity_obj.get("components") != null) {
+            log.err(
+                "[unified-format] legacy \"components\" on a prefab reference is no longer accepted (removed in engine v2.0, #592): rename it to \"overrides\", or use flat PascalCase component keys (RFC #596). Run `labelle migrate unified` to convert this file.",
+                .{},
+            );
+            return error.InvalidFormat;
+        }
         if (entity_obj.getObject("overrides")) |overrides| {
-            if (entity_obj.getObject("components") != null) {
-                warnOnce(log, "[unified-format] prefab reference has both \"overrides\" and \"components\"; \"overrides\" wins — remove \"components\" (RFC #560)");
-            }
             if (hasPascalCaseKey(entity_obj)) {
                 warnOnce(log, "[unified-format] reference entry has both an \"overrides\" wrapper and flat PascalCase keys — \"overrides\" wins. Drop one shape (RFC #596).");
             }
             return overrides;
-        }
-        if (entity_obj.getObject("components")) |legacy| {
-            warnOnce(log, "[unified-format] legacy \"components\" on a prefab reference: rename it to \"overrides\" (RFC #560)");
-            if (hasPascalCaseKey(entity_obj)) {
-                warnOnce(log, "[unified-format] reference entry has both a \"components\" wrapper and flat PascalCase keys — wrapper wins. Drop one shape (RFC #596).");
-            }
-            return legacy;
         }
     } else {
         if (entity_obj.getObject("components")) |components| {
@@ -424,15 +449,6 @@ pub fn prefabComponents(prefab_root: Value.Object, allocator: std.mem.Allocator,
 /// (RFC #560, #561).
 pub fn effectiveName(file_obj: Value.Object, basename: []const u8) []const u8 {
     return file_obj.getString("name") orelse basename;
-}
-
-/// Warn once if a scene file still declares the dropped `"assets"`
-/// field. Under the unified format assets are inferred from sprite
-/// references (RFC #563); the field is ignored.
-pub fn warnLegacyAssets(file_obj: Value.Object, log: anytype) void {
-    if (file_obj.get("assets") != null) {
-        warnOnce(log, "[unified-format] legacy \"assets\" key is ignored — assets are inferred from sprite references (RFC #560, #563)");
-    }
 }
 
 /// RFC §B2 gate: a reference-mode entry (one that carries a

--- a/test/editor_api_test.zig
+++ b/test/editor_api_test.zig
@@ -678,7 +678,7 @@ const CONDENSER_V2 =
 fn bootPrefabGame(game: *engine.Game) !void {
     try PrefabBridge.addEmbeddedPrefab(game, "condenser", CONDENSER_V1, "prefabs");
     try PrefabBridge.loadSceneFromSource(game,
-        \\{ "entities": [] }
+        \\{ "children": [] }
     , "prefabs");
 }
 
@@ -1182,7 +1182,7 @@ test "scene loader: a scene-authored \"Camera\" component attaches as the built-
 
     const Bridge = engine.JsoncSceneBridge(CameraTestGame, EmptyComponents);
     try Bridge.loadSceneFromSource(&game,
-        \\{ "entities": [
+        \\{ "children": [
         \\   { "components": { "Position": { "x": 512, "y": 384 }, "Camera": { "zoom": 3.0 } } }
         \\ ] }
     , "prefabs");
@@ -1920,7 +1920,7 @@ test "scene JSONC: an authored Camera \"tag\" seeds the inline bounded field" {
 
     const Bridge = engine.JsoncSceneBridge(CameraTestGame, EmptyComponents);
     try Bridge.loadSceneFromSource(&game,
-        \\{ "entities": [
+        \\{ "children": [
         \\   { "components": { "Position": { "x": 512, "y": 384 }, "Camera": { "zoom": 1.0, "tag": "sky_parallax" } } }
         \\ ] }
     , "prefabs");

--- a/test/example_prefab_animation_walkthrough_test.zig
+++ b/test/example_prefab_animation_walkthrough_test.zig
@@ -158,7 +158,7 @@ fn boot(tmp_dir: *std.testing.TmpDir) !Fixture {
     errdefer game.deinit();
 
     try Bridge.loadSceneFromSource(&game,
-        \\{ "entities": [] }
+        \\{ "children": [] }
     , prefab_dir);
 
     return .{ .game = game, .prefab_dir = prefab_dir };

--- a/test/jsonc/bridge_deserialize_test.zig
+++ b/test/jsonc/bridge_deserialize_test.zig
@@ -65,7 +65,7 @@ fn oneEntity(game: *TestGame) TestGame.EntityType {
 
 test "deserialize optional: JSONC null → field is null (success path)" {
     var game = try boot(
-        \\{ "entities": [
+        \\{ "children": [
         \\  { "components": { "Decoration": { "label": null, "priority": 7 } } }
         \\] }
     );
@@ -78,7 +78,7 @@ test "deserialize optional: JSONC null → field is null (success path)" {
 
 test "deserialize optional: JSONC string → field is that string (success path)" {
     var game = try boot(
-        \\{ "entities": [
+        \\{ "children": [
         \\  { "components": { "Decoration": { "label": "banner", "priority": 3 } } }
         \\] }
     );
@@ -106,7 +106,7 @@ test "deserialize optional: malformed non-null value fails (does NOT silently be
     // pin is specifically that `label` is null because the field
     // failed, not because "null" was accepted as a non-null integer.
     var game = try boot(
-        \\{ "entities": [
+        \\{ "children": [
         \\  { "components": { "Decoration": { "label": 42, "priority": 5 } } }
         \\] }
     );

--- a/test/jsonc/bridge_leak_test.zig
+++ b/test/jsonc/bridge_leak_test.zig
@@ -48,7 +48,7 @@ test "loadScene: simple scene with components does not leak" {
         .sub_path = "scene.jsonc",
         .data =
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    { "components": { "Position": { "x": 10, "y": 20 }, "Health": { "current": 50, "max": 100 } } },
         \\    { "components": { "Position": { "x": 30, "y": 40 }, "Inventory": { "slots": 5 } } }
         \\  ]
@@ -78,7 +78,7 @@ test "loadSceneFromSource: simple scene with components does not leak" {
 
     const source =
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    { "components": { "Position": { "x": 10, "y": 20 }, "Health": { "current": 50, "max": 100 } } },
         \\    { "components": { "Position": { "x": 30, "y": 40 }, "Inventory": { "slots": 5 } } }
         \\  ]
@@ -112,9 +112,9 @@ test "loadScene: scene with prefabs does not leak" {
         .sub_path = "scene.jsonc",
         .data =
         \\{
-        \\  "entities": [
-        \\    { "prefab": "enemy", "components": { "Position": { "x": 100, "y": 200 } } },
-        \\    { "prefab": "enemy", "components": { "Position": { "x": 300, "y": 400 } } },
+        \\  "children": [
+        \\    { "prefab": "enemy", "overrides": { "Position": { "x": 100, "y": 200 } } },
+        \\    { "prefab": "enemy", "overrides": { "Position": { "x": 300, "y": 400 } } },
         \\    { "prefab": "enemy" }
         \\  ]
         \\}
@@ -143,7 +143,7 @@ test "loadScene: nested entity arrays (spawnAndLinkNestedEntities) do not leak" 
         .sub_path = "scene.jsonc",
         .data =
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    {
         \\      "components": {
         \\        "Position": { "x": 0, "y": 0 },
@@ -181,7 +181,7 @@ test "loadScene: children entities do not leak" {
         .sub_path = "scene.jsonc",
         .data =
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    {
         \\      "components": { "Position": { "x": 0, "y": 0 } },
         \\      "children": [

--- a/test/jsonc/bridge_prefab_tags_test.zig
+++ b/test/jsonc/bridge_prefab_tags_test.zig
@@ -92,8 +92,8 @@ test "jsonc_scene_bridge: prefab-sourced entity gets PrefabInstance tag" {
         ,
     },
         \\{
-        \\  "entities": [
-        \\    { "prefab": "enemy", "components": { "Position": { "x": 10, "y": 20 } } }
+        \\  "children": [
+        \\    { "prefab": "enemy", "overrides": { "Position": { "x": 10, "y": 20 } } }
         \\  ]
         \\}
     );
@@ -117,7 +117,7 @@ test "jsonc_scene_bridge: non-prefab entity does NOT get PrefabInstance" {
 
     var fixture = try setupFixture(&tmp_dir, .{},
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    { "components": { "Health": { "current": 50, "max": 50 } } }
         \\  ]
         \\}
@@ -147,9 +147,9 @@ test "jsonc_scene_bridge: multiple prefab instances each get their own PrefabIns
         ,
     },
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    { "prefab": "warrior" },
-        \\    { "prefab": "warrior", "components": { "Position": { "x": 5, "y": 5 } } },
+        \\    { "prefab": "warrior", "overrides": { "Position": { "x": 5, "y": 5 } } },
         \\    { "prefab": "archer" }
         \\  ]
         \\}
@@ -199,7 +199,7 @@ test "jsonc_scene_bridge: prefab children get PrefabChild tags on scene load" {
         ,
     },
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    { "prefab": "tree" }
         \\  ]
         \\}
@@ -286,7 +286,7 @@ test "jsonc_scene_bridge: scene-declared children on a prefab reference are a §
     // also declares `children`.
     const scene_source =
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    {
         \\      "prefab": "room",
         \\      "children": [
@@ -316,7 +316,7 @@ test "jsonc_scene_bridge: PrefabInstance.path survives save/load round-trip" {
         ,
     },
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    { "prefab": "unit" }
         \\  ]
         \\}

--- a/test/jsonc/image_component_test.zig
+++ b/test/jsonc/image_component_test.zig
@@ -96,7 +96,7 @@ test "Image: scene entity parses into the engine built-in with the RFC shape" {
     defer game.deinit();
 
     try BuiltinBridge.loadSceneFromSource(&game,
-        \\{ "entities": [
+        \\{ "children": [
         \\  { "components": { "Image": {
         \\      "name": "logo_splash",
         \\      "pivot": "bottom_left",
@@ -124,7 +124,7 @@ test "Image: defaults land for a minimal block" {
     defer game.deinit();
 
     try BuiltinBridge.loadSceneFromSource(&game,
-        \\{ "entities": [
+        \\{ "children": [
         \\  { "components": { "Image": { "name": "bare" } } }
         \\] }
     , "/tmp/labelle-nonexistent");
@@ -154,7 +154,7 @@ test "Image: parsed name resolves end-to-end through the AssetCatalog image load
     try game.assets.register("logo_splash", engine.LoaderKind.image, "png", "fake-png-bytes");
 
     try BuiltinBridge.loadSceneFromSource(&game,
-        \\{ "entities": [
+        \\{ "children": [
         \\  { "components": { "Image": { "name": "logo_splash", "pivot": "center" } } }
         \\] }
     , "/tmp/labelle-nonexistent");
@@ -237,7 +237,7 @@ test "Image: a registered component named Image wins over the engine built-in" {
     defer game.deinit();
 
     try OverrideBridge.loadSceneFromSource(&game,
-        \\{ "entities": [
+        \\{ "children": [
         \\  { "components": { "Image": { "width": 320, "height": 240 } } }
         \\] }
     , "/tmp/labelle-nonexistent");

--- a/test/jsonc/nested_lifecycle_test.zig
+++ b/test/jsonc/nested_lifecycle_test.zig
@@ -128,7 +128,7 @@ test "nested postLoad fires exactly once" {
 
     try loadSource(&game,
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    {
         \\      "components": {
         \\        "Container": {
@@ -164,7 +164,7 @@ test "nested onReady fires exactly once per nested entity" {
 
     try loadSource(&game,
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    {
         \\      "components": {
         \\        "Container": {
@@ -189,7 +189,7 @@ test "top-level postLoad still fires (regression guard)" {
 
     try loadSource(&game,
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    { "components": { "PostLoadBump": {} } }
         \\  ]
         \\}
@@ -220,7 +220,7 @@ test "nested prefab-only postLoad fires exactly once" {
     });
     const scene_src =
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    {
         \\      "components": {
         \\        "Container": {
@@ -266,14 +266,14 @@ test "nested scene override + prefab definition fires postLoad exactly once (no 
     });
     const scene_src =
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    {
         \\      "components": {
         \\        "Container": {
         \\          "slots": [
         \\            {
         \\              "prefab": "overridable",
-        \\              "components": { "PostLoadBump": { "calls": 0 } }
+        \\              "overrides": { "PostLoadBump": { "calls": 0 } }
         \\            }
         \\          ]
         \\        }
@@ -316,14 +316,14 @@ test "nested scene override + prefab definition fires onReady exactly once" {
     });
     const scene_src =
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    {
         \\      "components": {
         \\        "Container": {
         \\          "slots": [
         \\            {
         \\              "prefab": "overridable_ready",
-        \\              "components": { "OnReadyBump": {} }
+        \\              "overrides": { "OnReadyBump": {} }
         \\            }
         \\          ]
         \\        }
@@ -355,7 +355,7 @@ test "nested postLoad sees resolved ref-array (spawned child IDs patched)" {
 
     try loadSource(&game,
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    {
         \\      "components": {
         \\        "Container": {
@@ -402,7 +402,7 @@ test "nested postLoad sees resolved @ref entity-ref" {
 
     try loadSource(&game,
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    {
         \\      "components": {
         \\        "Container": {

--- a/test/jsonc/tilemap_precedence_test.zig
+++ b/test/jsonc/tilemap_precedence_test.zig
@@ -46,7 +46,7 @@ test "a registered component named Tilemap wins over the engine built-in" {
     defer game.deinit();
 
     try Bridge.loadSceneFromSource(&game,
-        \\{ "entities": [
+        \\{ "children": [
         \\  { "components": { "Tilemap": { "rows": 4, "cols": 7 } } }
         \\] }
     , "/tmp/labelle-nonexistent");

--- a/test/jsonc/unified_format_test.zig
+++ b/test/jsonc/unified_format_test.zig
@@ -1,17 +1,18 @@
 //! Loader acceptance tests for the unified scene/prefab format
 //! (RFC #560, ticket #561).
 //!
-//! Pins that the loader walks both shapes down the same code path:
+//! Pins that the loader walks every current shape down the same
+//! code path:
 //!
 //!  - the unified `"root"` wrapper at the file top,
-//!  - `"overrides"` (not `"components"`) on a prefab reference,
-//!  - and the legacy spellings — top-level `"entities"`,
-//!    `"components"` on a reference, a dropped `"assets"` field —
-//!    still load during the migration window.
+//!  - the flat top-level form and the RFC #596 bundle Array,
+//!  - `"overrides"` (not `"components"`) on a prefab reference.
 //!
-//! Cross-compatibility matters most: a unified scene referencing a
-//! legacy prefab (and vice-versa) must resolve, since files migrate
-//! one at a time.
+//! And pins that the pre-#560 legacy spellings — a top-level
+//! `"entities"` array, a `"components"` wrapper on a prefab
+//! reference, and a top-level `"assets"` array — are REJECTED as of
+//! engine v2.0 (#592) with `error.InvalidFormat`. `labelle migrate
+//! unified` converts a legacy file to the unified/flat form.
 
 const std = @import("std");
 const testing = std.testing;
@@ -130,25 +131,23 @@ test "unified: nested children under the root wrapper load" {
     try testing.expectEqualSlices(i32, &.{ 1, 2 }, markerIds(&game, &buf));
 }
 
-// ── Legacy shapes still accepted ────────────────────────────────
+// ── Legacy shapes now rejected (engine v2.0, #592) ──────────────
 
-test "legacy: top-level entities array still loads" {
-    var game = try boot(
+test "legacy: top-level entities array is a load-time error" {
+    // The pre-#560 top-level `"entities"` wrapper is no longer
+    // accepted — use `"children"` (or a top-level bundle Array).
+    try testing.expectError(error.InvalidFormat, boot(
         \\{ "entities": [ { "components": { "Marker": { "id": 9 } } } ] }
-    );
-    defer game.deinit();
-
-    try testing.expectEqual(@as(i32, 9), soleMarker(&game).id);
+    ));
 }
 
-test "legacy: dropped assets field is ignored, scene still loads" {
-    var game = try boot(
+test "legacy: top-level assets field is a load-time error" {
+    // Assets are inferred from sprite references (RFC #563); a
+    // dropped `"assets"` field is now rejected, not ignored.
+    try testing.expectError(error.InvalidFormat, boot(
         \\{ "assets": ["rooms", "props"],
-        \\  "entities": [ { "components": { "Marker": { "id": 8 } } } ] }
-    );
-    defer game.deinit();
-
-    try testing.expectEqual(@as(i32, 8), soleMarker(&game).id);
+        \\  "children": [ { "components": { "Marker": { "id": 8 } } } ] }
+    ));
 }
 
 // ── Prefab references: overrides vs. legacy components ──────────
@@ -169,41 +168,45 @@ test "unified: reference with overrides patches a unified prefab" {
     try testing.expectEqual(@as(i32, 7), soleMarker(&game).id);
 }
 
-test "legacy: reference with components still patches a legacy prefab" {
+test "legacy: components on a prefab reference is a load-time error" {
+    // A reference patches via `"overrides"` (or flat PascalCase
+    // keys); the pre-#560 `"components"` wrapper on a reference is
+    // rejected in v2.0 (#592).
     var game = TestGame.init(testing.allocator);
     defer game.deinit();
 
-    try Bridge.addEmbeddedPrefab(&game, "legacy_widget",
+    try Bridge.addEmbeddedPrefab(&game, "widget",
         \\{ "components": { "Marker": { "id": 200 } } }
     , PREFAB_DIR);
-    try Bridge.loadSceneFromSource(&game,
-        \\{ "entities": [
-        \\  { "prefab": "legacy_widget", "components": { "Marker": { "id": 5 } } }
+    try testing.expectError(error.InvalidFormat, Bridge.loadSceneFromSource(&game,
+        \\{ "children": [
+        \\  { "prefab": "widget", "components": { "Marker": { "id": 5 } } }
         \\] }
-    , PREFAB_DIR);
-
-    try testing.expectEqual(@as(i32, 5), soleMarker(&game).id);
+    , PREFAB_DIR));
 }
 
 // ── Cross-compatibility (files migrate one at a time) ───────────
 
-test "cross: unified scene + overrides references a legacy prefab" {
+test "cross: flat prefab (components wrapper, no root) resolves via overrides" {
     var game = TestGame.init(testing.allocator);
     defer game.deinit();
 
-    try Bridge.addEmbeddedPrefab(&game, "legacy_prefab",
+    // The prefab uses the flat form — a top-level `"components"`
+    // wrapper with no `"root"` (valid, RFC #594). The scene patches
+    // it with `"overrides"`.
+    try Bridge.addEmbeddedPrefab(&game, "flat_prefab",
         \\{ "components": { "Marker": { "id": 300 } } }
     , PREFAB_DIR);
     try Bridge.loadSceneFromSource(&game,
         \\{ "root": { "children": [
-        \\  { "prefab": "legacy_prefab", "overrides": { "Marker": { "id": 11 } } }
+        \\  { "prefab": "flat_prefab", "overrides": { "Marker": { "id": 11 } } }
         \\] } }
     , PREFAB_DIR);
 
     try testing.expectEqual(@as(i32, 11), soleMarker(&game).id);
 }
 
-test "cross: legacy scene + components references a unified prefab" {
+test "cross: bundle scene + overrides references a root-wrapped prefab" {
     var game = TestGame.init(testing.allocator);
     defer game.deinit();
 
@@ -211,9 +214,9 @@ test "cross: legacy scene + components references a unified prefab" {
         \\{ "root": { "components": { "Marker": { "id": 400 } } } }
     , PREFAB_DIR);
     try Bridge.loadSceneFromSource(&game,
-        \\{ "entities": [
-        \\  { "prefab": "unified_prefab", "components": { "Marker": { "id": 13 } } }
-        \\] }
+        \\[
+        \\  { "prefab": "unified_prefab", "overrides": { "Marker": { "id": 13 } } }
+        \\]
     , PREFAB_DIR);
 
     try testing.expectEqual(@as(i32, 13), soleMarker(&game).id);

--- a/test/prefab_refresh_test.zig
+++ b/test/prefab_refresh_test.zig
@@ -80,7 +80,7 @@ fn boot(game: *engine.Game, prefabs: []const struct { name: []const u8, src: []c
         try Bridge.addEmbeddedPrefab(game, p.name, p.src, "prefabs");
     }
     try Bridge.loadSceneFromSource(game,
-        \\{ "entities": [] }
+        \\{ "children": [] }
     , "prefabs");
 }
 

--- a/test/save_load_two_phase_test.zig
+++ b/test/save_load_two_phase_test.zig
@@ -87,7 +87,7 @@ fn setupFixture(
 
     // Empty scene boot — we'll spawn prefabs manually via the runtime API.
     try Bridge.loadSceneFromSource(&game,
-        \\{ "entities": [] }
+        \\{ "children": [] }
     , prefab_dir);
 
     return .{ .game = game, .prefab_dir = prefab_dir };
@@ -281,7 +281,7 @@ test "two-phase load: scene-loaded prefab with children round-trips end-to-end" 
 
     try Bridge.loadSceneFromSource(&game,
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    { "prefab": "room" }
         \\  ]
         \\}
@@ -446,7 +446,7 @@ test "two-phase load: nested prefab doesn't duplicate into a ghost root" {
 
     try Bridge.loadSceneFromSource(&game,
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    { "prefab": "outer" }
         \\  ]
         \\}

--- a/test/scene_ref_test.zig
+++ b/test/scene_ref_test.zig
@@ -84,7 +84,7 @@ test "@ref: basic bidirectional cross-reference" {
 
     try loadSource(&game,
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    { "ref": "box", "components": { "HoldsItem": { "item_id": "@apple" } } },
         \\    { "ref": "apple", "components": { "StoredIn": { "container_id": "@box" } } }
         \\  ]
@@ -124,7 +124,7 @@ test "@ref: forward reference (referenced entity declared after)" {
     // apple references box, but box is declared AFTER apple
     try loadSource(&game,
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    { "ref": "apple", "components": { "StoredIn": { "container_id": "@box" } } },
         \\    { "ref": "box", "components": { "Health": { "current": 50, "max": 50 } } }
         \\  ]
@@ -158,7 +158,7 @@ test "@ref: multiple entity refs in one component" {
 
     try loadSource(&game,
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    { "ref": "a", "components": { "Health": { "current": 1, "max": 1 } } },
         \\    { "ref": "b", "components": { "Health": { "current": 2, "max": 2 } } },
         \\    { "ref": "link", "components": { "Link": { "source": "@a", "target": "@b" } } }
@@ -202,7 +202,7 @@ test "@ref: entities without refs work unchanged" {
 
     try loadSource(&game,
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    { "components": { "Health": { "current": 42, "max": 100 } } },
         \\    { "components": { "Health": { "current": 99, "max": 200 } } }
         \\  ]
@@ -223,7 +223,7 @@ test "@ref: mixed refs and non-refs in same scene" {
 
     try loadSource(&game,
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    { "components": { "Health": { "current": 10, "max": 10 } } },
         \\    { "ref": "box", "components": { "Health": { "current": 20, "max": 20 } } },
         \\    { "components": { "StoredIn": { "container_id": "@box" } } }
@@ -262,7 +262,7 @@ test "@ref: no memory leaks" {
 
     try loadSource(&game,
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    { "ref": "a", "components": { "HoldsItem": { "item_id": "@b" } } },
         \\    { "ref": "b", "components": { "StoredIn": { "container_id": "@a" } } }
         \\  ]
@@ -278,7 +278,7 @@ test "@ref: ref with non-ref components on same entity" {
 
     try loadSource(&game,
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    { "ref": "target", "components": { "Health": { "current": 77, "max": 77 } } },
         \\    { "components": { "Health": { "current": 33, "max": 33 }, "StoredIn": { "container_id": "@target" } } }
         \\  ]
@@ -349,8 +349,8 @@ test "@ref: refs inside prefab with children" {
         .sub_path = "scene.jsonc",
         .data =
         \\{
-        \\  "entities": [
-        \\    { "prefab": "box_with_item", "components": { "Position": { "x": 10, "y": 20 } } }
+        \\  "children": [
+        \\    { "prefab": "box_with_item", "overrides": { "Position": { "x": 10, "y": 20 } } }
         \\  ]
         \\}
         ,
@@ -413,8 +413,8 @@ test "@ref: cross-reference between prefab and scene entity" {
         .sub_path = "scene.jsonc",
         .data =
         \\{
-        \\  "entities": [
-        \\    { "ref": "mybox", "prefab": "container", "components": { "Position": { "x": 0, "y": 0 } } },
+        \\  "children": [
+        \\    { "ref": "mybox", "prefab": "container", "overrides": { "Position": { "x": 0, "y": 0 } } },
         \\    { "components": { "StoredIn": { "container_id": "@mybox" } } }
         \\  ]
         \\}
@@ -488,8 +488,8 @@ test "@ref: position offset applied correctly with refs" {
         .sub_path = "scene.jsonc",
         .data =
         \\{
-        \\  "entities": [
-        \\    { "prefab": "parent_with_child", "components": { "Position": { "x": 100, "y": 200 } } }
+        \\  "children": [
+        \\    { "prefab": "parent_with_child", "overrides": { "Position": { "x": 100, "y": 200 } } }
         \\  ]
         \\}
         ,
@@ -548,7 +548,7 @@ test "@ref: nested entity arrays register refs (#415)" {
 
     try loadSource(&game,
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    {
         \\      "components": {
         \\        "Container": {
@@ -628,12 +628,12 @@ test "@ref: nested entities with children and cross-refs (#415)" {
         .sub_path = "scene.jsonc",
         .data =
         \\{
-        \\  "entities": [
+        \\  "children": [
         \\    {
         \\      "components": {
         \\        "Container": {
         \\          "slots": [
-        \\            { "prefab": "filled_slot", "components": { "Position": { "x": 10, "y": 0 } } },
+        \\            { "prefab": "filled_slot", "overrides": { "Position": { "x": 10, "y": 0 } } },
         \\            { "components": { "Health": { "current": 1, "max": 1 } } }
         \\          ]
         \\        }
@@ -724,8 +724,8 @@ test "children with Sprite render at correct position (#417)" {
         .sub_path = "scene.jsonc",
         .data =
         \\{
-        \\  "entities": [
-        \\    { "prefab": "room_with_decor", "components": { "Position": { "x": 100, "y": 200 } } }
+        \\  "children": [
+        \\    { "prefab": "room_with_decor", "overrides": { "Position": { "x": 100, "y": 200 } } }
         \\  ]
         \\}
         ,
@@ -800,8 +800,8 @@ test "destroying parent also destroys children (#417)" {
         .sub_path = "scene.jsonc",
         .data =
         \\{
-        \\  "entities": [
-        \\    { "prefab": "parent_with_child", "components": { "Position": { "x": 0, "y": 0 } } }
+        \\  "children": [
+        \\    { "prefab": "parent_with_child", "overrides": { "Position": { "x": 0, "y": 0 } } }
         \\  ]
         \\}
         ,

--- a/test/scene_source_override_test.zig
+++ b/test/scene_source_override_test.zig
@@ -27,14 +27,14 @@ const Bridge = engine.JsoncSceneBridge(Game, Components);
 
 // One entity in the compiled-in ("embedded") source…
 const base_src =
-    \\{ "entities": [
+    \\{ "children": [
     \\  { "components": { "Position": { "x": 1, "y": 1 } } }
     \\] }
 ;
 
 // …two in the editor's override.
 const override_src =
-    \\{ "entities": [
+    \\{ "children": [
     \\  { "components": { "Position": { "x": 10, "y": 10 } } },
     \\  { "components": { "Position": { "x": 20, "y": 20 } } }
     \\] }
@@ -43,7 +43,7 @@ const override_src =
 // Three in a second override, to prove replacement takes effect (and
 // frees the first copy).
 const override2_src =
-    \\{ "entities": [
+    \\{ "children": [
     \\  { "components": { "Position": { "x": 1, "y": 0 } } },
     \\  { "components": { "Position": { "x": 2, "y": 0 } } },
     \\  { "components": { "Position": { "x": 3, "y": 0 } } }
@@ -116,20 +116,20 @@ test "sceneSourceOverride: exact key first, then path stem; no false positives" 
 const root_with_include_src =
     \\{
     \\  "include": ["scenes/frag.jsonc"],
-    \\  "entities": [
+    \\  "children": [
     \\    { "components": { "Position": { "x": 0, "y": 0 } } }
     \\  ]
     \\}
 ;
 
 const frag_src =
-    \\{ "entities": [
+    \\{ "children": [
     \\  { "components": { "Position": { "x": 5, "y": 5 } } }
     \\] }
 ;
 
 const frag_override_src =
-    \\{ "entities": [
+    \\{ "children": [
     \\  { "components": { "Position": { "x": 6, "y": 6 } } },
     \\  { "components": { "Position": { "x": 7, "y": 7 } } }
     \\] }

--- a/test/spawn_from_prefab_test.zig
+++ b/test/spawn_from_prefab_test.zig
@@ -56,7 +56,7 @@ fn bootGameWithPrefab(
     errdefer game.deinit();
 
     try Bridge.loadSceneFromSource(&game,
-        \\{ "entities": [] }
+        \\{ "children": [] }
     , prefab_dir);
 
     return .{ .game = game, .prefab_dir = prefab_dir };


### PR DESCRIPTION
Closes #592.

**This is the engine v2.0.0 breaking change.** The unified scene/prefab loader now accepts **only** the unified/flat form. The three pre-#560 legacy aliases are removed; a legacy-form scene now fails at load with `error.InvalidFormat` and an actionable message pointing at **`labelle migrate unified`** (the CLI migrator that rewrites legacy files to the unified form).

FP is already on the unified/flat form, so it is unaffected once it bumps to engine 2.0.

### What was removed (in `src/jsonc/unified_format.zig`)

| Legacy alias | Now |
|---|---|
| top-level `"entities"` array | rejected — use `"children"` or a top-level bundle `Array` |
| `"components"` wrapper on a **prefab reference** | rejected — use `"overrides"` (or flat PascalCase keys) |
| top-level `"assets"` array | rejected — assets are inferred from sprite references (RFC #563) |

- `fileChildren` drops the `"entities"` fallback (and its now-unused `log` param).
- `entityPatch` drops the legacy-`components`-on-reference branch and now returns `error.InvalidFormat` for it.
- `warnLegacyAssets` -> `rejectLegacyAliases` (rejects top-level `entities`/`assets`), called from `scene_process.zig` before the entity walk.
- `tree_walker.zig`'s cycle pre-pass tolerates the new `InvalidFormat` from `entityPatch` (the real loader surfaces the error).

### Warn-once infra retained (intentional)

The `warnOnce` / `warnOnceKey` dedup infra is **kept**. Once the legacy call sites are gone, its only remaining callers are RFC #596 **forward-compat** diagnostics — the defense-in-depth "mixed wrapper + flat PascalCase" warnings and `warnUnknownComponent`. Those are not part of the removed legacy compatibility layer, so removing the infra would regress live v2.0+ behavior. Comment updated to reflect this.

### Tests

- Converted the legacy-acceptance tests in `test/jsonc/unified_format_test.zig` and `spec/unified_format_spec.zig` into **error tests** (assert `error.InvalidFormat`), and added positive coverage for the unified/flat + bundle forms.
- Migrated every in-tree scene-test fixture to the unified/flat form (`entities` -> `children`, reference `components` -> `overrides`).
- Left untouched: the **save-file** `"entities"` key (serialization format, different code path) and the **asset-inference walker**'s tolerance of a legacy top-level `assets` list (`inferAssets`, does not go through the scene loader).

`zig build test` -> exit 0 (Zig 0.16, 901 tests).

Note: version bump intentionally not included here — the v2.0.0 release commit + tag will be cut after merge.

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw