### PR TITLE
feat(assets): transitively walk prefab refs for asset inference (#754)

### DIFF
--- a/src/asset_manifest.zig
+++ b/src/asset_manifest.zig
@@ -46,36 +46,43 @@
 //! atlas's sprite paths → its bundle name; see `ensureReverseIndex`). Scenes
 //! WITH an explicit manifest are untouched — inference never runs for them.
 //!
-//! ── Completeness audit + known limitations (#566) ──
+//! ── Completeness audit + known limitations (#566, #754) ──
 //!
 //! What sprite/image-ref inference over a scene's inline tree CAN see:
 //!   - Inline `Sprite`/`Image` references (any string that exactly matches an
 //!     atlas sprite path / image name), including refs nested inside
 //!     entity-bearing component fields (`Room.movement_nodes`, etc.).
 //!   - `AssetManifest.load` escape-hatch declarations anywhere in the tree.
+//!   - **Prefab references** (`{ "prefab": "condenser" }`) — followed
+//!      *transitively* into the referenced prefab's own tree when a
+//!      `PrefabResolver` is supplied (the scene-load path wires one from the
+//!      engine's `PrefabCache`; see `inferAssetsFromSourceWithPrefabs`). This
+//!      closes the load-bearing gap: Flying-Platform's top-level scenes
+//!      (`colony`, `main`, …) are *pure prefab compositions* (dozens of
+//!      `"prefab":` entries, zero inline `Sprite`), so before #754 scene-level
+//!      inference resolved ~nothing for them; now their prefabs' atlas bundles
+//!      union in. Prefab→prefab chains recurse; a cycle (A→B→A) terminates via
+//!      a visited-set guard; an unknown prefab name is skipped. Inference over
+//!      each prefab source individually still works standalone (verified:
+//!      `prefabs/rooms/wc.jsonc` → `rooms` atlas). Without a resolver (the
+//!      old 3-arg entry points) a prefab ref still contributes only its literal
+//!      name string, preserving pre-#754 behavior.
 //!
 //! What it CANNOT see (a scene relying ONLY on these still needs an explicit
 //! `meta.assets` or an `AssetManifest`):
-//!   1. **Prefab references.** A `{ "prefab": "condenser" }` entry contributes
-//!      only the literal string `"condenser"` to the walk — the referenced
-//!      prefab's own `Sprite` refs live in a different file the walker isn't
-//!      handed. This is the load-bearing gap in practice: Flying-Platform's
-//!      top-level scenes (`colony`, `main`, …) are *pure prefab compositions*
-//!      (dozens of `"prefab":` entries, zero inline `Sprite`), so scene-level
-//!      inference resolves ~nothing for them. Inference over each PREFAB source
-//!      individually works (verified: `prefabs/rooms/wc.jsonc` → `rooms`
-//!      atlas); the missing piece is *transitively* following a scene's prefab
-//!      refs to their trees — the `TODO(#563 follow-up)` on `inferAssets`.
-//!      Until that lands, prefab-composition scenes keep their explicit list.
-//!   2. **Scene includes.** `"include": [...]` fragments are referenced by
-//!      path, not inlined into the walked tree — same shape as (1).
-//!   3. **Script-computed sprite names.** A name assembled at runtime
+//!   1. **Scene includes.** `"include": [...]` fragments are referenced by
+//!      path, not inlined into the walked tree — same shape as a prefab ref,
+//!      but the included fragment's source is not reachable through the
+//!      `PrefabResolver` (which is keyed by prefab effective-name, not include
+//!      path). Left as a documented follow-up to #754; a scene pulling in a
+//!      fragment keeps its explicit list until an include-resolver lands.
+//!   2. **Script-computed sprite names.** A name assembled at runtime
 //!      (`std.fmt`, config lookup) is invisible to a static walk. Lazy-on-miss
 //!      (#568/#563 Phase-B) recovers these via pop-in for VISUALS; anything
 //!      that must be ready *before* first render needs `AssetManifest`.
 //!      Flying-Platform has one script-acquire site today
 //!      (`scripts/menu/menu_ui.zig`) — the pattern the audit flags.
-//!   4. **Audio banks / fonts / raw bytes.** No `Sprite`/`Image` reference
+//!   3. **Audio banks / fonts / raw bytes.** No `Sprite`/`Image` reference
 //!      surfaces these, and audio in particular often must be decoded *before*
 //!      a trigger fires (lazy pop-in is too late). These are the canonical
 //!      `AssetManifest.load` case. (Flying-Platform's current `.resources` are
@@ -88,11 +95,12 @@
 //! For inline-Sprite scenes measured here the inferred set was a subset of the
 //! declared list (no over-load), but this is not yet audited at scale.
 //!
-//! **Migration guidance.** Before dropping a scene's `meta.assets`: if the
-//! scene composes prefabs (case 1) or pulls in fragments (case 2), keep the
-//! explicit list OR add an `AssetManifest` until transitive prefab-walk lands;
-//! if it uses inline `Sprite`/`Image` refs only, inference covers it; for
-//! script-loaded audio/overlays (cases 3–4), add an `AssetManifest.load`.
+//! **Migration guidance.** Before dropping a scene's `meta.assets`: a scene
+//! that composes prefabs is now covered (their trees are walked transitively
+//! at load time), as are inline `Sprite`/`Image`-ref scenes; if it pulls in
+//! `"include"` fragments (case 1) keep the explicit list OR add an
+//! `AssetManifest` until an include-resolver lands; for script-loaded
+//! audio/overlays (cases 2–3), add an `AssetManifest.load`.
 //!
 //! False-positive over-load auditing at scale is the remaining open part of
 //! #566.
@@ -369,24 +377,19 @@ pub const InferredManifest = struct {
 /// bundle. The mobile over-load cost of that is #566's audit, not this
 /// function's concern.
 ///
-/// **Prefab references and scene-includes are NOT followed (yet).** The walk
+/// **This `std.json.Value` overload does NOT follow prefab references.** It
 /// infers only from the *inline* `Sprite`/`Image` refs (and nested
-/// entity-bearing fields) present in the tree it is given. When an entity
-/// references another prefab by name (`"prefab": "condenser"` / `@ref`), or a
-/// scene pulls in another scene/fragment by an include reference, this walker
-/// sees only the reference *string*, not the referenced tree — resolving it
-/// needs the prefab / scene-include registry/cache, which lives on the
-/// comptime/assembler side, not here. A ref whose name happens to match an
-/// index key is treated as a plain string (usually a miss). Assets that live
-/// *only* inside a referenced prefab/scene must, for now, be surfaced by the
-/// referencing scene either through inference of that prefab/scene when *it*
-/// is loaded as a top-level tree, or via an `AssetManifest` on the referencing
-/// entity.
-/// TODO(#563 follow-up): resolve prefab references AND scene-includes against
-/// their trees so a referencing scene pulls in the referenced assets
-/// transitively. This is part of the same assembler-side wiring (build the
-/// reverse index from `project.labelle` + walk the comptime prefab / scene
-/// registry) noted in the PR body.
+/// entity-bearing fields) present in the tree it is given; a `"prefab":
+/// "condenser"` ref contributes only its literal name string. Transitive
+/// prefab-walking (#754) lives on the `jsonc.Value` path that the scene loader
+/// actually runs — see `inferAssetsJsoncWithPrefabs` /
+/// `inferAssetsFromSourceWithPrefabs`, which thread a `PrefabResolver` so a
+/// referenced prefab's own tree is unioned in. This overload stays inline-only
+/// because the runtime `PrefabCache` holds `jsonc.Value` trees, not
+/// `std.json.Value`, so a resolver here would have nothing to resolve against.
+/// Scene `"include"` fragments are still followed by neither path (a smaller
+/// documented follow-up to #754 — the include source is not reachable through
+/// the prefab-name-keyed resolver).
 ///
 /// Caller owns the returned `InferredManifest` (call `.deinit()`).
 pub fn inferAssets(
@@ -489,19 +492,79 @@ fn collectManifestLoad(
 // actually runs at scene-load time consumes that shape. `inferAssetsFromSource`
 // is the entry a loader calls: parse the scene source once, walk it, get the
 // inferred `meta.assets` list. Structurally identical to the `std.json.Value`
-// walk above.
+// walk above, PLUS transitive prefab-reference walking (#754) — see
+// `PrefabResolver`.
+
+/// Resolves a prefab *effective name* to its parsed entity tree so the walker
+/// can follow `{ "prefab": "<name>" }` references transitively into the assets
+/// they contribute (#754). Returns `null` for an unknown name (the reference
+/// is then skipped gracefully — no crash, no partial result).
+///
+/// Deliberately a tiny type-erased callback rather than a hard dependency on
+/// the engine's `PrefabCache`, so `asset_manifest.zig` stays lifecycle-free
+/// and unit-testable: the scene-load path wires the live `PrefabCache` behind
+/// it (via `getInstalled`, a registry-only lookup with no disk/side effects);
+/// a test wires a plain name→tree map. The returned `jsonc.Value` must stay
+/// valid for the duration of the `inferAssets*` call (the cache's trees are
+/// game-lifetime, so this holds at runtime).
+pub const PrefabResolver = struct {
+    ctx: *anyopaque,
+    resolveFn: *const fn (ctx: *anyopaque, name: []const u8) ?jsonc.Value,
+
+    pub fn resolve(self: PrefabResolver, name: []const u8) ?jsonc.Value {
+        return self.resolveFn(self.ctx, name);
+    }
+};
+
+/// Threaded through the recursive `jsonc.Value` walk so every level can reach
+/// the resolver + the cycle-guard set without a growing parameter list.
+const JsoncWalkCtx = struct {
+    out: *InferredManifest,
+    index: *const ReverseIndex,
+    /// `null` = don't follow prefab refs (the pre-#754 3-arg entry points).
+    resolver: ?PrefabResolver,
+    /// Prefab names already walked into — the cycle guard AND redundant-work
+    /// dedup. Keys alias the walked trees (stable for the whole call), so no
+    /// dupe is needed; the set itself is freed by the entry point.
+    visited: *std.StringHashMapUnmanaged(void),
+    gpa: std.mem.Allocator,
+};
 
 /// Walk a `jsonc.Value` entity tree and infer its required resource bundles.
-/// The scene-load counterpart to `inferAssets`. Caller owns the returned
-/// `InferredManifest`.
+/// The scene-load counterpart to `inferAssets`. Does NOT follow prefab
+/// references — use `inferAssetsJsoncWithPrefabs` for that. Caller owns the
+/// returned `InferredManifest`.
 pub fn inferAssetsJsonc(
     gpa: std.mem.Allocator,
     index: *const ReverseIndex,
     scene: jsonc.Value,
 ) std.mem.Allocator.Error!InferredManifest {
+    return inferAssetsJsoncWithPrefabs(gpa, index, scene, null);
+}
+
+/// Like `inferAssetsJsonc`, but follows `{ "prefab": "<name>" }` references
+/// transitively through `resolver` (#754): a referenced prefab's own tree is
+/// walked and its assets unioned in. Prefab→prefab chains recurse; cycles
+/// terminate via a visited-set guard; an unknown prefab name is skipped.
+/// Passing `resolver == null` is exactly `inferAssetsJsonc`.
+pub fn inferAssetsJsoncWithPrefabs(
+    gpa: std.mem.Allocator,
+    index: *const ReverseIndex,
+    scene: jsonc.Value,
+    resolver: ?PrefabResolver,
+) std.mem.Allocator.Error!InferredManifest {
     var out = InferredManifest{ .gpa = gpa };
     errdefer out.deinit();
-    try walkJsonc(&out, index, scene);
+    var visited: std.StringHashMapUnmanaged(void) = .empty;
+    defer visited.deinit(gpa);
+    var ctx = JsoncWalkCtx{
+        .out = &out,
+        .index = index,
+        .resolver = resolver,
+        .visited = &visited,
+        .gpa = gpa,
+    };
+    try walkJsonc(&ctx, scene);
     return out;
 }
 
@@ -511,10 +574,30 @@ pub fn inferAssetsJsonc(
 /// name copies. `error.ParseFailed` wraps a genuine JSONC *syntax* error;
 /// `error.OutOfMemory` propagates distinctly (a transient allocation failure
 /// is not a malformed scene and callers may want to retry, not reject).
+///
+/// Does NOT follow prefab references — see `inferAssetsFromSourceWithPrefabs`.
 pub fn inferAssetsFromSource(
     gpa: std.mem.Allocator,
     index: *const ReverseIndex,
     source: []const u8,
+) (error{ ParseFailed, OutOfMemory })!InferredManifest {
+    return inferAssetsFromSourceWithPrefabs(gpa, index, source, null);
+}
+
+/// Like `inferAssetsFromSource`, but follows prefab references transitively
+/// through `resolver` (#754). This is the entry the scene-load path (#563
+/// wiring in `game/scene_mixin.zig`) calls, passing a resolver backed by the
+/// engine's `PrefabCache`, so a pure prefab-composition scene (zero inline
+/// `Sprite`) still derives the union of its prefabs' atlas bundles.
+///
+/// Only the *scene* source is parsed here; referenced prefab trees come from
+/// `resolver` already-parsed (the cache holds `jsonc.Value` trees), so no
+/// re-parse happens per reference.
+pub fn inferAssetsFromSourceWithPrefabs(
+    gpa: std.mem.Allocator,
+    index: *const ReverseIndex,
+    source: []const u8,
+    resolver: ?PrefabResolver,
 ) (error{ ParseFailed, OutOfMemory })!InferredManifest {
     var arena = std.heap.ArenaAllocator.init(gpa);
     defer arena.deinit();
@@ -525,25 +608,37 @@ pub fn inferAssetsFromSource(
         error.OutOfMemory => return error.OutOfMemory,
         else => return error.ParseFailed,
     };
-    return inferAssetsJsonc(gpa, index, root);
+    return inferAssetsJsoncWithPrefabs(gpa, index, root, resolver);
 }
 
 fn walkJsonc(
-    out: *InferredManifest,
-    index: *const ReverseIndex,
+    ctx: *JsoncWalkCtx,
     node: jsonc.Value,
 ) std.mem.Allocator.Error!void {
     switch (node) {
         .string => |s| {
-            if (index.lookup(s)) |ref| try out.add(ref.resourceName());
+            if (ctx.index.lookup(s)) |ref| try ctx.out.add(ref.resourceName());
         },
         .array => |arr| {
-            for (arr.items) |item| try walkJsonc(out, index, item);
+            for (arr.items) |item| try walkJsonc(ctx, item);
         },
         .object => |obj| {
+            // Transitive prefab-walk (#754): an entity that references another
+            // prefab by name pulls in that prefab's own tree. Done BEFORE the
+            // generic entry walk so the referenced assets union in regardless
+            // of where `"prefab"` sits among the object's keys. The generic
+            // walk below still visits the `"prefab"` string value itself
+            // (usually an index miss — the name isn't a sprite path), and any
+            // sibling `overrides`/`components` keys, so a reference-with-
+            // overrides entity contributes both its own and its prefab's refs.
+            if (ctx.resolver) |resolver| {
+                if (obj.getString("prefab")) |prefab_name| {
+                    try walkPrefabRef(ctx, resolver, prefab_name);
+                }
+            }
             for (obj.entries) |entry| {
                 if (std.mem.eql(u8, entry.key, "AssetManifest")) {
-                    try collectManifestLoadJsonc(out, entry.value);
+                    try collectManifestLoadJsonc(ctx.out, entry.value);
                 }
                 // Skip the explicit `meta.assets` list — see the `walk`
                 // counterpart for the rationale (derive independently to
@@ -551,7 +646,7 @@ fn walkJsonc(
                 if (std.mem.eql(u8, entry.key, "meta") and entry.value == .object) {
                     for (entry.value.object.entries) |meta_entry| {
                         if (std.mem.eql(u8, meta_entry.key, "assets")) continue;
-                        try walkJsonc(out, index, meta_entry.value);
+                        try walkJsonc(ctx, meta_entry.value);
                     }
                     continue;
                 }
@@ -560,12 +655,29 @@ fn walkJsonc(
                 if (std.mem.eql(u8, entry.key, "assets") and entry.value == .array) {
                     continue;
                 }
-                try walkJsonc(out, index, entry.value);
+                try walkJsonc(ctx, entry.value);
             }
         },
         // number / bool / null / enum_literal carry no sprite references.
         else => {},
     }
+}
+
+/// Resolve a `"prefab": "<name>"` reference and walk the referenced tree,
+/// unioning its assets in. The visited set is the cycle guard (A→B→A stops
+/// when A is re-encountered) and also dedups redundant work in a diamond
+/// (A→B, A→C, B→D, C→D walks D once). Marking BEFORE the recurse is what
+/// makes the cycle terminate. An unknown name (resolver miss) is skipped —
+/// inference is best-effort and must never crash on a dangling reference.
+fn walkPrefabRef(
+    ctx: *JsoncWalkCtx,
+    resolver: PrefabResolver,
+    name: []const u8,
+) std.mem.Allocator.Error!void {
+    const gop = try ctx.visited.getOrPut(ctx.gpa, name);
+    if (gop.found_existing) return;
+    const tree = resolver.resolve(name) orelse return;
+    try walkJsonc(ctx, tree);
 }
 
 fn collectManifestLoadJsonc(

--- a/src/game/scene_mixin.zig
+++ b/src/game/scene_mixin.zig
@@ -2,6 +2,30 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const asset_manifest_mod = @import("../asset_manifest.zig");
+const prefab_cache_mod = @import("../jsonc/prefab_cache.zig");
+const PrefabCache = prefab_cache_mod.PrefabCache;
+
+/// Build a `PrefabResolver` over the game's live `PrefabCache` so sprite-based
+/// asset inference (#563) can follow `{ "prefab": "<name>" }` references
+/// transitively into the referenced prefab's tree (#754). Returns `null` when
+/// no cache is attached yet (a first `setScene` before any prefab is
+/// registered) — inference then behaves as pre-#754 (prefab refs contribute
+/// only their name string).
+///
+/// Uses `getInstalled` (registry-only, no disk fallback, no insertion side
+/// effects) so inference stays a pure read: the assembler emits every project
+/// prefab via `addEmbeddedPrefab` at init — before the first `setScene` — so
+/// the cache is populated by the time inference runs on all assembler builds.
+fn prefabResolver(game: anytype) ?asset_manifest_mod.PrefabResolver {
+    const ptr = game.prefab_cache_ptr orelse return null;
+    const Resolve = struct {
+        fn resolve(ctx: *anyopaque, name: []const u8) ?@import("jsonc").Value {
+            const cache: *PrefabCache = @ptrCast(@alignCast(ctx));
+            return cache.getInstalled(name);
+        }
+    };
+    return .{ .ctx = ptr, .resolveFn = Resolve.resolve };
+}
 
 /// Collect every asset name currently registered in the catalog into a
 /// fresh allocator-owned slice. The returned slice borrows the name
@@ -100,7 +124,11 @@ fn resolveSceneAssets(game: anytype, name: []const u8) []const []const u8 {
     const index = ensureReverseIndex(game) orelse return &.{};
     if (index.count() == 0) return &.{};
 
-    var manifest = asset_manifest_mod.inferAssetsFromSource(game.allocator, index, source) catch |err| {
+    // Follow prefab references transitively (#754): a pure prefab-composition
+    // scene (zero inline `Sprite`) derives the union of its prefabs' atlas
+    // bundles instead of an empty manifest. Resolver is best-effort — `null`
+    // (no cache yet) falls back to inline-only inference.
+    var manifest = asset_manifest_mod.inferAssetsFromSourceWithPrefabs(game.allocator, index, source, prefabResolver(game)) catch |err| {
         game.log.warn(
             "[Scene] '{s}': asset inference skipped ({s}) — falling back to declared/eager behavior",
             .{ name, @errorName(err) },

--- a/src/root.zig
+++ b/src/root.zig
@@ -112,6 +112,10 @@ pub const InferredManifest = asset_manifest_mod.InferredManifest;
 pub const inferAssets = asset_manifest_mod.inferAssets;
 pub const inferAssetsJsonc = asset_manifest_mod.inferAssetsJsonc;
 pub const inferAssetsFromSource = asset_manifest_mod.inferAssetsFromSource;
+// #754 — transitive prefab-reference walking for asset inference.
+pub const PrefabResolver = asset_manifest_mod.PrefabResolver;
+pub const inferAssetsJsoncWithPrefabs = asset_manifest_mod.inferAssetsJsoncWithPrefabs;
+pub const inferAssetsFromSourceWithPrefabs = asset_manifest_mod.inferAssetsFromSourceWithPrefabs;
 
 // ── Input ──
 pub const InputInterface = input_mod.InputInterface;

--- a/test/asset_inference_wire_test.zig
+++ b/test/asset_inference_wire_test.zig
@@ -150,3 +150,58 @@ test "setSceneSource: unknown scene returns SceneNotFound" {
     defer game.deinit();
     try testing.expectError(error.SceneNotFound, game.setSceneSource("nope", "{}"));
 }
+
+// ── End-to-end: transitive prefab-walk through the live PrefabCache (#754) ──
+
+test "setScene: pure prefab-composition scene infers via the PrefabCache (#754)" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    // Two atlases, each provided by a different prefab.
+    try installAtlas(&game, "rooms", &.{"room/floor"});
+    try installAtlas(&game, "chars", &.{"worker/idle"});
+
+    // Register the prefabs into the real PrefabCache the resolver reads
+    // (`reloadPrefabSource` is the same cache-install seam the assembler's
+    // `addEmbeddedPrefab` uses; here it stands in without the full bridge).
+    // Each prefab carries an inline Sprite from its atlas; the second is
+    // reached transitively (condenser → worker).
+    try game.reloadPrefabSource("worker",
+        \\{ "Sprite": { "sprite_name": "worker/idle", "pivot": "center" } }
+    );
+    try game.reloadPrefabSource("condenser",
+        \\{ "children": [
+        \\  { "Sprite": { "sprite_name": "room/floor", "pivot": "center" } },
+        \\  { "prefab": "worker", "Position": { "x": 10, "y": 10 } }
+        \\] }
+    );
+
+    // A manifest-less scene that is ONLY prefab references (FP `colony` shape):
+    // a top-level array of `{ "prefab": ... }` with zero inline Sprite.
+    // Pre-#754 this inferred an EMPTY manifest.
+    game.registerSceneSimple("colony", emptyLoader);
+    try game.setSceneSource("colony",
+        \\[ { "prefab": "condenser", "Position": { "x": 0, "y": 0 } } ]
+    );
+
+    try game.setScene("colony");
+
+    // The scene now derives a NON-empty manifest: both atlases, unioned from
+    // the referenced prefab and its transitively-referenced child prefab.
+    const entry = game.scenes.get("colony").?;
+    try testing.expectEqual(@as(usize, 2), entry.assets.len);
+    var saw_rooms = false;
+    var saw_chars = false;
+    for (entry.assets) |a| {
+        if (std.mem.eql(u8, a, "rooms")) saw_rooms = true;
+        if (std.mem.eql(u8, a, "chars")) saw_chars = true;
+    }
+    try testing.expect(saw_rooms);
+    try testing.expect(saw_chars);
+
+    // Both inferred atlases were acquired through the gate, and the scene
+    // committed.
+    try testing.expect(game.assets.entries.getPtr("rooms").?.refcount >= 1);
+    try testing.expect(game.assets.entries.getPtr("chars").?.refcount >= 1);
+    try testing.expectEqualStrings("colony", game.getCurrentSceneName().?);
+}

--- a/test/asset_manifest_test.zig
+++ b/test/asset_manifest_test.zig
@@ -15,6 +15,10 @@
 //!   5. The `AssetManifest` escape hatch unions in assets the walker can't
 //!      see from a sprite reference (audio banks, script overlays).
 //!   6. `inferAssetsFromSource` — the JSONC scene-load wiring entry.
+//!   7. Transitive prefab-reference walking (#754): a pure prefab-composition
+//!      scene infers the union of its prefabs' bundles, prefab→prefab chains
+//!      resolve, reference cycles terminate, and unknown prefab names are
+//!      skipped — while inline-Sprite scenes stay unchanged.
 
 const std = @import("std");
 const testing = std.testing;
@@ -431,4 +435,247 @@ test "inferAssetsFromSource: JSONC scene source (comments + trailing commas)" {
     try testing.expectEqual(@as(usize, 2), inferred.slice().len);
     try testing.expect(inferred.contains("rooms"));
     try testing.expect(inferred.contains("logo_splash"));
+}
+
+// ── #754: transitive prefab-reference walking ──────────────────────────────
+//
+// A pure prefab-composition scene (dozens of `{ "prefab": ... }` entries, zero
+// inline `Sprite`) derives its manifest by following each prefab reference into
+// the referenced prefab's own tree. These tests wire a `PrefabResolver` over a
+// plain name→tree map — the unit-test analog of the scene loader wiring the
+// live `PrefabCache` behind the same interface.
+
+/// A name→parsed-tree prefab registry standing in for the engine's runtime
+/// `PrefabCache`. Parses prefab sources into `arena` up front and hands the
+/// walker a `PrefabResolver` over the resulting map.
+const PrefabReg = struct {
+    map: std.StringHashMap(engine.SceneValue),
+    arena: std.mem.Allocator,
+
+    fn init(arena: std.mem.Allocator) PrefabReg {
+        return .{ .map = std.StringHashMap(engine.SceneValue).init(arena), .arena = arena };
+    }
+
+    fn add(self: *PrefabReg, name: []const u8, src: []const u8) !void {
+        var parser = engine.JsoncParser.init(self.arena, src);
+        try self.map.put(name, try parser.parse());
+    }
+
+    fn resolveFn(ctx: *anyopaque, name: []const u8) ?engine.SceneValue {
+        const self: *PrefabReg = @ptrCast(@alignCast(ctx));
+        return self.map.get(name);
+    }
+
+    fn resolver(self: *PrefabReg) engine.PrefabResolver {
+        return .{ .ctx = self, .resolveFn = resolveFn };
+    }
+};
+
+test "prefab-walk: pure prefab-composition scene infers the union of its prefabs' bundles" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var idx = ReverseIndex.init(testing.allocator);
+    defer idx.deinit();
+    try idx.addAtlasFromJson("rooms", rooms_atlas_json);
+    try idx.addAtlasFromJson("characters", chars_atlas_json);
+
+    // Two prefabs, each carrying an inline Sprite from a DIFFERENT atlas.
+    var reg = PrefabReg.init(arena);
+    try reg.add("condenser",
+        \\{ "children": [
+        \\  { "Sprite": { "sprite_name": "room/floor.png", "pivot": "center" } }
+        \\] }
+    );
+    try reg.add("worker",
+        \\{ "Sprite": { "sprite_name": "worker/idle.png", "pivot": "center" } }
+    );
+
+    // The scene mirrors FP's `colony`: a top-level ARRAY of `{ "prefab": ... }`
+    // entries (with sibling `Position`), ZERO inline Sprite. Before #754 this
+    // derived an EMPTY manifest; now it unions both prefabs' bundles.
+    const scene_src =
+        \\[
+        \\  { "prefab": "condenser", "Position": { "x": 0, "y": 0 } },
+        \\  { "prefab": "worker", "Position": { "x": 156, "y": 0 } }
+        \\]
+    ;
+
+    // Without a resolver, the pre-#754 behavior: prefab names are misses → empty.
+    var no_prefab = try engine.inferAssetsFromSource(testing.allocator, &idx, scene_src);
+    defer no_prefab.deinit();
+    try testing.expectEqual(@as(usize, 0), no_prefab.slice().len);
+
+    // With the resolver, both prefabs' atlas bundles are derived.
+    var inferred = try engine.inferAssetsFromSourceWithPrefabs(
+        testing.allocator,
+        &idx,
+        scene_src,
+        reg.resolver(),
+    );
+    defer inferred.deinit();
+
+    try testing.expectEqual(@as(usize, 2), inferred.slice().len);
+    try testing.expect(inferred.contains("rooms"));
+    try testing.expect(inferred.contains("characters"));
+}
+
+test "prefab-walk: prefab→prefab chain resolves transitively" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var idx = ReverseIndex.init(testing.allocator);
+    defer idx.deinit();
+    try idx.addAtlasFromJson("rooms", rooms_atlas_json);
+    try idx.addAtlasFromJson("characters", chars_atlas_json);
+
+    var reg = PrefabReg.init(arena);
+    // `room` references `workstation` (a nested prefab ref, exactly like FP's
+    // `condenser` → `industry__condenser_workstation`), which carries the only
+    // Sprite from the `characters` atlas. `room` itself uses `rooms`.
+    try reg.add("room",
+        \\{ "children": [
+        \\  { "Sprite": { "sprite_name": "room/wall.png" } },
+        \\  { "prefab": "workstation", "Position": { "x": 10, "y": 10 } }
+        \\] }
+    );
+    try reg.add("workstation",
+        \\{ "Sprite": { "sprite_name": "worker/walk.png" } }
+    );
+
+    const scene_src =
+        \\[ { "prefab": "room", "Position": { "x": 0, "y": 0 } } ]
+    ;
+
+    var inferred = try engine.inferAssetsFromSourceWithPrefabs(
+        testing.allocator,
+        &idx,
+        scene_src,
+        reg.resolver(),
+    );
+    defer inferred.deinit();
+
+    // `rooms` from the room's own Sprite, `characters` from the transitively
+    // resolved workstation prefab.
+    try testing.expectEqual(@as(usize, 2), inferred.slice().len);
+    try testing.expect(inferred.contains("rooms"));
+    try testing.expect(inferred.contains("characters"));
+}
+
+test "prefab-walk: a reference cycle (A→B→A) terminates" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var idx = ReverseIndex.init(testing.allocator);
+    defer idx.deinit();
+    try idx.addAtlasFromJson("rooms", rooms_atlas_json);
+    try idx.addAtlasFromJson("characters", chars_atlas_json);
+
+    var reg = PrefabReg.init(arena);
+    // A → B → A. A malformed content cycle must not loop forever.
+    try reg.add("a",
+        \\{ "children": [
+        \\  { "Sprite": { "sprite_name": "room/door.png" } },
+        \\  { "prefab": "b" }
+        \\] }
+    );
+    try reg.add("b",
+        \\{ "children": [
+        \\  { "Sprite": { "sprite_name": "worker/idle.png" } },
+        \\  { "prefab": "a" }
+        \\] }
+    );
+
+    const scene_src =
+        \\[ { "prefab": "a" } ]
+    ;
+
+    var inferred = try engine.inferAssetsFromSourceWithPrefabs(
+        testing.allocator,
+        &idx,
+        scene_src,
+        reg.resolver(),
+    );
+    defer inferred.deinit();
+
+    // Terminates, and still collects both atlases before the cycle is cut.
+    try testing.expectEqual(@as(usize, 2), inferred.slice().len);
+    try testing.expect(inferred.contains("rooms"));
+    try testing.expect(inferred.contains("characters"));
+}
+
+test "prefab-walk: unknown prefab name is skipped gracefully" {
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var idx = ReverseIndex.init(testing.allocator);
+    defer idx.deinit();
+    try idx.addAtlasFromJson("rooms", rooms_atlas_json);
+
+    var reg = PrefabReg.init(arena);
+    try reg.add("known",
+        \\{ "Sprite": { "sprite_name": "room/floor.png" } }
+    );
+
+    // The scene references one KNOWN prefab and one that the resolver can't
+    // find (a dangling ref). The unknown one must be skipped, not crash, and
+    // the known one still resolves.
+    const scene_src =
+        \\[
+        \\  { "prefab": "known" },
+        \\  { "prefab": "does_not_exist", "Position": { "x": 5, "y": 5 } }
+        \\]
+    ;
+
+    var inferred = try engine.inferAssetsFromSourceWithPrefabs(
+        testing.allocator,
+        &idx,
+        scene_src,
+        reg.resolver(),
+    );
+    defer inferred.deinit();
+
+    try testing.expectEqual(@as(usize, 1), inferred.slice().len);
+    try testing.expect(inferred.contains("rooms"));
+}
+
+test "prefab-walk: inline-Sprite scene is unchanged when a resolver is present" {
+    // Preserve the existing behavior: a scene that ALREADY has inline Sprite
+    // refs (no prefab refs) infers exactly the same set whether or not a
+    // resolver is threaded — the resolver only adds coverage, never changes
+    // the inline path.
+    var arena_state = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_state.deinit();
+    const arena = arena_state.allocator();
+
+    var idx = ReverseIndex.init(testing.allocator);
+    defer idx.deinit();
+    try idx.addAtlasFromJson("rooms", rooms_atlas_json);
+
+    var reg = PrefabReg.init(arena);
+    // A prefab exists in the registry but is never referenced by the scene.
+    try reg.add("unused",
+        \\{ "Sprite": { "sprite_name": "worker/idle.png" } }
+    );
+
+    const scene_src =
+        \\{ "root": { "children": [
+        \\  { "components": { "Sprite": { "sprite_name": "room/floor.png" } } }
+        \\] } }
+    ;
+
+    var inferred = try engine.inferAssetsFromSourceWithPrefabs(
+        testing.allocator,
+        &idx,
+        scene_src,
+        reg.resolver(),
+    );
+    defer inferred.deinit();
+
+    try testing.expectEqual(@as(usize, 1), inferred.slice().len);
+    try testing.expect(inferred.contains("rooms"));
 }


### PR DESCRIPTION
## What & why

Follow-up to sprite-based asset inference (#563/#566, shipped in engine v2.1.0). The scene-level walker resolved only a scene's **inline** `Sprite`/`Image` refs; a `{ "prefab": "condenser" }` entry contributed only the literal string `"condenser"`, not the referenced prefab's own `Sprite` refs (which live in a different file). So **pure prefab-composition scenes derived an empty manifest** — Flying-Platform's `colony`/`main` are dozens of `"prefab":` entries with zero inline `Sprite`, so inference resolved ~nothing and they had to keep an explicit `meta.assets`. This closes that gap (the `TODO(#563 follow-up)` on `inferAssets`).

## Resolver design

`asset_manifest.zig` stays lifecycle-free and unit-testable. A tiny type-erased callback is threaded into the jsonc walk:

```zig
pub const PrefabResolver = struct {
    ctx: *anyopaque,
    resolveFn: *const fn (ctx: *anyopaque, name: []const u8) ?jsonc.Value,
};
```

- New entry points `inferAssetsJsoncWithPrefabs` / `inferAssetsFromSourceWithPrefabs` take an optional resolver; the existing 3-arg `inferAssetsJsonc` / `inferAssetsFromSource` delegate with `null` (pre-#754 behavior byte-for-byte preserved).
- The resolver returns a **parsed `jsonc.Value`** (not source bytes) because the runtime `PrefabCache` already holds parsed trees — no re-parse per reference.
- The scene-load path (`game/scene_mixin.zig::resolveSceneAssets`) wires a resolver over the live `PrefabCache` via `getInstalled` (registry-only lookup: no disk fallback, no insertion side effects, pure read). The assembler emits every project prefab via `addEmbeddedPrefab` at `init()` — before the first `setScene` — so the cache is populated when inference runs. If no cache is attached yet the resolver is `null` and inference falls back to inline-only (best-effort, never crashes).
- The `std.json.Value` overload (`inferAssets`) stays inline-only: it's the test-only path, and the runtime cache holds `jsonc.Value` trees, so a resolver there would have nothing to resolve against. Documented in its doc-comment.

## Cycle guard + dedup

A `visited` prefab-name set is threaded through the walk. A prefab is marked **before** recursing, so `A→B→A` terminates when `A` is re-encountered, and a diamond (`A→B`, `A→C`, `B→D`, `C→D`) walks `D` once. Assets are deduped by the existing `InferredManifest.seen` set.

## `include` fragments

Left as a smaller documented follow-up to #754. `"include": [...]` fragments are referenced by path, not prefab effective-name, so the included source isn't reachable through the prefab-name-keyed resolver. Not folded in to avoid blocking the prefab-walk. Noted in the module-doc audit + migration guidance.

## Tests (`zig build test` → exit 0)

Unit (`test/asset_manifest_test.zig`):
- pure prefab-composition scene (top-level array of `{"prefab":...}`, FP shape) infers the union of its prefabs' bundles — and with **no** resolver derives empty (proves the old behavior);
- prefab→prefab chain resolves transitively;
- reference cycle (A→B→A) terminates;
- unknown prefab name skipped gracefully (no crash);
- inline-Sprite scene unchanged when a resolver is present.

End-to-end (`test/asset_inference_wire_test.zig`):
- registers prefabs into the **real `PrefabCache`** (via `reloadPrefabSource`, the same install seam as `addEmbeddedPrefab`), then a manifest-less prefab-composition scene through `setScene` derives a non-empty manifest (`rooms` + `chars`, the latter via a transitively-referenced child prefab), both acquired through the gate.

All existing inference tests (inline-Sprite scenes, explicit-manifest scenes, dedup, `AssetManifest` escape hatch) continue to pass.

## Audit doc

Moved "prefab references" out of the #566 CANNOT-see list into CAN-see; renumbered remaining items; updated migration guidance.

Refs #754, #563, #566.

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw