### PR TITLE
Plugin-command response channel — respond capability, out-buffer + fetch (contract v1.2, bridge v1.8)

### DIFF
--- a/contract/labelle_script.h
+++ b/contract/labelle_script.h
@@ -350,6 +350,15 @@ void labelle_input_mouse(float *x_out, float *y_out);
  * executes the handler again. On N > out_cap, read the stored response
  * via labelle_plugin_response_fetch instead; it never re-executes.
  *
+ * Calls may NEST: a handler may itself issue a labelle_plugin_call
+ * mid-dispatch (bounded only by the game's own recursion depth). Each
+ * call's response travels in per-call host storage — an inner call
+ * never corrupts the enclosing call's response — and each call
+ * publishes the fetch store as it COMPLETES, inner first, outer last,
+ * so a fetch made after the whole stack unwinds reads the OUTERMOST
+ * call's outcome. A handler that wants the inner response reads it
+ * from its own call's `out`, not from a later fetch.
+ *
  * The channel is a broadcast the handlers name-filter THEMSELVES, so
  * the host cannot tell an unknown plugin/command from a
  * delivered-and-ignored one: both return 0 wherever a handler exists.
@@ -360,17 +369,19 @@ size_t labelle_plugin_call(const char *plugin, size_t plugin_len,
                            const char *params_json, size_t params_len,
                            char *out, size_t out_cap);
 
-/* Read the response of the MOST RECENT labelle_plugin_call — the
- * side-effect-free half of the response channel (since v1.2): the
- * handler is NEVER re-executed, so the shared sizing convention's
+/* Read the response of the most recently COMPLETED labelle_plugin_call
+ * — the side-effect-free half of the response channel (since v1.2):
+ * the handler is NEVER re-executed, so the shared sizing convention's
  * probe/retry legs live here. NULL/cap-0 `out` is the pure sizing
  * probe; otherwise the write is ALL-OR-NOTHING and the return is the
  * bytes the complete response requires. 0 = nothing stored (no call
- * yet, or the last call was unroutable / produced no response). A
- * stored response is never empty, so a non-zero return cannot be
- * confused with nothing-stored. NON-consuming — fetch repeatedly; the
- * store is replaced (or cleared) by the next labelle_plugin_call,
- * whatever that call's outcome. */
+ * yet, or the last completed call was unroutable / produced no
+ * response). A stored response is never empty, so a non-zero return
+ * cannot be confused with nothing-stored. NON-consuming — fetch
+ * repeatedly; the store is replaced (or cleared) as each
+ * labelle_plugin_call COMPLETES, whatever that call's outcome —
+ * "completed" being the nesting rule above: after nested calls unwind,
+ * the store holds the OUTERMOST call's outcome. */
 size_t labelle_plugin_response_fetch(char *out, size_t out_cap);
 
 #ifdef __cplusplus

--- a/contract/labelle_script.h
+++ b/contract/labelle_script.h
@@ -51,6 +51,11 @@
  *     poll consumes its entry, truncation included; its sizing story
  *     is the paired NULL/cap-0 probe, which returns the NEXT entry's
  *     size without consuming — probe, grow, then poll.
+ *     labelle_plugin_call (v1.2) is required-size / all-or-nothing
+ *     like the get, but do not probe or cap-retry IT — a call executes
+ *     the plugin's handler again; its probe/retry legs live on the
+ *     paired, side-effect-free labelle_plugin_response_fetch (see the
+ *     plugin-commands section).
  *   - Main-thread only; calls are valid during the plugin's tick.
  *   - Before the host binds its game (once, at startup, before plugin
  *     setup), every call is a safe no-op following the same
@@ -74,8 +79,11 @@ extern "C" {
  * is probed per-symbol (embedded VMs bind against the running host,
  * which either exports it or doesn't; native plugins find out at link
  * time) — the editor-bridge contract's exact convention (its v1.1–v1.7
- * were all additive). This header describes contract v1.1 = v1 +
- * labelle_plugin_call (labelle-engine#744). */
+ * were all additive). This header describes contract v1.2:
+ *   v1.1 = v1 + labelle_plugin_call (labelle-engine#744);
+ *   v1.2 = v1.1 + plugin-call responses — out/out_cap activated per
+ *          their reserved semantics + labelle_plugin_response_fetch
+ *          (labelle-engine#758; probe for the fetch symbol). */
 #define LABELLE_CONTRACT_VERSION 1u
 
 /* Contract version the host binary was built with. Pure — callable
@@ -285,20 +293,28 @@ int32_t labelle_input_key_pressed(uint32_t key);
  * may be NULL to skip that axis. 0 on backends with no mouse. */
 void labelle_input_mouse(float *x_out, float *y_out);
 
-/* ── Plugin commands (since v1.1, labelle-engine#744) ─────────────────
+/* ── Plugin commands (since v1.1 #744; responses since v1.2 #758) ─────
  *
  * Call a named command on a Zig engine PLUGIN (e.g. pathfinder
  * "navigate") — the script-side entry to the same handler channel
- * labelle-studio's plugin panels use (the editor-bridge v1.7
- * editor_plugin_command export): a plugin registers ONE handler by
+ * labelle-studio's plugin panels use (the editor-bridge v1.7/v1.8
+ * editor_plugin_command exports): a plugin registers ONE handler by
  * subscribing to the `engine__editor_plugin_command` engine event, and
  * that single registration is reachable from studio panels AND every
- * scripting language alike. */
+ * scripting language alike.
+ *
+ * Since v1.2 a handler may RESPOND (engine.plugin_command.respond,
+ * called inside the synchronous dispatch; one response per command,
+ * first-writer-wins) and the caller receives it — either directly in
+ * the call's `out` buffer, or afterwards through the side-effect-free
+ * labelle_plugin_response_fetch. Responses are host-capped (currently
+ * 4096 bytes); the fetch probe returns exact per-response sizes, so no
+ * caller needs to hard-code the cap. */
 
 /* labelle_plugin_call's failure sentinel: the rc convention's -1
  * carried in its size_t return. Distinct from 0 = dispatched — and
- * from any future response-size return, which could never require the
- * whole address space. */
+ * from any response-size return, which could never require the whole
+ * address space. */
 #define LABELLE_PLUGIN_CALL_UNROUTABLE ((size_t)-1)
 
 /* Dispatch command `command` of plugin `plugin` with `params_json` as
@@ -309,31 +325,53 @@ void labelle_input_mouse(float *x_out, float *y_out);
  *
  * Return (size_t):
  *   0                               dispatched into the handler
- *                                   channel. v1.1 dispatch is
- *                                   fire-and-forward — handlers
- *                                   produce no return payload; results
- *                                   and acks arrive as game events
+ *                                   channel; no handler responded (the
+ *                                   v1.1 fire-and-forward outcome — a
+ *                                   v1.1-style caller passing NULL/0
+ *                                   observes the old contract
+ *                                   verbatim). Also the outcome for an
+ *                                   EMPTY response; handlers that want
+ *                                   a bare ack respond "{}". Results
+ *                                   can still arrive as game events
  *                                   (labelle_event_subscribe/poll).
+ *   N                               a handler responded (since v1.2);
+ *                                   the response requires N bytes and
+ *                                   was written into `out` only when
+ *                                   N <= out_cap (ALL-OR-NOTHING, like
+ *                                   labelle_component_get — otherwise
+ *                                   `out` is untouched).
  *   LABELLE_PLUGIN_CALL_UNROUTABLE  not routable: empty plugin/command
  *                                   name, no plugin registered a
  *                                   handler in this build, or the host
  *                                   is not bound.
  *
+ * DOUBLE-EXECUTION WARNING: unlike component_get, do not "retry
+ * right-sized" (or NULL/cap-0 probe) by calling AGAIN — every call
+ * executes the handler again. On N > out_cap, read the stored response
+ * via labelle_plugin_response_fetch instead; it never re-executes.
+ *
  * The channel is a broadcast the handlers name-filter THEMSELVES, so
  * the host cannot tell an unknown plugin/command from a
  * delivered-and-ignored one: both return 0 wherever a handler exists.
- * A caller that needs an acknowledgment listens for the plugin's
- * response event.
- *
- * `out`/`out_cap` are RESERVED for handler response payloads (a future
- * minor revision: the return becomes the bytes the response REQUIRES,
- * all-or-nothing like labelle_component_get, with 0 keeping its
- * dispatched-no-response meaning and the sentinel staying unroutable).
- * v1.1 never writes to `out`; pass NULL/0. */
+ * A caller that needs an acknowledgment asks the plugin to respond (or
+ * listens for its response event). */
 size_t labelle_plugin_call(const char *plugin, size_t plugin_len,
                            const char *command, size_t command_len,
                            const char *params_json, size_t params_len,
                            char *out, size_t out_cap);
+
+/* Read the response of the MOST RECENT labelle_plugin_call — the
+ * side-effect-free half of the response channel (since v1.2): the
+ * handler is NEVER re-executed, so the shared sizing convention's
+ * probe/retry legs live here. NULL/cap-0 `out` is the pure sizing
+ * probe; otherwise the write is ALL-OR-NOTHING and the return is the
+ * bytes the complete response requires. 0 = nothing stored (no call
+ * yet, or the last call was unroutable / produced no response). A
+ * stored response is never empty, so a non-zero return cannot be
+ * confused with nothing-stored. NON-consuming — fetch repeatedly; the
+ * store is replaced (or cleared) by the next labelle_plugin_call,
+ * whatever that call's outcome. */
+size_t labelle_plugin_response_fetch(char *out, size_t out_cap);
 
 #ifdef __cplusplus
 }

--- a/contract/labelle_script.h
+++ b/contract/labelle_script.h
@@ -326,13 +326,14 @@ void labelle_input_mouse(float *x_out, float *y_out);
  * Return (size_t):
  *   0                               dispatched into the handler
  *                                   channel; no handler responded (the
- *                                   v1.1 fire-and-forward outcome — a
- *                                   v1.1-style caller passing NULL/0
- *                                   observes the old contract
- *                                   verbatim). Also the outcome for an
- *                                   EMPTY response; handlers that want
- *                                   a bare ack respond "{}". Results
- *                                   can still arrive as game events
+ *                                   v1.1 fire-and-forward outcome).
+ *                                   Also the outcome for an EMPTY
+ *                                   response (handlers that want a
+ *                                   bare ack respond "{}"), and for
+ *                                   ANY dispatched call made in the
+ *                                   v1.1 NULL/0 shape — the compat
+ *                                   rule below. Results can still
+ *                                   arrive as game events
  *                                   (labelle_event_subscribe/poll).
  *   N                               a handler responded (since v1.2);
  *                                   the response requires N bytes and
@@ -344,6 +345,20 @@ void labelle_input_mouse(float *x_out, float *y_out);
  *                                   name, no plugin registered a
  *                                   handler in this build, or the host
  *                                   is not bound.
+ *
+ * V1.1-COMPAT RULE: a call with out == NULL and out_cap == 0 — the ONE
+ * shape the v1.1 header sanctioned ("v1.1 never writes to `out`; pass
+ * NULL/0") — keeps the exact v1.1 rc contract: it returns 0 for every
+ * dispatched call, EVEN when a handler responded, so a binding built
+ * against v1.1 that checks rc == 0 never misreads a successful
+ * responding dispatch as failure. The response is still stored: a
+ * caller without a buffer sizes/reads it via
+ * labelle_plugin_response_fetch (probe with NULL/0 THERE — never by
+ * re-calling here). The fold is exactly that shape and no wider:
+ * out != NULL with out_cap == 0 is the v1.2 sizing leg (N returned,
+ * nothing written), and NULL out with a nonzero cap — illegal per the
+ * conventions block (NULL only together with cap 0) — is tolerated as
+ * sizing too, matching labelle_component_get's NULL tolerance.
  *
  * DOUBLE-EXECUTION WARNING: unlike component_get, do not "retry
  * right-sized" (or NULL/cap-0 probe) by calling AGAIN — every call

--- a/src/editor_api.zig
+++ b/src/editor_api.zig
@@ -16,9 +16,11 @@
 //! they carry no comptime type information themselves.
 //!
 //! Before `bind` runs, every export is a safe no-op: `editor_scene_digest`
-//! writes `{}`, the i32-returning scene/state ops return -1, and the
+//! writes `{}`, the i32-returning scene/state ops return -1,
+//! `editor_plugin_command_out` returns its unroutable sentinel, and the
 //! void setters silently ignore. `editor_pause` / `editor_step` are pure
-//! editor-side state and work even before `bind`.
+//! editor-side state and work even before `bind`, as is
+//! `editor_plugin_response_cap` (a compile-time constant).
 //!
 //! ## No symbols in non-preview builds
 //!
@@ -54,6 +56,10 @@
 
 const std = @import("std");
 const core = @import("labelle-core");
+/// The plugin-command channel's shared pieces (#758): `max_response_len`
+/// is what `editor_plugin_response_cap` publishes (and what sizes the
+/// dispatch buffer in `pluginCommandOutImpl`).
+const plugin_command = @import("game/editor_command_mixin.zig");
 
 // ── Editor-local state (functional pre-bind) ────────────────────────
 
@@ -80,6 +86,9 @@ const VTable = struct {
     set_entity_position: *const fn (id: u64, x: f32, y: f32) void,
     set_component: *const fn (id: u64, name: []const u8, json: []const u8) i32,
     plugin_command: *const fn (plugin: []const u8, command: []const u8, params_json: []const u8) i32,
+    // v1.8 (#758): returns the export's wire value (sentinel / 0 /
+    // required size) and writes the response into `out` all-or-nothing.
+    plugin_command_out: *const fn (plugin: []const u8, command: []const u8, params_json: []const u8, out: []u8) usize,
     scene_digest: *const fn (out: []u8) usize,
     apply_camera: *const fn (x: f32, y: f32, zoom: f32) void,
 };
@@ -370,6 +379,68 @@ pub export fn editor_plugin_command(
     );
 }
 
