### PR TITLE
Wire sprite-based asset inference into scene load (part of #563)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -110,6 +110,7 @@ pub fn build(b: *std.Build) void {
         // unification; assembler-side codegen (making `meta.assets` optional)
         // is the follow-up.
         "test/asset_manifest_test.zig",
+        "test/asset_inference_wire_test.zig",
         "test/animation_def_test.zig",
         "test/animation_state_transitions_test.zig",
         "test/animation_def_runtime_test.zig",

--- a/src/asset_manifest.zig
+++ b/src/asset_manifest.zig
@@ -36,10 +36,66 @@
 //! **Scope of this module / PR:** the reverse-index + walker *core*. It takes
 //! no gfx dependency, touches no lifecycle, and reuses the existing
 //! `AssetCatalog` for the actual acquire/decode/upload/release (Phase B).
-//! Wiring the walker's output into `setScene`'s acquire gate (replacing the
-//! Debug eager-load fallback) and building the reverse index from the real
-//! `project.labelle` `.resources` at codegen time is assembler-side follow-up
-//! — see the PR body. False-positive over-load auditing is #566.
+//! **Wiring status (#563 follow-up — this PR).** The walker is now wired into
+//! the scene-load path (`game/scene_mixin.zig`): a scene that declares NO
+//! explicit `meta.assets` but carries its JSONC `source` (handed over by the
+//! assembler via `Game.setSceneSource`) has its manifest *derived* on first
+//! load and cached onto `SceneEntry.assets`, from which the existing
+//! acquire/gate/release machinery drives loading unchanged. The runtime
+//! reverse index is built lazily from the live `TextureManager` (every loaded
+//! atlas's sprite paths → its bundle name; see `ensureReverseIndex`). Scenes
+//! WITH an explicit manifest are untouched — inference never runs for them.
+//!
+//! ── Completeness audit + known limitations (#566) ──
+//!
+//! What sprite/image-ref inference over a scene's inline tree CAN see:
+//!   - Inline `Sprite`/`Image` references (any string that exactly matches an
+//!     atlas sprite path / image name), including refs nested inside
+//!     entity-bearing component fields (`Room.movement_nodes`, etc.).
+//!   - `AssetManifest.load` escape-hatch declarations anywhere in the tree.
+//!
+//! What it CANNOT see (a scene relying ONLY on these still needs an explicit
+//! `meta.assets` or an `AssetManifest`):
+//!   1. **Prefab references.** A `{ "prefab": "condenser" }` entry contributes
+//!      only the literal string `"condenser"` to the walk — the referenced
+//!      prefab's own `Sprite` refs live in a different file the walker isn't
+//!      handed. This is the load-bearing gap in practice: Flying-Platform's
+//!      top-level scenes (`colony`, `main`, …) are *pure prefab compositions*
+//!      (dozens of `"prefab":` entries, zero inline `Sprite`), so scene-level
+//!      inference resolves ~nothing for them. Inference over each PREFAB source
+//!      individually works (verified: `prefabs/rooms/wc.jsonc` → `rooms`
+//!      atlas); the missing piece is *transitively* following a scene's prefab
+//!      refs to their trees — the `TODO(#563 follow-up)` on `inferAssets`.
+//!      Until that lands, prefab-composition scenes keep their explicit list.
+//!   2. **Scene includes.** `"include": [...]` fragments are referenced by
+//!      path, not inlined into the walked tree — same shape as (1).
+//!   3. **Script-computed sprite names.** A name assembled at runtime
+//!      (`std.fmt`, config lookup) is invisible to a static walk. Lazy-on-miss
+//!      (#568/#563 Phase-B) recovers these via pop-in for VISUALS; anything
+//!      that must be ready *before* first render needs `AssetManifest`.
+//!      Flying-Platform has one script-acquire site today
+//!      (`scripts/menu/menu_ui.zig`) — the pattern the audit flags.
+//!   4. **Audio banks / fonts / raw bytes.** No `Sprite`/`Image` reference
+//!      surfaces these, and audio in particular often must be decoded *before*
+//!      a trigger fires (lazy pop-in is too late). These are the canonical
+//!      `AssetManifest.load` case. (Flying-Platform's current `.resources` are
+//!      all atlases, so it has no such case yet — but any project adding a
+//!      sound bank referenced only from a script will.)
+//!
+//! Over-load (false positives): every string is matched, so a component field
+//! that happens to equal a sprite path pre-loads an unneeded bundle. Harmless
+//! for correctness; the mobile memory cost is the remaining open item of #566.
+//! For inline-Sprite scenes measured here the inferred set was a subset of the
+//! declared list (no over-load), but this is not yet audited at scale.
+//!
+//! **Migration guidance.** Before dropping a scene's `meta.assets`: if the
+//! scene composes prefabs (case 1) or pulls in fragments (case 2), keep the
+//! explicit list OR add an `AssetManifest` until transitive prefab-walk lands;
+//! if it uses inline `Sprite`/`Image` refs only, inference covers it; for
+//! script-loaded audio/overlays (cases 3–4), add an `AssetManifest.load`.
+//!
+//! False-positive over-load auditing at scale is the remaining open part of
+//! #566.
 
 const std = @import("std");
 const jsonc = @import("jsonc");
@@ -205,6 +261,54 @@ pub const ReverseIndex = struct {
             },
             else => return IndexError.InvalidAtlasJson,
         }
