### PR TITLE
feat(#305): Game.setPostFx passthrough + post-fx type re-exports (P2 Slice C)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -239,6 +239,11 @@ pub fn build(b: *std.Build) void {
         // queries, event emit-by-name, and the subscribe/drain/poll FIFO
         // (incl. the two-arena payload lifetime).
         "test/script_contract_test.zig",
+        // labelle-gfx#305 Phase 2 Slice C — post-fx type re-exports
+        // (engine.PostPass/PostPassKind/PostPassUniforms are the SAME
+        // labelle-core types gfx re-exports, unified diamond) + the
+        // `Game.setPostFx/pushPostPass/clearPostFx` passthrough seam.
+        "test/post_fx_passthrough_test.zig",
     };
 
     for (test_files) |test_file| {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -65,8 +65,8 @@
         // RenderImpl), so the effective gfx floor is enforced at the consuming
         // game's build; this pin only feeds the tilemap sub-package test.
         .labelle_gfx = .{
-            .url = "https://github.com/labelle-toolkit/labelle-gfx/archive/refs/tags/v1.26.0.tar.gz",
-            .hash = "labelle_gfx-1.26.0-nMpCPMYYBQBBX_7Js1AHBQKWYeI7Hm8U2aEL8t9cOIJO",
+            .url = "https://github.com/labelle-toolkit/labelle-gfx/archive/refs/tags/v1.28.0.tar.gz",
+            .hash = "labelle_gfx-1.28.0-nMpCPE-eBQB1N-aZQGQMvyIA6XBB3CgiA3Wwkf2U9jbJ",
             .lazy = true,
         },
     },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -54,16 +54,21 @@
         // test (`test/tilemap_test.zig`) can decode a real `.tmx` through
         // gfx's std-only `tilemap` sub-package + drive gfx's
         // `TileMapRendererWith(MockBackend)` post-sprite, proving the whole