+/// `editor_plugin_command_out`'s unroutable sentinel: the v1.7 rc's -1
+/// carried in the export's usize (C/JS: `(size_t)-1`; on wasm32 the
+/// bridge reads it as `0xFFFFFFFF`). Distinct from 0 = dispatched-no-
+/// response and from any response size, which is capped far below it.
+pub const plugin_command_unroutable: usize = std.math.maxInt(usize);
+
+/// `editor_plugin_command` with the response channel (editor-bridge
+/// contract **v1.8**, #758) — same dispatch, same payload, but a handler's
+/// response (written via `engine.plugin_command.respond` during the
+/// synchronous dispatch; one per command, first-writer-wins — see
+/// `game/editor_command_mixin.zig`) comes back to the studio. This is what
+/// the Script Console's eval round-trip rides (labelle-studio#78).
+///
+/// Returns (usize): `plugin_command_unroutable` = not bound / empty
+/// plugin/command / no plugin subscribed (v1.7's -1 legs, graceful
+/// degrade); 0 = dispatched, no handler responded (fire-and-forward — a
+/// handler responding EMPTY also reads as 0); N = a handler responded and
+/// the response requires N bytes, written into `out` ALL-OR-NOTHING (only
+/// when `N <= out_cap` — a truncated response payload is useless, the
+/// `editor_scene_digest` truncate-to-valid-JSON trick doesn't apply to
+/// opaque handler bytes).
+///
+/// Sizing: do NOT probe/retry this export — every call EXECUTES the
+/// handler again. Instead pre-size once: responses are hard-capped at
+/// `editor_plugin_response_cap()` bytes, so a studio that `editor_alloc`s
+/// that many can never overflow. (A NULL/cap-0 `out` is tolerated but is
+/// a dispatch-that-discards, not a probe.)
+///
+/// Optional on older builds, per the bridge's additive convention: a
+/// studio that finds no `editor_plugin_command_out` degrades to the v1.7
+/// dispatch-only export.
+pub export fn editor_plugin_command_out(
+    plugin_ptr: [*]const u8,
+    plugin_len: usize,
+    command_ptr: [*]const u8,
+    command_len: usize,
+    params_ptr: [*]const u8,
+    params_len: usize,
+    out: ?[*]u8,
+    out_cap: usize,
+) usize {
+    const vt = vtable orelse return plugin_command_unroutable;
+    const out_slice: []u8 = if (out) |p| p[0..out_cap] else &.{};
+    return vt.plugin_command_out(
+        plugin_ptr[0..plugin_len],
+        command_ptr[0..command_len],
+        params_ptr[0..params_len],
+        out_slice,
+    );
+}
+
+/// The plugin-command response size cap, in bytes (editor-bridge contract
+/// **v1.8**, #758). Pure — callable before `bind`. The studio allocates
+/// this many bytes once and passes them as `editor_plugin_command_out`'s
+/// `out`/`out_cap`; since every response is truncated to this cap at the
+/// WRITE side (the handler's `respond`), such a buffer can never see the
+/// all-or-nothing write refuse — the pre-sizing story that replaces
+/// probe/retry on an export that must not run twice.
+pub export fn editor_plugin_response_cap() usize {
+    return plugin_command.max_response_len;
+}
+
 /// v1: always -1 — the studio picks client-side from the scene digest.
 pub export fn editor_pick(x: f32, y: f32) i64 {
     _ = x;
@@ -469,6 +540,7 @@ fn Holder(comptime GP: type, comptime RP: type) type {
             .set_entity_position = &setEntityPositionImpl,
             .set_component = &setComponentImpl,
             .plugin_command = &pluginCommandImpl,
+            .plugin_command_out = &pluginCommandOutImpl,
             .scene_digest = &sceneDigestImpl,
             .apply_camera = &applyCameraImpl,
         };
@@ -623,6 +695,31 @@ fn Holder(comptime GP: type, comptime RP: type) type {
             // `game/editor_command_mixin.zig`.
             if (comptime !@hasDecl(G, "editorPluginCommand")) return -1;
             return game.editorPluginCommand(plugin, command, params_json);
+        }
+
+        /// The v1.8 response-aware dispatch (#758). The response lands in
+        /// an INTERMEDIATE cap-sized buffer, not straight in `out`:
+        /// dispatching into `out` would truncate an over-cap response at
+        /// `out.len` DURING the write, making the return equal `out.len` —
+        /// indistinguishable from an exact fit, a lying required-size. The
+        /// intermediate keeps the required size honest up to the channel
+        /// cap and gives `out` the all-or-nothing write the export
+        /// documents. (One extra memcpy on game-command scale — irrelevant,
+        /// same trade `stringifyInto`'s double serialization makes.)
+        fn pluginCommandOutImpl(plugin: []const u8, command: []const u8, params_json: []const u8, out: []u8) usize {
+            // Same duck-typed-stand-in belt as pluginCommandImpl.
+            if (comptime !@hasDecl(G, "editorPluginCommandOut")) return plugin_command_unroutable;
+            var buf: [plugin_command.max_response_len]u8 = undefined;
+            return switch (game.editorPluginCommandOut(plugin, command, params_json, &buf)) {
+                .unroutable => plugin_command_unroutable,
+                .dispatched => 0,
+                .responded => |r| blk: {
+                    // Never 0 bytes: the mixin folds empty responses to
+                    // `.dispatched`.
+                    if (r.bytes.len <= out.len) @memcpy(out[0..r.bytes.len], r.bytes);
+                    break :blk r.bytes.len;
+                },
+            };
         }
 
         fn applyCameraImpl(x: f32, y: f32, zoom: f32) void {

--- a/src/game.zig
+++ b/src/game.zig
@@ -962,6 +962,15 @@ pub fn GameConfigWithYAxis(
         /// declared handler. See `game/editor_command_mixin.zig`.
         pub const editorPluginCommand = EditorCommandMixin.editorPluginCommand;
 
+        /// Response-aware plugin-command dispatch (#758): same routing, plus
+        /// the caller receives the (at most one) response a handler wrote via
+        /// `engine.plugin_command.respond` during the synchronous dispatch.
+        /// Backs the `editor_plugin_command_out` bridge export (v1.8) and the
+        /// script contract's `labelle_plugin_call` out-buffer (v1.2). See
+        /// `game/editor_command_mixin.zig` for the channel's semantics
+        /// (first-writer-wins, bounded, empty-folds-to-dispatched).
+        pub const editorPluginCommandOut = EditorCommandMixin.editorPluginCommandOut;
+
         // ── Debug entity guards (#419, #420) ─────────────────────
 
         pub const recordTombstone = EntityMixin.recordTombstone;

--- a/src/game/editor_command_mixin.zig
+++ b/src/game/editor_command_mixin.zig
@@ -30,8 +30,188 @@
 //! for the handler with no copy, and the bridge can hand the studio a real
 //! result code. The trade-off (re-entrancy / buffered-event ordering) is
 //! irrelevant for this leaf, host-initiated action channel.
+//!
+//! ## The response channel (#758)
+//!
+//! v1.7 / contract v1.1 were deliberately fire-and-forward. Two consumers
+//! now want results back — the studio Script Console (labelle-studio#78,
+//! eval output) and script-language typed wrappers (RFC-LANGUAGE-PLUGINS
+//! rev 10 stretch) — so the dispatch grew a digest-style out-buffer: a
+//! handler may WRITE one response during the synchronous dispatch window
+//! and the caller receives it (`editorPluginCommandOut`; surfaced to C as
+//! `editor_plugin_command_out` (bridge v1.8) and the activated `out`/
+//! `out_cap` of `labelle_plugin_call` + `labelle_plugin_response_fetch`
+//! (script contract v1.2)).
+//!
+//! ### Why handlers respond through `respond()`, not a writer parameter
+//!
+//! Handlers are invoked by labelle-core's dispatchers (`HookDispatcher.emit`
+//! / `MergeHooks.emit`), whose call sites are fixed at exactly
+//! `handler(receiver, payload)` — a third response-writer parameter cannot
+//! reach a handler without a labelle-core change (a cross-repo release this
+//! additive engine feature must not gate on), and having the engine walk
+//! `hooks.receivers` itself to arity-dispatch would fork core's dispatch
+//! semantics (consumable ordering, receiver unwrapping) into a second
+//! implementation. Embedding a responder pointer in the event payload was
+//! also rejected: the assembler AST-folds `engine.Events` payload structs
+//! into each project's generated `PluginEvents`, so a new field only exists
+//! after an assembler release + project re-generation — every already-
+//! generated project would silently stay response-less. The module-scope
+//! `respond()` capability works with every existing project the day the
+//! engine ships, keeps handler signatures literally unchanged (the strongest
+//! form of "old handlers still compile"), and follows the module-state idiom
+//! of this C-ABI-adjacent layer (`script_contract`'s subs/inbox,
+//! `editor_api`'s pause/step). Single-threaded by design, like everything
+//! here: the window is set and torn down around one synchronous `emitSync`
+//! on the main thread.
+//!
+//! ### First-writer-wins (one response per broadcast)
+//!
+//! The channel is a BROADCAST that handlers name-filter themselves, so
+//! MULTIPLE handlers may receive one command — but only ONE response can
+//! return. The dispatch cannot attribute buffer writes to individual
+//! receivers (core's fan-out is opaque to it), so a per-handler appendable
+//! writer cannot be policed; instead `respond()` is SINGLE-SHOT: the first
+//! call claims the response (empty payload included), and every later call
+//! in the same window is refused with `false` + a `std.log.warn` — loud in
+//! dev, harmless in prod. A registry-of-responders (addressed, per-plugin
+//! response slots) is a deliberate non-goal for v1; commands are already
+//! conventionally addressed `<plugin>__<command>`, so collisions mean two
+//! plugins claimed the same name — a project bug worth a warning, not a
+//! protocol.
+//!
+//! ### Bounded, truncate-at-cap
+//!
+//! Responses are capped at `max_response_len` so they can cross the sized
+//! C surfaces with digest-style semantics and callers can PRE-SIZE buffers
+//! (the studio allocates `editor_plugin_response_cap()` bytes once and can
+//! then never overflow). A `respond`/`respondFmt` payload longer than the
+//! dispatch buffer is truncated at the cap and flagged
+//! (`Result.responded.truncated`) — all-or-nothing at the WRITE side would
+//! silently drop eval output entirely, while a flagged prefix is still
+//! useful console text.
 
 const std = @import("std");
+
+/// Response size cap, in bytes. The one number the whole channel is sized
+/// by: the mixin's dispatch buffer on the editor-bridge path, the script
+/// contract's response store, and the studio's `editor_plugin_response_cap()`
+/// pre-sizing export all quote it, so bumping it here re-sizes every
+/// consumer coherently. 4 KiB: generous for console/eval digests, trivial
+/// as a stack temporary (the wasm main thread's default stack is 64 KiB+).
+pub const max_response_len: usize = 4096;
+
+/// Outcome of a response-aware dispatch (`Game.editorPluginCommandOut`).
+pub const Result = union(enum) {
+    /// Not dispatched: empty plugin/command (most likely a host-side
+    /// length bug), or no plugin subscribed to
+    /// `engine__editor_plugin_command` in this build (the graceful-degrade
+    /// path). Maps to the v1.7 rc's -1 / the C sentinels.
+    unroutable,
+    /// Dispatched into the handler channel, no handler responded — the
+    /// fire-and-forward outcome (v1.7's only success shape). Also the
+    /// outcome when a handler responded EMPTY: an empty response is
+    /// indistinguishable from no response in the sized C returns (0 is
+    /// already "dispatched, no response"), so it is folded here once,
+    /// keeping every consumer consistent. Handlers wanting a bare ack
+    /// should respond `"{}"` (documented in `contract/labelle_script.h`).
+    dispatched,
+    /// A handler responded. `bytes` is the response, a slice of the
+    /// CALLER's `out` buffer (valid exactly as long as that buffer);
+    /// `truncated` is set when the handler wrote more than `out` could
+    /// hold (the response was cut at `out.len`).
+    responded: Response,
+
+    pub const Response = struct {
+        bytes: []u8,
+        truncated: bool,
+    };
+};
+
+/// The active dispatch window's response accumulator. `buf` is the
+/// dispatching caller's storage; `claimed` is the first-writer-wins latch.
+const Slot = struct {
+    buf: []u8,
+    len: usize = 0,
+    claimed: bool = false,
+    truncated: bool = false,
+};
+
+/// The dispatch window: non-null exactly while `editorPluginCommandOut` is
+/// inside its `emitSync`. Module-scope (not per-Game) because `respond` is
+/// a free function handlers can call without a game pointer; single-
+/// threaded by design (main-thread dispatch, same justification as
+/// `script_contract`'s module state). Saved/restored around the dispatch,
+/// so a handler that itself issues a nested `editorPluginCommand*` gives
+/// the inner dispatch its own window and the outer one resumes intact.
+var active_slot: ?*Slot = null;
+
+/// Respond to the plugin command currently being dispatched — callable
+/// from inside an `engine__editor_plugin_command` handler only (the
+/// synchronous dispatch window). SINGLE-SHOT, first-writer-wins: the first
+/// respond in a window claims the response (see the module doc for why a
+/// per-handler appendable writer is not policeable on a broadcast); later
+/// calls — same handler or another receiver — are refused.
+///
+/// `bytes` is copied immediately (the handler may pass a stack buffer);
+/// payloads longer than the window's buffer are truncated at its length
+/// (at most `max_response_len`, less when the caller is fire-and-forward —
+/// the v1.7 `editor_plugin_command` export dispatches with a zero-length
+/// buffer, so responses to it are silently discarded, by design).
+///
+/// Returns `true` when this call claimed the response; `false` when
+/// refused (already claimed, or no dispatch window is active). Handlers
+/// may ignore the return — the refusal legs also `std.log.warn`, which is
+/// the debug-visible signal for the two-responders project bug.
+pub fn respond(bytes: []const u8) bool {
+    const slot = claimSlot() orelse return false;
+    const n = @min(bytes.len, slot.buf.len);
+    @memcpy(slot.buf[0..n], bytes[0..n]);
+    slot.len = n;
+    slot.truncated = n < bytes.len;
+    return true;
+}
+
+/// `respond` with `std.fmt` formatting straight into the response buffer —
+/// the print-flavored convenience so handlers don't hand-roll a bufPrint.
+/// Same single-shot claim semantics; output longer than the window's
+/// buffer is truncated at its length and flagged.
+pub fn respondFmt(comptime fmt: []const u8, args: anytype) bool {
+    const slot = claimSlot() orelse return false;
+    var w = std.Io.Writer.fixed(slot.buf);
+    w.print(fmt, args) catch {
+        // Fixed writer: the buffer prefix up to `end` is written, the
+        // rest didn't fit — the documented truncate-at-cap outcome.
+        slot.len = w.end;
+        slot.truncated = true;
+        return true;
+    };
+    slot.len = w.end;
+    slot.truncated = false;
+    return true;
+}
+
+/// The shared claim gate for `respond`/`respondFmt`: latches
+/// first-writer-wins and warns on the two refusal legs.
+fn claimSlot() ?*Slot {
+    const slot = active_slot orelse {
+        std.log.warn(
+            "plugin_command.respond called outside a command dispatch window; ignored",
+            .{},
+        );
+        return null;
+    };
+    if (slot.claimed) {
+        std.log.warn(
+            "plugin_command.respond: a handler already responded to this command; " ++
+                "second response ignored (first-writer-wins)",
+            .{},
+        );
+        return null;
+    }
+    slot.claimed = true;
+    return slot;
+}
 
 /// Returns the editor-command mixin for a given Game type.
 pub fn Mixin(comptime Game: type) type {
@@ -65,14 +245,62 @@ pub fn Mixin(comptime Game: type) type {
         /// subscribed to `engine__editor_plugin_command` (the graceful-degrade
         /// path). The handler's own success/failure is out of band — a
         /// play-time action is fire-and-forward, like an input event.
+        ///
+        /// This is the v1.7-shaped rc entry, now sugar over
+        /// `editorPluginCommandOut` with a zero-length response buffer: the
+        /// dispatch WINDOW still exists (so a responding handler driven
+        /// through this legacy path never trips the outside-window warn —
+        /// its response is just truncated to nothing and discarded), and the
+        /// rc semantics are bit-identical to v1.7.
         pub fn editorPluginCommand(
             self: *Game,
             plugin: []const u8,
             command: []const u8,
             params_json: []const u8,
         ) i32 {
-            if (plugin.len == 0 or command.len == 0) return -1;
-            if (comptime !has_channel) return -1;
+            var none: [0]u8 = .{};
+            return switch (editorPluginCommandOut(self, plugin, command, params_json, &none)) {
+                .unroutable => -1,
+                .dispatched, .responded => 0,
+            };
+        }
+
+        /// Response-aware dispatch (#758): route the command exactly like
+        /// `editorPluginCommand` AND collect the (at most one) response a
+        /// handler wrote via `plugin_command.respond`/`respondFmt` during
+        /// the synchronous dispatch. `out` is the caller's response
+        /// storage; `Result.responded.bytes` is a slice of it, so it stays
+        /// valid as long as `out` does. Handlers see the response cap as
+        /// `out.len` — bridge/contract callers pass `max_response_len`-
+        /// sized storage so the whole channel agrees on one cap.
+        ///
+        /// An empty response (a handler `respond("")`) folds to
+        /// `.dispatched`: the sized C returns can't distinguish it from
+        /// no-response (0 already means dispatched-no-response), so the
+        /// fold happens here, once, for every consumer.
+        ///
+        /// Zero-cost rule: for a game with no handler channel this returns
+        /// `.unroutable` before any window/slot state is touched — the
+        /// whole response machinery is reached only from the comptime-live
+        /// branch, exactly like the v1.7 path folded away.
+        pub fn editorPluginCommandOut(
+            self: *Game,
+            plugin: []const u8,
+            command: []const u8,
+            params_json: []const u8,
+            out: []u8,
+        ) Result {
+            // Same leg order as v1.7 pinned: empties are refused even in
+            // handler-less builds.
+            if (plugin.len == 0 or command.len == 0) return .unroutable;
+            if (comptime !has_channel) return .unroutable;
+            var slot: Slot = .{ .buf = out };
+            // Save/restore rather than set/clear: a handler that itself
+            // dispatches a nested plugin command must not tear down THIS
+            // window when the inner dispatch returns.
+            const prev = active_slot;
+            active_slot = &slot;
+            defer active_slot = prev;
             // Synchronous dispatch so studio-owned buffers stay valid and the
             // handler runs before we return. The payload type is the merged
             // union's declared shape (`engine.Events.editor_plugin_command`);
@@ -83,7 +311,11 @@ pub fn Mixin(comptime Game: type) type {
                 .command = command,
                 .params = params_json,
             }));
-            return 0;
+            if (!slot.claimed or slot.len == 0) return .dispatched;
+            return .{ .responded = .{
+                .bytes = out[0..slot.len],
+                .truncated = slot.truncated,
+            } };
         }
     };
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -566,6 +566,15 @@ pub const Events = struct {
     /// `command`, and `params` the field values as a JSON object. All three
     /// are borrowed from the studio's wasm buffers for the SYNCHRONOUS
     /// dispatch only — a handler that retains them must copy.
+    ///
+    /// A handler may RESPOND to the command it is handling (#758) by calling
+    /// `engine.plugin_command.respond(bytes)` (or `.respondFmt`) inside the
+    /// dispatch — the response travels back to the caller (studio bridge
+    /// v1.8 / script contract v1.2). One response per command,
+    /// first-writer-wins; see `game/editor_command_mixin.zig`. The field
+    /// set here is deliberately unchanged: the respond seam is a module
+    /// function, not a payload member, so already-generated projects (whose
+    /// assembler folded this struct before #758) can respond too.
     pub const editor_plugin_command = struct {
         plugin: []const u8,
         command: []const u8,
@@ -762,6 +771,18 @@ pub const editor_api = @import("editor_api.zig");
 // the file, so script-less builds emit no `labelle_*` symbols — the
 // same zero-cost gate as `editor_api` above.
 pub const script_contract = @import("script_contract.zig");
+
+// ── Plugin-command response channel (#758) ──
+// The handler-side seam of the plugin-command channel: a subscriber to
+// `engine__editor_plugin_command` calls `engine.plugin_command.respond`
+// (or `.respondFmt`) inside the synchronous dispatch to send a response
+// back to whoever issued the command — the studio's
+// `editor_plugin_command_out` (bridge v1.8) or a script's
+// `labelle_plugin_call`/`labelle_plugin_response_fetch` (contract v1.2).
+// Also home to the channel's shared constants (`max_response_len`) and
+// the dispatch `Result` type. The dispatch itself is the Game mixin
+// (`game.editorPluginCommandOut`); this namespace is what HANDLERS import.
+pub const plugin_command = @import("game/editor_command_mixin.zig");
 
 // ── Out-of-band screenshot request (labelle-cli#227) ──
 // Read by the assembler-generated `main.zig`'s frame loop after the

--- a/src/script_contract.zig
+++ b/src/script_contract.zig
@@ -24,7 +24,8 @@
 //! (incl. `labelle_entity_find`) return 0, rc-returning ops return -1
 //! (`labelle_plugin_call` its unroutable sentinel — the same -1, carried
 //! in its usize), `labelle_component_get` / `labelle_query` /
-//! `labelle_event_poll` write nothing and return 0, the void ops
+//! `labelle_event_poll` / `labelle_plugin_response_fetch` write nothing
+//! and return 0, the void ops
 //! silently ignore, the `labelle_input_key_*` reads report not-down (0),
 //! and `labelle_input_mouse` writes the origin.
 //! `labelle_contract_version` is pure and works even before `bind`.
@@ -124,6 +125,11 @@
 //! could not be retried; its sizing story is the paired NULL/cap-0
 //! probe instead — the NEXT entry's size, nothing read or consumed —
 //! so a sizing caller probes, grows its buffer, then polls.
+//! `labelle_plugin_call` (v1.2) is required-size / all-or-nothing
+//! like the get, but its probe/retry legs live on the PAIRED
+//! `labelle_plugin_response_fetch`: a call EXECUTES the handler, so
+//! re-calling to resize would double-execute (see "Plugin commands"
+//! below).
 //!
 //! ## Component name space (registry + scene built-ins)
 //!
@@ -143,7 +149,7 @@
 //! per-name `get` caveats (renderer-handle fields are omitted; `Camera`
 //! serializes `tag` as a string).
 //!
-//! ## Plugin commands (`labelle_plugin_call`, contract v1.1, #744)
+//! ## Plugin commands (`labelle_plugin_call`, contract v1.1 #744 / v1.2 #758)
 //!
 //! Scripts call Zig PLUGIN commands (pathfinder navigate, dungeon
 //! generate, …) through the SAME handler channel labelle-studio's
@@ -157,20 +163,38 @@
 //! after the handler ran, so the script's transient buffers stay valid
 //! with no copy).
 //!
-//! The mixin is fire-and-forward — handlers produce no return payload
-//! — so the export's usize return is an rc, not a size: 0 = dispatched
-//! into the channel; `plugin_call_unroutable` (`maxInt(usize)`, C's
-//! `(size_t)-1` — the rc convention's -1 in a usize) = empty
-//! plugin/command, no handler registered in this build (the variant
-//! never landed on the merged `GameEvents`), or not bound. The channel
-//! is a broadcast that handlers name-filter THEMSELVES, so the engine
-//! cannot tell an unknown plugin/command from a delivered-and-ignored
-//! one: both dispatch as 0 wherever a handler exists. Results and acks
-//! travel back as game events — the subscribe/poll tap above.
-//! `out`/`out_cap` are reserved for a future response payload
-//! (required-size return, all-or-nothing write, `component_get`-style;
-//! 0 would keep meaning dispatched-no-response and the sentinel
-//! unroutable) and are never written in v1.1.
+//! The usize return keeps the v1.1 rc encoding and grows a size leg:
+//! `plugin_call_unroutable` (`maxInt(usize)`, C's `(size_t)-1` — the rc
+//! convention's -1 in a usize) = empty plugin/command, no handler
+//! registered in this build (the variant never landed on the merged
+//! `GameEvents`), or not bound; 0 = dispatched, no handler responded
+//! (the v1.1 fire-and-forward outcome — a v1.1 caller passing NULL/0
+//! observes exactly the old contract); N = a handler RESPONDED (v1.2,
+//! #758: `engine.plugin_command.respond` during the synchronous
+//! dispatch — one response per command, first-writer-wins, see the
+//! mixin), and N is the bytes the response requires, written into
+//! `out` all-or-nothing (`component_get`-style, exactly as v1.1
+//! reserved). The channel is a broadcast that handlers name-filter
+//! THEMSELVES, so the engine cannot tell an unknown plugin/command
+//! from a delivered-and-ignored one: both dispatch as 0 wherever a
+//! handler exists. Multi-event results and acks can still travel back
+//! as game events — the subscribe/poll tap above.
+//!
+//! ### Why responses have a paired fetch (`labelle_plugin_response_fetch`)
+//!
+//! The shared sizing convention's "retry right-sized" leg is WRONG on
+//! `labelle_plugin_call` alone: a call EXECUTES the handler, so
+//! retrying an over-cap response (or NULL/0 sizing-probing it) would
+//! run the command twice — unacceptable for non-idempotent commands.
+//! So every responded call also STORES the response (module state,
+//! capped at `plugin_command.max_response_len`), and
+//! `labelle_plugin_response_fetch` reads the MOST RECENT call's
+//! response with the full sizing semantics and ZERO side effects:
+//! NULL/cap-0 probe, required-size return, all-or-nothing write,
+//! repeatable (non-consuming — the store is replaced/cleared by the
+//! next `labelle_plugin_call`, whatever its outcome, and on unbind).
+//! This mirrors `labelle_event_poll`'s no-consume probe precedent: the
+//! side-effecting op stays single-shot, the sizing/read op is free.
 //!
 //! Single-threaded by design (main thread, during the plugin's tick);
 //! no atomics.
@@ -179,6 +203,10 @@ const std = @import("std");
 const core = @import("labelle-core");
 const jsonc = @import("jsonc");
 const component_apply = @import("jsonc/component_apply.zig");
+/// The plugin-command channel's shared pieces (#758): `max_response_len`
+/// sizes the response store below, and the mixin `Result` is what
+/// `editorPluginCommandOut` hands back through the vtable impl.
+const plugin_command = @import("game/editor_command_mixin.zig");
 
 /// Contract version consumers compile against — bumped on BREAKING ABI
 /// or semantic changes only. Language plugins check it via
@@ -188,7 +216,9 @@ const component_apply = @import("jsonc/component_apply.zig");
 /// "since v1.x" in `contract/labelle_script.h` and detected by probing
 /// for the symbol — the editor-bridge contract's exact convention
 /// (v1.1–v1.7). Current surface: v1.1 = v1 + `labelle_plugin_call`
-/// (#744).
+/// (#744); v1.2 = v1.1 + plugin-call responses — `out`/`out_cap`
+/// activated per their reserved semantics + `labelle_plugin_response_fetch`
+/// (#758).
 pub const CONTRACT_VERSION: u32 = 1;
 
 /// `labelle_plugin_call`'s unroutable sentinel: the rc convention's -1
@@ -248,6 +278,17 @@ var stamped_dt: ?f32 = null;
 /// at every `drainEvents`.
 var emit_arenas: [2]?std.heap.ArenaAllocator = .{ null, null };
 var emit_active: u1 = 0;
+/// The MOST RECENT `labelle_plugin_call`'s handler response (#758) —
+/// what `labelle_plugin_response_fetch` reads. A static buffer, not an
+/// allocation: the channel is capped at `plugin_command.max_response_len`
+/// by design, the store only exists in binaries that reference this
+/// module at all (the script-less zero-cost gate), and a static store
+/// removes the free-on-unbind/replace bug class entirely. `null` len =
+/// no stored response (pre-bind, never called, last call unroutable or
+/// fire-and-forward). Replaced/cleared on EVERY `labelle_plugin_call`
+/// entry — the fetch's "most recent call" contract — and on unbind.
+var response_store: [plugin_command.max_response_len]u8 = undefined;
+var response_len: ?usize = null;
 
 // ── Type-erased dispatch ────────────────────────────────────────────
 
@@ -268,7 +309,11 @@ const VTable = struct {
     input_key_down: *const fn (key: u32) bool,
     input_key_pressed: *const fn (key: u32) bool,
     input_mouse: *const fn () core.Position,
-    plugin_call: *const fn (plugin: []const u8, command: []const u8, params_json: []const u8) i32,
+    // Returns the export's wire value directly: `plugin_call_unroutable`,
+    // 0 (dispatched, no response), or the response's required size — the
+    // impl also deposits responded bytes into `response_store` (same
+    // module, so the plain fn ptr needs no out-slice threading).
+    plugin_call: *const fn (plugin: []const u8, command: []const u8, params_json: []const u8) usize,
 };
 
 // ── Generated-main API (non-export) ─────────────────────────────────
@@ -326,6 +371,10 @@ pub fn unbind() void {
     emit_active = 0;
     stamped_dt = null;
     bound_allocator = null;
+    // The stored plugin-call response belongs to the session too — a
+    // fetch after unbind (or across a re-bind) must not read a previous
+    // game's response.
+    response_len = null;
 }
 
 /// Per-frame event tap, called by the generated main AFTER `g.tick(dt)`
@@ -773,11 +822,11 @@ pub export fn labelle_input_mouse(x_out: ?*f32, y_out: ?*f32) void {
     if (y_out) |p| p.* = pos.y;
 }
 
-// ── Plugin commands (contract v1.1, #744) ───────────────────────────
+// ── Plugin commands (contract v1.1 #744 / v1.2 responses #758) ──────
 
 /// Call a named command on a Zig engine PLUGIN — the script-side entry
 /// to the handler channel labelle-studio's panels reach through
-/// `editor_plugin_command` (editor-bridge v1.7): the game's
+/// `editor_plugin_command` (editor-bridge v1.7/v1.8): the game's
 /// `editorPluginCommand` mixin `emitSync`s `engine__editor_plugin_command`
 /// to the handler the plugin registered by subscribing to that event,
 /// so ONE registration serves studio panels and every scripting
@@ -786,19 +835,28 @@ pub export fn labelle_input_mouse(x_out: ?*f32, y_out: ?*f32) void {
 /// is SYNCHRONOUS — the handler has run by the time this returns — and
 /// all three strings are borrowed for the call only.
 ///
-/// Fire-and-forward v1.1 rc, carried in the usize return: 0 =
-/// dispatched into the handler channel; `plugin_call_unroutable`
-/// (`maxInt(usize)`, C's `(size_t)-1`) = unroutable — empty
-/// plugin/command, no handler registered in this build, a game shape
-/// without the mixin, or not bound. Handlers name-filter the broadcast
-/// themselves, so a name no plugin claims still returns 0 wherever a
-/// handler exists — dispatched-and-ignored is indistinguishable from
-/// handled BY DESIGN; responses and acks arrive as game events through
-/// the subscribe/poll tap. `out`/`out_cap` are RESERVED for handler
-/// response payloads (a future minor revision: required-size return
-/// with `labelle_component_get`'s all-or-nothing write; 0 keeps its
-/// dispatched-no-response meaning, the sentinel stays unroutable);
-/// v1.1 never writes them — pass NULL/0.
+/// usize return (v1.2 activates the semantics v1.1 reserved):
+/// `plugin_call_unroutable` (`maxInt(usize)`, C's `(size_t)-1`) =
+/// unroutable — empty plugin/command, no handler registered in this
+/// build, a game shape without the mixin, or not bound; 0 = dispatched
+/// into the handler channel, no handler responded (fire-and-forward — a
+/// v1.1 caller passing NULL/0 observes the old contract verbatim); N =
+/// a handler responded via `engine.plugin_command.respond` and the
+/// response requires N bytes, written into `out` ALL-OR-NOTHING (only
+/// when `N <= out_cap`, `labelle_component_get`-style — a truncated
+/// response is useless). Handlers name-filter the broadcast themselves,
+/// so a name no plugin claims still returns 0 wherever a handler exists
+/// — dispatched-and-ignored is indistinguishable from
+/// handled-without-response BY DESIGN.
+///
+/// Do NOT sizing-probe or cap-retry THIS export: every call executes
+/// the handler again. The response is also stored (until the next
+/// `labelle_plugin_call`, whatever its outcome) — retry/probe through
+/// `labelle_plugin_response_fetch`, which is side-effect-free. An empty
+/// response reads as 0 (no response); handlers ack with `"{}"`.
+/// Responses are host-capped at 4096 bytes (`plugin_command
+/// .max_response_len`); a caller passing a buffer of that size never
+/// needs the fetch.
 pub export fn labelle_plugin_call(
     plugin_ptr: [*]const u8,
     plugin_len: usize,
@@ -809,18 +867,46 @@ pub export fn labelle_plugin_call(
     out: ?[*]u8,
     out_cap: usize,
 ) usize {
-    // Reserved for handler responses (see the doc above) — v1.1 never
-    // writes them.
-    _ = out;
-    _ = out_cap;
+    // "Fetch reads the MOST RECENT call": the previous response dies on
+    // every entry, even the failure legs — a fetch after an unroutable
+    // or response-less call must find nothing, never stale bytes.
+    response_len = null;
     const vt = vtable orelse return plugin_call_unroutable;
     if (plugin_len == 0 or command_len == 0) return plugin_call_unroutable;
-    const rc = vt.plugin_call(
+    const n = vt.plugin_call(
         plugin_ptr[0..plugin_len],
         command_ptr[0..command_len],
         optionalJson(params_ptr, params_len, "{}"),
     );
-    return if (rc == 0) 0 else plugin_call_unroutable;
+    if (n == 0 or n == plugin_call_unroutable) return n;
+    // Responded: the impl deposited the bytes in `response_store` (and
+    // set `response_len = n`). All-or-nothing into the caller's buffer.
+    if (out) |p| {
+        if (n <= out_cap) @memcpy(p[0..n], response_store[0..n]);
+    }
+    return n;
+}
+
+/// Read the response of the MOST RECENT `labelle_plugin_call` — the
+/// side-effect-free half of the response channel (since v1.2, #758):
+/// the handler is NEVER re-executed, so this is where the shared sizing
+/// convention's probe/retry legs live. NULL or zero-capacity `out` is
+/// the pure sizing probe; otherwise the write is ALL-OR-NOTHING
+/// (`labelle_component_get`-style) and the return is the bytes the
+/// complete response requires. 0 = nothing stored: no call yet, the
+/// last call was unroutable or fire-and-forward (no handler responded,
+/// or it responded empty), or not bound. NON-consuming — fetch as many
+/// times as needed; the store is replaced/cleared by the next
+/// `labelle_plugin_call` and on unbind.
+pub export fn labelle_plugin_response_fetch(out: ?[*]u8, out_cap: usize) usize {
+    const n = response_len orelse return 0;
+    // The mixin folds empty responses to dispatched-no-response, so a
+    // stored response is never empty and a non-zero return can't be
+    // confused with "nothing stored" (the event_poll probe's argument).
+    const p = out orelse return n;
+    if (out_cap == 0) return n;
+    if (n <= out_cap) @memcpy(p[0..n], response_store[0..n]);
+    return n;
 }
 
 // ── Implementation ──────────────────────────────────────────────────
@@ -1502,19 +1588,36 @@ fn Holder(comptime GP: type) type {
 
         // ── Plugin commands ──────────────────────────────────────
 
-        /// Straight through the game's `editorPluginCommand` mixin —
-        /// the very dispatch the `editor_plugin_command` bridge export
-        /// uses, NOT a reimplementation: the routing/handler-channel
-        /// decision lives in `game/editor_command_mixin.zig` alone.
-        /// Every GameConfig-built Game carries the decl; the `@hasDecl`
-        /// belt keeps a minimal duck-typed stand-in compiling (it
-        /// degrades to the unroutable -1) — the same belt editor_api's
-        /// pluginCommandImpl wears. A game whose merged `GameEvents`
-        /// never consumed `engine__editor_plugin_command` folds to -1
-        /// INSIDE the mixin (the zero-cost no-handler gate).
-        fn pluginCallImpl(plugin: []const u8, command: []const u8, params_json: []const u8) i32 {
-            if (comptime !@hasDecl(G, "editorPluginCommand")) return -1;
-            return game.editorPluginCommand(plugin, command, params_json);
+        /// Straight through the game's `editorPluginCommandOut` mixin —
+        /// the very dispatch the `editor_plugin_command*` bridge exports
+        /// use, NOT a reimplementation: the routing/handler-channel/
+        /// response decisions live in `game/editor_command_mixin.zig`
+        /// alone. Every GameConfig-built Game carries the decl; the
+        /// `@hasDecl` belt keeps a minimal duck-typed stand-in compiling
+        /// (it degrades to unroutable) — the same belt editor_api's
+        /// impls wear. A game whose merged `GameEvents` never consumed
+        /// `engine__editor_plugin_command` folds to unroutable INSIDE
+        /// the mixin (the zero-cost no-handler gate).
+        ///
+        /// The dispatch writes any response STRAIGHT into the module's
+        /// `response_store` (same file — no out-slice threading through
+        /// the plain fn ptr) and records its length for
+        /// `labelle_plugin_response_fetch`; the return is already the
+        /// export's wire value (sentinel / 0 / required size).
+        fn pluginCallImpl(plugin: []const u8, command: []const u8, params_json: []const u8) usize {
+            if (comptime !@hasDecl(G, "editorPluginCommandOut")) return plugin_call_unroutable;
+            return switch (game.editorPluginCommandOut(plugin, command, params_json, &response_store)) {
+                .unroutable => plugin_call_unroutable,
+                .dispatched => 0,
+                .responded => |r| blk: {
+                    // `r.bytes` aliases `response_store` (we passed it as
+                    // the out buffer) — only the length needs recording.
+                    // Never 0: the mixin folds empty responses to
+                    // `.dispatched`.
+                    response_len = r.bytes.len;
+                    break :blk r.bytes.len;
+                },
+            };
         }
 
         // ── Helpers ──────────────────────────────────────────────

--- a/src/script_contract.zig
+++ b/src/script_contract.zig
@@ -188,13 +188,23 @@
 //! run the command twice — unacceptable for non-idempotent commands.
 //! So every responded call also STORES the response (module state,
 //! capped at `plugin_command.max_response_len`), and
-//! `labelle_plugin_response_fetch` reads the MOST RECENT call's
-//! response with the full sizing semantics and ZERO side effects:
-//! NULL/cap-0 probe, required-size return, all-or-nothing write,
-//! repeatable (non-consuming — the store is replaced/cleared by the
-//! next `labelle_plugin_call`, whatever its outcome, and on unbind).
-//! This mirrors `labelle_event_poll`'s no-consume probe precedent: the
+//! `labelle_plugin_response_fetch` reads the most recently COMPLETED
+//! call's response with the full sizing semantics and ZERO side
+//! effects: NULL/cap-0 probe, required-size return, all-or-nothing
+//! write, repeatable (non-consuming — the store is replaced/cleared as
+//! each `labelle_plugin_call` COMPLETES, and on unbind). This mirrors
+//! `labelle_event_poll`'s no-consume probe precedent: the
 //! side-effecting op stays single-shot, the sizing/read op is free.
+//!
+//! Calls NEST: a handler may itself issue a `labelle_plugin_call`
+//! (the mixin gives the inner dispatch its own response window). Each
+//! call dispatches into PER-CALL stack storage and publishes the
+//! module store only at its own completion — inner first, outer last —
+//! so concurrent in-flight responses never share bytes, and a fetch
+//! made after the stack unwinds reads the OUTERMOST call's outcome
+//! (the handler already received the inner response in its own call's
+//! `out` buffer). Publish-on-completion is what keeps both fetch
+//! semantics and response integrity honest under recursion.
 //!
 //! Single-threaded by design (main thread, during the plugin's tick);
 //! no atomics.
@@ -278,15 +288,23 @@ var stamped_dt: ?f32 = null;
 /// at every `drainEvents`.
 var emit_arenas: [2]?std.heap.ArenaAllocator = .{ null, null };
 var emit_active: u1 = 0;
-/// The MOST RECENT `labelle_plugin_call`'s handler response (#758) —
-/// what `labelle_plugin_response_fetch` reads. A static buffer, not an
-/// allocation: the channel is capped at `plugin_command.max_response_len`
-/// by design, the store only exists in binaries that reference this
-/// module at all (the script-less zero-cost gate), and a static store
-/// removes the free-on-unbind/replace bug class entirely. `null` len =
-/// no stored response (pre-bind, never called, last call unroutable or
-/// fire-and-forward). Replaced/cleared on EVERY `labelle_plugin_call`
-/// entry — the fetch's "most recent call" contract — and on unbind.
+/// The most recently COMPLETED `labelle_plugin_call`'s handler response
+/// (#758) — what `labelle_plugin_response_fetch` reads. A static
+/// buffer, not an allocation: the channel is capped at
+/// `plugin_command.max_response_len` by design, the store only exists
+/// in binaries that reference this module at all (the script-less
+/// zero-cost gate), and a static store removes the
+/// free-on-unbind/replace bug class entirely. `null` len = no stored
+/// response (pre-bind, never called, last completed call unroutable or
+/// fire-and-forward).
+///
+/// PUBLISH-ON-COMPLETION discipline: this is never the live dispatch
+/// target — each `labelle_plugin_call` dispatches into its own stack
+/// buffer and copies/clears here only as it COMPLETES (`pluginCallImpl`),
+/// plus an entry-clear in the export for the pre-dispatch failure legs.
+/// Nested calls (a handler calling `labelle_plugin_call`) therefore
+/// can't corrupt an in-flight outer response, and the store settles on
+/// the OUTERMOST call's outcome. Cleared on unbind.
 var response_store: [plugin_command.max_response_len]u8 = undefined;
 var response_len: ?usize = null;
 
@@ -850,13 +868,17 @@ pub export fn labelle_input_mouse(x_out: ?*f32, y_out: ?*f32) void {
 /// handled-without-response BY DESIGN.
 ///
 /// Do NOT sizing-probe or cap-retry THIS export: every call executes
-/// the handler again. The response is also stored (until the next
-/// `labelle_plugin_call`, whatever its outcome) — retry/probe through
-/// `labelle_plugin_response_fetch`, which is side-effect-free. An empty
-/// response reads as 0 (no response); handlers ack with `"{}"`.
-/// Responses are host-capped at 4096 bytes (`plugin_command
-/// .max_response_len`); a caller passing a buffer of that size never
-/// needs the fetch.
+/// the handler again. The response is also stored as the call
+/// COMPLETES — retry/probe through `labelle_plugin_response_fetch`,
+/// which is side-effect-free. Calls may NEST (a handler issuing its own
+/// `labelle_plugin_call` mid-dispatch): each call's response travels in
+/// per-call storage (no cross-talk with the enclosing call's `out`),
+/// and each publishes the store at its own completion — inner first,
+/// outer last — so a fetch afterwards reads the OUTERMOST call's
+/// outcome. An empty response reads as 0 (no response); handlers ack
+/// with `"{}"`. Responses are host-capped at 4096 bytes
+/// (`plugin_command.max_response_len`); a caller passing a buffer of
+/// that size never needs the fetch.
 pub export fn labelle_plugin_call(
     plugin_ptr: [*]const u8,
     plugin_len: usize,
@@ -867,9 +889,14 @@ pub export fn labelle_plugin_call(
     out: ?[*]u8,
     out_cap: usize,
 ) usize {
-    // "Fetch reads the MOST RECENT call": the previous response dies on
-    // every entry, even the failure legs — a fetch after an unroutable
-    // or response-less call must find nothing, never stale bytes.
+    // Cover the PRE-DISPATCH failure legs (not bound / empty names):
+    // they complete this call too, so the previous response dies here —
+    // a fetch through them must find nothing, never stale bytes.
+    // Dispatched calls don't rely on this clear: `pluginCallImpl`
+    // PUBLISHES the store at completion on every outcome (see its doc
+    // for the nested-call rationale) — which is what makes fetch's
+    // "most recently COMPLETED call" contract hold even when a handler
+    // issues its own labelle_plugin_call mid-dispatch.
     response_len = null;
     const vt = vtable orelse return plugin_call_unroutable;
     if (plugin_len == 0 or command_len == 0) return plugin_call_unroutable;
@@ -887,17 +914,23 @@ pub export fn labelle_plugin_call(
     return n;
 }
 
-/// Read the response of the MOST RECENT `labelle_plugin_call` — the
-/// side-effect-free half of the response channel (since v1.2, #758):
-/// the handler is NEVER re-executed, so this is where the shared sizing
-/// convention's probe/retry legs live. NULL or zero-capacity `out` is
-/// the pure sizing probe; otherwise the write is ALL-OR-NOTHING
-/// (`labelle_component_get`-style) and the return is the bytes the
-/// complete response requires. 0 = nothing stored: no call yet, the
-/// last call was unroutable or fire-and-forward (no handler responded,
-/// or it responded empty), or not bound. NON-consuming — fetch as many
-/// times as needed; the store is replaced/cleared by the next
-/// `labelle_plugin_call` and on unbind.
+/// Read the response of the most recently COMPLETED
+/// `labelle_plugin_call` — the side-effect-free half of the response
+/// channel (since v1.2, #758): the handler is NEVER re-executed, so
+/// this is where the shared sizing convention's probe/retry legs live.
+/// NULL or zero-capacity `out` is the pure sizing probe; otherwise the
+/// write is ALL-OR-NOTHING (`labelle_component_get`-style) and the
+/// return is the bytes the complete response requires. 0 = nothing
+/// stored: no call yet, the last completed call was unroutable or
+/// fire-and-forward (no handler responded, or it responded empty), or
+/// not bound. NON-consuming — fetch as many times as needed; the store
+/// is replaced/cleared as each `labelle_plugin_call` COMPLETES and on
+/// unbind. "Completed" carries the nesting semantics: when a handler
+/// itself issues a `labelle_plugin_call`, the inner call publishes
+/// first and the enclosing call — completing last — overwrites or
+/// clears it, so a fetch made after the whole stack unwinds reads the
+/// OUTERMOST call's outcome (a handler that wants the inner response
+/// reads it from its own call's `out`, not from a later fetch).
 pub export fn labelle_plugin_response_fetch(out: ?[*]u8, out_cap: usize) usize {
     const n = response_len orelse return 0;
     // The mixin folds empty responses to dispatched-no-response, so a
@@ -1599,25 +1632,48 @@ fn Holder(comptime GP: type) type {
         /// `engine__editor_plugin_command` folds to unroutable INSIDE
         /// the mixin (the zero-cost no-handler gate).
         ///
-        /// The dispatch writes any response STRAIGHT into the module's
-        /// `response_store` (same file — no out-slice threading through
-        /// the plain fn ptr) and records its length for
-        /// `labelle_plugin_response_fetch`; the return is already the
-        /// export's wire value (sentinel / 0 / required size).
+        /// The dispatch lands in PER-CALL stack storage, never the
+        /// module `response_store` directly: a handler may itself issue
+        /// a nested `labelle_plugin_call` (the mixin gives it its own
+        /// response window), and two in-flight dispatches sharing one
+        /// buffer would let the inner response scribble over the outer
+        /// one's bytes while the outer window still reports its
+        /// original length — a corrupted outer response (review finding
+        /// on PR #760). One `max_response_len` frame per nesting level
+        /// is the bounded, cheap price (4 KiB; depth is the game's own
+        /// handler-recursion depth).
+        ///
+        /// The module store is PUBLISHED at completion, on every
+        /// outcome — responded → copied in, dispatched/unroutable →
+        /// cleared — so under nesting the inner call publishes first
+        /// and the outer call, completing last, overwrites or clears
+        /// it: a later `labelle_plugin_response_fetch` always reads the
+        /// most-recently-COMPLETED (i.e. outermost) call's outcome. The
+        /// return is already the export's wire value (sentinel / 0 /
+        /// required size).
         fn pluginCallImpl(plugin: []const u8, command: []const u8, params_json: []const u8) usize {
             if (comptime !@hasDecl(G, "editorPluginCommandOut")) return plugin_call_unroutable;
-            return switch (game.editorPluginCommandOut(plugin, command, params_json, &response_store)) {
-                .unroutable => plugin_call_unroutable,
-                .dispatched => 0,
-                .responded => |r| blk: {
-                    // `r.bytes` aliases `response_store` (we passed it as
-                    // the out buffer) — only the length needs recording.
-                    // Never 0: the mixin folds empty responses to
-                    // `.dispatched`.
-                    response_len = r.bytes.len;
-                    break :blk r.bytes.len;
+            var buf: [plugin_command.max_response_len]u8 = undefined;
+            switch (game.editorPluginCommandOut(plugin, command, params_json, &buf)) {
+                .unroutable => {
+                    response_len = null;
+                    return plugin_call_unroutable;
                 },
-            };
+                .dispatched => {
+                    response_len = null;
+                    return 0;
+                },
+                .responded => |r| {
+                    // `r.bytes` aliases this call's stack frame —
+                    // publish a copy. Never 0 bytes (the mixin folds
+                    // empty responses to `.dispatched`) and never over
+                    // the cap (`buf` IS the cap; the mixin truncates at
+                    // `out.len`).
+                    @memcpy(response_store[0..r.bytes.len], r.bytes);
+                    response_len = r.bytes.len;
+                    return r.bytes.len;
+                },
+            }
         }
 
         // ── Helpers ──────────────────────────────────────────────

--- a/src/script_contract.zig
+++ b/src/script_contract.zig
@@ -168,13 +168,19 @@
 //! convention's -1 in a usize) = empty plugin/command, no handler
 //! registered in this build (the variant never landed on the merged
 //! `GameEvents`), or not bound; 0 = dispatched, no handler responded
-//! (the v1.1 fire-and-forward outcome — a v1.1 caller passing NULL/0
-//! observes exactly the old contract); N = a handler RESPONDED (v1.2,
+//! (the v1.1 fire-and-forward outcome); N = a handler RESPONDED (v1.2,
 //! #758: `engine.plugin_command.respond` during the synchronous
 //! dispatch — one response per command, first-writer-wins, see the
 //! mixin), and N is the bytes the response requires, written into
 //! `out` all-or-nothing (`component_get`-style, exactly as v1.1
-//! reserved). The channel is a broadcast that handlers name-filter
+//! reserved). One deliberate exception keeps old bindings whole — the
+//! v1.1-COMPAT FOLD: a call in the exact shape the v1.1 header
+//! sanctioned (`out == NULL && out_cap == 0`, "pass NULL/0") returns
+//! the v1.1 rc even when a handler responded — 0, never N — so a
+//! v1.1-built binding checking `rc == 0` doesn't misread a successful
+//! responding dispatch as failure; the response is still published for
+//! `labelle_plugin_response_fetch` (the export doc pins the boundary
+//! shapes). The channel is a broadcast that handlers name-filter
 //! THEMSELVES, so the engine cannot tell an unknown plugin/command
 //! from a delivered-and-ignored one: both dispatch as 0 wherever a
 //! handler exists. Multi-event results and acks can still travel back
@@ -857,15 +863,33 @@ pub export fn labelle_input_mouse(x_out: ?*f32, y_out: ?*f32) void {
 /// `plugin_call_unroutable` (`maxInt(usize)`, C's `(size_t)-1`) =
 /// unroutable — empty plugin/command, no handler registered in this
 /// build, a game shape without the mixin, or not bound; 0 = dispatched
-/// into the handler channel, no handler responded (fire-and-forward — a
-/// v1.1 caller passing NULL/0 observes the old contract verbatim); N =
-/// a handler responded via `engine.plugin_command.respond` and the
-/// response requires N bytes, written into `out` ALL-OR-NOTHING (only
-/// when `N <= out_cap`, `labelle_component_get`-style — a truncated
-/// response is useless). Handlers name-filter the broadcast themselves,
-/// so a name no plugin claims still returns 0 wherever a handler exists
-/// — dispatched-and-ignored is indistinguishable from
+/// into the handler channel with no handler response (fire-and-forward)
+/// — OR any dispatched call made in the exact v1.1 shape, see the
+/// compat fold below; N = a handler responded via
+/// `engine.plugin_command.respond` and the response requires N bytes,
+/// written into `out` ALL-OR-NOTHING (only when `N <= out_cap`,
+/// `labelle_component_get`-style — a truncated response is useless).
+/// Handlers name-filter the broadcast themselves, so a name no plugin
+/// claims still returns 0 wherever a handler exists —
+/// dispatched-and-ignored is indistinguishable from
 /// handled-without-response BY DESIGN.
+///
+/// ## The v1.1-compat fold (NULL/0)
+///
+/// `out == NULL && out_cap == 0` — the ONE caller shape the v1.1
+/// header sanctioned ("v1.1 never writes to `out`; pass NULL/0") —
+/// keeps the exact v1.1 rc contract: a responding dispatch STILL
+/// returns 0, never N, so a v1.1-built binding checking `rc == 0`
+/// keeps working when a handler it dispatches to grows a response.
+/// The response is published all the same — a v1.2 caller without a
+/// buffer sizes/reads it through `labelle_plugin_response_fetch`
+/// (whose NULL/0 probe is the sanctioned sizing path anyway; probing
+/// by re-CALL is forbidden below). The boundary is exactly the
+/// promised shape: `out != NULL` with `out_cap == 0` is the v1.2
+/// sizing leg (required size returned, nothing written), and a NULL
+/// `out` with a nonzero cap — illegal per the conventions block (NULL
+/// only together with cap 0) — is tolerated as sizing too, matching
+/// `labelle_component_get`'s NULL tolerance.
 ///
 /// Do NOT sizing-probe or cap-retry THIS export: every call executes
 /// the handler again. The response is also stored as the call
@@ -907,7 +931,17 @@ pub export fn labelle_plugin_call(
     );
     if (n == 0 or n == plugin_call_unroutable) return n;
     // Responded: the impl deposited the bytes in `response_store` (and
-    // set `response_len = n`). All-or-nothing into the caller's buffer.
+    // set `response_len = n`).
+    if (out == null and out_cap == 0) {
+        // The v1.1-compat fold (export doc): the exact legacy shape
+        // keeps the legacy rc — 0, never the response size — while the
+        // publish above still serves labelle_plugin_response_fetch.
+        return 0;
+    }
+    // All-or-nothing into the caller's buffer; NULL out (with a
+    // nonzero cap — an illegal-but-tolerated shape) and the non-NULL
+    // cap-0 shape both fall through as pure sizing: N returned,
+    // nothing written.
     if (out) |p| {
         if (n <= out_cap) @memcpy(p[0..n], response_store[0..n]);
     }

--- a/test/editor_api_test.zig
+++ b/test/editor_api_test.zig
@@ -87,6 +87,15 @@ test "pre-bind: every export is a safe no-op" {
     // Play-time plugin command (v1.7) reports "not bound" pre-bind.
     try testing.expectEqual(@as(i32, -1), editor_api.editor_plugin_command("dungeon", 7, "generate", 8, "{}", 2));
 
+    // The response-aware sibling (v1.8, #758) reports its usize sentinel…
+    var cmd_out: [8]u8 = undefined;
+    try testing.expectEqual(
+        editor_api.plugin_command_unroutable,
+        editor_api.editor_plugin_command_out("dungeon", 7, "generate", 8, "{}", 2, &cmd_out, cmd_out.len),
+    );
+    // …while the response cap is pure and already answers.
+    try testing.expectEqual(engine.plugin_command.max_response_len, editor_api.editor_plugin_response_cap());
+
     // Pick is the documented v1 stub.
     try testing.expectEqual(@as(i64, -1), editor_api.editor_pick(10.0, 20.0));
 
@@ -2179,4 +2188,189 @@ test "editor_plugin_command: -1 pre-bind, with no subscriber (graceful), and on 
     try testing.expectEqual(@as(i32, -1), editor_api.editor_plugin_command("", 0, "generate", 8, "{}", 2));
     try testing.expectEqual(@as(i32, -1), editor_api.editor_plugin_command("dungeon", 7, "", 0, "{}", 2));
     try testing.expectEqual(@as(usize, 0), recorder.count);
+}
+
+// ── editor_plugin_command_out: response channel (v1.8, #758) ─────────
+//
+// The v1.8 sibling returns the handler's response to the studio (the
+// Script Console's eval round-trip, labelle-studio#78): usize wire
+// convention — sentinel = unroutable, 0 = dispatched-no-response, N =
+// response required size with an all-or-nothing write. The studio
+// pre-sizes its buffer from `editor_plugin_response_cap()` (pure), so
+// it never needs a probe/retry on an export that re-executes handlers.
+
+/// Handler that responds to `"eval"` commands and stays silent for the
+/// rest — the console shape.
+const EvalRecorder = struct {
+    count: usize = 0,
+    accepted: ?bool = null,
+
+    pub fn engine__editor_plugin_command(self: *EvalRecorder, info: anytype) void {
+        self.count += 1;
+        if (!std.mem.eql(u8, info.command, "eval")) return;
+        self.accepted = engine.plugin_command.respondFmt("{{\"result\":{s}}}", .{info.params});
+    }
+};
+
+const EvalGame = engine.game_mod.GameConfig(
+    core.StubRender(PluginCmdMockEcs.Entity),
+    PluginCmdMockEcs,
+    engine.input_mod.StubInput,
+    engine.audio_mod.StubAudio,
+    engine.StubVideo,
+    engine.gui_mod.StubGui,
+    *EvalRecorder,
+    core.StubLogSink,
+    PluginCmdComponents,
+    &.{},
+    PluginCmdEvents,
+);
+
+test "editor_plugin_command_out: returns the handler's response (all-or-nothing)" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var recorder = EvalRecorder{};
+    var game = EvalGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&recorder);
+    game.dispatchEvents(); // drain any buffered game_init
+    recorder = .{};
+    var runner = DummyRunner{};
+    editor_api.bind(&game, &runner);
+
+    // The studio's pre-sized buffer: never smaller than the cap, so the
+    // all-or-nothing write can never refuse.
+    var out: [4096]u8 = undefined;
+    const n = editor_api.editor_plugin_command_out("lua", 3, "eval", 4, "42", 2, &out, out.len);
+    try testing.expectEqualStrings("{\"result\":42}", out[0..n]);
+    try testing.expectEqual(@as(usize, 1), recorder.count);
+    try testing.expectEqual(@as(?bool, true), recorder.accepted);
+
+    // Dispatched-and-unclaimed (the handler name-filters "eval" only):
+    // rc 0, buffer untouched — a v1.7-style outcome on the v1.8 export.
+    @memset(out[0..8], 0xAA);
+    try testing.expectEqual(
+        @as(usize, 0),
+        editor_api.editor_plugin_command_out("lua", 3, "reset", 5, "{}", 2, &out, out.len),
+    );
+    for (out[0..8]) |b| try testing.expectEqual(@as(u8, 0xAA), b);
+    try testing.expectEqual(@as(usize, 2), recorder.count);
+
+    // An under-sized cap: required size returned, buffer untouched
+    // (all-or-nothing — no truncated JSON prefix reaches the studio).
+    var small: [4]u8 = undefined;
+    @memset(&small, 0xAA);
+    try testing.expectEqual(
+        @as(usize, 13),
+        editor_api.editor_plugin_command_out("lua", 3, "eval", 4, "42", 2, &small, small.len),
+    );
+    for (small) |b| try testing.expectEqual(@as(u8, 0xAA), b);
+}
+
+test "editor_plugin_command_out: unroutable sentinel pre-bind, without a channel, and on empty names" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    // Pre-bind.
+    var out: [16]u8 = undefined;
+    try testing.expectEqual(
+        editor_api.plugin_command_unroutable,
+        editor_api.editor_plugin_command_out("p", 1, "c", 1, "{}", 2, &out, out.len),
+    );
+
+    // Bound to a project with no editor-command channel: graceful degrade.
+    {
+        var game = PluginCmdNoChannelGame.init(testing.allocator);
+        defer game.deinit();
+        var runner = DummyRunner{};
+        editor_api.bind(&game, &runner);
+        try testing.expectEqual(
+            editor_api.plugin_command_unroutable,
+            editor_api.editor_plugin_command_out("p", 1, "c", 1, "{}", 2, &out, out.len),
+        );
+    }
+
+    // Bound WITH a channel: empty names refused before dispatch.
+    editor_api.unbind();
+    var recorder = EvalRecorder{};
+    var game = EvalGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&recorder);
+    var runner = DummyRunner{};
+    editor_api.bind(&game, &runner);
+    try testing.expectEqual(
+        editor_api.plugin_command_unroutable,
+        editor_api.editor_plugin_command_out("", 0, "eval", 4, "{}", 2, &out, out.len),
+    );
+    try testing.expectEqual(
+        editor_api.plugin_command_unroutable,
+        editor_api.editor_plugin_command_out("lua", 3, "", 0, "{}", 2, &out, out.len),
+    );
+    try testing.expectEqual(@as(usize, 0), recorder.count);
+}
+
+test "editor_plugin_response_cap: pure, pre-bind, and an actual bound on responses" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    // Pure — callable before bind, and it IS the engine channel cap.
+    try testing.expectEqual(engine.plugin_command.max_response_len, editor_api.editor_plugin_response_cap());
+
+    // A handler over-writing the channel is truncated to the cap, so a
+    // cap-sized studio buffer always receives the whole (stored)
+    // response — the pre-sizing guarantee the export documents.
+    const Overflower = struct {
+        pub fn engine__editor_plugin_command(_: *@This(), _: anytype) void {
+            var big: [engine.plugin_command.max_response_len + 64]u8 = undefined;
+            @memset(&big, 'y');
+            _ = engine.plugin_command.respond(&big);
+        }
+    };
+    const OverflowGame = engine.game_mod.GameConfig(
+        core.StubRender(PluginCmdMockEcs.Entity),
+        PluginCmdMockEcs,
+        engine.input_mod.StubInput,
+        engine.audio_mod.StubAudio,
+        engine.StubVideo,
+        engine.gui_mod.StubGui,
+        *Overflower,
+        core.StubLogSink,
+        PluginCmdComponents,
+        &.{},
+        PluginCmdEvents,
+    );
+
+    var hooks = Overflower{};
+    var game = OverflowGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&hooks);
+    var runner = DummyRunner{};
+    editor_api.bind(&game, &runner);
+
+    const cap = editor_api.editor_plugin_response_cap();
+    const buf = try testing.allocator.alloc(u8, cap);
+    defer testing.allocator.free(buf);
+    const n = editor_api.editor_plugin_command_out("any", 3, "cmd", 3, "{}", 2, buf.ptr, buf.len);
+    try testing.expectEqual(cap, n);
+    for (buf) |b| try testing.expectEqual(@as(u8, 'y'), b);
+}
+
+test "editor_plugin_command (v1.7) keeps its rc contract when the handler responds" {
+    editor_api.unbind();
+    defer editor_api.unbind();
+
+    var recorder = EvalRecorder{};
+    var game = EvalGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&recorder);
+    var runner = DummyRunner{};
+    editor_api.bind(&game, &runner);
+
+    // A v1.7-era studio driving a RESPONDING handler: rc 0, response
+    // silently discarded, respond still accepted (no outside-window
+    // warn on the legacy export — the dispatch window exists there too).
+    try testing.expectEqual(@as(i32, 0), editor_api.editor_plugin_command("lua", 3, "eval", 4, "1", 1));
+    try testing.expectEqual(@as(usize, 1), recorder.count);
+    try testing.expectEqual(@as(?bool, true), recorder.accepted);
 }

--- a/test/script_contract_test.zig
+++ b/test/script_contract_test.zig
@@ -2211,7 +2211,7 @@ test "plugin_call responses: over-cap out is untouched; fetch retries without re
     try testing.expectEqual(@as(usize, 1), recorder.count);
 }
 
-test "plugin_call responses: fetch reads the MOST RECENT call — cleared by response-less and failed calls" {
+test "plugin_call responses: fetch reads the most recently COMPLETED call — cleared by response-less and failed calls" {
     contract.unbind();
     defer contract.unbind();
 
@@ -2221,7 +2221,7 @@ test "plugin_call responses: fetch reads the MOST RECENT call — cleared by res
     game.setHooks(&recorder);
     contract.bind(&game);
 
-    // Responded call stores…
+    // Responded call stores (at completion)…
     try testing.expectEqual(@as(usize, 13), pluginCall("pathfinder", "ping", "{}"));
     try testing.expectEqual(@as(usize, 13), contract.labelle_plugin_response_fetch(null, 0));
 
@@ -2234,6 +2234,104 @@ test "plugin_call responses: fetch reads the MOST RECENT call — cleared by res
     // empty command name.
     try testing.expectEqual(@as(usize, 13), pluginCall("pathfinder", "ping", "{}"));
     try testing.expectEqual(contract.plugin_call_unroutable, pluginCall("pathfinder", "", "{}"));
+    try testing.expectEqual(@as(usize, 0), contract.labelle_plugin_response_fetch(null, 0));
+}
+
+// ── Nested plugin calls (PR #760 review finding) ────────────────────
+//
+// A handler may itself issue a labelle_plugin_call mid-dispatch. Two
+// in-flight dispatches must not share response storage: with a shared
+// dispatch buffer the inner response scribbles over the outer one's
+// bytes while the outer window still reports its original length —
+// the outer caller reads a corrupted splice. The fix dispatches each
+// call into per-call stack storage and publishes the fetch store only
+// at completion (inner first, outer last), which this recorder pins
+// end to end.
+
+const NestedRecorder = struct {
+    outer_count: usize = 0,
+    inner_count: usize = 0,
+    /// What the NESTED labelle_plugin_call returned to the handler…
+    inner_rc: usize = 0,
+    /// …and what it wrote into the handler's own out buffer.
+    inner_buf: [64]u8 = undefined,
+
+    pub fn engine__editor_plugin_command(self: *NestedRecorder, info: anytype) void {
+        if (std.mem.eql(u8, info.command, "outer")) {
+            self.outer_count += 1;
+            // The corruption ordering: respond FIRST (the outer window
+            // now holds bytes), THEN issue the nested call.
+            _ = engine.plugin_command.respond("OUTER-RESPONSE");
+            self.inner_rc = pluginCallOut("nested", "inner", "{}", &self.inner_buf);
+        } else if (std.mem.eql(u8, info.command, "outer_silent")) {
+            self.outer_count += 1;
+            // No respond on the outer window — only the nested call.
+            self.inner_rc = pluginCallOut("nested", "inner", "{}", &self.inner_buf);
+        } else if (std.mem.eql(u8, info.command, "inner")) {
+            self.inner_count += 1;
+            _ = engine.plugin_command.respond("inner!!");
+        }
+    }
+};
+
+const NestedGame = engine.GameConfig(
+    core.StubRender(MockEcs.Entity),
+    MockEcs,
+    engine.StubInput,
+    engine.StubAudio,
+    engine.StubVideo,
+    engine.StubGui,
+    *NestedRecorder,
+    core.StubLogSink,
+    TestComponents,
+    &.{},
+    PluginCallEvents,
+);
+
+test "plugin_call responses: a nested call cannot corrupt the outer response; fetch reads the outermost outcome" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var recorder = NestedRecorder{};
+    var game = NestedGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&recorder);
+    contract.bind(&game);
+
+    // Outer call: handler responds "OUTER-RESPONSE" (14 bytes), then
+    // nests a call whose handler responds "inner!!" (7 bytes — shorter
+    // ON PURPOSE, so a shared dispatch buffer would splice the two).
+    var out: [64]u8 = undefined;
+    const n = pluginCallOut("nested", "outer", "{}", &out);
+    try testing.expectEqual(@as(usize, 1), recorder.outer_count);
+    try testing.expectEqual(@as(usize, 1), recorder.inner_count);
+
+    // (a) The outer caller's bytes are the OUTER response, uncorrupted.
+    try testing.expectEqual(@as(usize, 14), n);
+    try testing.expectEqualStrings("OUTER-RESPONSE", out[0..14]);
+
+    // (c) The handler (the inner caller) received the INNER response in
+    // ITS out buffer — the two responses never shared storage.
+    try testing.expectEqual(@as(usize, 7), recorder.inner_rc);
+    try testing.expectEqualStrings("inner!!", recorder.inner_buf[0..7]);
+
+    // (b) Fetch after the stack unwound: the most recently COMPLETED
+    // call is the OUTER one (it completes last), so its response is
+    // what's stored — not the inner one.
+    var fetched: [64]u8 = undefined;
+    const fn_ = contract.labelle_plugin_response_fetch(&fetched, fetched.len);
+    try testing.expectEqualStrings("OUTER-RESPONSE", fetched[0..fn_]);
+
+    // (d) Response-less outer around a RESPONDING inner: the outer call
+    // completes last and clears — a later fetch must not resurrect the
+    // stale inner bytes (the inner response was already delivered to
+    // the handler's own out buffer above).
+    recorder.inner_rc = 0;
+    try testing.expectEqual(@as(usize, 0), pluginCallOut("nested", "outer_silent", "{}", &out));
+    try testing.expectEqual(@as(usize, 2), recorder.outer_count);
+    try testing.expectEqual(@as(usize, 2), recorder.inner_count);
+    try testing.expectEqual(@as(usize, 7), recorder.inner_rc); // inner still served
+    try testing.expectEqualStrings("inner!!", recorder.inner_buf[0..7]);
     try testing.expectEqual(@as(usize, 0), contract.labelle_plugin_response_fetch(null, 0));
 }
 

--- a/test/script_contract_test.zig
+++ b/test/script_contract_test.zig
@@ -127,9 +127,11 @@ fn findEntity(name: []const u8) u64 {
     return contract.labelle_entity_find(name.ptr, name.len);
 }
 
-/// Call plugin_call in its v1.1 fire-and-forward shape (NULL/0 out) —
-/// the shape response-less callers keep using under v1.2. The response
-/// tests drive `labelle_plugin_call` with a real out buffer directly.
+/// Call plugin_call in the exact v1.1 shape (NULL/0 out) — the shape
+/// the v1.1-compat fold pins to the v1.1 rc contract: 0 for EVERY
+/// dispatched call (a handler response is published for fetch, never
+/// returned as N here), sentinel for unroutable. The response tests
+/// drive `labelle_plugin_call` with a real out buffer (`pluginCallOut`).
 fn pluginCall(plugin: []const u8, command: []const u8, params: []const u8) usize {
     return contract.labelle_plugin_call(
         plugin.ptr,
@@ -2221,8 +2223,9 @@ test "plugin_call responses: fetch reads the most recently COMPLETED call — cl
     game.setHooks(&recorder);
     contract.bind(&game);
 
-    // Responded call stores (at completion)…
-    try testing.expectEqual(@as(usize, 13), pluginCall("pathfinder", "ping", "{}"));
+    // Responded call stores at completion (the NULL/0 v1.1 shape folds
+    // its rc to 0 — the fetch is where the response shows up)…
+    try testing.expectEqual(@as(usize, 0), pluginCall("pathfinder", "ping", "{}"));
     try testing.expectEqual(@as(usize, 13), contract.labelle_plugin_response_fetch(null, 0));
 
     // …a fire-and-forward call clears (0 = dispatched-no-response, and
@@ -2232,7 +2235,8 @@ test "plugin_call responses: fetch reads the most recently COMPLETED call — cl
 
     // …and so does a failed (unroutable) call: store again, then an
     // empty command name.
-    try testing.expectEqual(@as(usize, 13), pluginCall("pathfinder", "ping", "{}"));
+    try testing.expectEqual(@as(usize, 0), pluginCall("pathfinder", "ping", "{}"));
+    try testing.expectEqual(@as(usize, 13), contract.labelle_plugin_response_fetch(null, 0));
     try testing.expectEqual(contract.plugin_call_unroutable, pluginCall("pathfinder", "", "{}"));
     try testing.expectEqual(@as(usize, 0), contract.labelle_plugin_response_fetch(null, 0));
 }
@@ -2368,11 +2372,76 @@ test "plugin_call responses: payloads truncate at the channel cap" {
 
     // The handler writes cap+100 bytes; the channel truncates at the
     // cap — required size reports the STORED (truncated) length, so a
-    // right-sized fetch reads exactly what exists.
+    // right-sized fetch reads exactly what exists. Driven with a real
+    // (under-sized) out buffer so the return carries the size: the
+    // NULL/0 shape would fold it to the v1.1 rc 0.
     const cap = engine.plugin_command.max_response_len;
-    try testing.expectEqual(cap, pluginCall("pathfinder", "huge", "{}"));
+    var small: [8]u8 = undefined;
+    try testing.expectEqual(cap, pluginCallOut("pathfinder", "huge", "{}", &small));
     try testing.expectEqual(@as(?bool, true), recorder.respond_accepted);
     try testing.expectEqual(cap, contract.labelle_plugin_response_fetch(null, 0));
+}
+
+test "plugin_call v1.1 compat: the NULL/0 shape folds a responding dispatch to rc 0 (response still fetchable)" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var recorder = RespondingRecorder{};
+    var game = RespondGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&recorder);
+    contract.bind(&game);
+
+    // A binding built against v1.1 passes NULL/0 (the only shape that
+    // header sanctioned) and checks rc == 0 for a dispatched call.
+    // With a RESPONDING handler the fold keeps that contract: rc 0,
+    // never the response size.
+    try testing.expectEqual(@as(usize, 0), pluginCall("pathfinder", "ping", "{}"));
+    try testing.expectEqual(@as(usize, 1), recorder.count);
+    try testing.expectEqual(@as(?bool, true), recorder.respond_accepted);
+
+    // The fold discards nothing: the response was published, so a v1.2
+    // caller without a buffer sizes via the fetch probe and reads it —
+    // no re-execution (count pinned).
+    try testing.expectEqual(@as(usize, 13), contract.labelle_plugin_response_fetch(null, 0));
+    var buf: [32]u8 = undefined;
+    const n = contract.labelle_plugin_response_fetch(&buf, buf.len);
+    try testing.expectEqualStrings("{\"pong\":true}", buf[0..n]);
+    try testing.expectEqual(@as(usize, 1), recorder.count);
+
+    // Unroutable in the same NULL/0 shape keeps the v1.1 sentinel.
+    try testing.expectEqual(contract.plugin_call_unroutable, pluginCall("", "ping", "{}"));
+
+    // The fold's boundary is EXACTLY the promised shape. A real pointer
+    // with cap 0 is the v1.2 sizing leg: size returned, nothing written…
+    const plugin = "pathfinder";
+    const command = "ping";
+    const params = "{}";
+    var canary: [4]u8 = undefined;
+    @memset(&canary, 0xAA);
+    try testing.expectEqual(@as(usize, 13), contract.labelle_plugin_call(
+        plugin.ptr,
+        plugin.len,
+        command.ptr,
+        command.len,
+        params.ptr,
+        params.len,
+        &canary,
+        0,
+    ));
+    for (canary) |b| try testing.expectEqual(@as(u8, 0xAA), b);
+    // …and NULL with a nonzero cap (illegal per the conventions block,
+    // tolerated like component_get's NULL) sizes too — no fold.
+    try testing.expectEqual(@as(usize, 13), contract.labelle_plugin_call(
+        plugin.ptr,
+        plugin.len,
+        command.ptr,
+        command.len,
+        params.ptr,
+        params.len,
+        null,
+        16,
+    ));
 }
 
 test "plugin_call responses: second respond within one handler is refused (first-writer-wins)" {

--- a/test/script_contract_test.zig
+++ b/test/script_contract_test.zig
@@ -127,9 +127,9 @@ fn findEntity(name: []const u8) u64 {
     return contract.labelle_entity_find(name.ptr, name.len);
 }
 
-/// Call plugin_call with the reserved out-buffer at its documented
-/// v1.1 shape (NULL/0). The reserved-buffer canary test drives
-/// `labelle_plugin_call` directly instead.
+/// Call plugin_call in its v1.1 fire-and-forward shape (NULL/0 out) —
+/// the shape response-less callers keep using under v1.2. The response
+/// tests drive `labelle_plugin_call` with a real out buffer directly.
 fn pluginCall(plugin: []const u8, command: []const u8, params: []const u8) usize {
     return contract.labelle_plugin_call(
         plugin.ptr,
@@ -212,6 +212,8 @@ test "pre-bind: every export is a safe no-op" {
     try testing.expectEqual(@as(usize, 0), getComp(1, "Health", &buf).len);
     try testing.expectEqual(@as(usize, 0), query("[\"Health\"]", &buf).len);
     try testing.expectEqual(@as(usize, 0), poll(&buf).len);
+    // No plugin_call ever ran → nothing stored to fetch (v1.2).
+    try testing.expectEqual(@as(usize, 0), contract.labelle_plugin_response_fetch(&buf, buf.len));
 
     // Time: no game, no dt.
     try testing.expectEqual(@as(f32, 0), contract.labelle_time_dt());
@@ -1945,8 +1947,9 @@ test "plugin_call: routes through the editorPluginCommand mixin to the registere
     try testing.expectEqual(@as(usize, 2), recorder.count);
     try testing.expectEqualStrings("nonexistent_plugin", recorder.lastPlugin());
 
-    // out/out_cap are RESERVED in v1.1: never written even on a
-    // dispatched call (canary intact), and the return stays the rc.
+    // A dispatched call whose handlers never respond leaves out/out_cap
+    // untouched (canary intact) and returns the rc 0 — under v1.2 this
+    // is exactly the v1.1 reserved behavior, byte for byte.
     var out: [32]u8 = undefined;
     @memset(&out, 0xAA);
     const plugin = "pathfinder";
@@ -2058,4 +2061,392 @@ test "plugin_call: the minimal engine.Game shape compiles and degrades to unrout
         contract.plugin_call_unroutable,
         pluginCall("pathfinder", "navigate", "{}"),
     );
+}
+
+// ── plugin-call responses (contract v1.2, #758) ─────────────────────
+//
+// A handler may RESPOND to the command it is handling by calling
+// `engine.plugin_command.respond`/`respondFmt` inside the synchronous
+// dispatch window; the caller receives it through the activated
+// `out`/`out_cap` (required-size, all-or-nothing — the semantics v1.1
+// reserved) and, side-effect-free, through the paired
+// `labelle_plugin_response_fetch`. One response per command,
+// first-writer-wins across the broadcast. These tests register
+// responders through the REAL registration path (hooks subscribers to
+// the engine event) and pin every leg, including the load-bearing
+// negative: a response READ never re-executes the handler.
+
+/// `labelle_plugin_call` with a real out buffer (the v1.2 shape).
+fn pluginCallOut(plugin: []const u8, command: []const u8, params: []const u8, out: []u8) usize {
+    return contract.labelle_plugin_call(
+        plugin.ptr,
+        plugin.len,
+        command.ptr,
+        command.len,
+        params.ptr,
+        params.len,
+        out.ptr,
+        out.len,
+    );
+}
+
+/// Responding handler — command-selected behaviors so one recorder
+/// covers every respond flavor. `count` is the double-execution canary;
+/// `respond_accepted` records what the (last) respond call returned.
+const RespondingRecorder = struct {
+    count: usize = 0,
+    respond_accepted: ?bool = null,
+
+    pub fn engine__editor_plugin_command(self: *RespondingRecorder, info: anytype) void {
+        self.count += 1;
+        if (std.mem.eql(u8, info.command, "silent")) return; // fire-and-forward leg
+        if (std.mem.eql(u8, info.command, "empty")) {
+            self.respond_accepted = engine.plugin_command.respond("");
+            return;
+        }
+        if (std.mem.eql(u8, info.command, "huge")) {
+            var big: [engine.plugin_command.max_response_len + 100]u8 = undefined;
+            @memset(&big, 'x');
+            self.respond_accepted = engine.plugin_command.respond(&big);
+            return;
+        }
+        if (std.mem.eql(u8, info.command, "fmt")) {
+            self.respond_accepted = engine.plugin_command.respondFmt(
+                "{{\"echo\":{s}}}",
+                .{info.params},
+            );
+            return;
+        }
+        if (std.mem.eql(u8, info.command, "double")) {
+            _ = engine.plugin_command.respond("first");
+            self.respond_accepted = engine.plugin_command.respond("second");
+            return;
+        }
+        // Default ("ping" etc.): a fixed 13-byte JSON response.
+        self.respond_accepted = engine.plugin_command.respond("{\"pong\":true}");
+    }
+};
+
+const RespondGame = engine.GameConfig(
+    core.StubRender(MockEcs.Entity),
+    MockEcs,
+    engine.StubInput,
+    engine.StubAudio,
+    engine.StubVideo,
+    engine.StubGui,
+    *RespondingRecorder,
+    core.StubLogSink,
+    TestComponents,
+    &.{},
+    PluginCallEvents,
+);
+
+test "plugin_call responses: respond returns required size + all-or-nothing write" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var recorder = RespondingRecorder{};
+    var game = RespondGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&recorder);
+    contract.bind(&game);
+
+    // Fits: required size returned, response written, tail canary intact.
+    var out: [32]u8 = undefined;
+    @memset(&out, 0xAA);
+    const n = pluginCallOut("pathfinder", "ping", "{}", &out);
+    try testing.expectEqual(@as(usize, 13), n);
+    try testing.expectEqualStrings("{\"pong\":true}", out[0..13]);
+    for (out[13..]) |b| try testing.expectEqual(@as(u8, 0xAA), b);
+    try testing.expectEqual(@as(?bool, true), recorder.respond_accepted);
+
+    // respondFmt formats straight into the channel.
+    var out2: [64]u8 = undefined;
+    const n2 = pluginCallOut("pathfinder", "fmt", "{\"x\":1}", &out2);
+    try testing.expectEqualStrings("{\"echo\":{\"x\":1}}", out2[0..n2]);
+}
+
+test "plugin_call responses: over-cap out is untouched; fetch retries without re-executing" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var recorder = RespondingRecorder{};
+    var game = RespondGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&recorder);
+    contract.bind(&game);
+
+    // The 13-byte response doesn't fit a 4-byte buffer: required size
+    // still returned, buffer untouched (all-or-nothing).
+    var small: [4]u8 = undefined;
+    @memset(&small, 0xAA);
+    try testing.expectEqual(@as(usize, 13), pluginCallOut("pathfinder", "ping", "{}", &small));
+    for (small) |b| try testing.expectEqual(@as(u8, 0xAA), b);
+    try testing.expectEqual(@as(usize, 1), recorder.count);
+
+    // ── The double-execution negative-verify (#758) ──
+    // Every read of the stored response leaves the handler UN-re-run:
+    // the probe, the right-sized fetch, and a repeat fetch all leave
+    // `count` at the single dispatch above.
+    try testing.expectEqual(@as(usize, 13), contract.labelle_plugin_response_fetch(null, 0));
+    try testing.expectEqual(@as(usize, 1), recorder.count);
+
+    var right: [13]u8 = undefined;
+    try testing.expectEqual(@as(usize, 13), contract.labelle_plugin_response_fetch(&right, right.len));
+    try testing.expectEqualStrings("{\"pong\":true}", &right);
+    try testing.expectEqual(@as(usize, 1), recorder.count);
+
+    // Non-consuming: a second fetch reads the same response.
+    var again: [32]u8 = undefined;
+    const n = contract.labelle_plugin_response_fetch(&again, again.len);
+    try testing.expectEqualStrings("{\"pong\":true}", again[0..n]);
+    try testing.expectEqual(@as(usize, 1), recorder.count);
+
+    // Fetch's own all-or-nothing: an under-sized fetch sizes but writes
+    // nothing.
+    var tiny: [2]u8 = undefined;
+    @memset(&tiny, 0xAA);
+    try testing.expectEqual(@as(usize, 13), contract.labelle_plugin_response_fetch(&tiny, tiny.len));
+    for (tiny) |b| try testing.expectEqual(@as(u8, 0xAA), b);
+    try testing.expectEqual(@as(usize, 1), recorder.count);
+}
+
+test "plugin_call responses: fetch reads the MOST RECENT call — cleared by response-less and failed calls" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var recorder = RespondingRecorder{};
+    var game = RespondGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&recorder);
+    contract.bind(&game);
+
+    // Responded call stores…
+    try testing.expectEqual(@as(usize, 13), pluginCall("pathfinder", "ping", "{}"));
+    try testing.expectEqual(@as(usize, 13), contract.labelle_plugin_response_fetch(null, 0));
+
+    // …a fire-and-forward call clears (0 = dispatched-no-response, and
+    // the previous response must not linger for a stale fetch).
+    try testing.expectEqual(@as(usize, 0), pluginCall("pathfinder", "silent", "{}"));
+    try testing.expectEqual(@as(usize, 0), contract.labelle_plugin_response_fetch(null, 0));
+
+    // …and so does a failed (unroutable) call: store again, then an
+    // empty command name.
+    try testing.expectEqual(@as(usize, 13), pluginCall("pathfinder", "ping", "{}"));
+    try testing.expectEqual(contract.plugin_call_unroutable, pluginCall("pathfinder", "", "{}"));
+    try testing.expectEqual(@as(usize, 0), contract.labelle_plugin_response_fetch(null, 0));
+}
+
+test "plugin_call responses: empty respond claims the channel but reads as no-response" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var recorder = RespondingRecorder{};
+    var game = RespondGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&recorder);
+    contract.bind(&game);
+
+    // respond("") is ACCEPTED (it claims first-writer-wins)…
+    var out: [8]u8 = undefined;
+    @memset(&out, 0xAA);
+    try testing.expectEqual(@as(usize, 0), pluginCallOut("pathfinder", "empty", "{}", &out));
+    try testing.expectEqual(@as(?bool, true), recorder.respond_accepted);
+    // …but the sized returns fold it to dispatched-no-response: 0,
+    // nothing written, nothing stored.
+    for (out) |b| try testing.expectEqual(@as(u8, 0xAA), b);
+    try testing.expectEqual(@as(usize, 0), contract.labelle_plugin_response_fetch(null, 0));
+}
+
+test "plugin_call responses: payloads truncate at the channel cap" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var recorder = RespondingRecorder{};
+    var game = RespondGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&recorder);
+    contract.bind(&game);
+
+    // The handler writes cap+100 bytes; the channel truncates at the
+    // cap — required size reports the STORED (truncated) length, so a
+    // right-sized fetch reads exactly what exists.
+    const cap = engine.plugin_command.max_response_len;
+    try testing.expectEqual(cap, pluginCall("pathfinder", "huge", "{}"));
+    try testing.expectEqual(@as(?bool, true), recorder.respond_accepted);
+    try testing.expectEqual(cap, contract.labelle_plugin_response_fetch(null, 0));
+}
+
+test "plugin_call responses: second respond within one handler is refused (first-writer-wins)" {
+    contract.unbind();
+    defer contract.unbind();
+    // The refusal deliberately warns; keep the intentional trigger out
+    // of the test runner's stderr (asserted via the return value below).
+    const prev_log = std.testing.log_level;
+    std.testing.log_level = .err;
+    defer std.testing.log_level = prev_log;
+
+    var recorder = RespondingRecorder{};
+    var game = RespondGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&recorder);
+    contract.bind(&game);
+
+    var out: [16]u8 = undefined;
+    const n = pluginCallOut("pathfinder", "double", "{}", &out);
+    try testing.expectEqualStrings("first", out[0..n]);
+    // The recorder stored the SECOND respond's return: refused.
+    try testing.expectEqual(@as(?bool, false), recorder.respond_accepted);
+}
+
+// Two-receiver broadcast: both handlers run (the v1.7 fan-out is
+// preserved), the FIRST responder's payload returns, the second's
+// respond is refused. Receivers are merged through core.MergeHooks —
+// the assembler-generated multi-plugin shape.
+const RespondAlpha = struct {
+    count: usize = 0,
+    accepted: ?bool = null,
+    pub fn engine__editor_plugin_command(self: *RespondAlpha, _: anytype) void {
+        self.count += 1;
+        self.accepted = engine.plugin_command.respond("alpha");
+    }
+};
+const RespondBeta = struct {
+    count: usize = 0,
+    accepted: ?bool = null,
+    pub fn engine__editor_plugin_command(self: *RespondBeta, _: anytype) void {
+        self.count += 1;
+        self.accepted = engine.plugin_command.respond("beta");
+    }
+};
+
+// The game's own merged payload shape, precomputed exactly as
+// `GameConfig` derives it (MergeHookPayloads over the engine payload +
+// the events union) so the MergeHooks instance type-checks against
+// `Game.PayloadExport` — the generated-main wiring order.
+const TwoRespPayload = core.MergeHookPayloads(.{ engine.HookPayload(u32), PluginCallEvents });
+const TwoRespHooks = core.MergeHooks(TwoRespPayload, .{ *RespondAlpha, *RespondBeta });
+
+const TwoResponderGame = engine.GameConfig(
+    core.StubRender(MockEcs.Entity),
+    MockEcs,
+    engine.StubInput,
+    engine.StubAudio,
+    engine.StubVideo,
+    engine.StubGui,
+    *TwoRespHooks,
+    core.StubLogSink,
+    TestComponents,
+    &.{},
+    PluginCallEvents,
+);
+
+test "plugin_call responses: broadcast preserved — first responder wins, second refused" {
+    contract.unbind();
+    defer contract.unbind();
+    // Beta's refusal warns by design; silence the intentional trigger.
+    const prev_log = std.testing.log_level;
+    std.testing.log_level = .err;
+    defer std.testing.log_level = prev_log;
+
+    var alpha = RespondAlpha{};
+    var beta = RespondBeta{};
+    var merged = TwoRespHooks{ .receivers = .{ &alpha, &beta } };
+    var game = TwoResponderGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&merged);
+    contract.bind(&game);
+
+    var out: [16]u8 = undefined;
+    const n = pluginCallOut("anyplugin", "anycmd", "{}", &out);
+    try testing.expectEqualStrings("alpha", out[0..n]);
+    // BOTH handlers ran — a response does not consume the broadcast…
+    try testing.expectEqual(@as(usize, 1), alpha.count);
+    try testing.expectEqual(@as(usize, 1), beta.count);
+    // …but only the first respond was accepted (the second warns).
+    try testing.expectEqual(@as(?bool, true), alpha.accepted);
+    try testing.expectEqual(@as(?bool, false), beta.accepted);
+}
+
+test "plugin_command.respond outside a dispatch window is refused" {
+    // No game, no dispatch — the module seam refuses (and warns)
+    // instead of scribbling anywhere. Silence the intentional warns.
+    const prev_log = std.testing.log_level;
+    std.testing.log_level = .err;
+    defer std.testing.log_level = prev_log;
+
+    try testing.expect(!engine.plugin_command.respond("stray"));
+    try testing.expect(!engine.plugin_command.respondFmt("stray {d}", .{7}));
+}
+
+test "editorPluginCommandOut: responded bytes alias the caller's buffer; truncated flag on overflow" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var recorder = RespondingRecorder{};
+    var game = RespondGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&recorder);
+
+    // Mixin-level (no C surface): the Result's bytes are a slice OF the
+    // caller's out buffer, truncated at its length when the response
+    // overflows it.
+    var small: [8]u8 = undefined;
+    switch (game.editorPluginCommandOut("pathfinder", "ping", "{}", &small)) {
+        .responded => |r| {
+            try testing.expectEqual(@as([*]u8, &small), r.bytes.ptr);
+            try testing.expectEqualStrings("{\"pong\":", r.bytes);
+            try testing.expect(r.truncated);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+
+    var fits: [64]u8 = undefined;
+    switch (game.editorPluginCommandOut("pathfinder", "ping", "{}", &fits)) {
+        .responded => |r| {
+            try testing.expectEqualStrings("{\"pong\":true}", r.bytes);
+            try testing.expect(!r.truncated);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+
+    // respondFmt's overflow leg: formatting that outgrows the window is
+    // cut at the window's length and flagged, keeping the written
+    // prefix (the fixed-writer catch path).
+    var fmt_small: [10]u8 = undefined;
+    switch (game.editorPluginCommandOut("pathfinder", "fmt", "{\"long\":\"xxxxxxxxxxxxxxxx\"}", &fmt_small)) {
+        .responded => |r| {
+            try testing.expectEqualStrings("{\"echo\":{\"", r.bytes);
+            try testing.expect(r.truncated);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+
+    // Fire-and-forward and unroutable legs of the mixin Result.
+    var buf: [8]u8 = undefined;
+    switch (game.editorPluginCommandOut("pathfinder", "silent", "{}", &buf)) {
+        .dispatched => {},
+        else => return error.TestUnexpectedResult,
+    }
+    switch (game.editorPluginCommandOut("", "ping", "{}", &buf)) {
+        .unroutable => {},
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "editorPluginCommand (v1.7 rc): the dispatch window exists — a response is accepted and discarded" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var recorder = RespondingRecorder{};
+    var game = RespondGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&recorder);
+
+    // The legacy rc path dispatches with a zero-length window: the
+    // handler's respond is ACCEPTED (no spurious outside-window warn on
+    // v1.7 callers), the payload is discarded, and the rc stays 0.
+    try testing.expectEqual(@as(i32, 0), game.editorPluginCommand("pathfinder", "ping", "{}"));
+    try testing.expectEqual(@as(usize, 1), recorder.count);
+    try testing.expectEqual(@as(?bool, true), recorder.respond_accepted);
 }


### PR DESCRIPTION
Closes #758. Two consumers want results back from plugin commands (studio Script Console eval output; script-language typed wrappers) — this is the one mechanism serving both.

## Design

**The respond seam is a module-scope capability** — `engine.plugin_command.respond(bytes)` / `respondFmt(fmt, args)` — not a handler parameter and not a payload field. The parameter shape is impossible engine-only: core's `HookDispatcher.emit`/`MergeHooks.emit` call sites are fixed at `handler(receiver, payload)`, so a third arg needs a core release; a payload-embedded responder was rejected because the assembler AST-folds event payload structs into generated projects — the field would exist only after an assembler release + re-gen, leaving every existing project silently response-less. The module fn works with **today's assembler output the day this ships**, keeps handler signatures literally unchanged, and matches the layer's module-state idiom (script_contract subs/inbox, editor pause/step). The window is saved/restored around the synchronous `emitSync`, so nested dispatches compose.

**Single-shot, first-writer-wins**: broadcast fan-out can't attribute writes per-receiver, so the first `respond` in a window claims it; later calls return `false` + `std.log.warn`. Registry-of-responders documented out of scope. Empty response folds to dispatched-no-response; bounded at `max_response_len` (4096) with a `truncated` flag.

**Double-execution resolved honestly** — both halves:
- `labelle_plugin_call` activates `out`/`out_cap` per the v1.1 reservation ((size_t)-1 unroutable / 0 no-response / N required, all-or-nothing) — the one-call fast path.
- NEW `labelle_plugin_response_fetch` — zero-side-effect probe/retry of the stored response (NULL/0 probe, non-consuming, cleared at every plugin_call entry + unbind). The header carries an explicit DOUBLE-EXECUTION WARNING against retry-by-re-call.
- CONTRACT_VERSION stays 1 (additive v1.2).

**Editor bridge v1.8** (optional exports): `editor_plugin_command_out(..., out, out_cap)` + pure `editor_plugin_response_cap()` — studio allocs the cap once, all-or-nothing can never refuse. v1.7 `editor_plugin_command` byte-identical (zero-length window, responses accepted-and-discarded).

**Zig side**: `game.editorPluginCommandOut(...) -> plugin_command.Result` (union `unroutable`/`dispatched`/`responded{bytes, truncated}`); v1.7 `editorPluginCommand` is now a wrapper.

## Tests

969/969 (+14 new), spec green, fmt clean. Coverage: round-trip through both C paths; over-cap all-or-nothing (canary); fetch probe/right-sized/repeat/undersized; most-recent-clear; empty-respond fold; truncation both legs; two-receiver broadcast (both run, first wins, second refused + warn); double-respond in one handler; outside-window refusal; pre-bind no-ops; v1.7 compat. **Double-execution pin**: after one call (handler counter = 1), probe + fetch ×3 all read the stored response with the counter still 1.

Downstream: this is the ABI scripting#4 (console eval handler) and the studio v1.8 bridge build on.

https://claude.ai/code/session_01P7YLw4hXFCCaY2LAUt4G1j