+    }
+
+    /// Register an atlas resource from an explicit sprite-path list,
+    /// **tolerating duplicate keys** (first-wins). Unlike `addAtlas`, a
+    /// sprite path already present in the index is silently skipped rather
+    /// than raising `DuplicateResourceName`.
+    ///
+    /// This is the entry the *runtime* reverse-index builder uses. That
+    /// builder indexes EVERY currently-loaded atlas from the live
+    /// `TextureManager`; two atlases that happen to declare the same sprite
+    /// path there must NOT abort the whole build (the renderer's
+    /// `findSprite` already resolves such a collision by first-match, so a
+    /// game that ships with a cross-atlas duplicate sprite name is already
+    /// running fine — inference must not be the thing that crashes it).
+    /// The strict `addAtlas` / `addAtlasFromJson` collision error is
+    /// retained for the codegen/authoring path where a duplicate really is
+    /// a fixable content bug. Returns the number of newly-inserted keys.
+    ///
+    /// `bundle_name` is duped only if at least one key is inserted, so an
+    /// atlas whose every sprite is already indexed costs nothing.
+    pub fn addAtlasLenient(
+        self: *ReverseIndex,
+        bundle_name: []const u8,
+        sprite_paths: []const []const u8,
+    ) IndexError!usize {
+        const a = self.arena.allocator();
+        var owned_bundle: ?[]const u8 = null;
+        var inserted: usize = 0;
+        for (sprite_paths) |path| {
+            if (self.map.contains(path)) continue;
+            if (owned_bundle == null) owned_bundle = try a.dupe(u8, bundle_name);
+            const key = try a.dupe(u8, path);
+            try self.insert(key, .{ .atlas = owned_bundle.? });
+            inserted += 1;
+        }
+        return inserted;
+    }
+
+    /// Register a standalone image resource tolerating a duplicate key
+    /// (first-wins). Runtime counterpart to `addImage` — see
+    /// `addAtlasLenient` for why the runtime builder can't hard-error on a
+    /// collision. Returns `true` if newly inserted.
+    pub fn addImageLenient(self: *ReverseIndex, asset_name: []const u8) IndexError!bool {
+        if (self.map.contains(asset_name)) return false;
+        const a = self.arena.allocator();
+        const key = try a.dupe(u8, asset_name);
+        try self.insert(key, .{ .image = key });
+        return true;
     }
 
     fn insert(self: *ReverseIndex, key: []const u8, ref: ResourceRef) IndexError!void {

--- a/src/game.zig
+++ b/src/game.zig
@@ -14,6 +14,7 @@ const PrefabChild = core.PrefabChild;
 
 const atlas_mod = @import("atlas.zig");
 const assets_mod = @import("assets/mod.zig");
+const asset_manifest_mod = @import("asset_manifest.zig");
 const game_log_mod = @import("game_log.zig");
 const preview_mode_mod = @import("preview_mode.zig");
 const scheduler_mod = @import("scheduler.zig");
@@ -425,6 +426,19 @@ pub fn GameConfigWithYAxis(
             /// Lifetime: stored by reference, must outlive the `Game`. The
             /// assembler emits a string-literal slice, which is program-lifetime.
             initial_state: ?[]const u8 = null,
+            /// Raw JSONC scene source, for **sprite-based asset inference**
+            /// (#563). Populated by the assembler via `setSceneSource` — a
+            /// program-lifetime `@embedFile` borrow of the scene's `.jsonc`.
+            /// When a scene declares NO explicit `assets` manifest and this
+            /// source is present, `setScene`/`setSceneAtomic` walk it against
+            /// the runtime reverse index (`inferAssetsFromSource`) to *derive*
+            /// the manifest, then cache the result into `assets` above so the
+            /// acquire/release/gate path behaves exactly as if it had been
+            /// declared. `null` (default) preserves pre-inference behavior
+            /// (the Debug eager-load-everything fallback still applies).
+            ///
+            /// Lifetime: stored by reference, must outlive the `Game`.
+            source: ?[]const u8 = null,
         };
 
         /// Runtime JSONC scene path info.
@@ -590,6 +604,25 @@ pub fn GameConfigWithYAxis(
         /// Cleared after the swap completes (success path) or after
         /// an explicit abort (`scene_assets_release_pending`).
         pending_scene_assets: ?[]const u8 = null,
+
+        /// Sprite-based asset-inference reverse index (#563), built lazily
+        /// the first time a manifest-less scene with a `source` is loaded.
+        /// Maps every atlas sprite path (and standalone image name) currently
+        /// known to the engine to its providing resource bundle, so
+        /// `inferAssetsFromSource` can derive a scene's manifest from its
+        /// `Sprite`/`Image` references. `null` until first needed (zero cost
+        /// for games that declare every manifest explicitly). Freed on
+        /// `deinit`. See `scene_mixin.ensureReverseIndex`.
+        reverse_index: ?asset_manifest_mod.ReverseIndex = null,
+
+        /// Owns the name copies of every *inferred* scene manifest (#563).
+        /// When `setScene` derives a manifest for a manifest-less scene, the
+        /// resulting `InferredManifest` is parked here and its stable slice is
+        /// cached onto `SceneEntry.assets`; this list keeps those name dupes
+        /// alive for the `Game`'s lifetime so the cached slice never dangles.
+        /// Each entry is `deinit`'d on `Game.deinit`. Explicitly-declared
+        /// scenes never touch this list.
+        inferred_manifests: std.ArrayListUnmanaged(asset_manifest_mod.InferredManifest) = .empty,
 
         /// Controls how `setScene` / `setSceneAtomic` react when
         /// `catalog.anyFailed(target.assets)` returns non-null during
@@ -1165,6 +1198,7 @@ pub fn GameConfigWithYAxis(
         /// `game/prefab_runtime_mixin.zig` for the scope contract.
         pub const reloadPrefabSource = PrefabRuntimeMixin.reloadPrefabSource;
         pub const setSceneAssets = SceneMixin.setSceneAssets;
+        pub const setSceneSource = SceneMixin.setSceneSource;
         pub const setSceneInitialState = SceneMixin.setSceneInitialState;
         pub const setScene = SceneMixin.setScene;
         pub const setSceneAtomic = SceneMixin.setSceneAtomic;

--- a/src/game/lifecycle_mixin.zig
+++ b/src/game/lifecycle_mixin.zig
@@ -99,6 +99,13 @@ pub fn Mixin(comptime Game: type) type {
             self.gizmo_state.deinit(self.allocator);
             self.scenes.deinit();
             self.jsonc_scenes.deinit();
+            // Sprite-based asset inference (#563): free the reverse index and
+            // every parked inferred manifest (each owns its name dupes). Both
+            // are lazily allocated — untouched for games that declare every
+            // manifest explicitly.
+            if (self.reverse_index) |*ri| ri.deinit();
+            for (self.inferred_manifests.items) |*m| m.deinit();
+            self.inferred_manifests.deinit(self.allocator);
             // Free duplicated keys; values are program-lifetime @embedFile
             // borrows so they aren't owned by this map.
             var emb_iter = self.embedded_scene_sources.iterator();

--- a/src/game/scene_mixin.zig
+++ b/src/game/scene_mixin.zig
@@ -1,6 +1,7 @@
 /// Scene mixin — scene registration, loading, transitions, and lifecycle.
 const std = @import("std");
 const builtin = @import("builtin");
+const asset_manifest_mod = @import("../asset_manifest.zig");
 
 /// Collect every asset name currently registered in the catalog into a
 /// fresh allocator-owned slice. The returned slice borrows the name
@@ -22,6 +23,108 @@ fn collectAllRegisteredAssetNames(allocator: std.mem.Allocator, catalog: anytype
         try list.append(allocator, key.*);
     }
     return list.toOwnedSlice(allocator);
+}
+
+/// Lazily build the sprite-based asset-inference reverse index (#563) from
+/// every atlas currently registered in `atlas_manager`, caching it on
+/// `game.reverse_index`. Returns a pointer to the built index, or `null` if
+/// the build could not complete (OOM) — in which case the caller skips
+/// inference and falls back to its existing behavior.
+///
+/// The index maps every atlas *sprite path* to its providing atlas *bundle
+/// name* (the same name used as the `AssetCatalog` resource key, so an
+/// inferred entry can be `acquire`d directly). Cross-atlas duplicate sprite
+/// names are first-wins and never fatal (`addAtlasLenient`) — the renderer's
+/// `findSprite` already resolves such collisions that way, so inference must
+/// not be the thing that turns a shipping game into a crash. Built once and
+/// reused; steady-state cost is zero for games that declare every manifest.
+///
+/// Standalone images (`Image` component, #568) are a documented gap here:
+/// they are not currently enumerable from a single runtime registry the way
+/// atlas sprites are. A scene relying on a standalone image with no explicit
+/// manifest should carry an `AssetManifest` until that registry lands. Sprite
+/// refs — the #563 acceptance case — are fully covered.
+fn ensureReverseIndex(game: anytype) ?*asset_manifest_mod.ReverseIndex {
+    if (game.reverse_index) |*ri| return ri;
+
+    var index = asset_manifest_mod.ReverseIndex.init(game.allocator);
+
+    var scratch: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer scratch.deinit(game.allocator);
+
+    var it = game.atlas_manager.atlases.iterator();
+    while (it.next()) |entry| {
+        scratch.clearRetainingCapacity();
+        var sit = entry.value_ptr.sprites.keyIterator();
+        while (sit.next()) |k| {
+            scratch.append(game.allocator, k.*) catch {
+                index.deinit();
+                return null;
+            };
+        }
+        _ = index.addAtlasLenient(entry.key_ptr.*, scratch.items) catch {
+            index.deinit();
+            return null;
+        };
+    }
+
+    game.reverse_index = index;
+    return &(game.reverse_index.?);
+}
+
+/// Resolve the asset manifest a scene should load through the gate.
+///
+/// This is the single point where sprite-based asset inference (#563) hooks
+/// into the existing acquire/gate/release machinery, and it is deliberately
+/// conservative:
+///
+///   - Scene has an explicit / already-cached manifest (`assets.len > 0`):
+///     returned untouched. Every existing scene loads byte-for-byte
+///     identically — inference never runs for it.
+///   - Scene has no manifest but no `source` either: returns empty, so the
+///     caller's existing Debug eager-load-everything fallback still applies.
+///   - Scene has no manifest but DOES carry its JSONC `source`: walk it
+///     against the runtime reverse index, and if that yields a non-empty set,
+///     cache it onto `SceneEntry.assets`. From then on the scene is
+///     indistinguishable from one with an explicit manifest — the gate
+///     acquires the inferred set and the scene-swap path releases it
+///     symmetrically. Inference runs once (result cached), and any failure
+///     (malformed source / OOM) is best-effort: it logs and returns empty
+///     rather than failing the load.
+fn resolveSceneAssets(game: anytype, name: []const u8) []const []const u8 {
+    const entry = game.scenes.getPtr(name) orelse return &.{};
+    // Explicit or already-inferred manifest — never re-derive.
+    if (entry.assets.len > 0) return entry.assets;
+    const source = entry.source orelse return &.{};
+
+    const index = ensureReverseIndex(game) orelse return &.{};
+    if (index.count() == 0) return &.{};
+
+    var manifest = asset_manifest_mod.inferAssetsFromSource(game.allocator, index, source) catch |err| {
+        game.log.warn(
+            "[Scene] '{s}': asset inference skipped ({s}) — falling back to declared/eager behavior",
+            .{ name, @errorName(err) },
+        );
+        return &.{};
+    };
+    if (manifest.slice().len == 0) {
+        manifest.deinit();
+        return &.{};
+    }
+
+    // Park the manifest so its heap-owned name copies outlive this call, then
+    // cache the (heap-stable) slice onto the SceneEntry. The slice pointer is
+    // owned by `manifest.names` — appending the struct to `inferred_manifests`
+    // copies the struct by value but leaves that buffer in place, so the
+    // cached slice stays valid even if the outer list later reallocs.
+    const slice = manifest.slice();
+    game.inferred_manifests.append(game.allocator, manifest) catch {
+        manifest.deinit();
+        return &.{};
+    };
+    entry.assets = slice;
+    std.log.info("[Scene] '{s}' has no manifest, inferred {d} asset(s) from sprite refs", .{ name, slice.len });
+    return slice;
 }
 
 /// Possible outcomes of the asset-manifest gate fired at the start
@@ -401,6 +504,31 @@ pub fn Mixin(comptime Game: type) type {
             entry.assets = assets;
         }
 
+        /// Attach the raw JSONC `source` of a previously-registered scene,
+        /// enabling sprite-based asset inference (#563) when the scene has no
+        /// explicit manifest. Mirrors `setSceneAssets` — the assembler emits
+        /// one call per comptime scene (gated on `@hasDecl` for forward-compat
+        /// with older engines) after the `registerScene*` loop, passing the
+        /// scene's `@embedFile`'d `.jsonc` source. Returns
+        /// `error.SceneNotFound` if `name` was never registered.
+        ///
+        /// Setting a source has NO effect on a scene that already declares an
+        /// explicit `assets` manifest — inference is skipped for those, so
+        /// their loading stays byte-for-byte identical. It only matters for
+        /// manifest-less scenes, where `setScene`/`setSceneAtomic` walk the
+        /// source to derive the manifest on first load.
+        ///
+        /// Lifetime: `source` is stored by reference and must outlive the
+        /// `Game`. The assembler emits a program-lifetime `@embedFile` slice.
+        pub fn setSceneSource(
+            self: *Game,
+            name: []const u8,
+            source: []const u8,
+        ) error{SceneNotFound}!void {
+            const entry = self.scenes.getPtr(name) orelse return error.SceneNotFound;
+            entry.source = source;
+        }
+
         /// Attach a declared `initial_state` to a previously-registered scene.
         /// `setScene` will call `setState(state)` after the scene loads.
         ///
@@ -434,10 +562,16 @@ pub fn Mixin(comptime Game: type) type {
             // the gate entirely. Scenes registered via the legacy
             // `registerSceneSimple` (no manifest) have `assets ==
             // &.{}` and behave identically to before this change.
-            const declared_assets: []const []const u8 = if (self.scenes.get(name)) |e|
-                e.assets
-            else
-                &.{};
+            // Sprite-based asset inference (#563): when the scene declares no
+            // explicit manifest but carries its JSONC `source`, derive the
+            // manifest from the entity tree's Sprite refs and cache it onto
+            // `SceneEntry.assets`. From that point the scene flows through the
+            // identical acquire/gate/release path as an explicitly-declared
+            // one; scenes WITH a manifest are returned untouched, so their
+            // loading is byte-for-byte unchanged. Returns empty when there is
+            // no source (or inference found nothing), preserving the Debug
+            // eager-load fallback below.
+            const declared_assets: []const []const u8 = resolveSceneAssets(self, name);
 
             // Dev-mode eager-load fallback (issue #502) — if the scene
             // declared no assets and we're a Debug build, load every
@@ -586,22 +720,29 @@ pub fn Mixin(comptime Game: type) type {
         /// Clears the scene entity list first so Scene.deinit skips entity destruction,
         /// then resets the ECS atomically, then loads the new scene.
         pub fn setSceneAtomic(self: *Game, name: []const u8) !void {
-            const entry = self.scenes.get(name) orelse return error.SceneNotFound;
+            if (!self.scenes.contains(name)) return error.SceneNotFound;
+
+            // Sprite-based asset inference (#563) — mirror of `setScene`.
+            // Derives + caches the manifest for a source-bearing, manifest-less
+            // scene before the entry is (re-)read below, so `declared_assets`
+            // reflects the inferred set. See `resolveSceneAssets` / `setScene`.
+            const declared_assets: []const []const u8 = resolveSceneAssets(self, name);
+            const entry = self.scenes.get(name).?;
 
             // Dev-mode eager-load fallback (issue #502) — same logic as
             // setScene, kept in sync. See setScene for the full rationale.
             var eager_buf: ?[][]const u8 = null;
             defer if (eager_buf) |b| self.allocator.free(b);
-            const target_assets: []const []const u8 = if (entry.assets.len == 0 and comptime builtin.mode == .Debug) blk: {
-                const all = collectAllRegisteredAssetNames(self.allocator, &self.assets) catch break :blk entry.assets;
+            const target_assets: []const []const u8 = if (declared_assets.len == 0 and comptime builtin.mode == .Debug) blk: {
+                const all = collectAllRegisteredAssetNames(self.allocator, &self.assets) catch break :blk declared_assets;
                 if (all.len == 0) {
                     self.allocator.free(all);
-                    break :blk entry.assets;
+                    break :blk declared_assets;
                 }
                 std.log.info("[Scene] '{s}' has no manifest, eager-loaded {d} resources (Debug build)", .{ name, all.len });
                 eager_buf = all;
                 break :blk @as([]const []const u8, all);
-            } else entry.assets;
+            } else declared_assets;
 
             // Manifest gate — see `setScene` for the full
             // explanation. Both entry points participate in the

--- a/test/asset_inference_wire_test.zig
+++ b/test/asset_inference_wire_test.zig
@@ -1,0 +1,152 @@
+//! Sprite-based asset inference wired into the scene-load path (#563).
+//!
+//! Proves the acceptance criterion of the #563 follow-up: a scene that
+//! declares NO `meta.assets` but references a sprite via a `Sprite` component
+//! loads the *inferred* asset set — while a scene that DOES declare an explicit
+//! manifest is left byte-for-byte unchanged (inference never runs for it).
+//!
+//! The wiring under test lives in `src/game/scene_mixin.zig`
+//! (`resolveSceneAssets` / `ensureReverseIndex` / `setSceneSource`) on top of
+//! the reverse-index + walker core in `src/asset_manifest.zig`.
+
+const std = @import("std");
+const testing = std.testing;
+
+const engine = @import("engine");
+const Game = engine.Game;
+const SpriteData = engine.SpriteData;
+
+fn emptyLoader(_: *Game) anyerror!void {}
+
+/// Register an atlas `bundle` into `atlas_manager` carrying `sprites`, and
+/// register the matching `AssetCatalog` resource forced to `.ready` so the
+/// scene-load gate proceeds without running the real decode worker.
+fn installAtlas(game: *Game, bundle: []const u8, sprites: []const []const u8) !void {
+    const atlas = try game.atlas_manager.addAtlas(bundle);
+    for (sprites) |s| {
+        try atlas.addSprite(s, .{ .x = 0, .y = 0, .width = 1, .height = 1 });
+    }
+    try game.assets.register(bundle, .image, "png", "stub-bytes");
+    const e = game.assets.entries.getPtr(bundle).?;
+    e.state = .ready;
+    e.refcount = 0;
+}
+
+// ── Module core: reverse index + source walker ───────────────────────
+
+test "inferAssetsFromSource: Sprite ref resolves to its atlas bundle" {
+    var index = engine.ReverseIndex.init(testing.allocator);
+    defer index.deinit();
+    try index.addAtlas("chars", &.{ "hero/idle", "hero/run" });
+    try index.addAtlas("ui", &.{"ui/button"});
+
+    const source =
+        \\{
+        \\  "meta": { "name": "world" },
+        \\  "root": {
+        \\    "components": { "Sprite": { "sprite_name": "hero/idle" } }
+        \\  }
+        \\}
+    ;
+
+    var manifest = try engine.inferAssetsFromSource(testing.allocator, &index, source);
+    defer manifest.deinit();
+
+    // Only the atlas that actually provides the referenced sprite is inferred.
+    try testing.expectEqual(@as(usize, 1), manifest.slice().len);
+    try testing.expect(manifest.contains("chars"));
+    try testing.expect(!manifest.contains("ui"));
+}
+
+// ── End-to-end: setScene over a manifest-less, source-bearing scene ──
+
+test "setScene: scene with NO manifest loads inferred asset set" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    try installAtlas(&game, "chars", &.{"hero/idle"});
+
+    // No manifest — only a source referencing the sprite.
+    game.registerSceneSimple("world", emptyLoader);
+    try game.setSceneSource("world",
+        \\{ "root": { "components": { "Sprite": { "sprite_name": "hero/idle" } } } }
+    );
+
+    try game.setScene("world");
+
+    // Inference derived + cached the manifest onto the SceneEntry.
+    const entry = game.scenes.get("world").?;
+    try testing.expectEqual(@as(usize, 1), entry.assets.len);
+    try testing.expectEqualStrings("chars", entry.assets[0]);
+
+    // The inferred atlas was actually acquired through the gate.
+    try testing.expect(game.assets.entries.getPtr("chars").?.refcount >= 1);
+
+    // The scene committed (it is the current scene).
+    try testing.expectEqualStrings("world", game.getCurrentSceneName().?);
+
+    // Exactly one manifest parked; the reverse index was built once.
+    try testing.expectEqual(@as(usize, 1), game.inferred_manifests.items.len);
+    try testing.expect(game.reverse_index != null);
+}
+
+test "setScene: explicit manifest is unchanged — inference never runs" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    // `chars` is what inference WOULD pick if it ran; `explicit` is the
+    // hand-declared manifest. They differ so we can tell which path won.
+    try installAtlas(&game, "chars", &.{"hero/idle"});
+    try game.assets.register("explicit", .image, "png", "stub-bytes");
+    const ex = game.assets.entries.getPtr("explicit").?;
+    ex.state = .ready;
+    ex.refcount = 0;
+
+    const manifest: []const []const u8 = &.{"explicit"};
+    game.registerSceneWithAssets("world", emptyLoader, manifest);
+    // A source is present too — inference must still be skipped because a
+    // manifest is already declared.
+    try game.setSceneSource("world",
+        \\{ "root": { "components": { "Sprite": { "sprite_name": "hero/idle" } } } }
+    );
+
+    try game.setScene("world");
+
+    // The explicit manifest is exactly preserved (same pointer, same content).
+    const entry = game.scenes.get("world").?;
+    try testing.expectEqual(manifest.ptr, entry.assets.ptr);
+    try testing.expectEqual(@as(usize, 1), entry.assets.len);
+    try testing.expectEqualStrings("explicit", entry.assets[0]);
+
+    // Inference produced nothing — no manifest parked, index never built.
+    try testing.expectEqual(@as(usize, 0), game.inferred_manifests.items.len);
+    try testing.expect(game.reverse_index == null);
+
+    // The explicit asset was acquired; the would-be inferred one was NOT.
+    try testing.expect(game.assets.entries.getPtr("explicit").?.refcount >= 1);
+    try testing.expectEqual(@as(u32, 0), game.assets.entries.getPtr("chars").?.refcount);
+}
+
+test "inference is one-shot: re-entering the scene reuses the cached manifest" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    try installAtlas(&game, "chars", &.{"hero/idle"});
+    game.registerSceneSimple("world", emptyLoader);
+    game.registerSceneSimple("menu", emptyLoader);
+    try game.setSceneSource("world",
+        \\{ "root": { "components": { "Sprite": { "sprite_name": "hero/idle" } } } }
+    );
+
+    try game.setScene("world"); // infers → parks 1
+    try game.setScene("menu"); // releases world's inferred manifest
+    try game.setScene("world"); // entry.assets already cached → no re-infer
+
+    try testing.expectEqual(@as(usize, 1), game.inferred_manifests.items.len);
+}
+
+test "setSceneSource: unknown scene returns SceneNotFound" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    try testing.expectError(error.SceneNotFound, game.setSceneSource("nope", "{}"));
+}


### PR DESCRIPTION
Wires the merged `asset_manifest.zig` core (#747) into the scene-load path so `meta.assets` becomes **derivable**. Part of #563; the completeness audit it records is #566.

## What this does
A scene that declares **no** explicit `meta.assets` but carries its JSONC `source` now has its manifest **inferred on first load** — walking the entity tree's `Sprite` refs against a runtime reverse index — and cached onto `SceneEntry.assets`. From there the existing acquire/gate/release machinery drives loading **unchanged**.

## Strictly additive (the guardrail)
- Scenes **with** an explicit `meta.assets` are untouched — `resolveSceneAssets` returns early on `assets.len > 0`, so they load byte-for-byte identically and inference never runs (zero cost, reverse index never even built).
- The inferred path activates **only** when the manifest is absent, replacing the Debug eager-load-everything fallback for source-bearing scenes. Manifest-less scenes with no source keep the existing eager (Debug) / silent (Release) behavior.

## Pieces
- `asset_manifest.zig`: `ReverseIndex.addAtlasLenient` / `addImageLenient` — duplicate-tolerant (first-wins) inserts for the runtime builder, which indexes every loaded atlas and must not hard-error on a cross-atlas dup the way the strict authoring path does (`findSprite` already resolves such dups first-match).
- `game/scene_mixin.zig`: `ensureReverseIndex` (lazy build from the live `TextureManager`), `resolveSceneAssets` (derive + cache when the manifest is absent), `setSceneSource` setter; `setScene` + `setSceneAtomic` route through `resolveSceneAssets`.
- `game.zig`: `SceneEntry.source`, `Game.reverse_index`, `Game.inferred_manifests`; freed in `lifecycle_mixin` deinit.

## Wired vs deferred
- **Wired:** reverse index built from the real loaded atlases at runtime; `meta.assets` optional via inference; symmetric acquire **and** release (inferred set cached onto `SceneEntry.assets`, so the scene-swap release path is balanced — no new refcount leak).
- **Deferred (documented):** transitive prefab-ref / scene-include walking (the `TODO(#563 follow-up)` — see #566 note below), standalone-image registry, and Phase-B lazy-on-miss pop-in beyond scene-swap symmetry.

## Tests
`test/asset_inference_wire_test.zig`:
- manifest-less scene with a `Sprite` ref loads the inferred set (`entry.assets == ["chars"]`, atlas acquired);
- explicit-manifest scene is unchanged (same pointer, would-be inferred atlas NOT acquired, index never built);
- inference is one-shot / cached across re-entry;
- `setSceneSource` returns `SceneNotFound` for an unknown scene.

`zig build test` → exit 0 (Zig 0.16).

Verified against Flying-Platform (not committed): inference over a real prefab `prefabs/rooms/wc.jsonc` resolves its inline `sprite_name` refs to the `rooms` atlas.

## #566 completeness audit
Recorded as the known-limitations spec in the `asset_manifest.zig` module doc. Key finding: **FP's top-level scenes (`colony`, `main`, …) are pure prefab compositions** (dozens of `"prefab":` entries, zero inline `Sprite`), so scene-level inference resolves ~nothing for them — they must keep an explicit list (or gain `AssetManifest`) until transitive prefab-walk lands. Prefab refs, scene includes, script-computed names, and audio banks are the documented gaps.

Companion assembler PR (emits `setSceneSource`): labelle-toolkit/labelle-assembler#feat/563-inference-emit.

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw