### PR TITLE
RFC: language purity mandate + language-agnostic assembler (rev 16)

### DIFF
--- a/RFC-LANGUAGE-PLUGINS.md
+++ b/RFC-LANGUAGE-PLUGINS.md
@@ -212,9 +212,11 @@ Components are comptime Zig types (typed ECS storage, reflection registry, save/
 
 ```json
 { "components": [ { "name": "Hunger", "persist": "persistent",
-                    "fields": [ { "name": "level", "type": "f32", "default": 0.875 } ] } ],
+                    "fields": [ { "name": "level", "type": "f32", "default": 0.875 },
+                                { "name": "starving", "type": "bool", "default": false } ] } ],
   "events":     [ { "name": "hunger__feed",
-                    "fields": [ { "name": "entity", "type": "u64", "default": 0 } ] } ] }
+                    "fields": [ { "name": "amount", "type": "f32", "default": 0.5 },
+                                { "name": "entity", "type": "u64", "default": 0 } ] } ] }
 ```
 
 - **Type vocabulary**: `f32` / `bool` / `i32` / `vec2` / `str` / `u64` — the last via the **`Labelle.id`** sentinel (event payloads carry entity ids; ids default to `0`; deliberately no value constructor in v1 — `Labelle.id` classifies, it does not wrap). Legal in component fields too. `"events"` is emitted **only when non-empty**, and events carry no `persist` (they aren't saved) — old assemblers read only `"components"` from the JSON Value tree, so the key was compat-safe by construction.
@@ -265,7 +267,7 @@ This completes the vendor story: a full content pack — atlases, prefabs, a gen
 
 Shipping five languages left per-language knowledge smeared across the assembler as built-in tables: the `DECLARE_RUNNERS` rows (declare tool step name, tool dir, extension, capability pins), the native-language splice rows (`NATIVE_LANGUAGES` wiring — which game dir stages over which module root), and the TS transpile phase's toolchain pins. Every row is data the assembler *consumes* but labelle-scripting *owns* — the same inversion the pluggable-backends RFC (labelle-assembler#378) applies to render backends, and rev 13's own rule ("plugin-specific options must never grow the assembler's config schema") applied to the assembler's internals instead of its config. The design: those tables migrate to **language capability rows in labelle-scripting's `plugin.labelle`**, and the assembler becomes a generic executor of rows.
 
-A row carries everything the assembler knows per language today: name, extension(s), family (`embedded` | `native`), the native module root (`mod.rs` / `game.cr`), the declare capability (tool step name + tool dir; the presence of an `.events` sub-capability is what "supports declared events" *means*), transpile needs (emitted extension + toolchain requirement), and the runtime embed wiring. Sketch, spelling aligned with the manifest's existing `params_schema` / `language_builds`:
+A row carries everything the assembler knows per language today: name, extension(s), kind (`embedded` | `native`), the native module root (`mod.rs` / `game.cr`), the declare capability (tool step name + tool dir; the presence of an `.events` sub-capability is what "supports declared events" *means*), transpile needs (emitted extension + toolchain requirement), and the runtime embed wiring. Sketch, spelling aligned with the manifest's existing `params_schema` / `language_builds`:
 
 ```zig
 .languages = .{

--- a/RFC-LANGUAGE-PLUGINS.md
+++ b/RFC-LANGUAGE-PLUGINS.md
@@ -3,7 +3,7 @@
 **Issue:** labelle-toolkit/labelle-engine#237 (updated 2026-07 — re-scoped from "Lua module" to the language-plugin family)  
 **Status:** Draft  
 **Author:** Alexandre  
-**Date:** 2026-07-10 (rev 2 — POC validated: PR #734; rev 3 — single-repo packaging: `labelle-scripting` with language sub-modules; rev 4 — reference bindings: Lua queries, Ruby events; rev 5 — Ruby controllers: script-language domain owners; rev 6 — script-declared components: generate-time codegen, runtime tier for mods; rev 7 — native declaration idioms per language; rev 8 — policy: one language per project, enforced at generate; rev 9 — policy rationale: role-based, pack/mod carve-outs; rev 10 — Zig plugins in script-language projects; rev 11 — script-language packs; rev 12 — TypeScript (QuickJS) and Go (c-archive) join the families; rev 13 — language rides generic plugin params; rev 14 — per-frame allocation idioms: FrameArray, into: reuse; rev 15 — idioms generalized per language)
+**Date:** 2026-07-10 (rev 2 — POC validated: PR #734; rev 3 — single-repo packaging: `labelle-scripting` with language sub-modules; rev 4 — reference bindings: Lua queries, Ruby events; rev 5 — Ruby controllers: script-language domain owners; rev 6 — script-declared components: generate-time codegen, runtime tier for mods; rev 7 — native declaration idioms per language; rev 8 — policy: one language per project, enforced at generate; rev 9 — policy rationale: role-based, pack/mod carve-outs; rev 10 — Zig plugins in script-language projects; rev 11 — script-language packs; rev 12 — TypeScript (QuickJS) and Go (c-archive) join the families; rev 13 — language rides generic plugin params; rev 14 — per-frame allocation idioms: FrameArray, into: reuse; rev 15 — idioms generalized per language; rev 16 — the 2026-07-12 product decisions: purity mandate (100% selected-language games), convention dirs shipped (scripts/, components/, events/), the declare contract as the language-neutral seam, the language-agnostic assembler (capability rows))
 
 ## Problem
 
@@ -37,6 +37,20 @@ The engine API is comptime-parameterized — there is no stable ABI a VM can cal
 
 WASM is a *third* possible mechanism unifying both (any language → wasm module in an embedded runtime, sandboxing for free) — treated in Alternatives; deliberately not the only path.
 
+## The purity mandate: 100% selected-language (rev 16)
+
+**Product decision (2026-07-12, #237): every shipped language must be able to go 100% selected-language — no Zig at all.** A ruby game is `scripts/*.rb` + `components/*.rb` + `events/*.rb` + scenes (data) + `project.labelle` (config); the same sentence must hold for every language the plugin ships. Native `hooks/*.zig` remain the **optional** escape hatch — a capability, not a requirement.
+
+Why a mandate and not a nice-to-have: the accessibility motivation is only real if the language stands alone — a "ruby game" that needs one `.zig` file for a custom event has a Zig prerequisite in its onboarding path, and the audience the language was added for is exactly the audience that trips there. The mandate also keeps the two-layer architecture honest from the other side: Zig is the *performance* layer, opted into for hot paths — never the tax for finishing a game.
+
+Consequences:
+
+- **Completeness is measured per kind**: everything a game must author — behavior, component declarations, event declarations — must be authorable in the selected language. Engine builtin events already need no declaration; the last gap was custom events, closed by #772.
+- **CI enforces it structurally**: each example game carries a *purity variant* — a scratch copy with `hooks/` deleted must generate, build, and run green. "Hooks are optional" stops being a claim and becomes a gate.
+- **The escape hatch stays load-bearing**: nothing here removes native hooks — the plugin-interop story (proposal 5) and the performance framing are unchanged. The mandate fixes the *floor* (zero Zig must work), not the ceiling.
+
+Status against the bar: **lua / ruby** close with #772 (components shipped, assembler v0.86.0; events in flight, v0.87.0); **typescript** → #773 (a declare runner over the already-pinned tsc + the already-vendored QuickJS — the cheap close, and the `.d.ts` loop closes on itself: a component declared in TS comes back to every script as typed `Entity.get/set`); **rust** → #774 (`labelle::component!`/`event!` macros + extraction, probe-vs-parser decided on the ticket — the typed-struct expansion is the prize *beyond* parity); **crystal** → #775 (follows rust's extraction decision, so both native lanes share one design).
+
 ## Proposal
 
 ### 1. The Script Runtime Contract (engine-side, the one shared piece)
@@ -67,7 +81,7 @@ scene_change(name)                log(level, msg)
 
 All languages ship in a single first-party plugin repo — **`labelle-scripting`** — rather than one repo per language. The shared layer (contract binding, script discovery, hot-reload machinery, the plugin controller) dominates every language integration; one repo writes it once, and each language is a thin sub-module over it (the in-tree sub-package convention, applied to a plugin). One `.plugins` entry, one version train pinned to one contract version — no per-language compat matrix — and should the one-language-per-project policy (below) ever be lifted, multi-language games get one controller with one deterministic tick order instead of N plugins with duplicated glue.
 
-**Policy: one language per project** (rev 8; declaration shape revised rev 13). The language is declared through the **generic plugin-parameters mechanism** — `.params = .{ .language = "lua" }` on the plugin entry — rather than a bespoke `PluginDep` field. Plugin-specific options must never grow the assembler's config schema: `.params` is a per-plugin bag validated against a schema the plugin declares in `plugin.labelle` (full mechanism is its own ticket; `language` is its first consumer, recognized natively until schema-driven validation lands). The parameter is **singular** — mixing stays unrepresentable. Enforcement is layered:
+**Policy: one language per project** (rev 8; declaration shape revised rev 13). The language is declared through the **generic plugin-parameters mechanism** — `.params = .{ .language = "lua" }` on the plugin entry — rather than a bespoke `PluginDep` field. Plugin-specific options must never grow the assembler's config schema: `.params` is a per-plugin bag validated against a schema the plugin declares in `plugin.labelle` (shipped: the manifest's `params_schema` declares the vocabulary — exactly the implemented languages, test-pinned against the `Language` enum — and the assembler validates at generate since v0.83.0, labelle-assembler#591). The parameter is **singular** — mixing stays unrepresentable. Enforcement is layered:
 
 - **Generate-time validation**: the assembler scans every script convention dir — game root *and* pack-bundled — and errors (file list included) on any script outside the declared language. Content packs/plugins that bundle scripts declare `requires_language = "…"` in their manifest (symmetric with `depends_on_resources`), validated on attach, so a Lua-scripted pack fails loudly in a Rust project.
 - **Comptime**: only the declared sub-module compiles; `b.lazyDependency` means other runtimes are never fetched, built, or linked — the binary physically contains one language runtime. Dir-presence detection remains as a cross-check, not the selector.
@@ -83,18 +97,18 @@ Anatomy (shared once, per-language where noted):
 
 1. **runtime**: each sub-module embeds or links its runtime (ziglua VM / mruby VM / CoreCLR host / nothing for Rust+Crystal), behind its comptime gate + lazy dependency;
 2. **one plugin controller**: `setup` (init the enabled runtimes, load scripts), `tick` (run script updates — in the plugin block of the two-block order), `deinit`;
-3. **script convention dirs** per language (`lua/`, `ruby/`, …) via `plugin.labelle` — the assembler **embeds** scripts (`@embedFile`) for release; dev builds disk-watch for hot reload;
+3. **the Zig convention dirs, extension-keyed** (revised rev 16 — `scripts/` + `components/` SHIPPED in assembler v0.86.0, `events/` lands in v0.87.0): script-language files live in the SAME structure a Zig game uses — not per-language dirs (`lua/`, `ruby/`, …), not a new name. Files live where their **kind** lives: behavior in `scripts/` (`scripts/hunger.rb` sits exactly where `scripts/hunger.zig` would; numeric ordering prefixes order registration; Zig and script files coexist in one dir — the two-layer architecture in one structure), component declarations in `components/*.<ext>`, event declarations in `events/*.<ext>`. The extension selects the language; registration order is pinned **components → events → scripts**, so declared constants exist when scripts load. The assembler **embeds** (`@embedFile`) for release; dev builds disk-watch for hot reload. The rev-2..15 per-language dirs got one release of grace with a pointed note, then examples and docs migrated;
 4. **idiomatic bindings** per sub-module over the shared contract binding — #237's Lua API sketch (`game:findEntity`, `entity:get/set`, `input:isKeyDown`, `vec2`) kept verbatim as the reference design;
 5. optionally a **studio panel** (asset-plugins RFC) — a script console / REPL panel is the natural v2.
 
 ### 3. Per-language notes (sub-modules of labelle-scripting)
 
-- **lua** — the flagship (P1). Lua 5.4 via ziglua (~200 KB), LuaJIT as a build option (the #237 open question stands). Everything in #237's Phases 1–2 carries over; only the integration points change (convention dir instead of scene prefixes; plugin config instead of a `.lua` project block).
-- **rust / crystal** — the native family. The contract ships as a C header; game Rust/Crystal code builds as a static lib the plugin's build integration links into the game binary. Full native performance, no VM, no sandbox; hot reload only as an optional dev-mode dylib swap. Crystal gives the Ruby-shaped syntax at native speed.
-- **ruby** — **mruby**, not CRuby (CRuby is not designed for embedding). Embedded-VM family; smaller community than Lua but the same shape.
-- **typescript** — **QuickJS** (the Lua of JS: small, embeddable, no JIT, sandboxes well — a strong mods candidate) with a **TS→JS transpile step at generate time** (esbuild via the plugin build hook; dev watch for hot reload). The largest-audience accessibility play, and the best-typed DX of the VM family: **`.d.ts` files are codegen'd from the component schemas + contract**, so scripts get real autocomplete, and TS interfaces feed declare-mode (the type system is the DSL, like Rust). Priority: right after Lua.
-- **go** — feasible via `-buildmode=c-archive` (cgo `//export` entries over the contract header), with honest caveats: Go brings its **own runtime as a guest** (scheduler, GC, signal handlers — coexistence needs explicit cgo configuration), +2–8 MB binary, goroutines vs the main-thread-only contract (guard rails), and cgo cross-compilation pain on mobile. The awkward middle of the native family; demand-driven, behind rust/crystal.
-- **csharp** — the heaviest: CoreCLR hosting via `hostfxr`, desktop-first (Android/iOS AOT constraints are real — Godot's Mono history is the cautionary precedent). Explicitly last.
+- **lua** — the flagship (P1) — **SHIPPED**. Lua 5.4 via ziglua (~200 KB), LuaJIT as a build option (the #237 open question stands). Everything in #237's Phases 1–2 carried over; only the integration points changed (convention dir instead of scene prefixes; plugin config instead of a `.lua` project block).
+- **rust / crystal** — the native family — **SHIPPED**. The contract ships as a C header; game code lives in `scripts/` under a native module root (`scripts/mod.rs` / `scripts/game.cr`) and builds via the manifest's `.language_builds` steps — cargo emits a static lib, crystal a main-localized object (the POC's `ld -r` recipe) — linked into the game binary. Full native performance, no VM, no sandbox; hot reload only as an optional dev-mode dylib swap. Crystal gives the Ruby-shaped syntax at native speed. Declarations close the purity bar: #774 (rust), #775 (crystal).
+- **ruby** — **mruby**, not CRuby (CRuby is not designed for embedding) — **SHIPPED**. Embedded-VM family; smaller community than Lua but the same shape.
+- **typescript** — **QuickJS** (the Lua of JS: small, embeddable, no JIT, sandboxes well — a strong mods candidate) — **SHIPPED**, with the **TS→JS transpile at generate** running on the pinned tsc 7 toolchain (#745/#613 — platform-package pins with hashes; the one trust exception in proposal 7), not esbuild as revs 12–15 sketched. The largest-audience accessibility play, and the best-typed DX of the VM family: **`.d.ts` files are codegen'd from the component schemas + contract**, so scripts get real autocomplete; declare-mode rides the same prelude pattern as lua/ruby (#773: a quickjs declare host evaluating the transpiled declaration files), and the loop closes on itself — a TS-declared component comes back to every script typed.
+- **go** — demand-driven (#746), unshipped. Feasible via `-buildmode=c-archive` (cgo `//export` entries over the contract header), with honest caveats: Go brings its **own runtime as a guest** (scheduler, GC, signal handlers — coexistence needs explicit cgo configuration), +2–8 MB binary, goroutines vs the main-thread-only contract (guard rails), and cgo cross-compilation pain on mobile. The awkward middle of the native family; behind rust/crystal.
+- **csharp** — the heaviest: CoreCLR hosting via `hostfxr`, desktop-first (Android/iOS AOT constraints are real — Godot's Mono history is the cautionary precedent). Explicitly last — **in flight** (#743, its own workstream; the manifest already carries its vocabulary row and `dotnet publish` step).
 
 ### 4. Reference bindings: what the sugar looks like
 
@@ -159,7 +173,7 @@ The unifying rule: the real per-frame allocator in every VM language is **the bo
 **Controllers in Ruby** — script-language *domain owners*, not just leaf behaviors. Subclassing registers (Ruby's `inherited` hook — convention over config); the file's numeric prefix orders ticks:
 
 ```ruby
-# ruby/controllers/10_hunger_controller.rb
+# scripts/10_hunger_controller.rb
 class HungerController < Labelle::Controller
   def setup
     on "hunger__feed" { |ev| feed(ev[:entity], ev[:amount] || 0.5) }  # command-as-event
@@ -182,31 +196,45 @@ end
 - **Cross-language API = commands-as-events + components-as-state** (the pathfinder-v4 triad, minus direct calls): any language "calls" a Ruby controller by emitting its command event; the controller answers via events and component writes. Direct cross-language function calls are deliberately not in v1 — the bus is the boundary. Same-language callers use plain method calls.
 - **Authoritative state lives in components; ivars are caches.** The VM is transient — save/load rehydration and hot reload reset it (the FP plugin-State lesson). Keeping durable state in engine-serialized components makes script controllers save-safe and hot-reloadable for free.
 
-**Components declared in script languages** — first-class via generate-time codegen:
+**Components and events declared in script languages** — first-class via generate-time codegen (components **SHIPPED**, assembler v0.86.0; events land in v0.87.0 — #772):
 
 ```ruby
-# ruby/components/hunger.rb
-class Hunger < Labelle::Component
-  field :level,    :f32,  default: 1.0
-  field :starving, :bool, default: false
-  persist :persistent          # Saveable bucket, same vocabulary as Zig components
-end
+# components/hunger.rb — beside components/worker.zig
+Hunger = Labelle.component "Hunger", level: 0.875, starving: false
+
+# events/hunger__feed.rb — one line, any number of consumers
+HungerFeed = Labelle.event "hunger__feed", entity: Labelle.id, amount: 0.5
 ```
 
-Components are comptime Zig types (typed ECS storage, reflection registry, save/load, scene instantiation) — a VM cannot conjure one at runtime. So the declaration is consumed at **`labelle generate`**: the sub-module ships a *declare-mode runner* (the vendored VM loads `ruby/**/*.rb` under a stub `Labelle` that records `field`/`persist` and dumps JSON — Ruby introspects itself, no Ruby parser in the assembler), and the assembler **codegens a real Zig component struct** into the normal registry (pack-namespaced when the `ruby/` dir lives in a pack). Everything then works with zero special cases: scenes/prefabs (`"Hunger": {"level": 0.8}`), save/load with the declared bucket, cross-language name access, typed queries, and boundary validation (`e.set(Hunger, h)` checks the schema → script errors instead of silent drift).
+Components are comptime Zig types (typed ECS storage, reflection registry, save/load, scene instantiation) and custom events are comptime union rows — a VM cannot conjure either at runtime. So declarations are consumed at **`labelle generate`**: the sub-module ships a *declare-mode runner* (the vendored VM loads `components/*.<ext>` and `events/*.<ext>` — plus in-script chunk-scope declarations, legal for compatibility — under a declare prelude that records declarations and dumps schema JSON; the language introspects itself, no ruby/lua parser in the assembler), and the assembler **codegens real Zig** into the normal paths (pack-namespaced when the declaring dir lives in a pack). Everything then works with zero special cases: scenes/prefabs (`"Hunger": {"level": 0.8}`), save/load with the declared bucket, cross-language name access, typed queries, boundary validation (`e.set(Hunger, h)` checks the schema → script errors instead of silent drift) — and a declared event's union row comes out byte-identical to a Zig-authored one.
+
+**The declare contract (rev 16) — THE language-neutral seam.** One schema JSON from any declare tool:
+
+```json
+{ "components": [ { "name": "Hunger", "persist": "persistent",
+                    "fields": [ { "name": "level", "type": "f32", "default": 0.875 } ] } ],
+  "events":     [ { "name": "hunger__feed",
+                    "fields": [ { "name": "entity", "type": "u64", "default": 0 } ] } ] }
+```
+
+- **Type vocabulary**: `f32` / `bool` / `i32` / `vec2` / `str` / `u64` — the last via the **`Labelle.id`** sentinel (event payloads carry entity ids; ids default to `0`; deliberately no value constructor in v1 — `Labelle.id` classifies, it does not wrap). Legal in component fields too. `"events"` is emitted **only when non-empty**, and events carry no `persist` (they aren't saved) — old assemblers read only `"components"` from the JSON Value tree, so the key was compat-safe by construction.
+- **Byte-parity is pinned by cross-runner goldens**: every declare tool must emit byte-identical JSON for the same declarations (alphabetized fields, shared field caps, one drift pin across the tools). The golden is the proof that downstream is producer-agnostic — the property proposal 7 builds on.
+- **Downstream never knows the producer**: components codegen into the registry as `scripting_components.zig`; events materialize as **one generated `scripting_events.zig`** whose union rows import it inline. One file rather than per-event staged `events/*.zig` for a load-bearing reason: staged convention dirs are **whole-directory symlinks** into the game tree, so per-event materialization would write through into the game's sources. Documented consequence: a native hook consuming a *declared* event spells its payload param `anytype` (the dispatcher never inspects param types; Zig-authored events keep their typed imports).
+- **Runtime halves in the same file**: the declaration file also **embeds and evaluates** at runtime — `Labelle.component` returns the view class, `Labelle.event` the frozen name string — so the declared constant feeds `get`/`set`/`emit`/`on` directly, and the pinned components → events → scripts order guarantees the constants exist when scripts load.
 
 Two tiers, one DSL:
 
-- **Tier 1 — game developers (v1)**: declaration → generate-time codegen → first-class component. The schema lives in Ruby, the type lives in Zig, nothing is written twice.
-- **Tier 2 — mods (later)**: the same class registers at **runtime** into a dynamic component store (JSON-typed, generic serde) — modders cannot run `labelle generate`. Dynamic components stay invisible to comptime Zig systems, which is acceptable for sandboxed mod content.
+- **Tier 1 — game developers (v1)**: declaration → generate-time codegen → first-class component. The schema lives in the script language, the type lives in Zig, nothing is written twice.
+- **Tier 2 — mods (later)**: the same declaration registers at **runtime** into a dynamic component store (JSON-typed, generic serde) — modders cannot run `labelle generate`. Dynamic components stay invisible to comptime Zig systems, which is acceptable for sandboxed mod content.
 
-**Native idioms per language, one schema underneath.** The `field` DSL is the explicit form; every language also declares in its own native shape, and the declare-mode extraction produces the same schema JSON:
+**Native idioms per language, one schema underneath.** The terse form above is canonical; every language declares in its own native shape, and the declare extraction produces the same schema JSON:
 
-- **Ruby terse form**: `Hunger = Labelle.component(level: 1.0, starving: false)` — types inferred from the default literals (`1.0`→f32, `0`→i32, `false`→bool, `""`→str, `{x:,y:}`→vec2); the class DSL remains for what inference can't express (`:entity`, enums, width control, `persist :transient`). Instances are **Struct-backed** with attribute accessors (`h.level -= …; e.set(h)`) — `mruby-struct` is in the standard gem set; `Data.define` is not in mruby and its immutability fights the get→mutate→set flow.
-- **Lua**: `labelle.component("Hunger", { level = 1.0, starving = false })` — table form, same inference.
-- **Rust**: `#[labelle::component] struct Hunger { level: f32, starving: bool }` — the proc-macro emits schema JSON at build; the type system is the DSL.
-- **Crystal**: annotated struct, schema dumped by a declare-mode compile (same runner pattern as Ruby).
-- **C#**: `[LabelleComponent] record Hunger(float Level, bool Starving);`
+- **Ruby**: types inferred from the default literals (`1.0`→f32, `0`→i32, `false`→bool, `""`→str, `{x:,y:}`→vec2, `Labelle.id`→u64); the class DSL (`field :level, :f32, default: 1.0`, `persist :transient`) remains for what inference can't express (enums, width control, non-default persistence). Instances are **Struct-backed** with attribute accessors (`h.level -= …; e.set(h)`) — `mruby-struct` is in the standard gem set; `Data.define` is not in mruby and its immutability fights the get→mutate→set flow.
+- **Lua**: `labelle.component("Hunger", { level = 1.0, starving = false })` — table form, same inference; `labelle.event` symmetric.
+- **TypeScript (#773)**: `export const Hunger = Labelle.component("Hunger", { level: 0.875, starving: false })` — evaluated by a quickjs declare host after the pinned-tsc transpile; joins the cross-runner golden.
+- **Rust (#774)**: `labelle::component! { Hunger { level: f32 = 0.875, starving: bool = false } }` + `labelle::event! { … }` — extraction is the ticket's decision: a compile-and-run probe under `cfg(feature = "declare")` with a persistent target-dir cache (recommended — the real compiler evaluates, and cargo is already required at build), vs a constrained literal-only grammar (zero toolchain at generate, grammar-drift risk). The same macro expands at build into a **real typed struct** over the ABI — typed component access is the prize beyond parity, and layout-parity by construction opens a later zero-serialization path for hot events.
+- **Crystal (#775)**: the rust twin (macros/DSL + probe with persistent cache — compiler speed makes the cache load-bearing), landing after rust's extraction decision settles so both native lanes share one design.
+- **C# (#743)**: `[LabelleComponent] record Hunger(float Level, bool Starving);`
 
 ### 5. Zig plugins in script-language projects
 
@@ -221,28 +249,61 @@ The performance framing is the architecture's best case: heavy machinery (graph,
 
 ### 6. Script-language packs
 
-Packs can be authored in a script language — `packs/dungeon/` with language-neutral `prefabs/` + `assets/` (asset-plugins #725) and a `ruby/` dir holding the pack's components and controllers. Composition of pinned decisions:
+Packs can be authored in a script language — `packs/dungeon/` with language-neutral `prefabs/` + `assets/` (asset-plugins #725) and the same extension-keyed convention dirs a game root uses (rev 16): the pack's controllers in `scripts/*.rb`, its declarations in `components/*.rb` and `events/*.rb`. Composition of pinned decisions:
 
-- **Components**: the declare-mode extraction already handles pack-nested language dirs — codegen'd Zig components arrive **pack-namespaced** (`dungeon__Room`); scenes, save buckets, and cross-language access identical to Zig-pack components.
+- **Components**: the declare-mode extraction already handles pack-nested declaration files — codegen'd Zig components arrive **pack-namespaced** (`dungeon__Room`); scenes, save buckets, and cross-language access identical to Zig-pack components.
 - **Controllers**: loaded into the existing two-block order — pack controllers tick in their pack's slot (project plugin order between packs, file prefix within).
 - **Policy**: the pack declares `requires_language = "ruby"` (v1 installs into matching projects); the rev-9 pack-language exemption is what later lets a script-language pack install anywhere, scoped to its own VM.
 - **New work item — event names**: the invisible bare→`pack__*` event rewrite is AST-level and does not translate safely to dynamic script strings. v1 rule: script-language pack code writes **namespaced event names explicitly**, with generate-time validation that emitted/subscribed names resolve.
-- **Crystal packs** inherit the native-family caveats: consumer toolchain, the assembler build hook, and the POC's non-raising-entry rules (a validator lint candidate).
+- **Crystal packs** inherit the native-family caveats: consumer toolchain, the `.language_builds` build steps, and the POC's non-raising-entry rules (a validator lint candidate).
 
 This completes the vendor story: a full content pack — atlases, prefabs, a generator controller, a studio panel — with **zero Zig**, sellable as one plugin. Zig remains the floor (engine, plugins, hot paths), not the entry fee.
+
+### 7. The language-agnostic assembler (rev 16)
+
+> "in the future languages like python can be added without touching the assembler, just the labelle-script" — the user directive, verbatim.
+
+Shipping five languages left per-language knowledge smeared across the assembler as built-in tables: the `DECLARE_RUNNERS` rows (declare tool step name, tool dir, extension, capability pins), the native-language splice rows (`NATIVE_LANGUAGES` wiring — which game dir stages over which module root), and the TS transpile phase's toolchain pins. Every row is data the assembler *consumes* but labelle-scripting *owns* — the same inversion the pluggable-backends RFC (labelle-assembler#378) applies to render backends, and rev 13's own rule ("plugin-specific options must never grow the assembler's config schema") applied to the assembler's internals instead of its config. The design: those tables migrate to **language capability rows in labelle-scripting's `plugin.labelle`**, and the assembler becomes a generic executor of rows.
+
+A row carries everything the assembler knows per language today: name, extension(s), family (`embedded` | `native`), the native module root (`mod.rs` / `game.cr`), the declare capability (tool step name + tool dir; the presence of an `.events` sub-capability is what "supports declared events" *means*), transpile needs (emitted extension + toolchain requirement), and the runtime embed wiring. Sketch, spelling aligned with the manifest's existing `params_schema` / `language_builds`:
+
+```zig
+.languages = .{
+    .{ .name = "ruby", .extensions = .{"rb"}, .kind = .embedded,
+       .declare = .{ .tool = "labelle-declare-ruby", .dir = "tools/declare-ruby",
+                     .events = true } },       // .events present ⇒ declared events supported
+    .{ .name = "rust", .extensions = .{"rs"}, .kind = .native,
+       .module_root = "mod.rs" },              // scripts/mod.rs; build steps stay in .language_builds
+    .{ .name = "typescript", .extensions = .{"ts"}, .kind = .embedded,
+       .transpile = .{ .emits = "js", .toolchain = "tsc" },
+       .declare = .{ .tool = "labelle-declare-ts", .dir = "tools/declare-ts", .events = true } },
+},
+```
+
+- **Self-describing capabilities replace min-pin tables.** Today the assembler carries `min_pin`/`events_min_pin` per runner row — a version compare against knowledge that lives in another repo, and a table that must grow every time labelle-scripting does. Under capability rows the check inverts: the **resolved pin's own manifest** declares what it supports. `events/*.rb` under an old pin fails because *that manifest's* ruby row lacks the `.events` capability — a pointed error naming the pin — with no version compare in the assembler at all. (The v0.85.0 forward-compat rule generalizes: only the *selected* language's row validates strictly; non-selected rows tolerate unknown keys, so a new capability never breaks bystander projects.)
+- **Trust model — nothing new.** Plugin-declared tool builds and fetches already execute at generate: the declare tools, `.language_builds` steps, build hooks. Capability rows add no new trust; they relocate existing knowledge from assembler tables into the manifest of the package that owns it. The ONE deliberate exception to full agnosticism: **third-party toolchain fetch pins** (the tsc platform-package sha512 hashes). Two options: (a) they stay assembler-owned as a supply-chain control point — the assembler decides what third-party code generate may fetch; (b) they move to the manifest with the assembler **enforcing hash presence** and doing the verifying. Recommended: **(b), manifest-with-mandatory-hashes** — agnosticism with integrity: labelle-scripting declares *what* to fetch and its exact hashes, the assembler refuses hash-less toolchain rows and still verifies every byte.
+- **Honest boundary.** Typed-binding sidecar generation — the `labelle-components.d.ts` built from the registry — is assembler *codegen keyed to a language*, not table-lookup wiring. v1 agnosticism deliberately scopes to collection, declare, embed, and native wiring; binding codegen stays a **named extension point** (future: template-driven, plugin-supplied templates), not a silent gap.
+- **Migration.** The assembler's built-in tables become **fallback defaults** for manifests predating `.languages` rows — resolved pins of today's releases keep working unchanged. New languages MUST come via manifest; the built-ins are frozen, never extended again.
+
+The litmus test this section must pass: **adding python = a labelle-scripting PR** — `src/python/` VM embed + `tools/declare-py` + a `.languages` row — **zero assembler changes**.
 
 ## Backward compatibility
 
 - Zero impact when no language plugin is attached (comptime-gated contract).
 - Zig scripts, flows, packs, and hooks are untouched; language scripts are additive and run in the plugin block of the existing order.
 - #237's authored Lua API surface is preserved; only its integration points are replaced (scene `lua:` prefixes → convention discovery; `.lua` project block → plugin declaration).
+- The convention-dir move (rev 16) shipped with one release of grace: legacy per-language dirs kept working with a pointed note; examples and docs migrated the same release, and examples CI fails if the deprecation note ever reappears.
+- The declare schema grows without breaking old assemblers: `"events"` is emitted only when non-empty, and old assemblers read only `"components"` from the JSON Value tree. Capability rows (proposal 7) keep the property — only the selected language's row validates strictly.
 
-## Phasing
+## Phasing and status
 
-- **Phase 1 — contract + labelle-scripting with Lua.** Script Runtime Contract v1 (JSON encoding, comptime-gated) in the engine; the `labelle-scripting` repo with the shared glue + the `lua` sub-module enabled: VM init, script loading from the convention dir (embedded), `init/update/deinit` per script, entity/component/input bindings. Proof: an FP-adjacent demo scene driven by a `.lua` behavior.
-- **Phase 2 — dev experience.** Hot reload (disk watch + studio preview integration), Lua stack-trace error UX, the sandbox profile for mods (no `io`/`os` by default), script console studio panel.
-- **Phase 3 — native family.** The `rust` (and `crystal`) sub-modules: C header generation from the contract, the **assembler build-integration hook** (plugins declaring "run cargo/crystal, link this artifact" — the one new assembler seam the native family needs), optional dev dylib swap. Decide WASM-vs-dylib here with real data.
-- **Phase 4 — the long tail.** The `typescript` (QuickJS + esbuild step + `.d.ts` codegen — first of this batch by audience), `ruby` (mruby), `go` (c-archive, demand-driven), and `csharp` (CoreCLR, desktop-first, last) sub-modules.
+Status at rev 16 (2026-07-12): **five languages live** — lua, ruby, typescript, rust, crystal — one runtime each behind the singular `.language` param (labelle-scripting builds and tests every sub-module per `-Dlanguage`); **csharp in flight** (#743, its own workstream); **go demand-driven** (#746). Version markers: labelle-scripting **v0.10.0** (declare tools + runtime preludes, events included), labelle-assembler **v0.86.0** (DECLARE_RUNNERS, `scripts/` + `components/` convention dirs, pinned-tsc transpile) → **v0.87.0-pending** (declared events, #772 slice 2).
+
+- **Phase 1 — contract + labelle-scripting with Lua** (**SHIPPED**). Script Runtime Contract v1 (JSON encoding, comptime-gated) in the engine; the `labelle-scripting` repo with the shared glue + the `lua` sub-module enabled: VM init, script loading from the convention dir (embedded), `init/update/deinit` per script, entity/component/input bindings. Proof: an FP-adjacent demo scene driven by a `.lua` behavior.
+- **Phase 2 — dev experience** (**partial**: the script console studio panel shipped as the bundled `scripting_console` pack; the rest is open). Hot reload (disk watch + studio preview integration), Lua stack-trace error UX, the sandbox profile for mods (no `io`/`os` by default).
+- **Phase 3 — native family** (**SHIPPED** — the build-integration seam landed as manifest `.language_builds` steps, not a bespoke assembler hook: cargo static-lib and crystal main-localized-object splice rows, with v0.85.0's forward-compat rule minted for this lane). The `rust` (and `crystal`) sub-modules: C header generation from the contract, optional dev dylib swap (still open; WASM stays an Alternatives candidate).
+- **Phase 4 — the long tail** (**in flight**). The `typescript` (QuickJS + pinned-tsc transpile + `.d.ts` codegen — **SHIPPED**) and `ruby` (mruby — **SHIPPED**) sub-modules; `go` (c-archive, demand-driven — #746) and `csharp` (CoreCLR, desktop-first, last — #743) remain.
+- **Phase 5 — purity + the agnostic assembler (new, rev 16).** Close the purity bar per language — #772 (lua/ruby events), #773 (ts declare), #774 (rust macros + extraction), #775 (crystal) — with the CI purity variant per example game; then migrate the assembler's per-language tables to the capability rows of proposal 7, freezing the built-ins into fallback defaults. Exit criterion: the python litmus test.
 
 ## Alternatives considered
 
@@ -258,4 +319,6 @@ This completes the vendor story: a full content pack — atlases, prefabs, a gen
 - **Encoding ceiling**: is JSON good enough for component-heavy scripts, or does v1 need the tagged-value ABI sooner? Measure on the Lua MVP.
 - **GC in the frame budget**: Lua incremental GC and CLR GC pauses — per-tick step budgets?
 - ~~**Script-defined components**~~ — resolved (rev 6): generate-time codegen from the script DSL makes them first-class for developers; a runtime dynamic-store tier covers mods later.
-- **mruby vs Crystal priority** for the Ruby-shaped slot — they are different beasts (embedded-dynamic vs compiled-static); demand should pick.
+- ~~**mruby vs Crystal priority** for the Ruby-shaped slot~~ — resolved by shipping (rev 16): demand picked *both* (they serve different buyers — embedded-dynamic vs compiled-static), and the purity bar now tracks them separately (#772 / #775).
+- **Native declare extraction (#774/#775)**: compile-and-run probe (recommended — the real compiler evaluates, and cargo/crystal are already required at build time) vs constrained literal-only grammar (zero toolchain at generate, grammar-drift risk). Decided on the rust ticket; crystal follows it.
+- **Toolchain-pin ownership (rev 16, proposal 7)**: assembler-owned fetch pins as the supply-chain control point, or manifest-owned with assembler-enforced mandatory hashes? The recommendation on the table is the manifest; decide on the first capability-row PR.


### PR DESCRIPTION
Rev 16 of RFC-LANGUAGE-PLUGINS.md, folding in the 2026-07-12 product decisions from the #237 epic. Four decision areas:

## 1. The purity mandate (new top-level principle)
**Every shipped language must be able to go 100% selected-language — no Zig at all.** A ruby game is `scripts/*.rb` + `components/*.rb` + `events/*.rb` + scenes + `project.labelle`; native `hooks/*.zig` stay the optional escape hatch (capability, not requirement), and each example game gains a CI purity variant (hooks/-deleted scratch copy must run green). Status against the bar: lua/ruby close with #772, ts #773, rust #774 (typed-struct macros — the prize beyond parity), crystal #775.

## 2. Convention dirs (shipped — per-language-dir text replaced)
Declaration files live where their kind lives, same structure as Zig: `scripts/` (numeric ordering prefixes, extension-keyed coexistence with `.zig`, assembler v0.86.0), `components/*.<ext>` (v0.86.0), `events/*.<ext>` (v0.87.0, #772). Registration order pinned components → events → scripts; legacy per-language dirs got one release of grace.

## 3. The declare contract (shipped — documented as THE language-neutral seam)
One schema JSON from any declare tool (`components` + `events`-when-non-empty; type vocabulary f32/bool/i32/vec2/str/u64 via the `Labelle.id` sentinel), byte-parity pinned by cross-runner goldens. Downstream is producer-agnostic: components codegen into `scripting_components.zig`, events materialize as a single `scripting_events.zig` (staged convention dirs are whole-dir symlinks — per-event materialization would write through into the game tree; native hooks consuming a declared event use `anytype` params). The same declaration file embeds and evaluates at runtime.

## 4. The language-agnostic assembler (new proposal 7 — the design centerpiece)
> "in the future languages like python can be added without touching the assembler, just the labelle-script"

The assembler's per-language tables (DECLARE_RUNNERS, native splice rows, transpile toolchain pins) migrate to **language capability rows in labelle-scripting's `plugin.labelle`**; self-describing capabilities replace min-pin tables (the resolved pin's manifest says what it supports — no version compare in the assembler); trust model unchanged except the one deliberate exception (third-party toolchain fetch pins — both options presented, manifest-with-mandatory-hashes recommended); `.d.ts` binding codegen named as the honest boundary/extension point; built-in tables freeze into fallback defaults. Cross-referenced with the pluggable-backends RFC (labelle-assembler#378).

**The litmus test written into the RFC: adding python = a labelle-scripting PR (`src/python/` VM embed + `tools/declare-py` + a `.languages` row) — zero assembler changes.**

Plus a status refresh (five languages live; csharp in flight #743; go demand-driven #746; scripting v0.10.0, assembler v0.86.0 → v0.87.0-pending) threaded through the per-language notes, phasing, and open questions.

https://claude.ai/code/session_01P7YLw4hXFCCaY2LAUt4G1j