### PR TITLE
feat(scripting): complete Script Runtime Contract v1 surface — entity_find + input (#237)

### DIFF
--- a/contract/labelle_script.h
+++ b/contract/labelle_script.h
@@ -80,6 +80,14 @@ uint64_t labelle_entity_create(void);
  * destroyEntity). Unknown / already-dead ids are ignored. */
 void labelle_entity_destroy(uint64_t id);
 
+/* Find an entity by name, via a registered `Name` (or `Tag`) component
+ * carrying a string field (name/value/tag). Returns the first live
+ * match's id, or 0 = no match / empty name / the game registers no such
+ * component (the lookup is compiled out for those — a zero-cost always-0)
+ * / not bound. Names are not required unique; the first the view yields
+ * wins. First-match snapshot over the ECS view at call time. */
+uint64_t labelle_entity_find(const char *name, size_t name_len);
+
 /* Spawn a named prefab (requires a JSONC scene to have been loaded —
  * the standard assembled-game boot). `params_json` is optional: pass
  * NULL/len 0 to spawn at the origin, or a {"x":…,"y":…} object for the
@@ -245,6 +253,25 @@ float labelle_time_dt(void);
  * received this tick even when a script changes the time scale
  * mid-tick. Ignored before the host binds. */
 void labelle_time_dt_stamp(float dt);
+
+/* ── Input ────────────────────────────────────────────────────────────
+ *
+ * Read-only polling over the host's unified input, valid during the
+ * plugin's tick (main thread). `key` is the backend-agnostic KeyboardKey
+ * code (the engine enum's integer value) — an unknown code simply reads
+ * as not-down. Safe no-ops before the host binds (keys not-down, mouse at
+ * the origin). */
+
+/* 1 while `key` is held down this frame; 0 otherwise. */
+int32_t labelle_input_key_down(uint32_t key);
+
+/* 1 on the frame `key` transitions up→down (the press edge); 0
+ * otherwise. */
+int32_t labelle_input_key_pressed(uint32_t key);
+
+/* Write the current mouse position into *x_out / *y_out; either pointer
+ * may be NULL to skip that axis. 0 on backends with no mouse. */
+void labelle_input_mouse(float *x_out, float *y_out);
 
 #ifdef __cplusplus
 }

--- a/src/script_contract.zig
+++ b/src/script_contract.zig
@@ -21,10 +21,12 @@
 //! vtable — they carry no comptime type information themselves.
 //!
 //! Before `bind` runs, every export is a safe no-op: id-returning ops
-//! return 0, rc-returning ops return -1, `labelle_component_get` /
-//! `labelle_query` / `labelle_event_poll` write nothing and return 0, and
-//! the void ops silently ignore. `labelle_contract_version` is pure and
-//! works even before `bind`.
+//! (incl. `labelle_entity_find`) return 0, rc-returning ops return -1,
+//! `labelle_component_get` / `labelle_query` / `labelle_event_poll` write
+//! nothing and return 0, the void ops silently ignore, the
+//! `labelle_input_key_*` reads report not-down (0), and
+//! `labelle_input_mouse` writes the origin. `labelle_contract_version` is
+//! pure and works even before `bind`.
 //!
 //! ## No symbols in script-less builds
 //!
