### PR TITLE
chore(engine): address CodeRabbit review follow-ups (#750/#751/#761/#762)

### DIFF
--- a/src/camera_viewport.zig
+++ b/src/camera_viewport.zig
@@ -72,12 +72,17 @@ pub const SplitLayout = enum {
 /// == 0` returns an empty slice; `count == 1` is always the full screen
 /// regardless of layout.
 pub fn splitScreen(
-    screen_w: i32,
-    screen_h: i32,
+    screen_w_in: i32,
+    screen_h_in: i32,
     count: usize,
     layout: SplitLayout,
     out: []Viewport,
 ) []Viewport {
+    // Clamp negative screen dimensions to 0 so no rect can carry a negative
+    // width/height into the renderer (which panics / mis-scissors on one) —
+    // a degenerate empty screen yields empty viewports rather than garbage.
+    const screen_w = @max(0, screen_w_in);
+    const screen_h = @max(0, screen_h_in);
     const n = @min(count, out.len);
     if (n == 0) return out[0..0];
     if (n == 1) {

--- a/src/game.zig
+++ b/src/game.zig
@@ -965,6 +965,11 @@ pub fn GameConfigWithYAxis(
         /// `@FieldType(GameEvents, tag)`, mirroring how
         /// `dispatchEvents` reconstructs the union variant.
         pub const emitEngineEvent = EventsMixin.emitEngineEvent;
+        /// Synchronous variant of `emitEngineEvent` — dispatches in-phase
+        /// instead of buffering. Used by the fixed-timestep phase so
+        /// flow-driven fixed systems run in the fixed slice, not a phase
+        /// late. Full docs in `game/events_mixin.zig`.
+        pub const emitEngineEventSync = EventsMixin.emitEngineEventSync;
 
         /// Emit a game event synchronously — dispatch to registered hooks
         /// immediately, bypassing the end-of-frame buffer. Use when the

--- a/src/game/events_mixin.zig
+++ b/src/game/events_mixin.zig
@@ -63,6 +63,41 @@ pub fn Mixin(comptime Game: type) type {
             comptime tag: []const u8,
             payload: anytype,
         ) void {
+            emitEngineEventImpl(self, tag, payload, false);
+        }
+
+        /// Like `emitEngineEvent`, but dispatches the constructed variant
+        /// SYNCHRONOUSLY (via `emitSync`) instead of buffering it for the
+        /// end-of-frame `dispatchEvents` drain.
+        ///
+        /// Needed by the fixed-timestep phase (#751): the fixed steps run
+        /// inside `tick` BEFORE the variable update, but the buffered
+        /// `emit` path only delivers to flow/Event-node consumers when the
+        /// generated loop drains the buffer AFTER `tick`. A buffered
+        /// `engine__fixed_tick` would therefore reach flow-driven fixed
+        /// systems a phase late (after the variable update + `frame_end`),
+        /// defeating the "fixed before Update, in-phase" contract that
+        /// physics/lockstep needs. Emitting synchronously runs those
+        /// handlers in the same fixed slice, matching the `fixed_update`
+        /// HookPayload path. See `emitSync`'s caveats for the re-entrancy
+        /// / ordering trade-offs a synchronous dispatch carries.
+        pub inline fn emitEngineEventSync(
+            self: *Game,
+            comptime tag: []const u8,
+            payload: anytype,
+        ) void {
+            emitEngineEventImpl(self, tag, payload, true);
+        }
+
+        /// Shared body of `emitEngineEvent` / `emitEngineEventSync`. The
+        /// `sync` flag selects the dispatch: buffered `emit` (end-of-frame)
+        /// or immediate `emitSync`.
+        inline fn emitEngineEventImpl(
+            self: *Game,
+            comptime tag: []const u8,
+            payload: anytype,
+            comptime sync: bool,
+        ) void {
             // Comptime gate: when the project's `GameEvents` doesn't
             // carry the requested variant — e.g. unit-test games using
             // `GameWith(Hooks)` with `GameEvents = void`, or any
@@ -105,7 +140,8 @@ pub fn Mixin(comptime Game: type) type {
                     @compileError("emitEngineEvent: missing field '" ++ f.name ++ "' for variant '" ++ tag ++ "'");
                 }
             }
-            emit(self, @unionInit(GameEvents, tag, typed));
+            const event = @unionInit(GameEvents, tag, typed);
+            if (comptime sync) emitSync(self, event) else emit(self, event);
         }
 
         /// Emit a game event synchronously — dispatch to registered hooks

--- a/src/game/fixed_timestep_mixin.zig
+++ b/src/game/fixed_timestep_mixin.zig
@@ -45,6 +45,8 @@
 //! `advanceFixedTimestep` early-returns when it's off, so a project with no
 //! `fixed/` systems is byte-identical to before this landed.
 
+const std = @import("std");
+
 /// Returns the fixed-timestep mixin for a given Game type.
 pub fn Mixin(comptime Game: type) type {
     return struct {
@@ -63,12 +65,15 @@ pub fn Mixin(comptime Game: type) type {
         }
 
         /// Set the fixed step length in seconds (project-configurable;
-        /// default 1/60). Values ≤ 0 are ignored — a non-positive step
-        /// would make the drain loop diverge — so a bad call leaves the
-        /// previous step in place. Does not reset the accumulator or the
+        /// default 1/60). Non-positive AND non-finite (`NaN` / `Infinity`)
+        /// values are ignored — a non-positive step would make the drain
+        /// loop diverge, and a `NaN` would silently poison `fixed_dt`,
+        /// `fixed_accumulator`, and `fixed_alpha` (every `NaN` comparison is
+        /// false, so it slips past a bare `<= 0` guard). A bad call leaves
+        /// the previous step in place. Does not reset the accumulator or the
         /// step counter.
         pub fn setFixedTimestep(self: *Game, seconds: f64) void {
-            if (seconds <= 0) return;
+            if (seconds <= 0 or !std.math.isFinite(seconds)) return;
             self.fixed_dt = seconds;
         }
 
@@ -101,15 +106,35 @@ pub fn Mixin(comptime Game: type) type {
         /// module doc for the determinism / pause / spiral-guard contract.
         pub fn advanceFixedTimestep(self: *Game, scaled_dt: f32) void {
             if (!self.fixed_timestep_enabled) return;
-            // Defensive: a non-positive step (never set through
-            // `setFixedTimestep`, but a game could poke the field) would
-            // make the drain loop never terminate. Treat it as "no phase".
-            if (self.fixed_dt <= 0) return;
+            // Defensive: a non-positive OR non-finite step (never set through
+            // `setFixedTimestep`, but a game could poke the field directly)
+            // would make the drain loop never terminate or poison the
+            // accumulator with `NaN`. Treat it as "no phase". The
+            // `isFinite` half also covers a directly-set `NaN`/`Inf`, which
+            // slips past a bare `<= 0` compare.
+            if (self.fixed_dt <= 0 or !std.math.isFinite(self.fixed_dt)) return;
+            // Reject a negative / non-finite frame dt (time reversal, clock
+            // jitter, a NaN from upstream) before it corrupts the
+            // accumulator — a negative fold would push the accumulator below
+            // zero and skew every subsequent step boundary. A zero dt is a
+            // valid no-progress frame and falls through harmlessly.
+            if (!std.math.isFinite(scaled_dt) or scaled_dt < 0) return;
 
             self.fixed_accumulator += @as(f64, scaled_dt);
 
+            // Boundary tolerance: f32 frame-dt chunkings that should sum to a
+            // whole number of steps (e.g. 50×`tick(0.02)` or 100×`tick(0.01)`
+            // ≈ 1s at the 1/60 default) land the accumulator a hair below the
+            // next `fixed_dt` and would run one FEWER step than a 60 FPS
+            // chunking — breaking the advertised cross-FPS deterministic step
+            // count at boundary times. Draining when within `drain_eps` of a
+            // step edge closes that gap; the epsilon is far too small
+            // (1e-4 of a step) to ever manufacture a spurious extra step, and
+            // the resulting slightly-negative remainder is clamped below.
+            const drain_eps = self.fixed_dt * 1e-4;
+
             var steps: u32 = 0;
-            while (self.fixed_accumulator >= self.fixed_dt) {
+            while (self.fixed_accumulator + drain_eps >= self.fixed_dt) {
                 self.fixed_accumulator -= self.fixed_dt;
 
                 self.emitHook(.{ .fixed_update = .{
@@ -119,8 +144,12 @@ pub fn Mixin(comptime Game: type) type {
                 // Tolerant dual-emit (#578): folds to a no-op unless the
                 // project's `GameEvents` carries `engine__fixed_tick`
                 // (assembler-built games) — unit-test games with
-                // `GameEvents = void` skip it entirely.
-                self.emitEngineEvent("engine__fixed_tick", .{
+                // `GameEvents = void` skip it entirely. Emitted SYNCHRONOUSLY
+                // (not buffered) so flow-driven fixed systems run in this
+                // fixed slice, before the variable update — not a phase late
+                // after the end-of-frame buffer drain. See
+                // `emitEngineEventSync`.
+                self.emitEngineEventSync("engine__fixed_tick", .{
                     .step_index = self.fixed_step_count,
                     .dt = @as(f32, @floatCast(self.fixed_dt)),
                 });
@@ -143,7 +172,11 @@ pub fn Mixin(comptime Game: type) type {
                 }
             }
 
-            self.fixed_alpha = @floatCast(self.fixed_accumulator / self.fixed_dt);
+            // Clamp to `[0, ∞)`: the `drain_eps` boundary drain can leave the
+            // remainder a hair below zero, and any residual fp underflow must
+            // not surface as a negative `fixed_alpha` (the documented range
+            // is `[0, 1)`). `@max` keeps it a valid interpolation factor.
+            self.fixed_alpha = @max(0.0, @as(f32, @floatCast(self.fixed_accumulator / self.fixed_dt)));
         }
     };
 }

--- a/src/game/save_load/json_read.zig
+++ b/src/game/save_load/json_read.zig
@@ -67,7 +67,11 @@ pub fn getStringField(obj: std.json.ObjectMap, name: []const u8) ?[]const u8 {
 pub fn getU64Field(obj: std.json.ObjectMap, name: []const u8) ?u64 {
     const v = obj.get(name) orelse return null;
     return switch (v) {
-        .integer => |i| if (i >= 0) @intCast(i) else null,
+        // `std.math.cast` returns null when the i64 doesn't fit u64
+        // (negatives, and — vacuously — any out-of-range value), so a
+        // negative / malformed entity id is dropped without an `@intCast`
+        // trap. Idiomatic replacement for the manual `i >= 0` guard.
+        .integer => |i| std.math.cast(u64, i),
         else => null,
     };
 }

--- a/src/particles.zig
+++ b/src/particles.zig
@@ -209,11 +209,29 @@ pub const ParticleSystem = struct {
 
     /// Kill every live particle and reseed to the config seed, returning the
     /// system to its exact initial state (retains pool capacity — no
-    /// allocation). Use to restart a deterministic replay.
+    /// allocation). Use to restart a deterministic replay. `emitting` is
+    /// restored to its `true` default so a system stopped via
+    /// `setEmitting(false)` (e.g. to let particles dissipate before reuse)
+    /// resumes continuous emission on the next `step` — otherwise an
+    /// identical post-reset `step` sequence would produce no particles,
+    /// breaking the deterministic-restart contract this method advertises.
     pub fn reset(self: *ParticleSystem) void {
         self.particles.clearRetainingCapacity();
         self.prng = std.Random.DefaultPrng.init(self.config.seed);
         self.spawn_accumulator = 0;
+        self.emitting = true;
+    }
+
+    /// Effective live-particle ceiling: the smaller of the authored
+    /// `config.max_particles` and the pool's RESERVED `capacity`. `config`
+    /// is publicly mutable, so a caller can raise `max_particles` after
+    /// `init` — but the pool was only reserved for the original ceiling, and
+    /// `appendAssumeCapacity` would append past the allocation (UB, or a
+    /// safety-build panic) if we honoured the raised value. Clamping to
+    /// `capacity` keeps every spawn within the reservation; lowering
+    /// `max_particles` is still respected (the smaller wins).
+    fn spawnCeiling(self: *const ParticleSystem) usize {
+        return @min(@as(usize, self.config.max_particles), self.particles.capacity);
     }
 
     /// Advance the simulation by `dt` seconds: integrate + age every live
@@ -245,53 +263,94 @@ pub const ParticleSystem = struct {
 
         if (!self.emitting or self.config.rate <= 0) return;
 
-        // Draw whole particles out of the fractional-spawn accumulator, so
-        // any rate (incl. < 1/frame) and any dt spawn the exact expected
-        // count over time. Capped at `max_particles` — surplus is dropped,
-        // never grows the pool.
-        self.spawn_accumulator += self.config.rate * dt;
-        while (self.spawn_accumulator >= 1) {
-            self.spawn_accumulator -= 1;
-            if (self.particles.items.len >= self.config.max_particles) {
+        // Continuous emission. Each particle due this frame is emitted at its
+        // precise sub-frame time and back-integrated to the frame's end, so a
+        // long (hitchy) frame doesn't dump the whole interval's worth of
+        // particles at age 0. `acc_start` is the fractional carry from prior
+        // frames (always in `[0, 1)`); adding `rate * dt` gives how many
+        // particle "credits" are available across `[0, dt]`. The k-th credit
+        // (k = 1, 2, …) is reached at frame-time `t_emit = (k - acc_start) /
+        // rate`, so that particle has already lived `dt - t_emit` seconds by
+        // the end of this step. Emissions older than their lifetime are
+        // skipped — that is exactly what caps a short-lived effect at ~one
+        // lifetime of live particles instead of one whole frame's worth.
+        const acc_start = self.spawn_accumulator;
+        const acc_end = acc_start + self.config.rate * dt;
+        const ceiling = self.spawnCeiling();
+        var k: f32 = 1;
+        while (k <= acc_end) : (k += 1) {
+            if (self.particles.items.len >= ceiling) {
                 // Pool full — discard the backlog so a starved frame can't
                 // burst past the ceiling once space frees up.
                 self.spawn_accumulator = 0;
-                break;
+                return;
             }
-            self.spawnOne();
+            const t_emit = (k - acc_start) / self.config.rate; // seconds into frame
+            const initial_age = dt - t_emit; // age at frame end
+            self.spawnOne(if (initial_age > 0) initial_age else 0);
         }
+        // Carry the sub-1 remainder to the next frame (acc_start was < 1, so
+        // `floor(acc_end)` is the count just emitted).
+        self.spawn_accumulator = acc_end - @floor(acc_end);
     }
 
     /// Emit `n` particles immediately (a one-shot burst — explosion, hit
     /// flash), independent of `rate`/`emitting`. Clamped to remaining pool
     /// space. No allocation.
     pub fn burst(self: *ParticleSystem, n: u32) void {
+        const ceiling = self.spawnCeiling();
         var k: u32 = 0;
         while (k < n) : (k += 1) {
-            if (self.particles.items.len >= self.config.max_particles) return;
-            self.spawnOne();
+            if (self.particles.items.len >= ceiling) return;
+            self.spawnOne(0);
         }
     }
 
-    /// Spawn a single particle at the origin with jittered lifetime, speed,
-    /// and direction drawn from the seeded PRNG. Assumes pool space (callers
-    /// check `max_particles`); `appendAssumeCapacity` keeps it alloc-free.
-    fn spawnOne(self: *ParticleSystem) void {
+    /// Spawn a single particle with jittered lifetime, speed, and direction
+    /// drawn from the seeded PRNG, then integrated forward by `initial_age`
+    /// seconds (0 for a burst / just-due particle; > 0 for one emitted
+    /// earlier within a long frame). A particle whose `initial_age` already
+    /// meets its lifetime is skipped — it would be born dead — which is what
+    /// keeps a long frame from over-spawning short-lived effects. Assumes
+    /// pool space (callers check `spawnCeiling`); `appendAssumeCapacity`
+    /// keeps it alloc-free. The RNG draws happen BEFORE the skip so the
+    /// sequence stays deterministic regardless of how many are skipped.
+    fn spawnOne(self: *ParticleSystem, initial_age: f32) void {
         const r = self.prng.random();
 
-        const life = self.config.lifetime * (1 + jitter(r, self.config.lifetime_jitter));
+        const life_raw = self.config.lifetime * (1 + jitter(r, self.config.lifetime_jitter));
         const speed = self.config.speed * (1 + jitter(r, self.config.speed_jitter));
         const angle = self.config.direction + jitter(r, 1) * self.config.spread;
 
+        // Guard a degenerate authored lifetime so `Particle.t` never divides
+        // by zero and the particle dies on its first step.
+        const life = if (life_raw > 0) life_raw else std.math.floatEps(f32);
+
+        // Emitted earlier in the frame than its own lifetime → already dead
+        // by frame end; don't occupy a pool slot for it.
+        if (initial_age >= life) return;
+
+        var vx = @cos(angle) * speed;
+        var vy = @sin(angle) * speed;
+        var x = self.origin_x;
+        var y = self.origin_y;
+        // Advance the sub-frame time already elapsed (semi-implicit Euler,
+        // matching `step`'s per-frame integration) so a back-in-time
+        // continuous spawn lands where it would have travelled to.
+        if (initial_age > 0) {
+            vx += self.config.gravity_x * initial_age;
+            vy += self.config.gravity_y * initial_age;
+            x += vx * initial_age;
+            y += vy * initial_age;
+        }
+
         self.particles.appendAssumeCapacity(.{
-            .x = self.origin_x,
-            .y = self.origin_y,
-            .vx = @cos(angle) * speed,
-            .vy = @sin(angle) * speed,
-            .age = 0,
-            // Guard a degenerate authored lifetime so `Particle.t` never
-            // divides by zero and the particle dies on its first step.
-            .lifetime = if (life > 0) life else std.math.floatEps(f32),
+            .x = x,
+            .y = y,
+            .vx = vx,
+            .vy = vy,
+            .age = initial_age,
+            .lifetime = life,
         });
     }
 

--- a/test/camera_viewport_test.zig
+++ b/test/camera_viewport_test.zig
@@ -39,6 +39,17 @@ test "count clamps to the output buffer length" {
     try testing.expectEqual(@as(usize, 2), vps.len);
 }
 
+test "negative screen dimensions never produce negative viewport rects" {
+    var buf: [4]Viewport = undefined;
+    inline for (.{ SplitLayout.horizontal, .vertical, .grid }) |layout| {
+        const vps = splitScreen(-1920, -1080, 4, layout, &buf);
+        for (vps) |v| {
+            try testing.expect(v.width >= 0);
+            try testing.expect(v.height >= 0);
+        }
+    }
+}
+
 // ── Horizontal bands ───────────────────────────────────────────────────────
 
 test "horizontal 2-way splits into stacked top/bottom halves" {

--- a/test/fixed_timestep_test.zig
+++ b/test/fixed_timestep_test.zig
@@ -138,6 +138,54 @@ test "fixed-step count is identical regardless of frame chunking (30/60/144fps)"
     }
 }
 
+test "boundary FPS caps run the same step count as 60fps (drain tolerance)" {
+    // The default 1/60 step with 50 / 100 FPS chunking: 50×tick(0.02) or
+    // 100×tick(0.01) sum (in f32) to a hair under 1.0s. Without the drain
+    // tolerance the accumulator stops one step short (59) while a 60fps
+    // chunking runs 60 — breaking the cross-FPS determinism guarantee. With
+    // the tolerance all three caps agree at 60.
+    const Case = struct { chunk: f32, frames: usize };
+    const cases = [_]Case{
+        .{ .chunk = 0.02, .frames = 50 }, // 50 fps
+        .{ .chunk = 1.0 / 60.0, .frames = 60 }, // 60 fps
+        .{ .chunk = 0.01, .frames = 100 }, // 100 fps
+    };
+    for (cases) |c| {
+        var game = TestGame.init(testing.allocator);
+        defer game.deinit();
+        // Default fixed_dt (1/60); raise the spiral cap so no frame clamps.
+        game.max_fixed_steps_per_frame = 100;
+        game.setFixedTimestepEnabled(true);
+
+        var f: usize = 0;
+        while (f < c.frames) : (f += 1) game.tick(c.chunk);
+
+        try testing.expectEqual(@as(u64, 60), game.fixedStepCount());
+        // alpha stays a valid interpolation factor (never negative).
+        try testing.expect(game.fixedAlpha() >= 0);
+        try testing.expect(game.fixedAlpha() < 1.0);
+    }
+}
+
+test "setFixedTimestep rejects NaN and infinity" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    game.setFixedTimestep(0.02);
+    game.setFixedTimestep(std.math.nan(f64));
+    try testing.expectApproxEqAbs(@as(f64, 0.02), game.fixedTimestep(), 1e-9);
+    game.setFixedTimestep(std.math.inf(f64));
+    try testing.expectApproxEqAbs(@as(f64, 0.02), game.fixedTimestep(), 1e-9);
+
+    // A non-finite fixed_dt poked directly must not poison alpha: the drain
+    // guard bails, leaving alpha untouched (0).
+    game.fixed_dt = std.math.nan(f64);
+    game.setFixedTimestepEnabled(true);
+    game.tick(1.0);
+    try testing.expectEqual(@as(f32, 0), game.fixedAlpha());
+    try testing.expectEqual(@as(u64, 0), game.fixedStepCount());
+}
+
 // ── Pause / time_scale interaction ─────────────────────────────────────────
 
 test "fixed phase freezes while paused and scales under slow-mo" {

--- a/test/particles_test.zig
+++ b/test/particles_test.zig
@@ -189,6 +189,60 @@ test "burst emits immediately regardless of rate, clamped to the ceiling" {
     try testing.expect(s.particles.capacity == 50);
 }
 
+test "raising max_particles after init never spawns past the reserved pool" {
+    // config is publicly mutable; a caller can bump max_particles above what
+    // init reserved. Spawns must still be clamped to the reserved capacity
+    // (spawnCeiling) — appending past it would be UB / a safety panic.
+    const cfg: EmitterConfig = .{ .rate = 1000, .lifetime = 100, .speed = 0, .max_particles = 8, .seed = 1 };
+    var s = try ParticleSystem.init(testing.allocator, cfg);
+    defer s.deinit(testing.allocator);
+
+    const reserved = s.particles.capacity; // == 8
+    s.config.max_particles = 10_000; // raise beyond the reservation
+
+    var f: usize = 0;
+    while (f < 20) : (f += 1) {
+        s.step(0.1); // 100 due per frame, far over the reservation
+        try testing.expect(s.liveCount() <= reserved);
+        try testing.expectEqual(reserved, s.particles.capacity); // no realloc
+    }
+    // Same guard on the burst path.
+    s.burst(10_000);
+    try testing.expectEqual(reserved, s.particles.capacity);
+    try testing.expect(s.liveCount() <= reserved);
+}
+
+test "reset re-enables emission so a stopped emitter restarts cleanly" {
+    const cfg: EmitterConfig = .{ .rate = 60, .lifetime = 10, .speed = 0, .max_particles = 256, .seed = 4 };
+    var s = try ParticleSystem.init(testing.allocator, cfg);
+    defer s.deinit(testing.allocator);
+
+    // Stop emitting (e.g. to let existing particles dissipate before reuse).
+    s.setEmitting(false);
+    var i: usize = 0;
+    while (i < 10) : (i += 1) s.step(1.0 / 60.0);
+    try testing.expectEqual(@as(usize, 0), s.liveCount()); // nothing emitted while stopped
+
+    // reset() must return to the fresh initial state — including emitting=true.
+    s.reset();
+    i = 0;
+    while (i < 10) : (i += 1) s.step(1.0 / 60.0);
+    try testing.expect(s.liveCount() > 0); // emission resumed
+}
+
+test "a long frame ages continuous spawns instead of dumping them all at age 0" {
+    // rate=100, lifetime≈0.105s, one giant 1.0s frame. Only emissions within
+    // the last ~lifetime of the frame should still be alive — roughly 10-11,
+    // NOT the full 100 the naive (spawn-all-at-age-0) path would leave.
+    const cfg: EmitterConfig = .{ .rate = 100, .lifetime = 0.105, .speed = 0, .max_particles = 1000, .seed = 6 };
+    var s = try ParticleSystem.init(testing.allocator, cfg);
+    defer s.deinit(testing.allocator);
+
+    s.step(1.0);
+    try testing.expect(s.liveCount() > 0);
+    try testing.expect(s.liveCount() <= 15); // ~one lifetime's worth, not 100
+}
+
 // ── Render readback ─────────────────────────────────────────────────────────
 
 test "renderData applies size and alpha ramps over life" {


### PR DESCRIPTION
Cleanup pass addressing CodeRabbit review nits from the merged feature PRs #764/#765/#766/#767. `zig build test` green (+6 new tests, zero regressions).

- **#762** `json_read.zig`: use `std.math.cast(u64, i)` for JSON field parsing.
- **#751** `fixed_timestep_mixin.zig`: reject NaN/Inf timestep, guard non-finite/negative `scaled_dt`, `@max(0,…)` alpha clamp, **dispatch `engine__fixed_tick` synchronously** (in-phase, not a frame late) via a shared sync emit path, and add drain tolerance so 50/60/100 FPS chunkings all run 60 steps. +2 tests.
- **#761** `camera_viewport.zig`: clamp negative screen dims to 0 in `splitScreen` (no release panic). +1 test.
- **#750** `particles.zig`: `reset()` restores the emission flag; clamp spawns to reserved pool capacity (continuous + burst); emit continuous spawns at precise sub-frame time and skip born-dead ones (long-frame fix). +3 tests.

Skipped the 3 "high" `std.Random.DefaultPrng` comments — false positives (`std.rand` was removed in Zig 0.16; the code compiles and all particle tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)