-        // path against the actually-shipped gfx 1.21.0 API rather than a
-        // hand-rolled stand-in. `lazy` so downstream consumers of the engine
-        // module never fetch it — it is reached only by the `test` step via
-        // `b.lazyDependency`, mirroring `zspec`.
-        // Bumped to gfx v1.26.0 for camera-bound layers (RFC #723): engine
-        // 1.83.0's tagged-camera seeding drives gfx's CameraManager
-        // setTag/findByTag/resetSecondary (added in 1.26.0). Test-only + lazy —
-        // the engine module takes no direct gfx dep (the renderer arrives via
-        // RenderImpl), so the effective gfx floor is enforced at the consuming
-        // game's build; this pin only feeds the tilemap sub-package test.
+        // path against the shipped gfx API rather than a hand-rolled stand-in.
+        // `lazy` so downstream consumers of the engine module never fetch it —
+        // it is reached only by the `test` step via `b.lazyDependency`,
+        // mirroring `zspec`.
+        // Pinned to gfx v1.28.0 for the post-fx passthrough (labelle-gfx#305
+        // Phase 2 Slice C): gfx v1.28.0 adds the `PostFxDriver` + the
+        // `setPostFx`/`pushPostPass`/`clearPostFx` runtime API that `Game`'s
+        // post-fx passthrough (`src/game/post_fx_mixin.zig`) forwards to via
+        // `renderer.inner`. (Supersedes the v1.26.0 camera-bound-layers pin,
+        // RFC #723, whose tagged-camera seeding drives gfx's CameraManager
+        // setTag/findByTag/resetSecondary — still present, floor now v1.28.0.)
+        // Test-only + lazy — the engine module takes no direct gfx dep (the
+        // renderer arrives via RenderImpl), so the effective gfx floor is
+        // enforced at the consuming game's build; this pin only feeds the
+        // tilemap sub-package test.
         .labelle_gfx = .{
             .url = "https://github.com/labelle-toolkit/labelle-gfx/archive/refs/tags/v1.28.0.tar.gz",
             .hash = "labelle_gfx-1.28.0-nMpCPE-eBQB1N-aZQGQMvyIA6XBB3CgiA3Wwkf2U9jbJ",

--- a/src/game.zig
+++ b/src/game.zig
@@ -41,6 +41,7 @@ const gui_mixin = @import("game/gui_mixin.zig");
 const gizmo_mixin = @import("game/gizmo_mixin.zig");
 const mesh_mixin = @import("game/mesh_mixin.zig");
 const render_target_mixin = @import("game/render_target_mixin.zig");
+const post_fx_mixin = @import("game/post_fx_mixin.zig");
 const scene_mixin = @import("game/scene_mixin.zig");
 const save_load_mixin = @import("game/save_load_mixin.zig");
 const state_mixin = @import("game/state_mixin.zig");
@@ -371,6 +372,7 @@ pub fn GameConfigWithYAxis(
         const GizmoMixin = gizmo_mixin.Mixin(Self);
         const MeshMixin = mesh_mixin.Mixin(Self);
         const RenderTargetMixin = render_target_mixin.Mixin(Self);
+        const PostFxMixin = post_fx_mixin.Mixin(Self);
         const SceneMixin = scene_mixin.Mixin(Self);
         const SaveLoadMixin = save_load_mixin.Mixin(Self);
         const StateMixin = state_mixin.Mixin(Self);
@@ -1158,6 +1160,15 @@ pub fn GameConfigWithYAxis(
         pub const endRenderTarget = RenderTargetMixin.endRenderTarget;
         pub const drawRenderTarget = RenderTargetMixin.drawRenderTarget;
         pub const destroyRenderTarget = RenderTargetMixin.destroyRenderTarget;
+
+        // ── Post-fx stack passthrough (labelle-gfx#305 Phase 2 Slice C, mixin) ──
+        /// Seed / mutate the full-screen post-fx stack at runtime — forwards to
+        /// the internal gfx retained engine's `PostFxDriver`. The same stack the
+        /// `project.labelle` `.post_fx` seed feeds. No-op on renderers/backends
+        /// without post-fx support (older gfx, StubRender, test mocks).
+        pub const setPostFx = PostFxMixin.setPostFx;
+        pub const pushPostPass = PostFxMixin.pushPostPass;
+        pub const clearPostFx = PostFxMixin.clearPostFx;
 
         // ── Scene Management (mixin) ─────────────────────────────
         pub const registerScene = SceneMixin.registerScene;

--- a/src/game/post_fx_mixin.zig
+++ b/src/game/post_fx_mixin.zig
@@ -1,0 +1,44 @@
+//! Post-fx stack passthrough (labelle-gfx#305 Phase 2 Slice C).
+//!
+//! Forwards the runtime post-fx stack API to the internal gfx retained
+//! engine's `PostFxDriver`. The static `project.labelle` `.post_fx` seed
+//! (assembler codegen) and these runtime mutators feed the SAME stack.
+//!
+//! Gated on `@hasDecl` of the renderer's retained-engine type
+//! (`GfxEngineType.setPostFx`) so a renderer without the post-fx API — an
+//! older gfx (< v1.28.0), StubRender, or a test mock — compiles to a no-op.
+
+const core = @import("labelle-core");
+
+const PostPass = core.backend_contract.PostPass;
+
+/// True when the renderer wraps a retained engine that exposes the post-fx
+/// runtime API (gfx >= v1.28.0). Non-gfx / stub renderers fail the guard.
+fn rendererHasPostFx(comptime Renderer: type) bool {
+    return @hasDecl(Renderer, "GfxEngineType") and
+        @hasDecl(Renderer.GfxEngineType, "setPostFx");
+}
+
+pub fn Mixin(comptime Game: type) type {
+    return struct {
+        /// Replace the whole post-fx stack (e.g. the `project.labelle`
+        /// `.post_fx` seed, or a "retro mode" swap). No-op when the active
+        /// renderer/backend has no post-fx support.
+        pub fn setPostFx(self: *Game, passes: []const PostPass) void {
+            const Renderer = @TypeOf(self.renderer.*);
+            if (comptime rendererHasPostFx(Renderer)) self.renderer.inner.setPostFx(passes);
+        }
+
+        /// Append one full-screen pass to the stack.
+        pub fn pushPostPass(self: *Game, pass: PostPass) void {
+            const Renderer = @TypeOf(self.renderer.*);
+            if (comptime rendererHasPostFx(Renderer)) self.renderer.inner.pushPostPass(pass);
+        }
+
+        /// Empty the post-fx stack — back to the straight-to-backbuffer path.
+        pub fn clearPostFx(self: *Game) void {
+            const Renderer = @TypeOf(self.renderer.*);
+            if (comptime rendererHasPostFx(Renderer)) self.renderer.inner.clearPostFx();
+        }
+    };
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -846,3 +846,13 @@ pub const GizmoInterface = core.GizmoInterface;
 pub const StubGizmos = core.StubGizmos;
 pub const PhysicsInterface = core.PhysicsInterface;
 pub const StubPhysics = core.StubPhysics;
+
+// ── Post-fx stack (labelle-gfx#305) ──
+// Full-screen post-processing value types, re-exported from labelle-core (the
+// canonical home of the backend contract). gfx re-exports the SAME core types,
+// so surfacing them here keeps the core diamond unified — the engine takes no
+// gfx module dependency. The runtime mutators live on `Game`
+// (`setPostFx`/`pushPostPass`/`clearPostFx`, see game/post_fx_mixin.zig).
+pub const PostPass = core.backend_contract.PostPass;
+pub const PostPassKind = core.backend_contract.PostPassKind;
+pub const PostPassUniforms = core.backend_contract.PostPassUniforms;

--- a/test/post_fx_passthrough_test.zig
+++ b/test/post_fx_passthrough_test.zig
@@ -1,6 +1,6 @@
 //! Post-fx stack passthrough + type re-export (labelle-gfx#305 Phase 2 Slice C).
 //!
-//! Two things under test:
+//! Three things under test:
 //!   1. The engine surfaces the post-fx VALUE TYPES (`engine.PostPass` /
 //!      `PostPassKind` / `PostPassUniforms`) and they are the SAME core types
 //!      gfx re-exports — proving the diamond stays unified (the engine takes no
@@ -8,12 +8,28 @@
 //!   2. A `PostPass` literal built through the engine surface round-trips its
 //!      uniform fields, so a game / assembler-generated main.zig can seed the
 //!      `.post_fx` stack via `engine.PostPass{ ... }`.
+//!   3. The actual `Game` forwarding seam: `Game.setPostFx` / `pushPostPass` /
+//!      `clearPostFx` reach `renderer.inner.<method>` when the renderer wraps a
+//!      gfx-shaped retained engine (the `GfxEngineType`/`inner` structure the
+//!      mixin's `@hasDecl` guard keys off), and compile to safe no-ops when it
+//!      does not (older gfx / StubRender / mock).
 
 const std = @import("std");
 const testing = std.testing;
 
 const engine = @import("engine");
 const core = @import("labelle-core");
+
+const PostPass = core.backend_contract.PostPass;
+const PostPassKind = core.backend_contract.PostPassKind;
+
+const GameConfig = engine.GameConfig;
+const MockEcsBackend = engine.MockEcsBackend;
+const StubInput = engine.StubInput;
+const StubAudio = engine.StubAudio;
+const StubVideo = engine.StubVideo;
+const StubGui = engine.StubGui;
+const StubLogSink = engine.StubLogSink;
 
 test "engine re-exports the labelle-core post-fx types (unified diamond)" {
     // Identity, not just structural equality: the engine surface hands back the
@@ -50,4 +66,161 @@ test "a slice of PostPass carries across the engine setPostFx signature type" {
     try testing.expectEqual(@as(usize, 2), stack.len);
     try testing.expectEqual(engine.PostPassKind.bloom, stack[0].kind);
     try testing.expectEqual(engine.PostPassKind.crt, stack[1].kind);
+}
+
+// ── Forwarding seam: Game.setPostFx/pushPostPass/clearPostFx → renderer.inner ──
+//
+// The mixin (`src/game/post_fx_mixin.zig`) forwards to
+// `self.renderer.inner.<method>`, gated on
+// `@hasDecl(Renderer, "GfxEngineType") and @hasDecl(Renderer.GfxEngineType, "setPostFx")`.
+// The recording renderer below mirrors the real gfx `GfxRenderer` shape (a
+// `pub const GfxEngineType` plus an `inner: GfxEngineType` field) and RECORDS
+// every post-fx call on its `inner`, so we can assert the forward genuinely
+// reaches `renderer.inner` — not merely that it compiles.
+
+/// Stands in for gfx's retained engine: exposes the three post-fx runtime
+/// methods the mixin calls and records what it was handed.
+const RecordingGfxEngine = struct {
+    set_calls: usize = 0,
+    last_set_len: usize = 0,
+    last_set_kinds: [8]PostPassKind = undefined,
+    push_calls: usize = 0,
+    last_pushed: ?PostPass = null,
+    clear_calls: usize = 0,
+
+    pub fn setPostFx(self: *@This(), passes: []const PostPass) void {
+        self.set_calls += 1;
+        self.last_set_len = passes.len;
+        for (passes, 0..) |p, i| {
+            if (i < self.last_set_kinds.len) self.last_set_kinds[i] = p.kind;
+        }
+    }
+    pub fn pushPostPass(self: *@This(), pass: PostPass) void {
+        self.push_calls += 1;
+        self.last_pushed = pass;
+    }
+    pub fn clearPostFx(self: *@This()) void {
+        self.clear_calls += 1;
+    }
+};
+
+/// A renderer that satisfies the engine's RenderInterface (mirrors
+/// `StubRender`, like render_mesh_test's RecordingRender) AND presents the
+/// gfx-shaped `GfxEngineType`/`inner` structure the post-fx mixin keys off.
+fn RecordingRender(comptime Entity: type) type {
+    return struct {
+        const Self = @This();
+
+        pub const Sprite = struct {
+            sprite_name: []const u8 = "",
+            visible: bool = true,
+            z_index: i16 = 0,
+            layer: enum { default } = .default,
+        };
+        pub const Shape = struct {
+            shape: union(enum) {
+                rectangle: struct { width: f32 = 10, height: f32 = 10 },
+                circle: struct { radius: f32 = 10 },
+            } = .{ .rectangle = .{} },
+            color: struct { r: u8 = 255, g: u8 = 255, b: u8 = 255, a: u8 = 255 } = .{},
+            visible: bool = true,
+            z_index: i16 = 0,
+            layer: enum { default } = .default,
+        };
+
+        /// The two decls the mixin's `rendererHasPostFx` guard requires.
+        pub const GfxEngineType = RecordingGfxEngine;
+        inner: RecordingGfxEngine = .{},
+
+        pub fn init(_: std.mem.Allocator) Self {
+            return .{};
+        }
+        pub fn deinit(_: *Self) void {}
+
+        pub fn trackEntity(_: *Self, _: Entity, _: core.render.VisualType) void {}
+        pub fn untrackEntity(_: *Self, _: Entity) void {}
+        pub fn markPositionDirty(_: *Self, _: Entity) void {}
+        pub fn markPositionDirtyWithChildren(_: *Self, comptime _: type, _: anytype, _: Entity) void {}
+        pub fn updateHierarchyFlag(_: *Self, _: Entity, _: bool) void {}
+        pub fn markVisualDirty(_: *Self, _: Entity) void {}
+        pub fn sync(_: *Self, comptime _: type, _: anytype) void {}
+        pub fn setScreenHeight(_: *Self, _: f32) void {}
+        pub fn renderGizmoDraws(_: *Self, _: []const core.gizmos.GizmoDraw) void {}
+        pub fn hasEntity(_: *const Self, _: Entity) bool {
+            return false;
+        }
+        pub fn render(_: *Self) void {}
+        pub fn clear(_: *Self) void {}
+    };
+}
+
+const EmptyComponents = struct {
+    pub fn has(comptime _: []const u8) bool {
+        return false;
+    }
+    pub fn names() []const []const u8 {
+        return &.{};
+    }
+};
+
+fn RecordingGame() type {
+    return GameConfig(
+        RecordingRender(u32),
+        MockEcsBackend(u32),
+        StubInput,
+        StubAudio,
+        StubVideo,
+        StubGui,
+        void, // Hooks
+        StubLogSink,
+        EmptyComponents,
+        &.{}, // gizmo categories
+        void, // game events
+    );
+}
+
+test "Game.setPostFx/pushPostPass/clearPostFx forward to renderer.inner" {
+    const RGame = RecordingGame();
+    var game = RGame.init(testing.allocator);
+    defer game.deinit();
+
+    // setPostFx forwards the whole stack.
+    game.setPostFx(&.{
+        .{ .kind = .bloom, .uniforms = .{ .scalar0 = 1.0 } },
+        .{ .kind = .crt },
+    });
+    try testing.expectEqual(@as(usize, 1), game.renderer.inner.set_calls);
+    try testing.expectEqual(@as(usize, 2), game.renderer.inner.last_set_len);
+    try testing.expectEqual(PostPassKind.bloom, game.renderer.inner.last_set_kinds[0]);
+    try testing.expectEqual(PostPassKind.crt, game.renderer.inner.last_set_kinds[1]);
+
+    // pushPostPass forwards a single pass with its uniforms.
+    game.pushPostPass(.{ .kind = .vignette, .uniforms = .{ .scalar0 = 0.7 } });
+    try testing.expectEqual(@as(usize, 1), game.renderer.inner.push_calls);
+    try testing.expect(game.renderer.inner.last_pushed != null);
+    try testing.expectEqual(PostPassKind.vignette, game.renderer.inner.last_pushed.?.kind);
+    try testing.expectEqual(@as(f32, 0.7), game.renderer.inner.last_pushed.?.uniforms.scalar0);
+
+    // clearPostFx forwards the reset.
+    game.clearPostFx();
+    try testing.expectEqual(@as(usize, 1), game.renderer.inner.clear_calls);
+    // The earlier forwards were not disturbed by the clear.
+    try testing.expectEqual(@as(usize, 1), game.renderer.inner.set_calls);
+    try testing.expectEqual(@as(usize, 1), game.renderer.inner.push_calls);
+}
+
+test "post-fx methods are safe no-ops on a renderer without GfxEngineType (back-compat)" {
+    // The default engine.Game uses StubRender, which has no `GfxEngineType` —
+    // the mixin's comptime guard fails, so all three calls compile to nothing
+    // and must not crash or touch anything (older gfx / StubRender / mock path).
+    var game = engine.Game.init(testing.allocator);
+    defer game.deinit();
+
+    game.setPostFx(&.{
+        .{ .kind = .bloom },
+        .{ .kind = .crt },
+    });
+    game.pushPostPass(.{ .kind = .vignette, .uniforms = .{ .scalar0 = 0.5 } });
+    game.clearPostFx();
+    // Reaching here without a crash is the assertion: guarded no-op.
 }

--- a/test/post_fx_passthrough_test.zig
+++ b/test/post_fx_passthrough_test.zig
@@ -1,0 +1,53 @@
+//! Post-fx stack passthrough + type re-export (labelle-gfx#305 Phase 2 Slice C).
+//!
+//! Two things under test:
+//!   1. The engine surfaces the post-fx VALUE TYPES (`engine.PostPass` /
+//!      `PostPassKind` / `PostPassUniforms`) and they are the SAME core types
+//!      gfx re-exports — proving the diamond stays unified (the engine takes no
+//!      gfx module dependency; the types come from labelle-core).
+//!   2. A `PostPass` literal built through the engine surface round-trips its
+//!      uniform fields, so a game / assembler-generated main.zig can seed the
+//!      `.post_fx` stack via `engine.PostPass{ ... }`.
+
+const std = @import("std");
+const testing = std.testing;
+
+const engine = @import("engine");
+const core = @import("labelle-core");
+
+test "engine re-exports the labelle-core post-fx types (unified diamond)" {
+    // Identity, not just structural equality: the engine surface hands back the
+    // exact core types gfx also re-exports, so values flow across the seam.
+    try testing.expect(engine.PostPass == core.backend_contract.PostPass);
+    try testing.expect(engine.PostPassKind == core.backend_contract.PostPassKind);
+    try testing.expect(engine.PostPassUniforms == core.backend_contract.PostPassUniforms);
+}
+
+test "PostPass literal built via the engine surface round-trips its uniforms" {
+    const pass = engine.PostPass{
+        .kind = .vignette,
+        .uniforms = .{ .scalar0 = 0.8, .scalar1 = 0.5, .r = 0.1, .g = 0.2, .b = 0.3 },
+    };
+
+    try testing.expectEqual(engine.PostPassKind.vignette, pass.kind);
+    try testing.expectEqual(@as(f32, 0.8), pass.uniforms.scalar0);
+    try testing.expectEqual(@as(f32, 0.5), pass.uniforms.scalar1);
+    try testing.expectEqual(@as(f32, 0.1), pass.uniforms.r);
+    try testing.expectEqual(@as(f32, 0.3), pass.uniforms.b);
+    // Defaulted fields stay zero (flat extern struct, unused = 0).
+    try testing.expectEqual(@as(f32, 0), pass.uniforms.scalar2);
+    try testing.expectEqual(@as(u32, 0), pass.uniforms.aux_texture);
+}
+
+test "a slice of PostPass carries across the engine setPostFx signature type" {
+    // The runtime mutator takes `[]const engine.PostPass`; assert a stack
+    // literal is assignable to that slice type (compile-time proof the seam
+    // types line up, without constructing a heavy Game).
+    const stack: []const engine.PostPass = &.{
+        .{ .kind = .bloom, .uniforms = .{ .scalar0 = 1.0 } },
+        .{ .kind = .crt },
+    };
+    try testing.expectEqual(@as(usize, 2), stack.len);
+    try testing.expectEqual(engine.PostPassKind.bloom, stack[0].kind);
+    try testing.expectEqual(engine.PostPassKind.crt, stack[1].kind);
+}


### PR DESCRIPTION
## What

Phase 2 Slice C of labelle-gfx#305 (material/post-fx). Adds a runtime post-fx stack passthrough on `Game` plus re-exports the post-fx value types through the engine surface, so a game — and the assembler-generated `main.zig` — can seed / mutate the post-fx stack via `engine.PostPass` etc.

## Approach

- **Passthrough (`src/game/post_fx_mixin.zig`).** `Game.setPostFx(passes)`, `pushPostPass(pass)`, `clearPostFx()` forward to the internal gfx retained engine's `PostFxDriver` via `self.renderer.inner.setPostFx(...)`. Each is gated on `@hasDecl(Renderer, "GfxEngineType") and @hasDecl(Renderer.GfxEngineType, "setPostFx")`. Because the guard is `comptime`-false on non-gfx renderers, the `self.renderer.inner` access is pruned from analysis — so `StubRender`, test mocks, and any gfx `< v1.28.0` compile to a no-op with no `inner` field required. This mirrors the existing `render_target_mixin` structure exactly (import → `PostFxMixin = post_fx_mixin.Mixin(Self)` → `pub const` forwarders next to the render-target block).
- **Type re-exports (`src/root.zig`).** `PostPass` / `PostPassKind` / `PostPassUniforms` are re-exported from **labelle-core** (`core.backend_contract`), NOT from gfx. gfx re-exports these SAME core types, so surfacing them here keeps the core diamond unified — the engine takes **no** gfx module dependency (the renderer arrives at the game level via `RenderImpl`, injected by the assembler).
- **gfx pin (`build.zig.zon`).** Bumped the test-only lazy `labelle_gfx` pin `v1.26.0 → v1.28.0` (the version whose `GfxRenderer` exposes `GfxEngineType` + the retained façade methods). `labelle-core` stays a path dependency (unchanged).
- **Test (`test/post_fx_passthrough_test.zig`).** Asserts the re-export identity (`engine.PostPass == core.backend_contract.PostPass`, same for the other two), a `PostPass` literal round-trip through the engine surface, and slice-type compatibility with the `setPostFx([]const PostPass)` signature. Wired into `build.zig`'s `test_files`.

`zig build test` is green (exit 0), including the lazy tilemap tests under the bumped pin — no diamond/core-unification fallout.

## Release order

**Merge + release labelle-engine FIRST.** This PR carries the gfx `v1.28.0` pin that makes the `PostFxDriver` real. The companion assembler PR's codegen is forward-compat gated on `@hasDecl(AssembledGame, "setPostFx")`, so it can land independently — but the seeded `.post_fx` stack only goes live once a game builds against this engine version.

## Refs

- labelle-gfx#305
- RFC `RFC-MATERIAL-POSTFX.md` §2.5 (declaration + runtime)

https://claude.ai/code/session_017pW3ifKf9wgxNg4viy6okw