### PR TITLE
feat(engine): split-screen viewport layout math (#761 Phase 3, partial)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -152,6 +152,7 @@ pub fn build(b: *std.Build) void {
         "test/entities_with_roster_test.zig",
         "test/set_sprite_flip_test.zig",
         "test/video_component_test.zig",
+        "test/camera_viewport_test.zig",
         // PIE viewport handshake (#543) — kept separate from
         // preview_mode_test.zig so the new coverage isn't gated on
         // that file's pre-existing 21-test subscription bug.

--- a/src/camera_viewport.zig
+++ b/src/camera_viewport.zig
@@ -1,0 +1,129 @@
+//! Camera viewport layout — split-screen composition math (#761 Phase 3).
+//!
+//! The renderer-agnostic half of the deferred camera-bound-layers work. RFC
+//! #723 Phase 1 (per-layer camera binding by tag) shipped in gfx 1.26;
+//! Phase 2 (a bound layer renders into a declared viewport rect) and Phase 3
+//! (N cameras × viewport = split-screen / minimap / PiP) need the renderer
+//! to make `setViewport` real across backends and to compose several
+//! cameras per frame — that lives in `labelle-gfx`. This module owns the
+//! part that does NOT: the pure geometry that turns "screen size + how many
+//! views + which layout" into the set of screen-space `Viewport` rects the
+//! renderer then draws each camera into.
+//!
+//! Keeping it here (engine-side, renderer-free) matches `camera.zig`'s
+//! stance that `Viewport` is an engine-local rect that deliberately does not
+//! reference gfx's `ScreenViewport`: the engine computes the layout, the gfx
+//! binding consumes it. It's also directly testable without any backend —
+//! the layouts tile the screen exactly (no uncovered gap, no overlap on the
+//! full-grid cases), which is the invariant a split-screen composition
+//! depends on.
+//!
+//! Remaining #761 work (gfx repo, out of this module): real `setViewport`
+//! per bound layer, wiring the declarative layer→camera binding to feed
+//! these rects, and the per-camera scissor in the render loop.
+
+const std = @import("std");
+const camera = @import("camera.zig");
+
+/// Engine-local screen-space rect (re-exported from `camera.zig` so callers
+/// have one `Viewport` type across the camera surface).
+pub const Viewport = camera.Viewport;
+
+/// A full-screen viewport for a `w × h` screen. The identity layout for a
+/// single camera (equivalent to `Camera.viewport == null`).
+pub fn fullscreen(w: i32, h: i32) Viewport {
+    return .{ .x = 0, .y = 0, .width = w, .height = h };
+}
+
+/// `true` when the rect has no area — the "unset / fullscreen" sentinel a
+/// zero-initialized or partially-authored `Viewport` carries.
+pub fn isEmpty(v: Viewport) bool {
+    return v.width <= 0 or v.height <= 0;
+}
+
+/// Rect area as `i64` (avoids i32 overflow on large screens).
+pub fn area(v: Viewport) i64 {
+    if (isEmpty(v)) return 0;
+    return @as(i64, v.width) * @as(i64, v.height);
+}
+
+/// How to divide the screen among N cameras.
+pub const SplitLayout = enum {
+    /// Horizontal bands, full width, stacked top→bottom (classic 2-player
+    /// co-op / racing split). Always tiles the screen exactly.
+    horizontal,
+    /// Vertical columns, full height, left→right. Always tiles exactly.
+    vertical,
+    /// Row-major 2-column grid (top→bottom, left→right), up to 4 views. A
+    /// count that fills the grid (1, 2, 4) tiles exactly; an odd count (3)
+    /// leaves the trailing cell empty (the conventional 3-player look).
+    grid,
+};
+
+/// Compute `count` screen-space viewport rects tiling a `screen_w ×
+/// screen_h` screen for `layout`, writing them into `out` and returning the
+/// filled prefix. `count` is clamped to `out.len` (pass a buffer at least as
+/// large as the number of cameras — `[4]Viewport` covers the split-screen
+/// maximum). Screen origin is top-left (gfx convention): band/row 0 is at
+/// the top, column 0 at the left.
+///
+/// For `horizontal`/`vertical` the integer-division remainder is folded into
+/// the LAST band/column so the rects cover every pixel with no seam. `count
+/// == 0` returns an empty slice; `count == 1` is always the full screen
+/// regardless of layout.
+pub fn splitScreen(
+    screen_w: i32,
+    screen_h: i32,
+    count: usize,
+    layout: SplitLayout,
+    out: []Viewport,
+) []Viewport {
+    const n = @min(count, out.len);
+    if (n == 0) return out[0..0];
+    if (n == 1) {
+        out[0] = fullscreen(screen_w, screen_h);
+        return out[0..1];
+    }
+
+    switch (layout) {
+        .horizontal => {
+            const ni: i32 = @intCast(n);
+            const band = @divTrunc(screen_h, ni);
+            var y: i32 = 0;
+            for (0..n) |i| {
+                // Last band absorbs the remainder so the stack reaches the
+                // bottom edge exactly.
+                const h = if (i == n - 1) screen_h - y else band;
+                out[i] = .{ .x = 0, .y = y, .width = screen_w, .height = h };
+                y += band;
+            }
+        },
+        .vertical => {
+            const ni: i32 = @intCast(n);
+            const col = @divTrunc(screen_w, ni);
+            var x: i32 = 0;
+            for (0..n) |i| {
+                const w = if (i == n - 1) screen_w - x else col;
+                out[i] = .{ .x = x, .y = 0, .width = w, .height = screen_h };
+                x += col;
+            }
+        },
+        .grid => {
+            // 2 columns, as many rows as needed (n ≤ 4 → 1 or 2 rows).
+            const cols: i32 = 2;
+            const rows: i32 = @intCast((n + 1) / 2);
+            const cell_w = @divTrunc(screen_w, cols);
+            const cell_h = @divTrunc(screen_h, rows);
+            for (0..n) |i| {
+                const ci: i32 = @intCast(i % 2);
+                const ri: i32 = @intCast(i / 2);
+                // Right column / bottom row absorb the remainder so a
+                // full grid (2 or 4) tiles exactly.
+                const w = if (ci == cols - 1) screen_w - cell_w * ci else cell_w;
+                const h = if (ri == rows - 1) screen_h - cell_h * ri else cell_h;
+                out[i] = .{ .x = cell_w * ci, .y = cell_h * ri, .width = w, .height = h };
+            }
+        },
+    }
+    return out[0..n];
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -117,6 +117,16 @@ pub const PrefabResolver = asset_manifest_mod.PrefabResolver;
 pub const inferAssetsJsoncWithPrefabs = asset_manifest_mod.inferAssetsJsoncWithPrefabs;
 pub const inferAssetsFromSourceWithPrefabs = asset_manifest_mod.inferAssetsFromSourceWithPrefabs;
 
+// ── Camera viewport layout (camera-bound layers Phase 3, #761) ──
+// Renderer-agnostic split-screen composition math: `splitScreen(w, h, n,
+// layout, out)` tiles a screen into N viewport rects (horizontal /
+// vertical / grid) for multi-camera split-screen / minimap / PiP. The
+// engine computes the layout; the gfx per-layer viewport binding consumes
+// it (that wiring + real cross-backend `setViewport` remain gfx-side work).
+pub const camera_viewport_mod = @import("camera_viewport.zig");
+pub const SplitLayout = camera_viewport_mod.SplitLayout;
+pub const splitScreen = camera_viewport_mod.splitScreen;
+
 // ── Input ──
 pub const InputInterface = input_mod.InputInterface;
 pub const StubInput = input_mod.StubInput;

--- a/test/camera_viewport_test.zig
+++ b/test/camera_viewport_test.zig
@@ -1,0 +1,146 @@
+/// Tests for the split-screen viewport layout math (#761 Phase 3).
+///
+/// Renderer-agnostic geometry: verifies the layouts tile the screen exactly
+/// (no uncovered gap, no overlap on full-grid cases) and place each view
+/// where the layout promises. The real per-layer `setViewport` + layer→camera
+/// binding that consume these rects are gfx-repo work and aren't exercised
+/// here.
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+
+const Viewport = engine.CameraViewport;
+const SplitLayout = engine.SplitLayout;
+const splitScreen = engine.splitScreen;
+
+const cvp = engine.camera_viewport_mod;
+
+// ── Degenerate counts ──────────────────────────────────────────────────────
+
+test "count 0 returns an empty slice" {
+    var buf: [4]Viewport = undefined;
+    const vps = splitScreen(1920, 1080, 0, .horizontal, &buf);
+    try testing.expectEqual(@as(usize, 0), vps.len);
+}
+
+test "count 1 is fullscreen for every layout" {
+    var buf: [4]Viewport = undefined;
+    inline for (.{ SplitLayout.horizontal, .vertical, .grid }) |layout| {
+        const vps = splitScreen(1920, 1080, 1, layout, &buf);
+        try testing.expectEqual(@as(usize, 1), vps.len);
+        try testing.expectEqual(Viewport{ .x = 0, .y = 0, .width = 1920, .height = 1080 }, vps[0]);
+    }
+}
+
+test "count clamps to the output buffer length" {
+    var buf: [2]Viewport = undefined;
+    const vps = splitScreen(100, 100, 4, .vertical, &buf);
+    try testing.expectEqual(@as(usize, 2), vps.len);
+}
+
+// ── Horizontal bands ───────────────────────────────────────────────────────
+
+test "horizontal 2-way splits into stacked top/bottom halves" {
+    var buf: [4]Viewport = undefined;
+    const vps = splitScreen(800, 600, 2, .horizontal, &buf);
+    try testing.expectEqual(@as(usize, 2), vps.len);
+    try testing.expectEqual(Viewport{ .x = 0, .y = 0, .width = 800, .height = 300 }, vps[0]);
+    try testing.expectEqual(Viewport{ .x = 0, .y = 300, .width = 800, .height = 300 }, vps[1]);
+}
+
+test "horizontal folds the division remainder into the last band (exact tiling)" {
+    // 1080 / 4 = 270 exactly, but use an odd height to force a remainder.
+    var buf: [4]Viewport = undefined;
+    const vps = splitScreen(500, 1001, 4, .horizontal, &buf);
+    try expectTilesExactly(vps, 500, 1001);
+    // Full width bands, stacked; last band takes the leftover pixel.
+    for (vps) |v| try testing.expectEqual(@as(i32, 500), v.width);
+    try testing.expectEqual(@as(i32, 1001 - 250 * 3), vps[3].height); // 251
+}
+
+// ── Vertical columns ───────────────────────────────────────────────────────
+
+test "vertical 2-way splits into left/right halves" {
+    var buf: [4]Viewport = undefined;
+    const vps = splitScreen(800, 600, 2, .vertical, &buf);
+    try testing.expectEqual(Viewport{ .x = 0, .y = 0, .width = 400, .height = 600 }, vps[0]);
+    try testing.expectEqual(Viewport{ .x = 400, .y = 0, .width = 400, .height = 600 }, vps[1]);
+}
+
+test "vertical 3-way tiles exactly with the remainder in the last column" {
+    var buf: [4]Viewport = undefined;
+    const vps = splitScreen(1000, 720, 3, .vertical, &buf);
+    try expectTilesExactly(vps, 1000, 720);
+    for (vps) |v| try testing.expectEqual(@as(i32, 720), v.height);
+}
+
+// ── Grid ────────────────────────────────────────────────────────────────────
+
+test "grid 4-way is a 2x2 that tiles exactly" {
+    var buf: [4]Viewport = undefined;
+    const vps = splitScreen(800, 600, 4, .grid, &buf);
+    try testing.expectEqual(@as(usize, 4), vps.len);
+    try expectTilesExactly(vps, 800, 600);
+    // Row-major placement: TL, TR, BL, BR.
+    try testing.expectEqual(Viewport{ .x = 0, .y = 0, .width = 400, .height = 300 }, vps[0]);
+    try testing.expectEqual(Viewport{ .x = 400, .y = 0, .width = 400, .height = 300 }, vps[1]);
+    try testing.expectEqual(Viewport{ .x = 0, .y = 300, .width = 400, .height = 300 }, vps[2]);
+    try testing.expectEqual(Viewport{ .x = 400, .y = 300, .width = 400, .height = 300 }, vps[3]);
+}
+
+test "grid 2-way is a single top row of two cells" {
+    var buf: [4]Viewport = undefined;
+    const vps = splitScreen(800, 600, 2, .grid, &buf);
+    // 1 row, 2 cols → each full height.
+    try expectTilesExactly(vps, 800, 600);
+    try testing.expectEqual(Viewport{ .x = 0, .y = 0, .width = 400, .height = 600 }, vps[0]);
+    try testing.expectEqual(Viewport{ .x = 400, .y = 0, .width = 400, .height = 600 }, vps[1]);
+}
+
+test "grid 3-way places three cells of a 2x2, leaving the last empty" {
+    var buf: [4]Viewport = undefined;
+    const vps = splitScreen(800, 600, 3, .grid, &buf);
+    try testing.expectEqual(@as(usize, 3), vps.len);
+    // TL, TR, BL — the BR cell is intentionally unused.
+    try testing.expectEqual(Viewport{ .x = 0, .y = 0, .width = 400, .height = 300 }, vps[0]);
+    try testing.expectEqual(Viewport{ .x = 400, .y = 0, .width = 400, .height = 300 }, vps[1]);
+    try testing.expectEqual(Viewport{ .x = 0, .y = 300, .width = 400, .height = 300 }, vps[2]);
+    // The three occupied cells cover 3/4 of the screen.
+    var total: i64 = 0;
+    for (vps) |v| total += cvp.area(v);
+    try testing.expectEqual(@as(i64, 800 * 600 / 4 * 3), total);
+}
+
+// ── Viewport helpers ─────────────────────────────────────────────────────────
+
+test "fullscreen / isEmpty / area helpers" {
+    const fs = cvp.fullscreen(640, 480);
+    try testing.expectEqual(Viewport{ .x = 0, .y = 0, .width = 640, .height = 480 }, fs);
+    try testing.expect(!cvp.isEmpty(fs));
+    try testing.expectEqual(@as(i64, 640 * 480), cvp.area(fs));
+
+    try testing.expect(cvp.isEmpty(.{ .x = 0, .y = 0, .width = 0, .height = 100 }));
+    try testing.expect(cvp.isEmpty(.{}));
+    try testing.expectEqual(@as(i64, 0), cvp.area(.{}));
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Assert the rects cover the whole `w × h` screen with no overlap: every
+/// pixel belongs to exactly one rect. O(w·h) but the test sizes are small.
+fn expectTilesExactly(vps: []const Viewport, w: i32, h: i32) !void {
+    // Total area must equal the screen (necessary condition).
+    var total: i64 = 0;
+    for (vps) |v| total += cvp.area(v);
+    try testing.expectEqual(@as(i64, w) * @as(i64, h), total);
+
+    // No two rects overlap (sufficient with the area check → exact cover).
+    for (vps, 0..) |a, i| {
+        for (vps[i + 1 ..]) |b| {
+            const overlap_x = @max(0, @min(a.x + a.width, b.x + b.width) - @max(a.x, b.x));
+            const overlap_y = @max(0, @min(a.y + a.height, b.y + b.height) - @max(a.y, b.y));
+            try testing.expectEqual(@as(i32, 0), overlap_x * overlap_y);
+        }
+    }
+}


### PR DESCRIPTION
Refs #761 (partial, engine-side slice).

Adds `camera_viewport.zig`: `splitScreen(...)` exact-tiling viewport rects (horizontal/vertical/grid, up to 4 views) + Viewport helpers. +11 tests. **Remains (gfx repo):** real `setViewport` across backends (Phase 2), declarative layer→camera binding, per-camera scissor in the render loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)