### PR TITLE
feat(#744): labelle_plugin_call — cross-language plugin commands (contract v1.1)

### DIFF
--- a/contract/labelle_script.h
+++ b/contract/labelle_script.h
@@ -35,7 +35,9 @@
  *   - rc convention: functions returning int32_t yield 0 = ok and
  *     -1 = failure (unknown name / unknown-or-dead entity / parse
  *     error / host not bound), except `labelle_component_has`, which
- *     is a boolean 1/0.
+ *     is a boolean 1/0. labelle_plugin_call carries the same rc in a
+ *     size_t: 0 = dispatched, LABELLE_PLUGIN_CALL_UNROUTABLE
+ *     ((size_t)-1) = failure — see its section.
  *   - Out-parameter sizing: labelle_component_get and labelle_query
  *     return the bytes the COMPLETE result REQUIRES (snprintf-style;
  *     required > out_cap is the truncation signal — retry right-sized;
@@ -63,7 +65,17 @@ extern "C" {
 #endif
 
 /* The contract version this header describes. Compare against
- * labelle_contract_version() at plugin startup and refuse a mismatch. */
+ * labelle_contract_version() at plugin startup and refuse a mismatch.
+ *
+ * The version bumps on BREAKING changes only — the check is an
+ * exact-match refusal, so a bump on additions would strand every
+ * still-compatible consumer. ADDITIVE growth (new exports) is a MINOR
+ * revision instead: the export is marked "since v1.x" and its presence
+ * is probed per-symbol (embedded VMs bind against the running host,
+ * which either exports it or doesn't; native plugins find out at link
+ * time) — the editor-bridge contract's exact convention (its v1.1–v1.7
+ * were all additive). This header describes contract v1.1 = v1 +
+ * labelle_plugin_call (labelle-engine#744). */
 #define LABELLE_CONTRACT_VERSION 1u
 
 /* Contract version the host binary was built with. Pure — callable
@@ -272,6 +284,56 @@ int32_t labelle_input_key_pressed(uint32_t key);
 /* Write the current mouse position into *x_out / *y_out; either pointer
  * may be NULL to skip that axis. 0 on backends with no mouse. */
 void labelle_input_mouse(float *x_out, float *y_out);
+
+/* ── Plugin commands (since v1.1, labelle-engine#744) ─────────────────
+ *
+ * Call a named command on a Zig engine PLUGIN (e.g. pathfinder
+ * "navigate") — the script-side entry to the same handler channel
+ * labelle-studio's plugin panels use (the editor-bridge v1.7
+ * editor_plugin_command export): a plugin registers ONE handler by
+ * subscribing to the `engine__editor_plugin_command` engine event, and
+ * that single registration is reachable from studio panels AND every
+ * scripting language alike. */
+
+/* labelle_plugin_call's failure sentinel: the rc convention's -1
+ * carried in its size_t return. Distinct from 0 = dispatched — and
+ * from any future response-size return, which could never require the
+ * whole address space. */
+#define LABELLE_PLUGIN_CALL_UNROUTABLE ((size_t)-1)
+
+/* Dispatch command `command` of plugin `plugin` with `params_json` as
+ * the arguments object — NULL/len 0 means "{}" (no arguments). The
+ * dispatch is SYNCHRONOUS: the plugin's handler has run by the time
+ * this returns, and all three strings are borrowed for the call only
+ * (stack/reused buffers are fine).
+ *
+ * Return (size_t):
+ *   0                               dispatched into the handler
+ *                                   channel. v1.1 dispatch is
+ *                                   fire-and-forward — handlers
+ *                                   produce no return payload; results
+ *                                   and acks arrive as game events
+ *                                   (labelle_event_subscribe/poll).
+ *   LABELLE_PLUGIN_CALL_UNROUTABLE  not routable: empty plugin/command
+ *                                   name, no plugin registered a
+ *                                   handler in this build, or the host
+ *                                   is not bound.
+ *
+ * The channel is a broadcast the handlers name-filter THEMSELVES, so
+ * the host cannot tell an unknown plugin/command from a
+ * delivered-and-ignored one: both return 0 wherever a handler exists.
+ * A caller that needs an acknowledgment listens for the plugin's
+ * response event.
+ *
+ * `out`/`out_cap` are RESERVED for handler response payloads (a future
+ * minor revision: the return becomes the bytes the response REQUIRES,
+ * all-or-nothing like labelle_component_get, with 0 keeping its
+ * dispatched-no-response meaning and the sentinel staying unroutable).
+ * v1.1 never writes to `out`; pass NULL/0. */
+size_t labelle_plugin_call(const char *plugin, size_t plugin_len,
+                           const char *command, size_t command_len,
+                           const char *params_json, size_t params_len,
+                           char *out, size_t out_cap);
 
 #ifdef __cplusplus
 }

--- a/src/script_contract.zig
+++ b/src/script_contract.zig
@@ -21,12 +21,13 @@
 //! vtable — they carry no comptime type information themselves.
 //!
 //! Before `bind` runs, every export is a safe no-op: id-returning ops
-//! (incl. `labelle_entity_find`) return 0, rc-returning ops return -1,
-//! `labelle_component_get` / `labelle_query` / `labelle_event_poll` write
-//! nothing and return 0, the void ops silently ignore, the
-//! `labelle_input_key_*` reads report not-down (0), and
-//! `labelle_input_mouse` writes the origin. `labelle_contract_version` is
-//! pure and works even before `bind`.
+//! (incl. `labelle_entity_find`) return 0, rc-returning ops return -1
+//! (`labelle_plugin_call` its unroutable sentinel — the same -1, carried
+//! in its usize), `labelle_component_get` / `labelle_query` /
+//! `labelle_event_poll` write nothing and return 0, the void ops
+//! silently ignore, the `labelle_input_key_*` reads report not-down (0),
+//! and `labelle_input_mouse` writes the origin.
+//! `labelle_contract_version` is pure and works even before `bind`.
 //!
 //! ## No symbols in script-less builds
 //!
@@ -142,6 +143,35 @@
 //! per-name `get` caveats (renderer-handle fields are omitted; `Camera`
 //! serializes `tag` as a string).
 //!
+//! ## Plugin commands (`labelle_plugin_call`, contract v1.1, #744)
+//!
+//! Scripts call Zig PLUGIN commands (pathfinder navigate, dungeon
+//! generate, …) through the SAME handler channel labelle-studio's
+//! plugin panels use: the game's `editorPluginCommand` mixin
+//! (`game/editor_command_mixin.zig`, #748) — a SYNCHRONOUS `emitSync`
+//! of `engine__editor_plugin_command` to the handler a plugin declared
+//! by subscribing to that engine event. One registration is dual-use:
+//! a handler written for a studio panel is reachable from every
+//! scripting language, unmodified — and the mixin's borrowed-slices
+//! handler contract carries over verbatim (the dispatch returns only
+//! after the handler ran, so the script's transient buffers stay valid
+//! with no copy).
+//!
+//! The mixin is fire-and-forward — handlers produce no return payload
+//! — so the export's usize return is an rc, not a size: 0 = dispatched
+//! into the channel; `plugin_call_unroutable` (`maxInt(usize)`, C's
+//! `(size_t)-1` — the rc convention's -1 in a usize) = empty
+//! plugin/command, no handler registered in this build (the variant
+//! never landed on the merged `GameEvents`), or not bound. The channel
+//! is a broadcast that handlers name-filter THEMSELVES, so the engine
+//! cannot tell an unknown plugin/command from a delivered-and-ignored
+//! one: both dispatch as 0 wherever a handler exists. Results and acks
+//! travel back as game events — the subscribe/poll tap above.
+//! `out`/`out_cap` are reserved for a future response payload
+//! (required-size return, all-or-nothing write, `component_get`-style;
+//! 0 would keep meaning dispatched-no-response and the sentinel
+//! unroutable) and are never written in v1.1.
+//!
 //! Single-threaded by design (main thread, during the plugin's tick);
 //! no atomics.
 
@@ -150,10 +180,22 @@ const core = @import("labelle-core");
 const jsonc = @import("jsonc");
 const component_apply = @import("jsonc/component_apply.zig");
 
-/// Contract version consumers compile against. Bump on any ABI or
-/// semantic change; language plugins check it via
-/// `labelle_contract_version()` at startup and refuse a mismatch.
+/// Contract version consumers compile against — bumped on BREAKING ABI
+/// or semantic changes only. Language plugins check it via
+/// `labelle_contract_version()` at startup and refuse a mismatch, so a
+/// bump on additions would strand every still-compatible consumer;
+/// ADDITIVE growth (new exports) is a minor revision instead, marked
+/// "since v1.x" in `contract/labelle_script.h` and detected by probing
+/// for the symbol — the editor-bridge contract's exact convention
+/// (v1.1–v1.7). Current surface: v1.1 = v1 + `labelle_plugin_call`
+/// (#744).
 pub const CONTRACT_VERSION: u32 = 1;
+
+/// `labelle_plugin_call`'s unroutable sentinel: the rc convention's -1
+/// carried in that export's usize return (C's `(size_t)-1`). Distinct
+/// from 0 = dispatched — and from any future response-size return,
+/// which could never require the whole address space.
+pub const plugin_call_unroutable: usize = std.math.maxInt(usize);
 
 /// Inbox back-pressure cap: pending (drained-but-unpolled) events beyond
 /// this are dropped NEWEST-first, matching the POC's fixed-ring behavior.
@@ -226,6 +268,7 @@ const VTable = struct {
     input_key_down: *const fn (key: u32) bool,
     input_key_pressed: *const fn (key: u32) bool,
     input_mouse: *const fn () core.Position,
+    plugin_call: *const fn (plugin: []const u8, command: []const u8, params_json: []const u8) i32,
 };
 
 // ── Generated-main API (non-export) ─────────────────────────────────
@@ -730,6 +773,56 @@ pub export fn labelle_input_mouse(x_out: ?*f32, y_out: ?*f32) void {
     if (y_out) |p| p.* = pos.y;
 }
 
+// ── Plugin commands (contract v1.1, #744) ───────────────────────────
+
+/// Call a named command on a Zig engine PLUGIN — the script-side entry
+/// to the handler channel labelle-studio's panels reach through
+/// `editor_plugin_command` (editor-bridge v1.7): the game's
+/// `editorPluginCommand` mixin `emitSync`s `engine__editor_plugin_command`
+/// to the handler the plugin registered by subscribing to that event,
+/// so ONE registration serves studio panels and every scripting
+/// language alike (module doc, "Plugin commands"). `params_json` is the
+/// arguments object; NULL or empty (`len == 0`) means `"{}"`. Dispatch
+/// is SYNCHRONOUS — the handler has run by the time this returns — and
+/// all three strings are borrowed for the call only.
+///
+/// Fire-and-forward v1.1 rc, carried in the usize return: 0 =
+/// dispatched into the handler channel; `plugin_call_unroutable`
+/// (`maxInt(usize)`, C's `(size_t)-1`) = unroutable — empty
+/// plugin/command, no handler registered in this build, a game shape
+/// without the mixin, or not bound. Handlers name-filter the broadcast
+/// themselves, so a name no plugin claims still returns 0 wherever a
+/// handler exists — dispatched-and-ignored is indistinguishable from
+/// handled BY DESIGN; responses and acks arrive as game events through
+/// the subscribe/poll tap. `out`/`out_cap` are RESERVED for handler
+/// response payloads (a future minor revision: required-size return
+/// with `labelle_component_get`'s all-or-nothing write; 0 keeps its
+/// dispatched-no-response meaning, the sentinel stays unroutable);
+/// v1.1 never writes them — pass NULL/0.
+pub export fn labelle_plugin_call(
+    plugin_ptr: [*]const u8,
+    plugin_len: usize,
+    command_ptr: [*]const u8,
+    command_len: usize,
+    params_ptr: ?[*]const u8,
+    params_len: usize,
+    out: ?[*]u8,
+    out_cap: usize,
+) usize {
+    // Reserved for handler responses (see the doc above) — v1.1 never
+    // writes them.
+    _ = out;
+    _ = out_cap;
+    const vt = vtable orelse return plugin_call_unroutable;
+    if (plugin_len == 0 or command_len == 0) return plugin_call_unroutable;
+    const rc = vt.plugin_call(
+        plugin_ptr[0..plugin_len],
+        command_ptr[0..command_len],
+        optionalJson(params_ptr, params_len, "{}"),
+    );
+    return if (rc == 0) 0 else plugin_call_unroutable;
+}
+
 // ── Implementation ──────────────────────────────────────────────────
 
 /// The documented consumer gate for `Game.GameEvents` (see game.zig):
@@ -882,6 +975,7 @@ fn Holder(comptime GP: type) type {
             .input_key_down = &inputKeyDownImpl,
             .input_key_pressed = &inputKeyPressedImpl,
             .input_mouse = &inputMouseImpl,
+            .plugin_call = &pluginCallImpl,
         };
 
         // ── Entities ─────────────────────────────────────────────
@@ -1404,6 +1498,23 @@ fn Holder(comptime GP: type) type {
 
         fn inputMouseImpl() core.Position {
             return .{ .x = G.Input.getMouseX(), .y = G.Input.getMouseY() };
+        }
+
+        // ── Plugin commands ──────────────────────────────────────
+
+        /// Straight through the game's `editorPluginCommand` mixin —
+        /// the very dispatch the `editor_plugin_command` bridge export
+        /// uses, NOT a reimplementation: the routing/handler-channel
+        /// decision lives in `game/editor_command_mixin.zig` alone.
+        /// Every GameConfig-built Game carries the decl; the `@hasDecl`
+        /// belt keeps a minimal duck-typed stand-in compiling (it
+        /// degrades to the unroutable -1) — the same belt editor_api's
+        /// pluginCommandImpl wears. A game whose merged `GameEvents`
+        /// never consumed `engine__editor_plugin_command` folds to -1
+        /// INSIDE the mixin (the zero-cost no-handler gate).
+        fn pluginCallImpl(plugin: []const u8, command: []const u8, params_json: []const u8) i32 {
+            if (comptime !@hasDecl(G, "editorPluginCommand")) return -1;
+            return game.editorPluginCommand(plugin, command, params_json);
         }
 
         // ── Helpers ──────────────────────────────────────────────

--- a/test/script_contract_test.zig
+++ b/test/script_contract_test.zig
@@ -127,6 +127,22 @@ fn findEntity(name: []const u8) u64 {
     return contract.labelle_entity_find(name.ptr, name.len);
 }
 
+/// Call plugin_call with the reserved out-buffer at its documented
+/// v1.1 shape (NULL/0). The reserved-buffer canary test drives
+/// `labelle_plugin_call` directly instead.
+fn pluginCall(plugin: []const u8, command: []const u8, params: []const u8) usize {
+    return contract.labelle_plugin_call(
+        plugin.ptr,
+        plugin.len,
+        command.ptr,
+        command.len,
+        params.ptr,
+        params.len,
+        null,
+        0,
+    );
+}
+
 /// Parse a query result (`[3,7]`) and check it equals `expected` as a
 /// SET — the mock backend iterates a hash map, so id order is
 /// unspecified.
@@ -184,6 +200,11 @@ test "pre-bind: every export is a safe no-op" {
     try testing.expectEqual(@as(i32, -1), removeComp(1, "Health"));
     try testing.expectEqual(@as(i32, -1), emitEvent("turret__fired", "{}"));
     try testing.expectEqual(@as(i32, -1), contract.labelle_scene_change("main", 4));
+    // plugin_call carries its rc in a usize: pre-bind is unroutable.
+    try testing.expectEqual(
+        contract.plugin_call_unroutable,
+        pluginCall("pathfinder", "navigate", "{}"),
+    );
 
     // Boolean / out-writing ops: 0 bytes, 0 answer.
     try testing.expectEqual(@as(i32, 0), hasComp(1, "Health"));
@@ -1826,4 +1847,215 @@ test "input_mouse: writes the reported position; NULL out-pointers are skipped" 
     contract.labelle_input_mouse(null, &only_y);
     try testing.expectEqual(@as(f32, 240.0), only_y);
     contract.labelle_input_mouse(&x, null); // both-write path already checked
+}
+
+// ── labelle_plugin_call: cross-language plugin commands (v1.1, #744) ──
+//
+// The export routes through the SAME handler channel labelle-studio's
+// panels use — the game's `editorPluginCommand` mixin
+// (`game/editor_command_mixin.zig`): a synchronous `emitSync` of
+// `engine__editor_plugin_command` to the handler a plugin registered by
+// subscribing to that engine event, so one registration is dual-use
+// (studio + every language). Dispatch is fire-and-forward; the usize
+// return is an rc — 0 = dispatched, `plugin_call_unroutable` = empty
+// name / no handler in this build / not bound. These tests register a
+// recorder through the REAL registration path (a hooks subscriber to
+// the engine event — the editor_api_test shape) and pin both legs plus
+// the reserved out-buffer.
+
+const PluginCallEvents = union(enum) {
+    engine__editor_plugin_command: engine.Events.editor_plugin_command,
+};
+
+const PluginCallRecorder = struct {
+    count: usize = 0,
+    last_plugin_buf: [64]u8 = undefined,
+    last_plugin_len: usize = 0,
+    last_command_buf: [64]u8 = undefined,
+    last_command_len: usize = 0,
+    last_params_buf: [128]u8 = undefined,
+    last_params_len: usize = 0,
+
+    // Dispatch is SYNCHRONOUS, so the borrowed script-owned slices are
+    // valid here; copy them out because the assertions read after the
+    // call returns.
+    pub fn engine__editor_plugin_command(self: *PluginCallRecorder, info: anytype) void {
+        self.count += 1;
+        @memcpy(self.last_plugin_buf[0..info.plugin.len], info.plugin);
+        self.last_plugin_len = info.plugin.len;
+        @memcpy(self.last_command_buf[0..info.command.len], info.command);
+        self.last_command_len = info.command.len;
+        @memcpy(self.last_params_buf[0..info.params.len], info.params);
+        self.last_params_len = info.params.len;
+    }
+    fn lastPlugin(self: *const PluginCallRecorder) []const u8 {
+        return self.last_plugin_buf[0..self.last_plugin_len];
+    }
+    fn lastCommand(self: *const PluginCallRecorder) []const u8 {
+        return self.last_command_buf[0..self.last_command_len];
+    }
+    fn lastParams(self: *const PluginCallRecorder) []const u8 {
+        return self.last_params_buf[0..self.last_params_len];
+    }
+};
+
+/// A project whose merged `GameEvents` carries the plugin-command
+/// channel (a plugin consumed `engine__editor_plugin_command`) — the
+/// wired-up path.
+const PluginCallGame = engine.GameConfig(
+    core.StubRender(MockEcs.Entity),
+    MockEcs,
+    engine.StubInput,
+    engine.StubAudio,
+    engine.StubVideo,
+    engine.StubGui,
+    *PluginCallRecorder,
+    core.StubLogSink,
+    TestComponents,
+    &.{},
+    PluginCallEvents,
+);
+
+test "plugin_call: routes through the editorPluginCommand mixin to the registered handler" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var recorder = PluginCallRecorder{};
+    var game = PluginCallGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&recorder);
+    contract.bind(&game);
+
+    // One call, the handler fired synchronously (before the return),
+    // {plugin, command, params} verbatim.
+    try testing.expectEqual(
+        @as(usize, 0),
+        pluginCall("pathfinder", "navigate", "{\"entity\":7,\"to\":{\"x\":3,\"y\":4}}"),
+    );
+    try testing.expectEqual(@as(usize, 1), recorder.count);
+    try testing.expectEqualStrings("pathfinder", recorder.lastPlugin());
+    try testing.expectEqualStrings("navigate", recorder.lastCommand());
+    try testing.expectEqualStrings("{\"entity\":7,\"to\":{\"x\":3,\"y\":4}}", recorder.lastParams());
+
+    // The channel is a BROADCAST handlers name-filter themselves: a
+    // plugin/command no handler claims still dispatches as 0 wherever a
+    // handler exists — dispatched-and-ignored is indistinguishable from
+    // handled (the documented encoding; acks travel back as events).
+    try testing.expectEqual(@as(usize, 0), pluginCall("nonexistent_plugin", "whatever", "{}"));
+    try testing.expectEqual(@as(usize, 2), recorder.count);
+    try testing.expectEqualStrings("nonexistent_plugin", recorder.lastPlugin());
+
+    // out/out_cap are RESERVED in v1.1: never written even on a
+    // dispatched call (canary intact), and the return stays the rc.
+    var out: [32]u8 = undefined;
+    @memset(&out, 0xAA);
+    const plugin = "pathfinder";
+    const command = "navigate";
+    const params = "{}";
+    try testing.expectEqual(@as(usize, 0), contract.labelle_plugin_call(
+        plugin.ptr,
+        plugin.len,
+        command.ptr,
+        command.len,
+        params.ptr,
+        params.len,
+        &out,
+        out.len,
+    ));
+    for (out) |b| try testing.expectEqual(@as(u8, 0xAA), b);
+    try testing.expectEqual(@as(usize, 3), recorder.count);
+}
+
+test "plugin_call: NULL/len-0 params dispatch as {} (the optionalJson convention)" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var recorder = PluginCallRecorder{};
+    var game = PluginCallGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&recorder);
+    contract.bind(&game);
+
+    // NULL params — a C caller's natural "no arguments".
+    const plugin = "pathfinder";
+    const command = "cancel";
+    try testing.expectEqual(@as(usize, 0), contract.labelle_plugin_call(
+        plugin.ptr,
+        plugin.len,
+        command.ptr,
+        command.len,
+        null,
+        0,
+        null,
+        0,
+    ));
+    try testing.expectEqual(@as(usize, 1), recorder.count);
+    try testing.expectEqualStrings("{}", recorder.lastParams());
+
+    // Non-NULL empty params take the same default.
+    try testing.expectEqual(@as(usize, 0), pluginCall("pathfinder", "cancel", ""));
+    try testing.expectEqual(@as(usize, 2), recorder.count);
+    try testing.expectEqualStrings("{}", recorder.lastParams());
+}
+
+test "plugin_call: unroutable sentinel — pre-bind, no handler channel, empty names" {
+    contract.unbind();
+    defer contract.unbind();
+
+    // The sentinel is the rc convention's -1 as a usize — the header's
+    // ((size_t)-1) — pinned so the C define and the Zig const can't
+    // drift apart.
+    try testing.expectEqual(std.math.maxInt(usize), contract.plugin_call_unroutable);
+
+    // Pre-bind: the documented no-op — unroutable, nothing dispatched.
+    try testing.expectEqual(
+        contract.plugin_call_unroutable,
+        pluginCall("pathfinder", "navigate", "{}"),
+    );
+
+    // Bound to a game whose GameEvents never consumed
+    // `engine__editor_plugin_command` (ContractGame's TestEvents): no
+    // handler registered in this build, so the mixin's comptime gate
+    // folds to the graceful degrade. This is what "unknown plugin"
+    // looks like at the engine level — nobody subscribed, unroutable.
+    {
+        var game = ContractGame.init(testing.allocator);
+        defer game.deinit();
+        contract.bind(&game);
+        try testing.expectEqual(
+            contract.plugin_call_unroutable,
+            pluginCall("pathfinder", "navigate", "{}"),
+        );
+    }
+    contract.unbind();
+
+    // Bound WITH a handler channel but an empty plugin/command: refused
+    // before dispatch — the handler never fires.
+    var recorder = PluginCallRecorder{};
+    var game = PluginCallGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&recorder);
+    contract.bind(&game);
+    try testing.expectEqual(contract.plugin_call_unroutable, pluginCall("", "navigate", "{}"));
+    try testing.expectEqual(contract.plugin_call_unroutable, pluginCall("pathfinder", "", "{}"));
+    try testing.expectEqual(@as(usize, 0), recorder.count);
+}
+
+test "plugin_call: the minimal engine.Game shape compiles and degrades to unroutable" {
+    contract.unbind();
+    defer contract.unbind();
+
+    // engine.Game is the GameWith(void) shape (EmptyComponents,
+    // `GameEvents = void`): the mixin decl exists but its handler
+    // channel comptime-folds away — the call must compile and return
+    // the degrade sentinel, never crash (the event-emit refusal test's
+    // pattern).
+    var game = engine.Game.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    try testing.expectEqual(
+        contract.plugin_call_unroutable,
+        pluginCall("pathfinder", "navigate", "{}"),
+    );
 }


### PR DESCRIPTION
Closes #744 (language-plugins epic #237, RFC rev 10). Scripts in any language can now command Zig plugins:

```lua
labelle.plugin_call("pathfinder", "navigate", '{"entity":12,"x":340,"y":186}')
```

- Routes through the **`editor_command_mixin` channel (#748)** — the same entry `editor_plugin_command` uses, so **one handler registration serves studio panels and every scripting language** (the dual-use promise from the RFC, delivered with zero dispatch duplication).
- The mixin is a fire-and-forward broadcast (handlers name-filter), so **v1.1 is command-only**: rc 0 = dispatched, `(size_t)-1` = unroutable; responses arrive as game events via the existing subscribe/poll. `out`/`out_cap` reserved for a future required-size response — the sentinel can never collide with a real size.
- **`LABELLE_CONTRACT_VERSION` stays 1** (additive v1.1 with `since` annotations): the check is an exact-match refusal, so bumping on additions would strand compatible consumers — policy codified in header + module doc, mirroring the editor bridge's v1.x practice.
- **955/955** (+4 tests incl. a round-trip through the real comptime hooks registration path and a C-define↔Zig-const drift pin).

https://claude.ai/code/session_01P7YLw4hXFCCaY2LAUt4G1j