@@ -210,6 +212,7 @@ var emit_active: u1 = 0;
 const VTable = struct {
     entity_create: *const fn () u64,
     entity_destroy: *const fn (id: u64) void,
+    entity_find: *const fn (name: []const u8) u64,
     prefab_spawn: *const fn (name: []const u8, params_json: []const u8) u64,
     component_set: *const fn (id: u64, name: []const u8, json: []const u8) i32,
     component_get: *const fn (id: u64, name: []const u8, out: []u8) usize,
@@ -220,6 +223,9 @@ const VTable = struct {
     scene_change: *const fn (name: []const u8) i32,
     log: *const fn (msg: []const u8) void,
     time_dt: *const fn () f32,
+    input_key_down: *const fn (key: u32) bool,
+    input_key_pressed: *const fn (key: u32) bool,
+    input_mouse: *const fn () core.Position,
 };
 
 // ── Generated-main API (non-export) ─────────────────────────────────
@@ -370,6 +376,22 @@ pub export fn labelle_entity_create() u64 {
 pub export fn labelle_entity_destroy(id: u64) void {
     const vt = vtable orelse return;
     vt.entity_destroy(id);
+}
+
+/// Find an entity by name — the RFC's `entity_find`, resolved through a
+/// registered `Name` (or `Tag`) component: the game's own
+/// `ComponentRegistry` is searched at COMPTIME for a component of that
+/// name carrying a `[]const u8` field (`name`/`value`/`tag`), and the
+/// first live entity whose field equals `name` wins. Returns its id, or
+/// 0 = no match / empty name / the game registers no such component
+/// (the whole lookup folds away at comptime for those, a zero-cost
+/// always-0) / not bound. First-match, snapshot over the ECS view at
+/// call time. Names are not guaranteed unique — a game that wants
+/// uniqueness enforces it; this returns the first the view yields.
+pub export fn labelle_entity_find(name_ptr: [*]const u8, name_len: usize) u64 {
+    const vt = vtable orelse return 0;
+    if (name_len == 0) return 0;
+    return vt.entity_find(name_ptr[0..name_len]);
 }
 
 /// Spawn a named prefab. `params_json` is optional: NULL or empty
@@ -674,6 +696,40 @@ pub export fn labelle_time_dt_stamp(dt: f32) void {
     stamped_dt = dt;
 }
 
+// ── Input ────────────────────────────────────────────────────────────
+//
+// Read-only polling over the game's unified `InputInterface`, valid
+// during the plugin's tick (main-thread, like every other op). `key` is
+// the backend-agnostic `KeyboardKey` code (the engine enum's integer
+// value — the same code Zig scripts pass `game.isKeyDown`); an unknown
+// code is simply never down. Mouse coordinates are the same space the
+// backend reports to Zig scripts. All three are safe no-ops pre-bind
+// (keys read as not-down, the mouse as the origin).
+
+/// 1 while key `key` is held down this frame; 0 otherwise (up, unknown
+/// code, or not bound).
+pub export fn labelle_input_key_down(key: u32) i32 {
+    const vt = vtable orelse return 0;
+    return @intFromBool(vt.input_key_down(key));
+}
+
+/// 1 on the frame `key` transitions from up to down (the press edge);
+/// 0 otherwise (not this frame, unknown code, or not bound).
+pub export fn labelle_input_key_pressed(key: u32) i32 {
+    const vt = vtable orelse return 0;
+    return @intFromBool(vt.input_key_pressed(key));
+}
+
+/// Write the current mouse position into `x_out`/`y_out` (either may be
+/// NULL to skip that axis). Pre-bind writes (0, 0). The values are the
+/// backend's reported cursor coordinates — 0 on platforms/backends with
+/// no mouse.
+pub export fn labelle_input_mouse(x_out: ?*f32, y_out: ?*f32) void {
+    const pos = if (vtable) |vt| vt.input_mouse() else core.Position{};
+    if (x_out) |p| p.* = pos.x;
+    if (y_out) |p| p.* = pos.y;
+}
+
 // ── Implementation ──────────────────────────────────────────────────
 
 /// The documented consumer gate for `Game.GameEvents` (see game.zig):
@@ -812,6 +868,7 @@ fn Holder(comptime GP: type) type {
         const vtable_impl = VTable{
             .entity_create = &entityCreateImpl,
             .entity_destroy = &entityDestroyImpl,
+            .entity_find = &entityFindImpl,
             .prefab_spawn = &prefabSpawnImpl,
             .component_set = &componentSetImpl,
             .component_get = &componentGetImpl,
@@ -822,6 +879,9 @@ fn Holder(comptime GP: type) type {
             .scene_change = &sceneChangeImpl,
             .log = &logImpl,
             .time_dt = &timeDtImpl,
+            .input_key_down = &inputKeyDownImpl,
+            .input_key_pressed = &inputKeyPressedImpl,
+            .input_mouse = &inputMouseImpl,
         };
 
         // ── Entities ─────────────────────────────────────────────
@@ -838,6 +898,47 @@ fn Holder(comptime GP: type) type {
             // no-op, not a panic.
             if (!game.ecs_backend.entityExists(ent)) return;
             game.destroyEntity(ent);
+        }
+
+        /// Comptime-resolved `(component-type, string-field)` for
+        /// `entity_find`: a registry component named `Name` or `Tag`
+        /// carrying a `[]const u8` field (`name`/`value`/`tag`). `null`
+        /// when the game registers no such component — the RFC's "by the
+        /// Name/tag component IF ONE EXISTS" — which makes
+        /// `labelle_entity_find` a zero-cost always-0 no-op there. The
+        /// convention is deliberately narrow (a single well-known
+        /// component) so the future language sub-modules bind ONE name;
+        /// widening it is a contract change, not an ad-hoc per-game one.
+        const name_lookup: ?struct { T: type, field: []const u8 } = blk: {
+            if (!@hasDecl(Components, "names") or !@hasDecl(Components, "getType")) break :blk null;
+            for (Components.names()) |n| {
+                if (!std.mem.eql(u8, n, "Name") and !std.mem.eql(u8, n, "Tag")) continue;
+                const T = Components.getType(n);
+                if (@typeInfo(T) != .@"struct") continue;
+                for (@typeInfo(T).@"struct".fields) |f| {
+                    if (f.type != []const u8) continue;
+                    if (std.mem.eql(u8, f.name, "name") or
+                        std.mem.eql(u8, f.name, "value") or
+                        std.mem.eql(u8, f.name, "tag"))
+                        break :blk .{ .T = T, .field = f.name };
+                }
+            }
+            break :blk null;
+        };
+
+        fn entityFindImpl(name: []const u8) u64 {
+            if (comptime name_lookup == null) return 0;
+            const lk = comptime name_lookup.?;
+            // Snapshot the view at call time (matches `query`): a
+            // per-id read on a since-destroyed entity is handled by the
+            // caller's later ops, not this scan.
+            var v = game.ecs_backend.view(.{lk.T}, .{});
+            defer v.deinit();
+            while (v.next()) |ent| {
+                const comp = game.getComponent(ent, lk.T) orelse continue;
+                if (std.mem.eql(u8, @field(comp.*, lk.field), name)) return entityId(ent);
+            }
+            return 0;
         }
 
         // ── Prefabs ──────────────────────────────────────────────
@@ -1284,6 +1385,25 @@ fn Holder(comptime GP: type) type {
             const n = fp.frame_times.len;
             const last = fp.frame_times[(fp.index + n - 1) % n];
             return last * game.time_scale;
+        }
+
+        // ── Input ────────────────────────────────────────────────
+        //
+        // Straight through the game's static `InputInterface` — the same
+        // path `game.isKeyDown`/`getMouse` take (the `input_mixin` just
+        // adds the `KeyboardKey` enum conversion the C surface skips, so
+        // the raw integer code goes to the backend unmodified).
+
+        fn inputKeyDownImpl(key: u32) bool {
+            return G.Input.isKeyDown(key);
+        }
+
+        fn inputKeyPressedImpl(key: u32) bool {
+            return G.Input.isKeyPressed(key);
+        }
+
+        fn inputMouseImpl() core.Position {
+            return .{ .x = G.Input.getMouseX(), .y = G.Input.getMouseY() };
         }
 
         // ── Helpers ──────────────────────────────────────────────

--- a/test/script_contract_test.zig
+++ b/test/script_contract_test.zig
@@ -123,6 +123,10 @@ fn spawnPrefab(name: []const u8, json: []const u8) u64 {
     return contract.labelle_prefab_spawn(name.ptr, name.len, json.ptr, json.len);
 }
 
+fn findEntity(name: []const u8) u64 {
+    return contract.labelle_entity_find(name.ptr, name.len);
+}
+
 /// Parse a query result (`[3,7]`) and check it equals `expected` as a
 /// SET — the mock backend iterates a hash map, so id order is
 /// unspecified.
@@ -158,6 +162,16 @@ test "pre-bind: every export is a safe no-op" {
     // Id-returning ops: 0 (never a valid entity id).
     try testing.expectEqual(@as(u64, 0), contract.labelle_entity_create());
     try testing.expectEqual(@as(u64, 0), spawnPrefab("turret", ""));
+    try testing.expectEqual(@as(u64, 0), findEntity("player"));
+
+    // Input reads: not-down, and the mouse writes the origin.
+    try testing.expectEqual(@as(i32, 0), contract.labelle_input_key_down(32));
+    try testing.expectEqual(@as(i32, 0), contract.labelle_input_key_pressed(32));
+    var mx: f32 = 7;
+    var my: f32 = 9;
+    contract.labelle_input_mouse(&mx, &my);
+    try testing.expectEqual(@as(f32, 0), mx);
+    try testing.expectEqual(@as(f32, 0), my);
 
     // Void ops silently ignore.
     contract.labelle_entity_destroy(42);
@@ -1660,4 +1674,156 @@ test "bind twice: the second bind starts a fresh session (no leaks, no stale sub
     contract.drainEvents(&game);
     game.dispatchEvents();
     try testing.expectEqual(@as(usize, 0), poll(&buf).len);
+}
+
+// ── entity_find + input: a game with a Name component and a ────────────
+//    controllable input backend
+//
+// `entity_find` resolves through a registry component named `Name`/`Tag`
+// carrying a string field, so the feature game registers a `Name`. The
+// input backend dispatches to *type* decls (static fns, process-global
+// state — the real backends' shape), reset between tests.
+
+const Name = struct { name: []const u8 = "" };
+
+/// Controllable input stub: reports one down key, one press-edge key, and
+/// a settable mouse position. Only `isKeyDown`/`isKeyPressed` are required
+/// by `InputInterface`; `getMouseX`/`getMouseY` are the optional mouse seam.
+const KeyInput = struct {
+    var down_key: ?u32 = null;
+    var pressed_key: ?u32 = null;
+    var mouse_x: f32 = 0;
+    var mouse_y: f32 = 0;
+
+    fn reset() void {
+        down_key = null;
+        pressed_key = null;
+        mouse_x = 0;
+        mouse_y = 0;
+    }
+
+    pub fn isKeyDown(key: u32) bool {
+        return down_key != null and down_key.? == key;
+    }
+    pub fn isKeyPressed(key: u32) bool {
+        return pressed_key != null and pressed_key.? == key;
+    }
+    pub fn getMouseX() f32 {
+        return mouse_x;
+    }
+    pub fn getMouseY() f32 {
+        return mouse_y;
+    }
+};
+
+const FeatureComponents = engine.ComponentRegistry(.{
+    .Name = Name,
+    .Health = Health,
+});
+
+const FeatureGame = engine.GameConfig(
+    core.StubRender(MockEcs.Entity),
+    MockEcs,
+    KeyInput,
+    engine.StubAudio,
+    engine.StubVideo,
+    engine.StubGui,
+    void,
+    core.StubLogSink,
+    FeatureComponents,
+    &.{},
+    TestEvents,
+);
+
+test "entity_find: resolves an entity by its Name component; first live match" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = FeatureGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const a = contract.labelle_entity_create();
+    try testing.expectEqual(@as(i32, 0), setComp(a, "Name", "{\"name\":\"player\"}"));
+    const b = contract.labelle_entity_create();
+    try testing.expectEqual(@as(i32, 0), setComp(b, "Name", "{\"name\":\"enemy\"}"));
+
+    try testing.expectEqual(a, findEntity("player"));
+    try testing.expectEqual(b, findEntity("enemy"));
+
+    // No match / empty name → 0.
+    try testing.expectEqual(@as(u64, 0), findEntity("nobody"));
+    try testing.expectEqual(@as(u64, 0), findEntity(""));
+
+    // After the named entity is destroyed the name no longer resolves.
+    contract.labelle_entity_destroy(a);
+    try testing.expectEqual(@as(u64, 0), findEntity("player"));
+    try testing.expectEqual(b, findEntity("enemy"));
+}
+
+test "entity_find: comptime-gated out for a game with no Name/Tag component" {
+    contract.unbind();
+    defer contract.unbind();
+
+    // ContractGame's registry has Health/Velocity/Doomed/Label — no
+    // Name/Tag — so the lookup folds away at comptime: always 0, never a
+    // crash, even after a real entity with a component exists.
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const e = contract.labelle_entity_create();
+    try testing.expectEqual(@as(i32, 0), setComp(e, "Label", "{\"text\":\"player\"}"));
+    try testing.expectEqual(@as(u64, 0), findEntity("player"));
+}
+
+test "input_key_down / input_key_pressed: reflect the backend, unknown codes read up" {
+    contract.unbind();
+    defer contract.unbind();
+    KeyInput.reset();
+    defer KeyInput.reset();
+
+    var game = FeatureGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const space: u32 = @intFromEnum(engine.KeyboardKey.space);
+    const enter: u32 = @intFromEnum(engine.KeyboardKey.enter);
+
+    KeyInput.down_key = space;
+    KeyInput.pressed_key = enter;
+
+    try testing.expectEqual(@as(i32, 1), contract.labelle_input_key_down(space));
+    try testing.expectEqual(@as(i32, 0), contract.labelle_input_key_down(enter));
+    try testing.expectEqual(@as(i32, 1), contract.labelle_input_key_pressed(enter));
+    try testing.expectEqual(@as(i32, 0), contract.labelle_input_key_pressed(space));
+
+    // A code nothing reports is simply not down.
+    try testing.expectEqual(@as(i32, 0), contract.labelle_input_key_down(9999));
+}
+
+test "input_mouse: writes the reported position; NULL out-pointers are skipped" {
+    contract.unbind();
+    defer contract.unbind();
+    KeyInput.reset();
+    defer KeyInput.reset();
+
+    var game = FeatureGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    KeyInput.mouse_x = 320.5;
+    KeyInput.mouse_y = 240.0;
+
+    var x: f32 = -1;
+    var y: f32 = -1;
+    contract.labelle_input_mouse(&x, &y);
+    try testing.expectEqual(@as(f32, 320.5), x);
+    try testing.expectEqual(@as(f32, 240.0), y);
+
+    // Either out-pointer may be NULL — the other axis still lands, no crash.
+    var only_y: f32 = -1;
+    contract.labelle_input_mouse(null, &only_y);
+    try testing.expectEqual(@as(f32, 240.0), only_y);
+    contract.labelle_input_mouse(&x, null); // both-write path already checked
 }


### PR DESCRIPTION
## What & why

The Script Runtime Contract v1 (RFC-LANGUAGE-PLUGINS, #237 Phase 1) already landed engine-side in #749 (`src/script_contract.zig`) — versioned, comptime-gated, JSON components over the serde-reflection registry, subscribe/poll events, full tests. **But that landing shipped a *subset* of the RFC §1 surface**: it omitted `entity_find` and the three input pollers the RFC (and the POC's `contract.h`) list. A language plugin that checks `labelle_contract_version() == 1` and then looks up those symbols would fail at bind/link.

This PR closes that gap so a **version-1 host binary actually conforms to the documented v1 surface**.

## Surface added

```
labelle_entity_find(name)          -> u64
labelle_input_key_down(key)        -> i32 (bool)
labelle_input_key_pressed(key)     -> i32 (bool)
labelle_input_mouse(x_out, y_out)  -> void
```

- **`entity_find`** resolves through a registered `Name` (or `Tag`) component carrying a `[]const u8` field (`name`/`value`/`tag`), **comptime-detected over the game's own `ComponentRegistry`**. Games that register no such component get a **zero-cost always-0 no-op** — the RFC's *"by the Name/tag component if one exists."* First-match snapshot over the ECS view at call time (same semantics as `query`). The single-well-known-component convention is deliberately narrow so the future language sub-modules bind one name; widening it is a contract change, not a per-game one.
- **`input_*`** poll the game's static `InputInterface` — the same path `game.isKeyDown` / `game.getMouse` take, minus the `KeyboardKey` enum conversion the C surface skips (the raw integer keycode goes straight to the backend). Main-thread, during the plugin tick.

## How it fits the existing machinery

- **Comptime-engine → runtime-C-ABI bridge**: reuses the merged `Holder(GP)` pattern verbatim — `bind(&g)` stores the concrete `*Game` behind a type-erased `VTable`; the new `export fn`s dispatch through three added vtable slots and carry no comptime type info. This is the POC (`spike/language-plugins/main.zig`, #734) shape.
- **Comptime gate**: unchanged — the whole file is reachable only via the lazy `root.script_contract` const, so script-less builds emit none of these symbols.
- **Contract version stays `1`.** These are additive symbols that *complete* v1 (they don't break existing v1 consumers); the header note frames it that way.
- **Safe pre-bind no-ops**: `entity_find` → 0, key reads → not-down (0), `input_mouse` → writes the origin. The pre-bind no-op test is extended to cover them.
- `contract/labelle_script.h` updated with the four decls + an `Input` section.

## Tests

`test/script_contract_test.zig` (+4 tests, pre-bind test extended):
- `entity_find`: resolves by `Name`; no-match/empty → 0; a destroyed named entity stops resolving.
- `entity_find`: **comptime-gated out** for a game whose registry has no `Name`/`Tag` (always 0, no crash).
- `input_key_down`/`input_key_pressed`: reflect a controllable input backend; unknown codes read up.
- `input_mouse`: writes reported coords; NULL out-pointers skip that axis.

Confirmed the new tests actually execute (canary-verified: the `script_contract` binary is now 39 tests, was 35). **Full engine suite green — 945 tests, `zig build test` exit 0.**

## Deferred to the next slice (unchanged by this PR)

The `labelle-scripting` plugin repo + Lua sub-module that *consumes* this contract: VM embedding, script discovery/embed, `init/update/deinit` per script, and the idiomatic bindings (`game:query`, `entity:get/set`, `input:isKeyDown`) that wrap these raw symbols. A batched `each(names, fn)` and a tagged-binary component encoding remain v2.

Refs #237, #749, RFC-LANGUAGE-PLUGINS §1.

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw