### PR TITLE
feat: packed component codec + batched query for the script contract (v1.3)

### DIFF
--- a/contract/labelle_script.h
+++ b/contract/labelle_script.h
@@ -79,11 +79,17 @@ extern "C" {
  * is probed per-symbol (embedded VMs bind against the running host,
  * which either exports it or doesn't; native plugins find out at link
  * time) — the editor-bridge contract's exact convention (its v1.1–v1.7
- * were all additive). This header describes contract v1.2:
+ * were all additive). This header describes contract v1.3:
  *   v1.1 = v1 + labelle_plugin_call (labelle-engine#744);
  *   v1.2 = v1.1 + plugin-call responses — out/out_cap activated per
  *          their reserved semantics + labelle_plugin_response_fetch
- *          (labelle-engine#758; probe for the fetch symbol). */
+ *          (labelle-engine#758; probe for the fetch symbol);
+ *   v1.3 = v1.2 + bulk component access — the packed component codec
+ *          (labelle_component_get_packed / _set_packed) and the
+ *          batched query (labelle_component_batch_get / _batch_set)
+ *          (labelle-scripting#41; probe for the symbols — an older
+ *          host simply doesn't export them and the binding keeps the
+ *          JSON / per-entity paths). */
 #define LABELLE_CONTRACT_VERSION 1u
 
 /* Contract version the host binary was built with. Pure — callable
@@ -398,6 +404,100 @@ size_t labelle_plugin_call(const char *plugin, size_t plugin_len,
  * "completed" being the nesting rule above: after nested calls unwind,
  * the store holds the OUTERMOST call's outcome. */
 size_t labelle_plugin_response_fetch(char *out, size_t out_cap);
+
+/* ── Bulk component access (since v1.3, labelle-scripting#41) ─────────
+ *
+ * Two additive fast paths over the per-entity JSON component ops.
+ * Both are probed BY SYMBOL (this contract's additive convention): an
+ * older host doesn't export them, and the binding keeps the JSON /
+ * per-entity paths as its degrade route.
+ *
+ * 1. PACKED CODEC — a binary twin of labelle_component_get/set for
+ *    scalar-only components, killing the JSON text round-trip. Wire
+ *    format (little-endian, self-describing):
+ *
+ *      [u8 field_count]                 ; 0xFF = "not packable"
+ *      repeat field_count times:
+ *        [u8 name_len][name bytes][u8 tag][value bytes]
+ *      tag: 0=f32(4B)  1=i64(8B)  2=bool(1B)  3=u64(8B)
+ *
+ *    GET writes the single sentinel byte 0xFF (return 1) for any
+ *    component the codec can't carry (non-scalar fields, built-ins
+ *    with handles/strings) — the caller falls back to
+ *    labelle_component_get. SET refuses with -1 (fall back to
+ *    labelle_component_set). Lossless for i64/u64 (unlike the batch
+ *    stream below).
+ *
+ * 2. BATCHED QUERY — one call moves ALL matching entities' scalar
+ *    component data as a flat f32 stream, collapsing the 4-per-entity
+ *    FFI crossings of a hot loop into 2 per tick. The entity set is
+ *    the labelle_query set (all entities carrying every named
+ *    component), walked in query order; per entity, each named
+ *    component's scalar fields in given-name order then
+ *    struct-declaration field order, one little-endian f32 per field
+ *    (f64 narrows, bool is 0/1; non-scalar fields are skipped
+ *    identically in both directions).
+ *
+ *    INT-FIELD REFUSAL: a named component with ANY int-typed field is
+ *    refused outright (LABELLE_BATCH_INT_REFUSED from _batch_get, -2
+ *    from _batch_set) — i64/u64 would silently corrupt through f32's
+ *    24-bit mantissa. Keep int-carrying components on the per-entity
+ *    paths (the packed codec carries ints losslessly).
+ *
+ *    POSITIONAL COUPLING: the stream carries no entity ids; _batch_set
+ *    re-resolves the query and applies the floats positionally. Do NOT
+ *    spawn or destroy entities between a paired _batch_get and
+ *    _batch_set. As a cheap guard, _batch_set requires buf_len to
+ *    EXACTLY match the re-queried set's stream size and refuses -1 on
+ *    mismatch (a count change since the get; a same-count membership
+ *    or order change is undetectable — hence the rule above). On -1
+ *    already-walked entities keep their writes: re-get and recompute. */
+
+/* labelle_component_batch_get's int-field refusal sentinel: the rc
+ * convention's -2 carried in its size_t return. Distinct from 0 =
+ * malformed/not-bound and from any required-size return. */
+#define LABELLE_BATCH_INT_REFUSED ((size_t)-2)
+
+/* Packed GET: serialize component `name` of entity `id` into `out` as
+ * the packed record above. Sizing/return conventions are EXACTLY
+ * labelle_component_get's: returns the bytes the complete record
+ * requires, all-or-nothing write, NULL/cap-0 sizing probe, 0 = absent
+ * / unknown name / dead entity / not bound. A non-packable component
+ * writes the 0xFF sentinel and returns 1. */
+size_t labelle_component_get_packed(uint64_t id,
+                                    const char *name, size_t name_len,
+                                    char *out, size_t out_cap);
+
+/* Packed SET: apply a packed record to component `name` of entity
+ * `id`, coercing each named field into the field's actual scalar type.
+ * REPLACE semantics like labelle_component_set (absent fields take the
+ * struct defaults). 0 = ok; -1 = refuse (unknown component / dead
+ * entity / non-scalar or non-default-constructible target / malformed
+ * record / not bound) — fall back to labelle_component_set. */
+int32_t labelle_component_set_packed(uint64_t id,
+                                     const char *name, size_t name_len,
+                                     const char *buf, size_t buf_len);
+
+/* Batched GET: `names_json` is the labelle_query names array (e.g.
+ * ["Position","Velocity"]). Writes [u32 entity_count][f32 stream] into
+ * `out`. Returns the bytes the COMPLETE buffer requires
+ * (snprintf-style — retry right-sized), LABELLE_BATCH_INT_REFUSED on
+ * an int-carrying named component, 0 = malformed names / not bound.
+ * Zero matching entities return the 4-byte count-0 header (distinct
+ * from the 0 sentinel). NULL/cap-0 `out` is a pure sizing probe. */
+size_t labelle_component_batch_get(const char *names_json,
+                                   size_t names_json_len,
+                                   char *out, size_t out_cap);
+
+/* Batched SET: `buf` is the pure f32 stream (NO count header) laid out
+ * exactly as _batch_get returned it. Re-resolves the query and applies
+ * positionally, routed through the same apply path as the per-entity
+ * set so hooks and dirty-tracking fire. 0 = ok; -1 = malformed names /
+ * entity-count mismatch (see the coupling guard above) / not bound;
+ * -2 = int-carrying named component. */
+int32_t labelle_component_batch_set(const char *names_json,
+                                    size_t names_json_len,
+                                    const char *buf, size_t buf_len);
 
 #ifdef __cplusplus
 }

--- a/contract/labelle_script.h
+++ b/contract/labelle_script.h
@@ -35,9 +35,14 @@
  *   - rc convention: functions returning int32_t yield 0 = ok and
  *     -1 = failure (unknown name / unknown-or-dead entity / parse
  *     error / host not bound), except `labelle_component_has`, which
- *     is a boolean 1/0. labelle_plugin_call carries the same rc in a
- *     size_t: 0 = dispatched, LABELLE_PLUGIN_CALL_UNROUTABLE
- *     ((size_t)-1) = failure — see its section.
+ *     is a boolean 1/0 — and labelle_component_batch_set (v1.3), which
+ *     adds -2 = int-typed-field refusal on top of the 0/-1 pair.
+ *     labelle_plugin_call carries the same rc in a size_t: 0 =
+ *     dispatched, LABELLE_PLUGIN_CALL_UNROUTABLE ((size_t)-1) =
+ *     failure — see its section. labelle_component_batch_get (v1.3)
+ *     likewise carries its int-field refusal as
+ *     LABELLE_BATCH_INT_REFUSED ((size_t)-2) in its size_t return —
+ *     check it BEFORE treating the return as a required size.
  *   - Out-parameter sizing: labelle_component_get and labelle_query
  *     return the bytes the COMPLETE result REQUIRES (snprintf-style;
  *     required > out_cap is the truncation signal — retry right-sized;
@@ -422,11 +427,21 @@ size_t labelle_plugin_response_fetch(char *out, size_t out_cap);
  *      tag: 0=f32(4B)  1=i64(8B)  2=bool(1B)  3=u64(8B)
  *
  *    GET writes the single sentinel byte 0xFF (return 1) for any
- *    component the codec can't carry (non-scalar fields, built-ins
- *    with handles/strings) — the caller falls back to
- *    labelle_component_get. SET refuses with -1 (fall back to
- *    labelle_component_set). Lossless for i64/u64 (unlike the batch
- *    stream below).
+ *    component the codec can't carry (non-scalar fields, f64 fields —
+ *    the wire only has an f32 tag, and silent precision loss is not
+ *    acceptable — built-ins with handles/strings, >=255 fields, a
+ *    >255-byte field name) — the caller falls back to
+ *    labelle_component_get, which carries all of those faithfully.
+ *    SET refuses with -1 (fall back to labelle_component_set); a
+ *    record with bytes past its declared fields is malformed (-1).
+ *    Lossless for i64/u64 (unlike the batch stream below), including
+ *    the 64-BIT BITCAST PAIR: a 64-bit int field accepts the OTHER
+ *    64-bit tag via two's-complement bitcast (i64 tag -> u64 field and
+ *    u64 tag -> i64 field), so a binding whose only integer type is
+ *    signed 64-bit (mruby) round-trips u64 values bit-exactly — GET
+ *    emits tag 3, the binding bitcasts to its signed integer, SET
+ *    re-emits tag 1, the host bitcasts back. Narrower int fields keep
+ *    the range-checked refusal (-1 on overflow — never clamped).
  *
  * 2. BATCHED QUERY — one call moves ALL matching entities' scalar
  *    component data as a flat f32 stream, collapsing the 4-per-entity
@@ -444,14 +459,22 @@ size_t labelle_plugin_response_fetch(char *out, size_t out_cap);
  *    24-bit mantissa. Keep int-carrying components on the per-entity
  *    paths (the packed codec carries ints losslessly).
  *
+ *    GET/SET SYMMETRY (read-modify-write): everything _batch_get emits
+ *    is writable. _batch_set fetches each queried component, overwrites
+ *    ONLY the scalar fields the stream carries (the exact mirror of the
+ *    get walk), preserves non-scalar fields, and applies through the
+ *    same channels as the per-entity set (built-ins included — a
+ *    batched Camera zoom write routes through the scene apply
+ *    machinery). No default-constructibility is required.
+ *
  *    POSITIONAL COUPLING: the stream carries no entity ids; _batch_set
  *    re-resolves the query and applies the floats positionally. Do NOT
  *    spawn or destroy entities between a paired _batch_get and
- *    _batch_set. As a cheap guard, _batch_set requires buf_len to
- *    EXACTLY match the re-queried set's stream size and refuses -1 on
- *    mismatch (a count change since the get; a same-count membership
- *    or order change is undetectable — hence the rule above). On -1
- *    already-walked entities keep their writes: re-get and recompute. */
+ *    _batch_set. As a cheap guard, _batch_set PREFLIGHTS: it sizes the
+ *    re-queried set FIRST and refuses -1 with NO writes unless buf_len
+ *    matches exactly (a count change since the get; a same-count
+ *    membership or order change is undetectable — hence the rule
+ *    above). On -1 nothing was applied: re-get and recompute. */
 
 /* labelle_component_batch_get's int-field refusal sentinel: the rc
  * convention's -2 carried in its size_t return. Distinct from 0 =

--- a/src/script_contract.zig
+++ b/src/script_contract.zig
@@ -2272,8 +2272,12 @@ fn Holder(comptime GP: type) type {
         /// Decode a packed record into `ptr.*` (already default-init),
         /// matching each field name to a struct field and COERCING the
         /// tagged value into that field's actual scalar type. Unknown
-        /// names / non-scalar target fields are skipped. Returns false on a
-        /// malformed record (a truncated field), true otherwise.
+        /// names / non-scalar target fields are skipped. Returns false —
+        /// the set refuses with -1 and the binding falls back to JSON —
+        /// on a malformed record (a truncated field) or on a value the
+        /// target field cannot represent (out-of-range int, NaN/Inf into
+        /// an int field): script-supplied bytes must never panic the
+        /// host, and must not be silently clamped either.
         fn applyPacked(comptime T: type, ptr: *T, buf: []const u8) bool {
             if (buf.len < 1) return false;
             const field_count = buf[0];
@@ -2296,7 +2300,8 @@ fn Holder(comptime GP: type) type {
                 inline for (@typeInfo(T).@"struct".fields) |f| {
                     if (comptime isPackableScalar(f.type)) {
                         if (std.mem.eql(u8, fname, f.name)) {
-                            @field(ptr.*, f.name) = coercePacked(f.type, tag, val_bytes);
+                            @field(ptr.*, f.name) =
+                                coercePacked(f.type, tag, val_bytes) orelse return false;
                         }
                     }
                 }
@@ -2318,10 +2323,18 @@ fn Holder(comptime GP: type) type {
 }
 
 /// A struct every field of which is a packable scalar (zero-field structs
-/// pack as an empty record — vacuously true).
+/// pack as an empty record — vacuously true) — AND that fits the wire's
+/// u8 headers, decided entirely at comptime: `field_count` is a u8 with
+/// 0xFF reserved as the "not packable" sentinel (so ≥ 255 fields cannot
+/// be represented), and each `name_len` is a u8 (so a > 255-byte field
+/// name cannot be). A struct beyond either limit simply takes the 0xFF
+/// sentinel / JSON path — never a runtime `@intCast` panic in `packInto`.
 fn isPackableStruct(comptime T: type) bool {
     if (@typeInfo(T) != .@"struct") return false;
-    inline for (@typeInfo(T).@"struct".fields) |f| {
+    const fields = @typeInfo(T).@"struct".fields;
+    if (fields.len >= 255) return false;
+    inline for (fields) |f| {
+        if (f.name.len > 255) return false;
         if (!isPackableScalar(f.type)) return false;
     }
     return true;
@@ -2386,32 +2399,61 @@ fn writePackedValue(comptime T: type, val: T, out: []u8) usize {
     }
 }
 
+/// Truncating float→int with REFUSAL (null) on NaN/Inf/out-of-range —
+/// the packed SET's safe cast. `@intFromFloat` panics on any of those,
+/// and the value is SCRIPT-SUPPLIED, so the host must refuse instead
+/// (never clamp/zero: a silently altered value is a corruption). The
+/// bounds are the exact powers of two 2^bits / ±2^(bits-1) — always
+/// representable in f64, unlike maxInt(T) itself, whose f64 rounding
+/// would re-admit the panicking boundary value for 64-bit targets.
+fn safeFloatToInt(comptime T: type, f: f32) ?T {
+    if (!std.math.isFinite(f)) return null;
+    const t: f64 = @trunc(@as(f64, f));
+    const info = @typeInfo(T).int;
+    // Degenerate 0-bit ints hold only 0 (and i0's bits-1 would underflow
+    // the shift below).
+    if (comptime info.bits == 0) return if (t == 0) @intFromFloat(t) else null;
+    const upper: f64 = comptime blk: {
+        const b: u7 = if (info.signedness == .signed) info.bits - 1 else info.bits;
+        break :blk @floatFromInt(@as(u128, 1) << b);
+    };
+    const lower: f64 = if (comptime info.signedness == .signed) -upper else 0;
+    if (t < lower or t >= upper) return null;
+    return @intFromFloat(t);
+}
+
 /// Coerce a tagged packed value into `T` (the target field's real type):
-/// widened ints narrow via @intCast, f32↔f64 via @floatCast, and a bool
-/// tag lands in an int/float field as 0/1 (the mirror of the write side's
-/// widening). Type mismatches degrade gracefully (a bool tag into a float
-/// field, etc.) rather than corrupting.
-fn coercePacked(comptime T: type, tag: u8, bytes: []const u8) T {
+/// f32↔f64 via @floatCast, ints via `std.math.cast`, and a bool tag
+/// lands in an int/float field as 0/1 (the mirror of the write side's
+/// widening). Returns null — the whole set REFUSES with -1 and the
+/// binding falls back to JSON — when the script value cannot represent
+/// itself in the field (out-of-range int, NaN/Inf/out-of-range float
+/// into an int field): the value is script-supplied, so the host must
+/// never panic on it, and must not silently clamp/zero it either — the
+/// JSON path surfaces the value faithfully (or refuses it visibly).
+fn coercePacked(comptime T: type, tag: u8, bytes: []const u8) ?T {
     return switch (@typeInfo(T)) {
         .float => switch (tag) {
             0 => @floatCast(@as(f32, @bitCast(std.mem.readInt(u32, bytes[0..4], .little)))),
+            // Int→float is total: may round (past 2^24/2^53) but can
+            // never trap, and rounding is inherent to a float target.
             1 => @floatFromInt(std.mem.readInt(i64, bytes[0..8], .little)),
             2 => if (bytes[0] != 0) 1 else 0,
             3 => @floatFromInt(std.mem.readInt(u64, bytes[0..8], .little)),
-            else => 0,
+            else => null,
         },
         .int => switch (tag) {
-            0 => @intFromFloat(@as(f32, @bitCast(std.mem.readInt(u32, bytes[0..4], .little)))),
-            1 => @intCast(std.mem.readInt(i64, bytes[0..8], .little)),
-            2 => @intFromBool(bytes[0] != 0),
-            3 => @intCast(std.mem.readInt(u64, bytes[0..8], .little)),
-            else => 0,
+            0 => safeFloatToInt(T, @as(f32, @bitCast(std.mem.readInt(u32, bytes[0..4], .little)))),
+            1 => std.math.cast(T, std.mem.readInt(i64, bytes[0..8], .little)),
+            2 => std.math.cast(T, @intFromBool(bytes[0] != 0)),
+            3 => std.math.cast(T, std.mem.readInt(u64, bytes[0..8], .little)),
+            else => null,
         },
         .bool => switch (tag) {
             2 => bytes[0] != 0,
             1 => std.mem.readInt(i64, bytes[0..8], .little) != 0,
             3 => std.mem.readInt(u64, bytes[0..8], .little) != 0,
-            else => false,
+            else => null,
         },
         else => unreachable,
     };
@@ -2425,8 +2467,11 @@ fn coercePacked(comptime T: type, tag: u8, bytes: []const u8) T {
 // the same way. Both iterate `@typeInfo(T).@"struct".fields` (declaration
 // order), emitting/consuming one f32 per scalar field and skipping
 // non-scalar fields identically. Int-carrying components never reach these
-// helpers — `batchEligible` refuses them upstream (`batch_int_refused`) —
-// but the int arms are kept total so the helpers stay usable on any struct.
+// helpers — `batchEligible` refuses them upstream (`batch_int_refused`).
+// The write/skip int arms stay total (`@floatFromInt` cannot trap), but
+// the READ side refuses int fields outright: an `@intFromFloat` there
+// could panic the host on a NaN/Inf/out-of-range script float, and no
+// reachable path needs it.
 
 /// A component type the BATCH codec accepts: no int-typed fields. Ints
 /// cannot survive the positional f32 stream (silent precision loss past
@@ -2474,26 +2519,32 @@ fn packFloatsInto(comptime T: type, value: T, out: []u8, pos: *usize) void {
     }
 }
 
-/// Read each scalar field of `ptr.*` from the f32 stream at `pos.*`,
-/// coercing the f32 back into the field's real type (int via
-/// `@intFromFloat`, bool via `!= 0`), advancing 4 per field. Non-scalar
-/// fields are skipped (no bytes consumed — the write side skipped them
-/// too). Returns false if the buffer runs out mid-layout.
+/// Read each scalar field of `ptr.*` from the f32 stream at `pos.*`
+/// (float via `@floatCast` — NaN/Inf land unchanged in a float field,
+/// which is defined and faithful; bool via `!= 0`, where NaN reads as
+/// true since NaN != 0), advancing 4 per field. Non-scalar fields are
+/// skipped (no bytes consumed — the write side skipped them too).
+/// Returns false if the buffer runs out mid-layout — or on an int field:
+/// int-carrying components are refused upstream by `batchEligible`
+/// before any entity walk, so that arm is unreachable through the batch
+/// exports, and it is kept as a REFUSAL rather than an `@intFromFloat`
+/// so no caller — present or future — can panic the host on a
+/// NaN/Inf/out-of-range script float.
 fn readFloatsFrom(comptime T: type, ptr: *T, buf: []const u8, pos: *usize) bool {
     if (comptime @typeInfo(T) != .@"struct") return true;
     inline for (@typeInfo(T).@"struct".fields) |f| {
         switch (@typeInfo(f.type)) {
-            .float, .int, .bool => {
+            .float, .bool => {
                 if (pos.* + 4 > buf.len) return false;
                 const fv: f32 = @bitCast(std.mem.readInt(u32, buf[pos.*..][0..4], .little));
                 pos.* += 4;
                 @field(ptr.*, f.name) = switch (@typeInfo(f.type)) {
                     .float => @floatCast(fv),
-                    .int => @intFromFloat(fv),
                     .bool => fv != 0,
                     else => unreachable,
                 };
             },
+            .int => return false,
             else => {},
         }
     }

--- a/src/script_contract.zig
+++ b/src/script_contract.zig
@@ -351,9 +351,11 @@ const VTable = struct {
     // `component_batch_get` writes `[u32 count][f32 stream]` (f32/f64 + bool
     // fields only — a named component with any INT field is refused with
     // `batch_int_refused` / -2, because ints would silently corrupt through
-    // f32); `component_batch_set` re-queries and reads the f32 stream
-    // positionally, refusing -1 unless the buffer length exactly matches the
-    // re-queried entity set (the positional-coupling guard).
+    // f32); `component_batch_set` re-queries and applies the f32 stream
+    // positionally, READ-MODIFY-WRITE (only scalar fields overwritten,
+    // non-scalar preserved — get/set symmetry), PREFLIGHTING the buffer
+    // length against the re-queried entity set and refusing -1 with NO
+    // writes on mismatch (the positional-coupling guard).
     component_batch_get: *const fn (names_json: []const u8, out: []u8) usize,
     component_batch_set: *const fn (names_json: []const u8, buf: []const u8) i32,
     component_has: *const fn (id: u64, name: []const u8) i32,
@@ -712,19 +714,23 @@ pub export fn labelle_component_batch_get(
 
 /// BATCHED (binary) whole-query write — twin of `labelle_component_batch_get`.
 /// Re-queries the same entity set in the same order and reads `buf` (the
-/// pure f32 stream, NO count header) positionally, converting each f32
-/// back into its field's real scalar type (REPLACE semantics), routed
-/// through the same `setPosition`/`setComponent` as the per-entity path so
-/// hooks and dirty-tracking fire identically.
+/// pure f32 stream, NO count header) positionally, READ-MODIFY-WRITE per
+/// component: only the batch-eligible scalar fields are overwritten (the
+/// mirror of what `_batch_get` emitted — get/set symmetry), non-scalar
+/// fields keep their existing values, and the mutated copy applies
+/// through the same channels as the per-entity paths (`setPosition` /
+/// `setComponent` / the scene-loader apply fns for built-ins) so hooks
+/// and dirty-tracking fire identically.
 ///
-/// POSITIONAL-COUPLING GUARD: `buf_len` must be EXACTLY the re-queried
-/// entity set's stream size (count × stride × 4) — a mismatch means the
-/// entity set changed between `_batch_get` and `_batch_set` (or the caller
-/// sized the buffer wrong) and the whole write is refused with -1 (entities
-/// walked before the mismatch was detected keep the partial write; treat -1
-/// as "re-get and recompute"). Do NOT spawn or destroy entities between the
-/// paired get and set: the layout is positional, so the guard can catch a
-/// count change but never a same-count membership/order change.
+/// POSITIONAL-COUPLING GUARD (PREFLIGHT): before writing anything, the
+/// host walks the re-resolved query and requires `buf_len` to EXACTLY
+/// match its stream size (count × stride × 4) — a mismatch means the
+/// entity set changed between `_batch_get` and `_batch_set` (or the
+/// caller sized the buffer wrong) and the call refuses -1 having written
+/// NOTHING, so "re-run batch_get and recompute" can never double-apply a
+/// prefix. Do NOT spawn or destroy entities between the paired get and
+/// set: the layout is positional, so the guard can catch a count change
+/// but never a same-count membership/order change.
 ///
 /// Returns 0 = ok; -1 = malformed names / entity-count mismatch (buffer
 /// size disagrees with the re-queried set) / not bound; -2 = a named
@@ -1946,6 +1952,32 @@ fn Holder(comptime GP: type) type {
             for (names[1..]) |rn| {
                 if (!nameResolvable(rn)) return -1;
             }
+            // PREFLIGHT — the positional-coupling guard, decided BEFORE any
+            // write: walk the re-resolved query once, summing the stream
+            // bytes its entities require, and refuse on any disagreement
+            // with the incoming buffer (spawn/destroy since the paired get,
+            // or a caller-mis-sized buffer). A refused batch_set performs
+            // NO writes — there is no partial-commit-then-refuse, so the
+            // documented "re-run batch_get and recompute" retry can never
+            // double-apply a prefix.
+            var expected: usize = 0;
+            {
+                var pre = game.ecs_backend.view(.{ViewT}, .{});
+                defer pre.deinit();
+                while (pre.next()) |ent| {
+                    const matches = blk: {
+                        for (names[1..]) |rn| {
+                            if (!hasByName(ent, rn)) break :blk false;
+                        }
+                        break :blk true;
+                    };
+                    if (!matches) continue;
+                    for (names) |nm| expected += nameStreamBytes(nm);
+                }
+            }
+            if (expected != buf.len) return -1;
+            // APPLY — the same walk again (same view construction, so the
+            // order agrees with the preflight and with batch_get).
             var pos: usize = 0; // set buffer has NO header — pure f32 stream
             var v = game.ecs_backend.view(.{ViewT}, .{});
             defer v.deinit();
@@ -1958,52 +1990,89 @@ fn Holder(comptime GP: type) type {
                 };
                 if (!matches) continue;
                 for (names) |nm| {
-                    // A buffer exhausted mid-walk = MORE entities now than the
-                    // buffer was computed for (spawn since the paired get) —
-                    // half of the positional-coupling guard.
                     if (!applyEntityFloats(ent, nm, buf, &pos)) return -1;
                 }
             }
-            // The other half: leftover bytes = FEWER entities now than the
-            // buffer was computed for (destroy since the paired get). The
-            // caller must re-get and recompute; entities already walked keep
-            // their (positionally suspect) writes — documented on the export.
+            // Belt on top of the preflight: the apply consumed exactly the
+            // stream the preflight sized.
             if (pos != buf.len) return -1;
             return 0;
         }
 
-        /// Read one entity's component's scalar fields from the f32 stream
-        /// (same name dispatch as `writeEntityFloats`, so get/set consume the
-        /// SAME field layout). Position and packable registry structs are
-        /// applied through `setPosition`/`setComponent`; scene built-ins (and
-        /// non-packable registry types) only advance `pos` past their scalar
-        /// fields to keep the positional stream aligned. Returns false on a
-        /// buffer too short for the layout.
+        /// Stream bytes one component contributes per entity (its scalar
+        /// fields × 4) — runtime name → comptime `streamBytes` dispatch,
+        /// the sizing mirror of `writeEntityFloats`/`applyEntityFloats`.
+        /// Unknown names contribute nothing (they also emit nothing).
+        fn nameStreamBytes(name: []const u8) usize {
+            if (std.mem.eql(u8, name, "Position")) {
+                return comptime streamBytes(core.Position);
+            }
+            inline for (builtin_comps) |spec| {
+                if (std.mem.eql(u8, name, spec.name)) {
+                    return comptime streamBytes(spec.T);
+                }
+            }
+            const comp_names = comptime Components.names();
+            inline for (comp_names) |comp_name| {
+                if (std.mem.eql(u8, name, comp_name)) {
+                    return comptime streamBytes(Components.getType(comp_name));
+                }
+            }
+            return 0;
+        }
+
+        /// Apply one entity's component's scalar fields from the f32 stream
+        /// — READ-MODIFY-WRITE (get/set symmetry: everything `batch_get`
+        /// emits is writable). The existing component is copied, ONLY the
+        /// batch-eligible scalar fields are overwritten by the mirror walk
+        /// (`readFloatsFrom` — same dispatch and field layout as
+        /// `writeEntityFloats`), and the mutated copy applies through the
+        /// same channels as the per-entity paths: `setPosition` for
+        /// Position, `setComponent` for registry components (non-scalar
+        /// fields — strings, optionals, nested structs — are PRESERVED
+        /// from the existing value, and no default-constructibility is
+        /// required), and the scene-loader apply fns for built-ins (the
+        /// mutated copy is serialized with the SAME serializer the JSON
+        /// get uses and routed through `setBuiltinComponent`, so e.g. a
+        /// batched Camera zoom write is indistinguishable from a scene
+        /// author's). Returns false (refuse -1) on a missing component
+        /// (the entity set changed mid-walk) or an exhausted stream.
         fn applyEntityFloats(ent: Entity, name: []const u8, buf: []const u8, pos: *usize) bool {
             if (std.mem.eql(u8, name, "Position")) {
-                var p = core.Position{};
+                var p = (game.getComponent(ent, core.Position) orelse return false).*;
                 if (!readFloatsFrom(core.Position, &p, buf, pos)) return false;
                 game.setPosition(ent, p);
                 return true;
             }
             inline for (builtin_comps) |spec| {
                 if (std.mem.eql(u8, name, spec.name)) {
-                    // Built-ins apply through the scene-loader fns (JSON only)
-                    // — consume their scalar floats to stay aligned, no apply.
-                    return skipFloats(spec.T, buf, pos);
+                    var comp = (game.getComponent(ent, spec.T) orelse return false).*;
+                    if (!readFloatsFrom(spec.T, &comp, buf, pos)) return false;
+                    // Serialize the MUTATED copy exactly as the JSON get
+                    // serializes this built-in (Camera's tag as a string,
+                    // renderer handles omitted), then route it through the
+                    // scene apply machinery — the per-entity set's path.
+                    var jbuf: [4096]u8 = undefined;
+                    const n = if (comptime std.mem.eql(u8, spec.name, "Camera"))
+                        stringifyInto(.{
+                            .zoom = comp.zoom,
+                            .viewport = comp.viewport,
+                            .tag = comp.tagSlice(),
+                        }, &jbuf)
+                    else
+                        stringifyFilteredInto(comp, &jbuf);
+                    if (n == 0 or n > jbuf.len) return false;
+                    return setBuiltinComponent(spec.name, ent, jbuf[0..n]) == 0;
                 }
             }
             const comp_names = comptime Components.names();
             inline for (comp_names) |comp_name| {
                 if (std.mem.eql(u8, name, comp_name)) {
                     const T = Components.getType(comp_name);
-                    if (comptime packableStruct(T)) {
-                        var cmp: T = .{};
-                        if (!readFloatsFrom(T, &cmp, buf, pos)) return false;
-                        game.setComponent(ent, cmp);
-                        return true;
-                    }
-                    return skipFloats(T, buf, pos);
+                    var comp = (game.getComponent(ent, T) orelse return false).*;
+                    if (!readFloatsFrom(T, &comp, buf, pos)) return false;
+                    game.setComponent(ent, comp);
+                    return true;
                 }
             }
             return true;
@@ -2306,16 +2375,23 @@ fn Holder(comptime GP: type) type {
                     }
                 }
             }
+            // Trailing bytes past the declared field records are a
+            // malformed buffer (e.g. a zero-count header ahead of field
+            // data) — refuse, don't half-accept.
+            if (pos != buf.len) return false;
             return true;
         }
 
         // ── Packed codec helpers (comptime-pure, Holder-nested) ──────
 
-        /// A field/component type the packed codec can carry: 32/64-bit
-        /// float, any int ≤ 64 bits, or bool.
+        /// A field/component type the packed codec can carry: f32, any int
+        /// ≤ 64 bits, or bool. f64 is deliberately NOT packable — the wire
+        /// has only an f32 tag, so packing an f64 field would silently
+        /// truncate its precision; such components take the 0xFF/JSON path,
+        /// which carries f64 faithfully.
         fn isPackableScalar(comptime T: type) bool {
     return switch (@typeInfo(T)) {
-        .float => |fl| fl.bits == 32 or fl.bits == 64,
+        .float => |fl| fl.bits == 32,
         .int => |i| i.bits <= 64,
         .bool => true,
         else => false,
@@ -2423,14 +2499,17 @@ fn safeFloatToInt(comptime T: type, f: f32) ?T {
 }
 
 /// Coerce a tagged packed value into `T` (the target field's real type):
-/// f32↔f64 via @floatCast, ints via `std.math.cast`, and a bool tag
-/// lands in an int/float field as 0/1 (the mirror of the write side's
-/// widening). Returns null — the whole set REFUSES with -1 and the
-/// binding falls back to JSON — when the script value cannot represent
-/// itself in the field (out-of-range int, NaN/Inf/out-of-range float
-/// into an int field): the value is script-supplied, so the host must
-/// never panic on it, and must not silently clamp/zero it either — the
-/// JSON path surfaces the value faithfully (or refuses it visibly).
+/// floats via @floatCast, ints via `std.math.cast` — EXCEPT the 64-bit
+/// bitcast pair (an i64 tag into a u64 field and vice versa are
+/// two's-complement `@bitCast`, the documented lossless round trip for
+/// signed-only bindings) — and a bool tag lands in an int/float field as
+/// 0/1 (the mirror of the write side's widening). Returns null — the
+/// whole set REFUSES with -1 and the binding falls back to JSON — when
+/// the script value cannot represent itself in the field (out-of-range
+/// int into a narrower target, NaN/Inf/out-of-range float into an int
+/// field): the value is script-supplied, so the host must never panic on
+/// it, and must not silently clamp/zero it either — the JSON path
+/// surfaces the value faithfully (or refuses it visibly).
 fn coercePacked(comptime T: type, tag: u8, bytes: []const u8) ?T {
     return switch (@typeInfo(T)) {
         .float => switch (tag) {
@@ -2442,11 +2521,31 @@ fn coercePacked(comptime T: type, tag: u8, bytes: []const u8) ?T {
             3 => @floatFromInt(std.mem.readInt(u64, bytes[0..8], .little)),
             else => null,
         },
-        .int => switch (tag) {
+        .int => |ti| switch (tag) {
             0 => safeFloatToInt(T, @as(f32, @bitCast(std.mem.readInt(u32, bytes[0..4], .little)))),
-            1 => std.math.cast(T, std.mem.readInt(i64, bytes[0..8], .little)),
+            // 64-BIT BITCAST PAIR (documented in the header): a 64-bit int
+            // field accepts the OTHER 64-bit tag via two's-complement
+            // @bitCast. This is what makes the round trip lossless for a
+            // binding whose only integer is signed 64-bit (mruby): GET
+            // emits a u64 field as tag 3, the binding bitcasts it into its
+            // signed Integer, SET re-emits tag 1, and the host bitcasts it
+            // back — bit-exact even with bit 63 set. Narrower targets keep
+            // the range-checked refusal.
+            1 => blk: {
+                const v = std.mem.readInt(i64, bytes[0..8], .little);
+                if (comptime ti.signedness == .unsigned and ti.bits == 64) {
+                    break :blk @as(T, @bitCast(v));
+                }
+                break :blk std.math.cast(T, v);
+            },
             2 => std.math.cast(T, @intFromBool(bytes[0] != 0)),
-            3 => std.math.cast(T, std.mem.readInt(u64, bytes[0..8], .little)),
+            3 => blk: {
+                const v = std.mem.readInt(u64, bytes[0..8], .little);
+                if (comptime ti.signedness == .signed and ti.bits == 64) {
+                    break :blk @as(T, @bitCast(v));
+                }
+                break :blk std.math.cast(T, v);
+            },
             else => null,
         },
         .bool => switch (tag) {
@@ -2551,21 +2650,20 @@ fn readFloatsFrom(comptime T: type, ptr: *T, buf: []const u8, pos: *usize) bool 
     return true;
 }
 
-/// Advance `pos.*` past one component's scalar fields WITHOUT applying —
-/// keeps the positional stream aligned for component types the batch set
-/// can't reconstruct (scene built-ins, non-packable registry structs).
-fn skipFloats(comptime T: type, buf: []const u8, pos: *usize) bool {
-    if (comptime @typeInfo(T) != .@"struct") return true;
+/// Stream bytes one component type contributes per entity: its scalar
+/// (float/int/bool) fields × 4 — the comptime sizing mirror of
+/// `packFloatsInto`/`readFloatsFrom`'s walks. Int fields count for
+/// totality, though int-carrying components are refused upstream.
+fn streamBytes(comptime T: type) usize {
+    if (@typeInfo(T) != .@"struct") return 0;
+    var n: usize = 0;
     inline for (@typeInfo(T).@"struct".fields) |f| {
         switch (@typeInfo(f.type)) {
-            .float, .int, .bool => {
-                if (pos.* + 4 > buf.len) return false;
-                pos.* += 4;
-            },
+            .float, .int, .bool => n += 4,
             else => {},
         }
     }
-    return true;
+    return n;
 }
 
         fn castEntity(id: u64) ?Entity {

--- a/src/script_contract.zig
+++ b/src/script_contract.zig
@@ -234,7 +234,10 @@ const plugin_command = @import("game/editor_command_mixin.zig");
 /// (v1.1–v1.7). Current surface: v1.1 = v1 + `labelle_plugin_call`
 /// (#744); v1.2 = v1.1 + plugin-call responses — `out`/`out_cap`
 /// activated per their reserved semantics + `labelle_plugin_response_fetch`
-/// (#758).
+/// (#758); v1.3 = v1.2 + bulk component access — the packed component
+/// codec (`labelle_component_get_packed`/`_set_packed`) and the batched
+/// query (`labelle_component_batch_get`/`_batch_set`)
+/// (labelle-scripting#41; probe for the symbols).
 pub const CONTRACT_VERSION: u32 = 1;
 
 /// `labelle_plugin_call`'s unroutable sentinel: the rc convention's -1
@@ -242,6 +245,17 @@ pub const CONTRACT_VERSION: u32 = 1;
 /// from 0 = dispatched — and from any future response-size return,
 /// which could never require the whole address space.
 pub const plugin_call_unroutable: usize = std.math.maxInt(usize);
+
+/// `labelle_component_batch_get`'s int-field refusal sentinel: the rc
+/// convention's -2 carried in that export's usize return (C's
+/// `(size_t)-2`). Returned when ANY named component carries an
+/// int-typed field — i64/u64 values cannot ride the batch's f32 stream
+/// without silent corruption (f32's 24-bit mantissa truncates large
+/// ints), so the host refuses the whole batch instead of degrading the
+/// data. The same refusal is `-2` from `labelle_component_batch_set`'s
+/// i32 return. Distinct from 0 = malformed/not-bound and from any
+/// required-size return, which could never need that much space.
+pub const batch_int_refused: usize = std.math.maxInt(usize) - 1;
 
 /// Inbox back-pressure cap: pending (drained-but-unpolled) events beyond
 /// this are dropped NEWEST-first, matching the POC's fixed-ring behavior.
@@ -323,6 +337,25 @@ const VTable = struct {
     prefab_spawn: *const fn (name: []const u8, params_json: []const u8) u64,
     component_set: *const fn (id: u64, name: []const u8, json: []const u8) i32,
     component_get: *const fn (id: u64, name: []const u8, out: []u8) usize,
+    // PACKED (binary) codec twins of component_get/set — the JSON-free hot
+    // path for scalar-only components. `component_get_packed` writes the
+    // packed record (or the 0xFF "not packable" sentinel) into `out` with
+    // the same required-size/all-or-nothing semantics as component_get;
+    // `component_set_packed` parses a packed record and coerces each field
+    // into the target struct (rc -1 = refuse → binding falls back to JSON).
+    component_get_packed: *const fn (id: u64, name: []const u8, out: []u8) usize,
+    component_set_packed: *const fn (id: u64, name: []const u8, buf: []const u8) i32,
+    // BATCHED codec — the whole-query fast path: one call moves ALL
+    // matching entities' scalar component data across the boundary as a flat
+    // f32 buffer, collapsing the per-entity FFI crossings into 2 per tick.
+    // `component_batch_get` writes `[u32 count][f32 stream]` (f32/f64 + bool
+    // fields only — a named component with any INT field is refused with
+    // `batch_int_refused` / -2, because ints would silently corrupt through
+    // f32); `component_batch_set` re-queries and reads the f32 stream
+    // positionally, refusing -1 unless the buffer length exactly matches the
+    // re-queried entity set (the positional-coupling guard).
+    component_batch_get: *const fn (names_json: []const u8, out: []u8) usize,
+    component_batch_set: *const fn (names_json: []const u8, buf: []const u8) i32,
     component_has: *const fn (id: u64, name: []const u8) i32,
     component_remove: *const fn (id: u64, name: []const u8) i32,
     query: *const fn (names_json: []const u8, out: []u8) usize,
@@ -600,6 +633,113 @@ pub export fn labelle_component_get(
     // computation runs, nothing is written. Same shape as the query's.
     const buf: []u8 = if (out) |p| p[0..out_cap] else &.{};
     return vt.component_get(id, name_ptr[0..name_len], buf);
+}
+
+/// PACKED (binary) twin of `labelle_component_get` — serializes component
+/// `name` of entity `id` into `out` as a self-describing little-endian
+/// record (see `packInto`) rather than JSON text, so a language plugin can
+/// refill a scalar view without any JSON parse. Sizing mirrors
+/// `labelle_component_get` exactly: required-size return, all-or-nothing
+/// write, NULL/cap-0 sizing probe, 0 = absent/unknown/dead/not-bound.
+/// When the component carries any non-scalar field the impl writes the
+/// single sentinel byte 0xFF and returns 1 — the caller then falls back to
+/// the JSON `labelle_component_get` path. Since v1.3, additive (probe by
+/// symbol like the editor-bridge additions).
+pub export fn labelle_component_get_packed(
+    id: u64,
+    name_ptr: [*]const u8,
+    name_len: usize,
+    out: ?[*]u8,
+    out_cap: usize,
+) usize {
+    const vt = vtable orelse return 0;
+    if (name_len == 0) return 0;
+    const buf: []u8 = if (out) |p| p[0..out_cap] else &.{};
+    return vt.component_get_packed(id, name_ptr[0..name_len], buf);
+}
+
+/// PACKED (binary) twin of `labelle_component_set` — applies a packed
+/// record (`packInto`'s format) to component `name` of entity `id`,
+/// coercing each named field into the target struct's actual scalar type.
+/// REPLACE semantics like the JSON set (absent fields take struct
+/// defaults). Returns 0 = ok; -1 = unknown component / dead entity /
+/// non-scalar-or-non-default-constructible target (the binding then falls
+/// back to `labelle_component_set`) / malformed record / not bound. Since
+/// v1.3, additive.
+pub export fn labelle_component_set_packed(
+    id: u64,
+    name_ptr: [*]const u8,
+    name_len: usize,
+    buf_ptr: ?[*]const u8,
+    buf_len: usize,
+) i32 {
+    const vt = vtable orelse return -1;
+    if (name_len == 0) return -1;
+    const buf: []const u8 = if (buf_ptr) |p| p[0..buf_len] else &.{};
+    return vt.component_set_packed(id, name_ptr[0..name_len], buf);
+}
+
+/// BATCHED (binary) whole-query read — the spike's per-tick fast path.
+/// Resolves the SAME entity set as `labelle_query` (all entities carrying
+/// every named component) and writes `[u32 entity_count][f32 stream]` into
+/// `out`: for each entity in query order, each named component's scalar
+/// fields (given-name order, struct-declaration field order) as raw
+/// little-endian f32 (f32/f64 fields directly, bool as 0/1; non-scalar
+/// fields skipped identically on get and set).
+///
+/// INT-FIELD REFUSAL: a named component with ANY int-typed field is
+/// refused with `batch_int_refused` (`(size_t)-2`) — i64/u64 would
+/// silently corrupt through the f32 stream, so the batch path rejects
+/// the whole request and the binding must keep such components on the
+/// per-entity paths (packed codec carries ints losslessly).
+///
+/// Sizing mirrors `labelle_query`: the return is the bytes the COMPLETE
+/// buffer requires (retry right-sized on required > cap), 0 = malformed
+/// names / not bound, NULL/cap-0 `out` sizes only. Zero matching entities
+/// return the 4-byte header alone (count 0), distinct from the 0 sentinel.
+/// Since v1.3, additive (probe by symbol).
+pub export fn labelle_component_batch_get(
+    names_json_ptr: [*]const u8,
+    names_json_len: usize,
+    out: ?[*]u8,
+    out_cap: usize,
+) usize {
+    const vt = vtable orelse return 0;
+    if (names_json_len == 0) return 0;
+    const buf: []u8 = if (out) |p| p[0..out_cap] else &.{};
+    return vt.component_batch_get(names_json_ptr[0..names_json_len], buf);
+}
+
+/// BATCHED (binary) whole-query write — twin of `labelle_component_batch_get`.
+/// Re-queries the same entity set in the same order and reads `buf` (the
+/// pure f32 stream, NO count header) positionally, converting each f32
+/// back into its field's real scalar type (REPLACE semantics), routed
+/// through the same `setPosition`/`setComponent` as the per-entity path so
+/// hooks and dirty-tracking fire identically.
+///
+/// POSITIONAL-COUPLING GUARD: `buf_len` must be EXACTLY the re-queried
+/// entity set's stream size (count × stride × 4) — a mismatch means the
+/// entity set changed between `_batch_get` and `_batch_set` (or the caller
+/// sized the buffer wrong) and the whole write is refused with -1 (entities
+/// walked before the mismatch was detected keep the partial write; treat -1
+/// as "re-get and recompute"). Do NOT spawn or destroy entities between the
+/// paired get and set: the layout is positional, so the guard can catch a
+/// count change but never a same-count membership/order change.
+///
+/// Returns 0 = ok; -1 = malformed names / entity-count mismatch (buffer
+/// size disagrees with the re-queried set) / not bound; -2 = a named
+/// component carries an int-typed field (same refusal as `_batch_get`'s
+/// `(size_t)-2` — see `batch_int_refused`). Since v1.3, additive.
+pub export fn labelle_component_batch_set(
+    names_json_ptr: [*]const u8,
+    names_json_len: usize,
+    buf_ptr: ?[*]const u8,
+    buf_len: usize,
+) i32 {
+    const vt = vtable orelse return -1;
+    if (names_json_len == 0) return -1;
+    const b: []const u8 = if (buf_ptr) |p| p[0..buf_len] else &.{};
+    return vt.component_batch_set(names_json_ptr[0..names_json_len], b);
 }
 
 /// 1 when entity `id` carries component `name`; 0 otherwise (absent,
@@ -1118,6 +1258,10 @@ fn Holder(comptime GP: type) type {
             .prefab_spawn = &prefabSpawnImpl,
             .component_set = &componentSetImpl,
             .component_get = &componentGetImpl,
+            .component_get_packed = &componentGetPackedImpl,
+            .component_set_packed = &componentSetPackedImpl,
+            .component_batch_get = &componentBatchGetImpl,
+            .component_batch_set = &componentBatchSetImpl,
             .component_has = &componentHasImpl,
             .component_remove = &componentRemoveImpl,
             .query = &queryImpl,
@@ -1346,6 +1490,87 @@ fn Holder(comptime GP: type) type {
             return 0;
         }
 
+        /// PACKED twin of `componentGetImpl`: the exact same name-dispatch
+        /// (Position → scene built-ins → registry `inline for`), but each
+        /// arm writes the binary record via `packInto` instead of JSON.
+        /// `packInto` self-selects: a component whose every field is a
+        /// supported scalar produces a real record; anything else (scene
+        /// built-ins carry renderer handles / strings / arrays) yields the
+        /// single 0xFF sentinel byte, so the binding transparently falls
+        /// back to the JSON path for those.
+        fn componentGetPackedImpl(id: u64, name: []const u8, out: []u8) usize {
+            const ent = castEntity(id) orelse return 0;
+            if (!game.ecs_backend.entityExists(ent)) return 0;
+            if (std.mem.eql(u8, name, "Position")) {
+                const pos = game.getComponent(ent, core.Position) orelse return 0;
+                return packInto(pos.*, out);
+            }
+            inline for (builtin_comps) |spec| {
+                if (std.mem.eql(u8, name, spec.name)) {
+                    const comp = game.getComponent(ent, spec.T) orelse return 0;
+                    // Built-ins never pack (Camera.tag / Sprite handles are
+                    // non-scalar) — packInto emits the sentinel and the
+                    // binding uses JSON. No Camera special-case needed here.
+                    return packInto(comp.*, out);
+                }
+            }
+            const comp_names = comptime Components.names();
+            inline for (comp_names) |comp_name| {
+                if (std.mem.eql(u8, name, comp_name)) {
+                    const T = Components.getType(comp_name);
+                    const comp = game.getComponent(ent, T) orelse return 0;
+                    return packInto(comp.*, out);
+                }
+            }
+            return 0;
+        }
+
+        /// PACKED twin of `componentSetImpl`: the same name-dispatch, but
+        /// each arm decodes the binary record into a DEFAULT-initialized
+        /// component (REPLACE semantics — absent fields keep their struct
+        /// defaults, exactly like the JSON set's `ignore_unknown_fields`
+        /// path) and routes through the same `setPosition`/`setComponent`
+        /// as the JSON path so hooks/dirty-tracking fire identically.
+        /// Returns -1 (host refuses → binding falls back to JSON) for the
+        /// scene built-ins and for any registry component that is not a
+        /// scalar-only, default-constructible struct.
+        fn componentSetPackedImpl(id: u64, name: []const u8, buf: []const u8) i32 {
+            const ent = castEntity(id) orelse return -1;
+            if (!game.ecs_backend.entityExists(ent)) return -1;
+            // A record the binding itself marked unpackable — refuse so it
+            // falls back to JSON. (The binding never sends this, but a raw
+            // caller might.)
+            if (buf.len >= 1 and buf[0] == 0xFF) return -1;
+            if (std.mem.eql(u8, name, "Position")) {
+                var pos = core.Position{};
+                if (!applyPacked(core.Position, &pos, buf)) return -1;
+                game.setPosition(ent, pos);
+                return 0;
+            }
+            // Scene built-ins go through the scene-loader apply fns (JSON
+            // only) — refuse the packed path for them.
+            inline for (builtin_comps) |spec| {
+                if (std.mem.eql(u8, name, spec.name)) return -1;
+            }
+            const comp_names = comptime Components.names();
+            inline for (comp_names) |comp_name| {
+                if (std.mem.eql(u8, name, comp_name)) {
+                    const T = Components.getType(comp_name);
+                    if (comptime packableStruct(T)) {
+                        var comp: T = .{};
+                        if (!applyPacked(T, &comp, buf)) return -1;
+                        game.setComponent(ent, comp);
+                        return 0;
+                    } else {
+                        // Non-scalar or non-default-constructible: the
+                        // packed path can't represent it — JSON fallback.
+                        return -1;
+                    }
+                }
+            }
+            return -1;
+        }
+
         fn componentHasImpl(id: u64, name: []const u8) i32 {
             const ent = castEntity(id) orelse return 0;
             // Liveness guard — see componentGetImpl. Dead → 0 (absent).
@@ -1551,6 +1776,237 @@ fn Holder(comptime GP: type) type {
                 }
             }
             return false;
+        }
+
+        /// Runtime component name → "may this component ride the f32 batch
+        /// stream". False when the resolved type carries ANY int-typed
+        /// field: i64/u64 values would silently corrupt through the f32
+        /// coercion (24-bit mantissa), so the batch path refuses them
+        /// outright (`batch_int_refused` / -2) — the packed per-entity
+        /// codec carries ints losslessly instead. f32/f64 and bool fields
+        /// are fine; non-scalar fields are skipped by the codec and don't
+        /// disqualify. Unknown names are vacuously eligible — the
+        /// resolvability checks own that outcome.
+        fn nameBatchEligible(name: []const u8) bool {
+            if (std.mem.eql(u8, name, "Position")) {
+                return comptime batchEligible(core.Position);
+            }
+            inline for (builtin_comps) |spec| {
+                if (std.mem.eql(u8, name, spec.name)) {
+                    return comptime batchEligible(spec.T);
+                }
+            }
+            const comp_names = comptime Components.names();
+            inline for (comp_names) |comp_name| {
+                if (std.mem.eql(u8, name, comp_name)) {
+                    return comptime batchEligible(Components.getType(comp_name));
+                }
+            }
+            return true;
+        }
+
+        // ── Batched query codec ──────────────────────────────────
+        //
+        // The whole-query fast path: one `_batch_get` and one `_batch_set`
+        // per tick move ALL matching entities' scalar component data across
+        // the boundary as a flat f32 buffer, instead of 4 per-entity FFI
+        // crossings (get_into ×2 + set_from ×2). Both re-resolve the query
+        // the same way (`queryImpl`'s view-on-first-name, filter-the-rest),
+        // so get and set walk the SAME entities in the SAME order — the
+        // positional f32 layout depends on that order agreeing.
+
+        fn componentBatchGetImpl(names_json: []const u8, out: []u8) usize {
+            const parsed = std.json.parseFromSlice(
+                []const []const u8,
+                game.allocator,
+                names_json,
+                .{},
+            ) catch return 0;
+            defer parsed.deinit();
+            const names = parsed.value;
+            if (names.len == 0) return 0;
+            if (std.mem.eql(u8, names[0], "Position")) {
+                return runBatchGet(core.Position, names, out);
+            }
+            inline for (builtin_comps) |spec| {
+                if (std.mem.eql(u8, names[0], spec.name)) {
+                    return runBatchGet(spec.T, names, out);
+                }
+            }
+            const comp_names = comptime Components.names();
+            inline for (comp_names) |comp_name| {
+                if (std.mem.eql(u8, names[0], comp_name)) {
+                    return runBatchGet(Components.getType(comp_name), names, out);
+                }
+            }
+            // Unknown first name → an empty (count-0) result, not an error —
+            // mirrors queryImpl's unknown-name handling.
+            return writeBatchCount0(out);
+        }
+
+        fn runBatchGet(comptime ViewT: type, names: []const []const u8, out: []u8) usize {
+            // Int-typed fields cannot ride the f32 stream without silent
+            // corruption — refuse the whole batch before any other outcome
+            // (see `batch_int_refused`).
+            for (names) |nm| {
+                if (!nameBatchEligible(nm)) return batch_int_refused;
+            }
+            // An unknown FILTER name can never match — empty result, decided
+            // before the view walk (queryImpl's precedent).
+            for (names[1..]) |rn| {
+                if (!nameResolvable(rn)) return writeBatchCount0(out);
+            }
+            var count: u32 = 0;
+            var pos: usize = 4; // reserve the u32 count header
+            var v = game.ecs_backend.view(.{ViewT}, .{});
+            defer v.deinit();
+            while (v.next()) |ent| {
+                const matches = blk: {
+                    for (names[1..]) |rn| {
+                        if (!hasByName(ent, rn)) break :blk false;
+                    }
+                    break :blk true;
+                };
+                if (!matches) continue;
+                count += 1;
+                // Each named component's scalar fields as f32, in name order
+                // then struct-declaration field order. `pos` advances even
+                // past the cap so the return is the full required size —
+                // the binding grows and retries (snprintf-style).
+                for (names) |nm| writeEntityFloats(ent, nm, out, &pos);
+            }
+            if (out.len >= 4) std.mem.writeInt(u32, out[0..4], count, .little);
+            return pos;
+        }
+
+        /// Write one entity's component's scalar fields as raw f32 (runtime
+        /// name → comptime type dispatch, same name space as the component
+        /// ops). The query guaranteed the component is present; a null read
+        /// is defended as zero fields.
+        fn writeEntityFloats(ent: Entity, name: []const u8, out: []u8, pos: *usize) void {
+            if (std.mem.eql(u8, name, "Position")) {
+                if (game.getComponent(ent, core.Position)) |cmp| {
+                    packFloatsInto(core.Position, cmp.*, out, pos);
+                }
+                return;
+            }
+            inline for (builtin_comps) |spec| {
+                if (std.mem.eql(u8, name, spec.name)) {
+                    if (game.getComponent(ent, spec.T)) |cmp| {
+                        packFloatsInto(spec.T, cmp.*, out, pos);
+                    }
+                    return;
+                }
+            }
+            const comp_names = comptime Components.names();
+            inline for (comp_names) |comp_name| {
+                if (std.mem.eql(u8, name, comp_name)) {
+                    const T = Components.getType(comp_name);
+                    if (game.getComponent(ent, T)) |cmp| {
+                        packFloatsInto(T, cmp.*, out, pos);
+                    }
+                    return;
+                }
+            }
+        }
+
+        fn componentBatchSetImpl(names_json: []const u8, buf: []const u8) i32 {
+            const parsed = std.json.parseFromSlice(
+                []const []const u8,
+                game.allocator,
+                names_json,
+                .{},
+            ) catch return -1;
+            defer parsed.deinit();
+            const names = parsed.value;
+            if (names.len == 0) return -1;
+            if (std.mem.eql(u8, names[0], "Position")) {
+                return runBatchSet(core.Position, names, buf);
+            }
+            inline for (builtin_comps) |spec| {
+                if (std.mem.eql(u8, names[0], spec.name)) {
+                    return runBatchSet(spec.T, names, buf);
+                }
+            }
+            const comp_names = comptime Components.names();
+            inline for (comp_names) |comp_name| {
+                if (std.mem.eql(u8, names[0], comp_name)) {
+                    return runBatchSet(Components.getType(comp_name), names, buf);
+                }
+            }
+            return -1;
+        }
+
+        fn runBatchSet(comptime ViewT: type, names: []const []const u8, buf: []const u8) i32 {
+            // Same int-field refusal as the get side, as -2 in this i32
+            // return (see `batch_int_refused`).
+            for (names) |nm| {
+                if (!nameBatchEligible(nm)) return -2;
+            }
+            for (names[1..]) |rn| {
+                if (!nameResolvable(rn)) return -1;
+            }
+            var pos: usize = 0; // set buffer has NO header — pure f32 stream
+            var v = game.ecs_backend.view(.{ViewT}, .{});
+            defer v.deinit();
+            while (v.next()) |ent| {
+                const matches = blk: {
+                    for (names[1..]) |rn| {
+                        if (!hasByName(ent, rn)) break :blk false;
+                    }
+                    break :blk true;
+                };
+                if (!matches) continue;
+                for (names) |nm| {
+                    // A buffer exhausted mid-walk = MORE entities now than the
+                    // buffer was computed for (spawn since the paired get) —
+                    // half of the positional-coupling guard.
+                    if (!applyEntityFloats(ent, nm, buf, &pos)) return -1;
+                }
+            }
+            // The other half: leftover bytes = FEWER entities now than the
+            // buffer was computed for (destroy since the paired get). The
+            // caller must re-get and recompute; entities already walked keep
+            // their (positionally suspect) writes — documented on the export.
+            if (pos != buf.len) return -1;
+            return 0;
+        }
+
+        /// Read one entity's component's scalar fields from the f32 stream
+        /// (same name dispatch as `writeEntityFloats`, so get/set consume the
+        /// SAME field layout). Position and packable registry structs are
+        /// applied through `setPosition`/`setComponent`; scene built-ins (and
+        /// non-packable registry types) only advance `pos` past their scalar
+        /// fields to keep the positional stream aligned. Returns false on a
+        /// buffer too short for the layout.
+        fn applyEntityFloats(ent: Entity, name: []const u8, buf: []const u8, pos: *usize) bool {
+            if (std.mem.eql(u8, name, "Position")) {
+                var p = core.Position{};
+                if (!readFloatsFrom(core.Position, &p, buf, pos)) return false;
+                game.setPosition(ent, p);
+                return true;
+            }
+            inline for (builtin_comps) |spec| {
+                if (std.mem.eql(u8, name, spec.name)) {
+                    // Built-ins apply through the scene-loader fns (JSON only)
+                    // — consume their scalar floats to stay aligned, no apply.
+                    return skipFloats(spec.T, buf, pos);
+                }
+            }
+            const comp_names = comptime Components.names();
+            inline for (comp_names) |comp_name| {
+                if (std.mem.eql(u8, name, comp_name)) {
+                    const T = Components.getType(comp_name);
+                    if (comptime packableStruct(T)) {
+                        var cmp: T = .{};
+                        if (!readFloatsFrom(T, &cmp, buf, pos)) return false;
+                        game.setComponent(ent, cmp);
+                        return true;
+                    }
+                    return skipFloats(T, buf, pos);
+                }
+            }
+            return true;
         }
 
         // ── Events ───────────────────────────────────────────────
@@ -1774,6 +2230,292 @@ fn Holder(comptime GP: type) type {
             }
             try jw.endObject();
         }
+
+        /// PACKED codec — `packInto` writes `value`'s scalar fields as the
+        /// self-describing little-endian record the binding decodes:
+        ///
+        ///   [u8 field_count]                (0xFF = "not packable")
+        ///   repeat: [u8 name_len][name][u8 type_tag][value bytes]
+        ///   type_tag: 0=f32(4B) 1=i64(8B) 2=bool(1B) 3=u64(8B)
+        ///
+        /// Same required-size / all-or-nothing contract as `stringifyInto`
+        /// (a counting pass sizes first). A struct with ANY non-scalar
+        /// field — or a non-struct type — writes a single 0xFF byte and
+        /// returns 1: the binding sees the sentinel and falls back to JSON.
+        fn packInto(value: anytype, out: []u8) usize {
+            const T = @TypeOf(value);
+            if (comptime !isPackableStruct(T)) {
+                if (out.len >= 1) out[0] = 0xFF;
+                return 1;
+            }
+            const fields = @typeInfo(T).@"struct".fields;
+            // Count-then-write: size the whole record so an over-cap value
+            // never scribbles a partial write (the get's all-or-nothing).
+            var required: usize = 1; // field_count byte
+            inline for (fields) |f| {
+                required += 1 + f.name.len + comptime packedFieldValueSize(f.type);
+            }
+            if (required > out.len) return required;
+            var pos: usize = 0;
+            out[pos] = @intCast(fields.len);
+            pos += 1;
+            inline for (fields) |f| {
+                out[pos] = @intCast(f.name.len);
+                pos += 1;
+                @memcpy(out[pos..][0..f.name.len], f.name);
+                pos += f.name.len;
+                pos += writePackedValue(f.type, @field(value, f.name), out[pos..]);
+            }
+            return required;
+        }
+
+        /// Decode a packed record into `ptr.*` (already default-init),
+        /// matching each field name to a struct field and COERCING the
+        /// tagged value into that field's actual scalar type. Unknown
+        /// names / non-scalar target fields are skipped. Returns false on a
+        /// malformed record (a truncated field), true otherwise.
+        fn applyPacked(comptime T: type, ptr: *T, buf: []const u8) bool {
+            if (buf.len < 1) return false;
+            const field_count = buf[0];
+            var pos: usize = 1;
+            var i: usize = 0;
+            while (i < field_count) : (i += 1) {
+                if (pos >= buf.len) return false;
+                const name_len = buf[pos];
+                pos += 1;
+                if (pos + name_len > buf.len) return false;
+                const fname = buf[pos..][0..name_len];
+                pos += name_len;
+                if (pos >= buf.len) return false;
+                const tag = buf[pos];
+                pos += 1;
+                const val_size = packedTagSize(tag) orelse return false;
+                if (pos + val_size > buf.len) return false;
+                const val_bytes = buf[pos..][0..val_size];
+                pos += val_size;
+                inline for (@typeInfo(T).@"struct".fields) |f| {
+                    if (comptime isPackableScalar(f.type)) {
+                        if (std.mem.eql(u8, fname, f.name)) {
+                            @field(ptr.*, f.name) = coercePacked(f.type, tag, val_bytes);
+                        }
+                    }
+                }
+            }
+            return true;
+        }
+
+        // ── Packed codec helpers (comptime-pure, Holder-nested) ──────
+
+        /// A field/component type the packed codec can carry: 32/64-bit
+        /// float, any int ≤ 64 bits, or bool.
+        fn isPackableScalar(comptime T: type) bool {
+    return switch (@typeInfo(T)) {
+        .float => |fl| fl.bits == 32 or fl.bits == 64,
+        .int => |i| i.bits <= 64,
+        .bool => true,
+        else => false,
+    };
+}
+
+/// A struct every field of which is a packable scalar (zero-field structs
+/// pack as an empty record — vacuously true).
+fn isPackableStruct(comptime T: type) bool {
+    if (@typeInfo(T) != .@"struct") return false;
+    inline for (@typeInfo(T).@"struct".fields) |f| {
+        if (!isPackableScalar(f.type)) return false;
+    }
+    return true;
+}
+
+/// Additionally require default values so `var comp: T = .{}` compiles for
+/// the packed SET path (REPLACE semantics start from defaults).
+fn packableStruct(comptime T: type) bool {
+    if (!isPackableStruct(T)) return false;
+    inline for (@typeInfo(T).@"struct".fields) |f| {
+        if (f.default_value_ptr == null) return false;
+    }
+    return true;
+}
+
+/// Bytes one field occupies in the record: tag byte + payload.
+fn packedFieldValueSize(comptime T: type) usize {
+    return switch (@typeInfo(T)) {
+        .float => 1 + 4, // tag + f32
+        .int => 1 + 8, // tag + i64/u64
+        .bool => 1 + 1, // tag + byte
+        else => unreachable,
+    };
+}
+
+/// Payload byte count for a wire type_tag (null = unknown tag).
+fn packedTagSize(tag: u8) ?usize {
+    return switch (tag) {
+        0 => 4, // f32
+        1 => 8, // i64
+        2 => 1, // bool
+        3 => 8, // u64
+        else => null,
+    };
+}
+
+/// Write one field's [tag][value] slot; returns bytes written.
+fn writePackedValue(comptime T: type, val: T, out: []u8) usize {
+    switch (@typeInfo(T)) {
+        .float => {
+            out[0] = 0;
+            const f: f32 = @floatCast(val);
+            std.mem.writeInt(u32, out[1..][0..4], @bitCast(f), .little);
+            return 5;
+        },
+        .int => |i| {
+            if (i.signedness == .signed) {
+                out[0] = 1;
+                std.mem.writeInt(i64, out[1..][0..8], @intCast(val), .little);
+            } else {
+                out[0] = 3;
+                std.mem.writeInt(u64, out[1..][0..8], @intCast(val), .little);
+            }
+            return 9;
+        },
+        .bool => {
+            out[0] = 2;
+            out[1] = @intFromBool(val);
+            return 2;
+        },
+        else => unreachable,
+    }
+}
+
+/// Coerce a tagged packed value into `T` (the target field's real type):
+/// widened ints narrow via @intCast, f32↔f64 via @floatCast, and a bool
+/// tag lands in an int/float field as 0/1 (the mirror of the write side's
+/// widening). Type mismatches degrade gracefully (a bool tag into a float
+/// field, etc.) rather than corrupting.
+fn coercePacked(comptime T: type, tag: u8, bytes: []const u8) T {
+    return switch (@typeInfo(T)) {
+        .float => switch (tag) {
+            0 => @floatCast(@as(f32, @bitCast(std.mem.readInt(u32, bytes[0..4], .little)))),
+            1 => @floatFromInt(std.mem.readInt(i64, bytes[0..8], .little)),
+            2 => if (bytes[0] != 0) 1 else 0,
+            3 => @floatFromInt(std.mem.readInt(u64, bytes[0..8], .little)),
+            else => 0,
+        },
+        .int => switch (tag) {
+            0 => @intFromFloat(@as(f32, @bitCast(std.mem.readInt(u32, bytes[0..4], .little)))),
+            1 => @intCast(std.mem.readInt(i64, bytes[0..8], .little)),
+            2 => @intFromBool(bytes[0] != 0),
+            3 => @intCast(std.mem.readInt(u64, bytes[0..8], .little)),
+            else => 0,
+        },
+        .bool => switch (tag) {
+            2 => bytes[0] != 0,
+            1 => std.mem.readInt(i64, bytes[0..8], .little) != 0,
+            3 => std.mem.readInt(u64, bytes[0..8], .little) != 0,
+            else => false,
+        },
+        else => unreachable,
+    };
+}
+
+// ── Batched f32 codec helpers (comptime-pure, positional) ────────────
+//
+// Unlike the packed codec these are NAMELESS/positional: the batch buffer
+// carries no field names or tags, only raw little-endian f32, so get and
+// set must agree on field COUNT and ORDER purely by walking the same struct
+// the same way. Both iterate `@typeInfo(T).@"struct".fields` (declaration
+// order), emitting/consuming one f32 per scalar field and skipping
+// non-scalar fields identically. Int-carrying components never reach these
+// helpers — `batchEligible` refuses them upstream (`batch_int_refused`) —
+// but the int arms are kept total so the helpers stay usable on any struct.
+
+/// A component type the BATCH codec accepts: no int-typed fields. Ints
+/// cannot survive the positional f32 stream (silent precision loss past
+/// 2^24), so components carrying them are refused rather than corrupted
+/// — use the per-entity packed codec (lossless i64/u64 tags) for those.
+/// f32/f64 and bool fields ride as f32 (bool as 0/1); non-scalar fields
+/// are skipped by both stream directions and don't disqualify.
+fn batchEligible(comptime T: type) bool {
+    if (@typeInfo(T) != .@"struct") return true;
+    inline for (@typeInfo(T).@"struct".fields) |f| {
+        if (@typeInfo(f.type) == .int) return false;
+    }
+    return true;
+}
+
+/// Empty batched result: the 4-byte `[u32 count = 0]` header alone,
+/// written only when it fits. Distinct from the 0 not-bound/malformed
+/// sentinel (queryImpl's `writeEmptyArray` analog).
+fn writeBatchCount0(out: []u8) usize {
+    if (out.len >= 4) std.mem.writeInt(u32, out[0..4], 0, .little);
+    return 4;
+}
+
+/// Write each scalar field of `value` as one raw little-endian f32 at
+/// `pos.*`, advancing `pos.*` by 4 per field. Int fields coerce via
+/// `@floatFromInt`, bool via 0/1; non-scalar fields are skipped (they
+/// contribute no float — get and set skip them identically). `pos.*`
+/// advances even past the cap so the caller's required-size return is
+/// exact (snprintf-style); the write itself is guarded by room.
+fn packFloatsInto(comptime T: type, value: T, out: []u8, pos: *usize) void {
+    if (comptime @typeInfo(T) != .@"struct") return;
+    inline for (@typeInfo(T).@"struct".fields) |f| {
+        const maybe: ?f32 = switch (@typeInfo(f.type)) {
+            .float => @floatCast(@field(value, f.name)),
+            .int => @floatFromInt(@field(value, f.name)),
+            .bool => if (@field(value, f.name)) @as(f32, 1) else @as(f32, 0),
+            else => null,
+        };
+        if (maybe) |fv| {
+            if (pos.* + 4 <= out.len) {
+                std.mem.writeInt(u32, out[pos.*..][0..4], @bitCast(fv), .little);
+            }
+            pos.* += 4;
+        }
+    }
+}
+
+/// Read each scalar field of `ptr.*` from the f32 stream at `pos.*`,
+/// coercing the f32 back into the field's real type (int via
+/// `@intFromFloat`, bool via `!= 0`), advancing 4 per field. Non-scalar
+/// fields are skipped (no bytes consumed — the write side skipped them
+/// too). Returns false if the buffer runs out mid-layout.
+fn readFloatsFrom(comptime T: type, ptr: *T, buf: []const u8, pos: *usize) bool {
+    if (comptime @typeInfo(T) != .@"struct") return true;
+    inline for (@typeInfo(T).@"struct".fields) |f| {
+        switch (@typeInfo(f.type)) {
+            .float, .int, .bool => {
+                if (pos.* + 4 > buf.len) return false;
+                const fv: f32 = @bitCast(std.mem.readInt(u32, buf[pos.*..][0..4], .little));
+                pos.* += 4;
+                @field(ptr.*, f.name) = switch (@typeInfo(f.type)) {
+                    .float => @floatCast(fv),
+                    .int => @intFromFloat(fv),
+                    .bool => fv != 0,
+                    else => unreachable,
+                };
+            },
+            else => {},
+        }
+    }
+    return true;
+}
+
+/// Advance `pos.*` past one component's scalar fields WITHOUT applying —
+/// keeps the positional stream aligned for component types the batch set
+/// can't reconstruct (scene built-ins, non-packable registry structs).
+fn skipFloats(comptime T: type, buf: []const u8, pos: *usize) bool {
+    if (comptime @typeInfo(T) != .@"struct") return true;
+    inline for (@typeInfo(T).@"struct".fields) |f| {
+        switch (@typeInfo(f.type)) {
+            .float, .int, .bool => {
+                if (pos.* + 4 > buf.len) return false;
+                pos.* += 4;
+            },
+            else => {},
+        }
+    }
+    return true;
+}
 
         fn castEntity(id: u64) ?Entity {
             if (comptime @typeInfo(Entity) != .int) return null;

--- a/test/script_contract_test.zig
+++ b/test/script_contract_test.zig
@@ -41,11 +41,22 @@ const Doomed = struct {
 /// returns).
 const Label = struct { text: []const u8 = "" };
 
+/// One field of each packed-codec scalar kind (f32/i64/bool/u64) — the
+/// v1.3 packed round-trip component. Declaration order IS the wire
+/// order, so the tests below hand-build the expected record.
+const Stats = struct {
+    power: f32 = 0,
+    score: i64 = 0,
+    alive: bool = false,
+    seed: u64 = 0,
+};
+
 const TestComponents = engine.ComponentRegistry(.{
     .Health = Health,
     .Velocity = Velocity,
     .Doomed = Doomed,
     .Label = Label,
+    .Stats = Stats,
 });
 
 const TestEvents = union(enum) {
@@ -2616,4 +2627,361 @@ test "editorPluginCommand (v1.7 rc): the dispatch window exists — a response i
     try testing.expectEqual(@as(i32, 0), game.editorPluginCommand("pathfinder", "ping", "{}"));
     try testing.expectEqual(@as(usize, 1), recorder.count);
     try testing.expectEqual(@as(?bool, true), recorder.respond_accepted);
+}
+
+// ── Bulk component access (v1.3, labelle-scripting#41) ──────────────
+//
+// The packed per-component codec (binary twin of get/set, 0xFF
+// sentinel → JSON fallback) and the batched whole-query f32 stream
+// (int-field refusal + the positional-coupling guard).
+
+fn getPacked(id: u64, name: []const u8, buf: []u8) usize {
+    return contract.labelle_component_get_packed(id, name.ptr, name.len, buf.ptr, buf.len);
+}
+
+fn setPacked(id: u64, name: []const u8, buf: []const u8) i32 {
+    return contract.labelle_component_set_packed(id, name.ptr, name.len, buf.ptr, buf.len);
+}
+
+fn batchGet(names_json: []const u8, buf: []u8) usize {
+    return contract.labelle_component_batch_get(names_json.ptr, names_json.len, buf.ptr, buf.len);
+}
+
+fn batchSet(names_json: []const u8, buf: []const u8) i32 {
+    return contract.labelle_component_batch_set(names_json.ptr, names_json.len, buf.ptr, buf.len);
+}
+
+/// Hand-builds packed records field by field — both the EXPECTED bytes
+/// for a get (declaration order, host-chosen tags) and the record a
+/// binding would send to a set (tags chosen by the script value's
+/// runtime type).
+const PackedRecord = struct {
+    buf: [128]u8 = undefined,
+    len: usize = 0,
+
+    fn init(field_count: u8) PackedRecord {
+        var r = PackedRecord{};
+        r.buf[0] = field_count;
+        r.len = 1;
+        return r;
+    }
+
+    fn name(self: *PackedRecord, n: []const u8) void {
+        self.buf[self.len] = @intCast(n.len);
+        self.len += 1;
+        @memcpy(self.buf[self.len..][0..n.len], n);
+        self.len += n.len;
+    }
+
+    fn f32Field(self: *PackedRecord, n: []const u8, v: f32) void {
+        self.name(n);
+        self.buf[self.len] = 0;
+        std.mem.writeInt(u32, self.buf[self.len + 1 ..][0..4], @bitCast(v), .little);
+        self.len += 5;
+    }
+
+    fn i64Field(self: *PackedRecord, n: []const u8, v: i64) void {
+        self.name(n);
+        self.buf[self.len] = 1;
+        std.mem.writeInt(i64, self.buf[self.len + 1 ..][0..8], v, .little);
+        self.len += 9;
+    }
+
+    fn boolField(self: *PackedRecord, n: []const u8, v: bool) void {
+        self.name(n);
+        self.buf[self.len] = 2;
+        self.buf[self.len + 1] = @intFromBool(v);
+        self.len += 2;
+    }
+
+    fn u64Field(self: *PackedRecord, n: []const u8, v: u64) void {
+        self.name(n);
+        self.buf[self.len] = 3;
+        std.mem.writeInt(u64, self.buf[self.len + 1 ..][0..8], v, .little);
+        self.len += 9;
+    }
+
+    fn bytes(self: *const PackedRecord) []const u8 {
+        return self.buf[0..self.len];
+    }
+};
+
+test "packed get/set: binary record round-trip over f32/i64/bool/u64 fields" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+    const ent: u32 = @intCast(id);
+    try testing.expectEqual(@as(i32, 0), setComp(
+        id,
+        "Stats",
+        "{\"power\":1.5,\"score\":-42,\"alive\":true,\"seed\":9000000000000000000}",
+    ));
+
+    // GET — the host writes declaration order with the field's own tag
+    // (f32→0, i64→1, bool→2, u64→3).
+    var expected = PackedRecord.init(4);
+    expected.f32Field("power", 1.5);
+    expected.i64Field("score", -42);
+    expected.boolField("alive", true);
+    expected.u64Field("seed", 9_000_000_000_000_000_000);
+
+    // NULL/cap-0 sizing probe, then all-or-nothing: an under-sized cap
+    // writes nothing and still returns the required size.
+    const nm = "Stats";
+    const required = contract.labelle_component_get_packed(id, nm, nm.len, null, 0);
+    try testing.expectEqual(expected.len, required);
+    var buf: [128]u8 = @splat(0xAA);
+    try testing.expectEqual(required, getPacked(id, "Stats", buf[0 .. required - 1]));
+    try testing.expectEqual(@as(u8, 0xAA), buf[0]);
+    try testing.expectEqual(required, getPacked(id, "Stats", &buf));
+    try testing.expectEqualSlices(u8, expected.bytes(), buf[0..required]);
+
+    // SET — tags as a binding chooses them from the SCRIPT value's
+    // runtime type: an Integer travels as i64 even into a u64 field
+    // (the host coerces into the field's real type).
+    var record = PackedRecord.init(4);
+    record.f32Field("power", 2.5);
+    record.i64Field("score", 7);
+    record.boolField("alive", false);
+    record.i64Field("seed", 123);
+    try testing.expectEqual(@as(i32, 0), setPacked(id, "Stats", record.bytes()));
+    const stats = game.getComponent(ent, Stats).?;
+    try testing.expectEqual(@as(f32, 2.5), stats.power);
+    try testing.expectEqual(@as(i64, 7), stats.score);
+    try testing.expectEqual(false, stats.alive);
+    try testing.expectEqual(@as(u64, 123), stats.seed);
+
+    // REPLACE semantics: a partial record resets absent fields to the
+    // struct defaults, exactly like the JSON set.
+    var partial = PackedRecord.init(1);
+    partial.i64Field("score", 9);
+    try testing.expectEqual(@as(i32, 0), setPacked(id, "Stats", partial.bytes()));
+    const reset = game.getComponent(ent, Stats).?;
+    try testing.expectEqual(@as(i64, 9), reset.score);
+    try testing.expectEqual(@as(f32, 0), reset.power);
+    try testing.expectEqual(@as(u64, 0), reset.seed);
+
+    // Int-carrying components are PACKABLE here (unlike the batch
+    // stream): Health's i32 rides the i64 tag losslessly.
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Health", "{\"hp\":250,\"regen\":0.5}"));
+    const hn = contract.labelle_component_get_packed(id, "Health", 6, null, 0);
+    try testing.expect(hn > 1); // a real record, not the sentinel
+}
+
+test "packed get: a non-scalar component writes the 0xFF sentinel (JSON-fallback signal)" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Label", "{\"text\":\"hi\"}"));
+
+    var buf: [64]u8 = @splat(0);
+    try testing.expectEqual(@as(usize, 1), getPacked(id, "Label", &buf));
+    try testing.expectEqual(@as(u8, 0xFF), buf[0]);
+
+    // Absent / unknown / dead keep component_get's 0 sentinel.
+    try testing.expectEqual(@as(usize, 0), getPacked(id, "Velocity", &buf));
+    try testing.expectEqual(@as(usize, 0), getPacked(id, "NoSuch", &buf));
+    contract.labelle_entity_destroy(id);
+    try testing.expectEqual(@as(usize, 0), getPacked(id, "Label", &buf));
+}
+
+test "packed set: non-scalar targets, built-ins and malformed records refuse with -1" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+
+    // Non-scalar target (Label carries a string) → JSON fallback.
+    var record = PackedRecord.init(0);
+    try testing.expectEqual(@as(i32, -1), setPacked(id, "Label", record.bytes()));
+
+    // Scene built-ins apply through the scene-loader JSON machinery
+    // only — the packed path refuses them.
+    try testing.expectEqual(@as(i32, -1), setPacked(id, "Sprite", record.bytes()));
+
+    // A buffer led by the 0xFF sentinel is never applicable.
+    const sentinel = [_]u8{0xFF};
+    try testing.expectEqual(@as(i32, -1), setPacked(id, "Stats", &sentinel));
+
+    // Truncated record (claims one field, carries none).
+    const truncated = [_]u8{1};
+    try testing.expectEqual(@as(i32, -1), setPacked(id, "Stats", &truncated));
+
+    // Unknown component / dead entity.
+    try testing.expectEqual(@as(i32, -1), setPacked(id, "NoSuch", record.bytes()));
+    contract.labelle_entity_destroy(id);
+    try testing.expectEqual(@as(i32, -1), setPacked(id, "Stats", record.bytes()));
+}
+
+/// Read the f32 at byte offset `off` of a batch buffer (unaligned-safe).
+fn batchFloat(buf: []const u8, off: usize) f32 {
+    return @bitCast(std.mem.readInt(u32, buf[off..][0..4], .little));
+}
+
+/// Overwrite the f32 at byte offset `off` of a batch buffer.
+fn batchFloatSet(buf: []u8, off: usize, v: f32) void {
+    std.mem.writeInt(u32, buf[off..][0..4], @bitCast(v), .little);
+}
+
+test "batch get/set: whole-query f32 stream round-trip" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const names = "[\"Position\",\"Velocity\"]";
+
+    // Zero matching entities: the count-0 header alone — 4 bytes,
+    // distinct from the 0 malformed/not-bound sentinel.
+    var buf: [256]u8 = @splat(0);
+    try testing.expectEqual(@as(usize, 4), batchGet(names, &buf));
+    try testing.expectEqual(@as(u32, 0), std.mem.readInt(u32, buf[0..4], .little));
+    // ...and an empty stream applies cleanly (0 entities × anything = 0 bytes).
+    try testing.expectEqual(@as(i32, 0), batchSet(names, buf[4..4]));
+
+    // Three full entities + one Position-only (filtered out of the set).
+    const ids = [3]u64{
+        contract.labelle_entity_create(),
+        contract.labelle_entity_create(),
+        contract.labelle_entity_create(),
+    };
+    for (ids, 0..) |id, i| {
+        var jbuf: [128]u8 = undefined;
+        const fi: f32 = @floatFromInt(i);
+        const pj = try std.fmt.bufPrint(&jbuf, "{{\"x\":{d},\"y\":{d}}}", .{ fi + 1, fi + 2 });
+        try testing.expectEqual(@as(i32, 0), setComp(id, "Position", pj));
+        var jbuf2: [128]u8 = undefined;
+        const vj = try std.fmt.bufPrint(&jbuf2, "{{\"dx\":{d},\"dy\":{d}}}", .{ (fi + 1) * 10, (fi + 1) * -10 });
+        try testing.expectEqual(@as(i32, 0), setComp(id, "Velocity", vj));
+    }
+    const lone = contract.labelle_entity_create();
+    try testing.expectEqual(@as(i32, 0), setComp(lone, "Position", "{\"x\":7,\"y\":8}"));
+
+    // Sizing probe: [u32 count][3 entities × 4 fields × 4B].
+    const required = contract.labelle_component_batch_get(names, names.len, null, 0);
+    try testing.expectEqual(@as(usize, 4 + 3 * 4 * 4), required);
+    // Under-sized cap: same required-size return (snprintf-style retry).
+    try testing.expectEqual(required, batchGet(names, buf[0 .. required - 3]));
+
+    try testing.expectEqual(required, batchGet(names, &buf));
+    try testing.expectEqual(@as(u32, 3), std.mem.readInt(u32, buf[0..4], .little));
+
+    // The hot loop, host-free: +1.0 to every float in the stream.
+    var off: usize = 4;
+    while (off < required) : (off += 4) {
+        batchFloatSet(&buf, off, batchFloat(&buf, off) + 1.0);
+    }
+    try testing.expectEqual(@as(i32, 0), batchSet(names, buf[4..required]));
+
+    // Every matched entity moved by exactly +1 on all four fields
+    // (order-independent — the mock backend's view order is unspecified,
+    // but get and set walked it identically).
+    for (ids, 0..) |id, i| {
+        const ent: u32 = @intCast(id);
+        const fi: f32 = @floatFromInt(i);
+        const pos = game.getComponent(ent, core.Position).?;
+        try testing.expectEqual(fi + 2, pos.x);
+        try testing.expectEqual(fi + 3, pos.y);
+        const vel = game.getComponent(ent, Velocity).?;
+        try testing.expectEqual((fi + 1) * 10 + 1, vel.dx);
+        try testing.expectEqual((fi + 1) * -10 + 1, vel.dy);
+    }
+    // The filtered-out entity is untouched.
+    const lp = game.getComponent(@as(u32, @intCast(lone)), core.Position).?;
+    try testing.expectEqual(@as(f32, 7), lp.x);
+    try testing.expectEqual(@as(f32, 8), lp.y);
+}
+
+test "batch: an int-carrying component is refused (get sentinel, set -2)" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Health", "{\"hp\":50,\"regen\":1}"));
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Velocity", "{\"dx\":1,\"dy\":2}"));
+
+    // Health.hp is i32 → i64/u64-class corruption through f32; the
+    // whole batch is refused, alone or anywhere in the name list.
+    var buf: [128]u8 = @splat(0);
+    const health = "[\"Health\"]";
+    try testing.expectEqual(contract.batch_int_refused, batchGet(health, &buf));
+    const mixed = "[\"Velocity\",\"Health\"]";
+    try testing.expectEqual(contract.batch_int_refused, batchGet(mixed, &buf));
+    try testing.expectEqual(@as(i32, -2), batchSet(health, buf[0..8]));
+    try testing.expectEqual(@as(i32, -2), batchSet(mixed, buf[0..16]));
+
+    // The refusal is the component's, not the entity's: the float-only
+    // Velocity still batches.
+    const vel = "[\"Velocity\"]";
+    try testing.expectEqual(@as(usize, 4 + 2 * 4), batchGet(vel, &buf));
+}
+
+test "batch set: entity-count mismatch refuses -1 (positional-coupling guard)" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const names = "[\"Position\",\"Velocity\"]";
+    const a = contract.labelle_entity_create();
+    const b = contract.labelle_entity_create();
+    for ([_]u64{ a, b }) |id| {
+        try testing.expectEqual(@as(i32, 0), setComp(id, "Position", "{\"x\":1,\"y\":1}"));
+        try testing.expectEqual(@as(i32, 0), setComp(id, "Velocity", "{\"dx\":1,\"dy\":1}"));
+    }
+
+    var buf: [256]u8 = @splat(0);
+    const required = batchGet(names, &buf);
+    try testing.expectEqual(@as(usize, 4 + 2 * 4 * 4), required);
+    const stream = buf[4..required];
+
+    // Same set → the stream applies.
+    try testing.expectEqual(@as(i32, 0), batchSet(names, stream));
+
+    // An entity DESTROYED since the get: the re-queried set consumes
+    // fewer bytes than the stream carries → refuse.
+    contract.labelle_entity_destroy(b);
+    try testing.expectEqual(@as(i32, -1), batchSet(names, stream));
+
+    // Entities SPAWNED since the get: the stream runs out mid-walk →
+    // refuse (the other half of the guard).
+    for (0..2) |_| {
+        const id = contract.labelle_entity_create();
+        try testing.expectEqual(@as(i32, 0), setComp(id, "Position", "{\"x\":2,\"y\":2}"));
+        try testing.expectEqual(@as(i32, 0), setComp(id, "Velocity", "{\"dx\":2,\"dy\":2}"));
+    }
+    try testing.expectEqual(@as(i32, -1), batchSet(names, stream));
+}
+
+test "bulk access pre-bind: safe no-ops in each op's failure convention" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var buf: [32]u8 = @splat(0);
+    try testing.expectEqual(@as(usize, 0), getPacked(1, "Stats", &buf));
+    try testing.expectEqual(@as(i32, -1), setPacked(1, "Stats", buf[0..1]));
+    try testing.expectEqual(@as(usize, 0), batchGet("[\"Position\"]", &buf));
+    try testing.expectEqual(@as(i32, -1), batchSet("[\"Position\"]", buf[0..0]));
 }

--- a/test/script_contract_test.zig
+++ b/test/script_contract_test.zig
@@ -59,6 +59,21 @@ const Tiny = struct { b: u8 = 7, w: i32 = -7 };
 /// a NaN stream float lands as true, since NaN != 0).
 const Flag = struct { on: bool = false, weight: f32 = 0 };
 
+/// Non-scalar field beside batch-eligible scalars — the batch
+/// read-modify-write test component (the string must SURVIVE a batch
+/// write that only carries x/on).
+const Mixed = struct { text: []const u8 = "", x: f32 = 0, on: bool = false };
+
+/// All-scalar but NO field defaults — RMW needs no `.{}` construction,
+/// so this batches on both sides (the packed SET still refuses it:
+/// REPLACE-from-defaults can't exist without defaults).
+const Bare = struct { x: f32, y: f32 };
+
+/// An f64 field — packable-looking but the packed wire only has an f32
+/// tag, so it must comptime-classify as NOT packable (0xFF/JSON keeps
+/// the precision).
+const Precise = struct { d: f64 = 0 };
+
 /// 300 f32 fields — over the packed wire's u8 field_count limit (0xFF
 /// reserved as the sentinel), so it must comptime-classify as NOT
 /// packable (get → 0xFF, set → -1) instead of panicking the `@intCast`
@@ -94,6 +109,9 @@ const TestComponents = engine.ComponentRegistry(.{
     .Stats = Stats,
     .Tiny = Tiny,
     .Flag = Flag,
+    .Mixed = Mixed,
+    .Bare = Bare,
+    .Precise = Precise,
     .Wide300 = Wide300,
     .LongName = LongName,
 });
@@ -2999,19 +3017,32 @@ test "batch set: entity-count mismatch refuses -1 (positional-coupling guard)" {
     // Same set → the stream applies.
     try testing.expectEqual(@as(i32, 0), batchSet(names, stream));
 
-    // An entity DESTROYED since the get: the re-queried set consumes
-    // fewer bytes than the stream carries → refuse.
+    // An entity DESTROYED since the get: the re-queried set needs fewer
+    // bytes than the stream carries → the PREFLIGHT refuses with NO
+    // writes — poison every float first and verify the survivor is
+    // untouched (a refused batch_set must never commit a prefix, or the
+    // documented "re-get and recompute" retry would double-apply).
     contract.labelle_entity_destroy(b);
+    var off: usize = 0;
+    while (off < stream.len) : (off += 4) batchFloatSet(stream, off, 99);
     try testing.expectEqual(@as(i32, -1), batchSet(names, stream));
+    const surv = game.getComponent(@as(u32, @intCast(a)), core.Position).?;
+    try testing.expectEqual(@as(f32, 1), surv.x);
+    try testing.expectEqual(@as(f32, 1), surv.y);
+    const surv_vel = game.getComponent(@as(u32, @intCast(a)), Velocity).?;
+    try testing.expectEqual(@as(f32, 1), surv_vel.dx);
+    try testing.expectEqual(@as(f32, 1), surv_vel.dy);
 
-    // Entities SPAWNED since the get: the stream runs out mid-walk →
-    // refuse (the other half of the guard).
+    // Entities SPAWNED since the get: the re-queried set needs MORE
+    // bytes → same preflight refusal, still nothing written.
     for (0..2) |_| {
         const id = contract.labelle_entity_create();
         try testing.expectEqual(@as(i32, 0), setComp(id, "Position", "{\"x\":2,\"y\":2}"));
         try testing.expectEqual(@as(i32, 0), setComp(id, "Velocity", "{\"dx\":2,\"dy\":2}"));
     }
     try testing.expectEqual(@as(i32, -1), batchSet(names, stream));
+    const still = game.getComponent(@as(u32, @intCast(a)), core.Position).?;
+    try testing.expectEqual(@as(f32, 1), still.x);
 }
 
 test "bulk access pre-bind: safe no-ops in each op's failure convention" {
@@ -3042,14 +3073,15 @@ test "packed set: out-of-range / non-finite script values refuse -1, never panic
     var over = PackedRecord.init(1);
     over.i64Field("b", 300);
     try testing.expectEqual(@as(i32, -1), setPacked(id, "Tiny", over.bytes()));
-    // Negative into unsigned — refuse.
+    // Negative into a NARROW unsigned — refuse (the 64-bit bitcast pair
+    // below is exactly 64-bit-to-64-bit, never a narrowing escape hatch).
     var neg = PackedRecord.init(1);
     neg.i64Field("b", -1);
     try testing.expectEqual(@as(i32, -1), setPacked(id, "Tiny", neg.bytes()));
-    // u64 tag past maxInt(i64) into an i64 field — refuse.
+    // u64 tag past the range of a NARROW signed target — refuse.
     var big = PackedRecord.init(1);
-    big.u64Field("score", std.math.maxInt(u64));
-    try testing.expectEqual(@as(i32, -1), setPacked(id, "Stats", big.bytes()));
+    big.u64Field("w", std.math.maxInt(u64));
+    try testing.expectEqual(@as(i32, -1), setPacked(id, "Tiny", big.bytes()));
     // f32 tag into an int field: NaN / Inf / out-of-range all refuse…
     inline for ([_]f32{
         std.math.nan(f32),
@@ -3137,4 +3169,166 @@ test "packed get/set: over-the-wire-limit structs comptime-classify as not packa
     try testing.expectEqual(@as(usize, 1), getPacked(id, "LongName", &buf));
     try testing.expectEqual(@as(u8, 0xFF), buf[0]);
     try testing.expectEqual(@as(i32, -1), setPacked(id, "LongName", rec.bytes()));
+}
+
+test "batch set: read-modify-write — mixed components keep non-scalar fields, no defaults needed" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+    const ent: u32 = @intCast(id);
+    // Mixed: a string beside batch-eligible scalars.
+    try testing.expectEqual(
+        @as(i32, 0),
+        setComp(id, "Mixed", "{\"text\":\"keep\",\"x\":1,\"on\":false}"),
+    );
+    // Bare: all-scalar, NO field defaults — set through the typed path
+    // (the JSON REPLACE path would demand every field anyway).
+    game.setComponent(ent, Bare{ .x = 10, .y = 20 });
+
+    const names = "[\"Mixed\",\"Bare\"]";
+    var buf: [64]u8 = @splat(0);
+    // Stream: Mixed.x, Mixed.on, Bare.x, Bare.y — 4 floats.
+    const required = batchGet(names, &buf);
+    try testing.expectEqual(@as(usize, 4 + 4 * 4), required);
+    try testing.expectEqual(@as(f32, 1), batchFloat(&buf, 4));
+    try testing.expectEqual(@as(f32, 0), batchFloat(&buf, 8)); // on=false
+    try testing.expectEqual(@as(f32, 10), batchFloat(&buf, 12));
+    try testing.expectEqual(@as(f32, 20), batchFloat(&buf, 16));
+
+    // Mutate every scalar, flip the bool, write back.
+    batchFloatSet(&buf, 4, 2);
+    batchFloatSet(&buf, 8, 1); // on=true
+    batchFloatSet(&buf, 12, 11);
+    batchFloatSet(&buf, 16, 21);
+    try testing.expectEqual(@as(i32, 0), batchSet(names, buf[4..required]));
+
+    const mixed = game.getComponent(ent, Mixed).?;
+    try testing.expectEqual(@as(f32, 2), mixed.x);
+    try testing.expectEqual(true, mixed.on);
+    // The RMW promise: the non-scalar field SURVIVED the batch write.
+    try testing.expectEqualStrings("keep", mixed.text);
+    const bare = game.getComponent(ent, Bare).?;
+    try testing.expectEqual(@as(f32, 11), bare.x);
+    try testing.expectEqual(@as(f32, 21), bare.y);
+}
+
+test "batch set: a built-in Camera zoom round-trips through the scene apply path" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+    try testing.expectEqual(
+        @as(i32, 0),
+        setComp(id, "Camera", "{\"zoom\":2,\"tag\":\"main\"}"),
+    );
+
+    // Camera's only batch-eligible scalar is zoom (viewport is optional,
+    // tag is a string) — stride 1.
+    const names = "[\"Camera\"]";
+    var buf: [16]u8 = @splat(0);
+    const required = batchGet(names, &buf);
+    try testing.expectEqual(@as(usize, 4 + 4), required);
+    try testing.expectEqual(@as(f32, 2), batchFloat(&buf, 4));
+
+    batchFloatSet(&buf, 4, 3.5);
+    try testing.expectEqual(@as(i32, 0), batchSet(names, buf[4..required]));
+
+    // Applied — and through the same scene apply machinery as the JSON
+    // set, preserving the non-scalar tag.
+    var jbuf: [256]u8 = undefined;
+    const json = getComp(id, "Camera", &jbuf);
+    try testing.expect(std.mem.indexOf(u8, json, "\"zoom\":3.5") != null);
+    try testing.expect(std.mem.indexOf(u8, json, "\"tag\":\"main\"") != null);
+}
+
+test "packed: an f64 field comptime-classifies as not packable (precision over speed)" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+    // A value an f32 cannot hold exactly.
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Precise", "{\"d\":1.0000000116860974}"));
+
+    var buf: [64]u8 = @splat(0);
+    try testing.expectEqual(@as(usize, 1), getPacked(id, "Precise", &buf));
+    try testing.expectEqual(@as(u8, 0xFF), buf[0]);
+    var rec = PackedRecord.init(0);
+    try testing.expectEqual(@as(i32, -1), setPacked(id, "Precise", rec.bytes()));
+    // …and the JSON path the sentinel redirects to carries the f64
+    // faithfully.
+    var jbuf: [128]u8 = undefined;
+    const json = getComp(id, "Precise", &jbuf);
+    try testing.expect(std.mem.indexOf(u8, json, "1.0000000116860974") != null);
+}
+
+test "packed set: trailing bytes after the declared fields refuse -1" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Tiny", "{\"b\":7,\"w\":-7}"));
+
+    // A well-formed record with appended garbage — malformed as a whole.
+    var rec = PackedRecord.init(1);
+    rec.i64Field("b", 5);
+    var padded: [64]u8 = undefined;
+    @memcpy(padded[0..rec.len], rec.bytes());
+    padded[rec.len] = 0xAB;
+    try testing.expectEqual(@as(i32, -1), setPacked(id, "Tiny", padded[0 .. rec.len + 1]));
+    // A zero-field header ahead of data is the same refusal.
+    const zero_then_junk = [_]u8{ 0, 1, 2, 3 };
+    try testing.expectEqual(@as(i32, -1), setPacked(id, "Tiny", &zero_then_junk));
+    // The entity kept its values through both.
+    const t = game.getComponent(@as(u32, @intCast(id)), Tiny).?;
+    try testing.expectEqual(@as(u8, 7), t.b);
+}
+
+test "packed: the 64-bit bitcast pair round-trips a bit-63 u64 losslessly" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+    const ent: u32 = @intCast(id);
+    const hi: u64 = 0x8000_0000_0000_0001; // bit 63 set
+    var jset: [128]u8 = undefined;
+    const set_json = try std.fmt.bufPrint(&jset, "{{\"seed\":{d}}}", .{hi});
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Stats", set_json));
+
+    // GET emits the u64 as tag 3…
+    var buf: [128]u8 = @splat(0);
+    const n = getPacked(id, "Stats", &buf);
+    try testing.expect(n > 1);
+    // …a signed-only binding (mruby) bitcasts it into its Integer and
+    // re-emits tag 1 on SET; the host bitcasts back — bit-exact.
+    var rec = PackedRecord.init(1);
+    rec.i64Field("seed", @bitCast(hi));
+    try testing.expectEqual(@as(i32, 0), setPacked(id, "Stats", rec.bytes()));
+    try testing.expectEqual(hi, game.getComponent(ent, Stats).?.seed);
+
+    // The reverse pair: a u64 tag lands in an i64 field the same way.
+    var rec2 = PackedRecord.init(1);
+    rec2.u64Field("score", @bitCast(@as(i64, -42)));
+    try testing.expectEqual(@as(i32, 0), setPacked(id, "Stats", rec2.bytes()));
+    try testing.expectEqual(@as(i64, -42), game.getComponent(ent, Stats).?.score);
 }

--- a/test/script_contract_test.zig
+++ b/test/script_contract_test.zig
@@ -51,12 +51,51 @@ const Stats = struct {
     seed: u64 = 0,
 };
 
+/// Narrow int fields — the packed SET's out-of-range refusal targets
+/// (a script i64/f32 that doesn't fit must refuse -1, never panic).
+const Tiny = struct { b: u8 = 7, w: i32 = -7 };
+
+/// bool + f32 — the batch stream's non-float scalar (bool rides as 0/1;
+/// a NaN stream float lands as true, since NaN != 0).
+const Flag = struct { on: bool = false, weight: f32 = 0 };
+
+/// 300 f32 fields — over the packed wire's u8 field_count limit (0xFF
+/// reserved as the sentinel), so it must comptime-classify as NOT
+/// packable (get → 0xFF, set → -1) instead of panicking the `@intCast`
+/// on packInto's count byte.
+const Wide300 = blk: {
+    @setEvalBranchQuota(1_000_000);
+    var names: [300][:0]const u8 = undefined;
+    var attrs: [300]std.builtin.Type.StructField.Attributes = undefined;
+    for (&names, &attrs, 0..) |*n, *a, i| {
+        n.* = std.fmt.comptimePrint("f{d}", .{i});
+        a.* = .{ .default_value_ptr = &@as(f32, 0) };
+    }
+    const cn = names;
+    const ca = attrs;
+    break :blk @Struct(.auto, null, &cn, &@splat(f32), &ca);
+};
+
+/// One field whose NAME is over the wire's u8 name_len limit — same
+/// comptime not-packable classification as Wide300.
+const LongName = @Struct(
+    .auto,
+    null,
+    &[_][:0]const u8{"x" ** 300},
+    &[_]type{f32},
+    &[_]std.builtin.Type.StructField.Attributes{.{ .default_value_ptr = &@as(f32, 0) }},
+);
+
 const TestComponents = engine.ComponentRegistry(.{
     .Health = Health,
     .Velocity = Velocity,
     .Doomed = Doomed,
     .Label = Label,
     .Stats = Stats,
+    .Tiny = Tiny,
+    .Flag = Flag,
+    .Wide300 = Wide300,
+    .LongName = LongName,
 });
 
 const TestEvents = union(enum) {
@@ -2984,4 +3023,118 @@ test "bulk access pre-bind: safe no-ops in each op's failure convention" {
     try testing.expectEqual(@as(i32, -1), setPacked(1, "Stats", buf[0..1]));
     try testing.expectEqual(@as(usize, 0), batchGet("[\"Position\"]", &buf));
     try testing.expectEqual(@as(i32, -1), batchSet("[\"Position\"]", buf[0..0]));
+}
+
+test "packed set: out-of-range / non-finite script values refuse -1, never panic" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+    const ent: u32 = @intCast(id);
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Tiny", "{\"b\":7,\"w\":-7}"));
+
+    // i64 tag that overflows the u8 target — refuse, entity untouched
+    // (the refusal happens before setComponent; JSON fallback owns it).
+    var over = PackedRecord.init(1);
+    over.i64Field("b", 300);
+    try testing.expectEqual(@as(i32, -1), setPacked(id, "Tiny", over.bytes()));
+    // Negative into unsigned — refuse.
+    var neg = PackedRecord.init(1);
+    neg.i64Field("b", -1);
+    try testing.expectEqual(@as(i32, -1), setPacked(id, "Tiny", neg.bytes()));
+    // u64 tag past maxInt(i64) into an i64 field — refuse.
+    var big = PackedRecord.init(1);
+    big.u64Field("score", std.math.maxInt(u64));
+    try testing.expectEqual(@as(i32, -1), setPacked(id, "Stats", big.bytes()));
+    // f32 tag into an int field: NaN / Inf / out-of-range all refuse…
+    inline for ([_]f32{
+        std.math.nan(f32),
+        std.math.inf(f32),
+        -std.math.inf(f32),
+        1e30,
+        -1e30,
+    }) |bad| {
+        var rec = PackedRecord.init(1);
+        rec.f32Field("w", bad);
+        try testing.expectEqual(@as(i32, -1), setPacked(id, "Tiny", rec.bytes()));
+    }
+    const untouched = game.getComponent(ent, Tiny).?;
+    try testing.expectEqual(@as(u8, 7), untouched.b);
+    try testing.expectEqual(@as(i32, -7), untouched.w);
+
+    // …while an in-range f32 truncates into the int field (the packed
+    // coercion's documented float→int semantics).
+    var ok = PackedRecord.init(2);
+    ok.i64Field("b", 200);
+    ok.f32Field("w", 42.9);
+    try testing.expectEqual(@as(i32, 0), setPacked(id, "Tiny", ok.bytes()));
+    const applied = game.getComponent(ent, Tiny).?;
+    try testing.expectEqual(@as(u8, 200), applied.b);
+    try testing.expectEqual(@as(i32, 42), applied.w);
+}
+
+test "batch set: NaN in the stream is defined behavior (float lands, bool reads true), no panic" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+    const ent: u32 = @intCast(id);
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Velocity", "{\"dx\":1,\"dy\":2}"));
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Flag", "{\"on\":false,\"weight\":3}"));
+
+    const names = "[\"Velocity\",\"Flag\"]";
+    // Stream layout: dx, dy, on, weight — poison all four with NaN.
+    var stream: [16]u8 = undefined;
+    const nan: f32 = std.math.nan(f32);
+    for (0..4) |i| {
+        std.mem.writeInt(u32, stream[i * 4 ..][0..4], @bitCast(nan), .little);
+    }
+    try testing.expectEqual(@as(i32, 0), batchSet(names, &stream));
+    const vel = game.getComponent(ent, Velocity).?;
+    try testing.expect(std.math.isNan(vel.dx));
+    try testing.expect(std.math.isNan(vel.dy));
+    const flag = game.getComponent(ent, Flag).?;
+    try testing.expect(flag.on); // NaN != 0 → true
+    try testing.expect(std.math.isNan(flag.weight));
+
+    // Sanity: the bool round-trips as 0/1 through the whole batch cycle.
+    var buf: [64]u8 = @splat(0);
+    const required = batchGet("[\"Flag\"]", &buf);
+    try testing.expectEqual(@as(usize, 4 + 2 * 4), required);
+    try testing.expectEqual(@as(f32, 1), batchFloat(&buf, 4)); // on == true → 1.0
+}
+
+test "packed get/set: over-the-wire-limit structs comptime-classify as not packable" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+    const ent: u32 = @intCast(id);
+    game.setComponent(ent, Wide300{});
+    game.setComponent(ent, LongName{});
+
+    // 300 fields > the u8 field_count wire limit (0xFF is the sentinel):
+    // the 0xFF/JSON path, decided at comptime — no runtime @intCast trap.
+    var buf: [64]u8 = @splat(0);
+    try testing.expectEqual(@as(usize, 1), getPacked(id, "Wide300", &buf));
+    try testing.expectEqual(@as(u8, 0xFF), buf[0]);
+    var rec = PackedRecord.init(0);
+    try testing.expectEqual(@as(i32, -1), setPacked(id, "Wide300", rec.bytes()));
+
+    // A 300-byte field name > the u8 name_len wire limit — same path.
+    try testing.expectEqual(@as(usize, 1), getPacked(id, "LongName", &buf));
+    try testing.expectEqual(@as(u8, 0xFF), buf[0]);
+    try testing.expectEqual(@as(i32, -1), setPacked(id, "LongName", rec.bytes()));
 }


### PR DESCRIPTION
Engine host for **bulk component access** — stage 1 of labelle-toolkit/labelle-scripting#41 (RFC-BULK-COMPONENT-ACCESS in that repo). Paired scripting PR: opens next on labelle-scripting `feat/bulk-component-access` (Ruby binding + mock-world exports).

## What

Two additive fast paths over the per-entity JSON component ops, landed as **contract v1.3**:

1. **Packed codec** — `labelle_component_get_packed` / `labelle_component_set_packed`: a binary twin of component get/set for scalar-only components. Self-describing little-endian record (`[u8 field_count]`, then per field `[u8 name_len][name][u8 tag][value]`; tags `0=f32 1=i64 2=bool 3=u64`). GET writes the single `0xFF` sentinel for any non-packable component; SET refuses with `-1` — either way the binding falls back to the JSON path, so this is a strictly-safe improvement. Lossless for i64/u64.

2. **Batched query** — `labelle_component_batch_get` / `labelle_component_batch_set`: one call moves ALL matching entities' scalar fields as a flat f32 stream (`[u32 count][f32 stream]`, set side is the headerless stream), collapsing a hot loop's 4-per-entity FFI crossings into 2 per tick. Both re-resolve the query identically (view on the first name, filter the rest), so the positional layout agrees.

### Stage-1 hardening over the measured prototype

- **Int-field refusal**: any named component carrying an int-typed field is refused — `batch_int_refused` (`(size_t)-2`, `LABELLE_BATCH_INT_REFUSED`) from `batch_get`, `-2` from `batch_set` — instead of silently corrupting i64/u64 through f32's 24-bit mantissa. f32/f64 and bool (0/1) ride the stream; non-scalar fields are skipped identically in both directions. Int-carrying components stay on the per-entity paths (the packed codec carries ints losslessly).
- **Positional-coupling guard**: `batch_set` re-resolves the query and refuses `-1` unless `buf_len` EXACTLY matches the re-queried set's stream size — the cheap guard catching any spawn/destroy between the paired get/set that changes the count (same-count membership/order changes remain undetectable; the documented rule is "no spawn/destroy between the paired calls"). On `-1`, already-walked entities keep their writes: re-get and recompute.

Both set paths route through the same `setPosition`/`setComponent` apply path as the JSON ops, so hooks and dirty-tracking fire identically.

## Versioning — the convention followed

Exactly the contract's own documented convention for additive growth (`src/script_contract.zig` CONTRACT_VERSION doc, `contract/labelle_script.h` header): **major stays 1** (the version check is exact-match, a bump would strand still-compatible consumers); the four exports are marked **"since v1.3"** in the header and detected **by symbol probe** — embedded VMs bind against the running host, native plugins find out at link time — the same way v1.1 (`labelle_plugin_call`, #744) and v1.2 (plugin-call responses + `labelle_plugin_response_fetch`, #758) landed. No new gating mechanism.

## Tests

`test/script_contract_test.zig` — packed round-trip over f32/i64/bool/u64 (incl. sizing probe, all-or-nothing, REPLACE semantics, i64→u64 coercion), non-scalar → 0xFF sentinel, packed-set refusals (-1: non-scalar target, built-ins, 0xFF-led buffer, truncated record, unknown/dead), batch round-trip (count header, filtered entities, under-sized-cap sizing, order-independent verification), int-field refusal (get sentinel + set -2, alone and mixed), count-mismatch batch_set → -1 (both destroy and spawn halves), pre-bind no-ops.

`zig build test`: **1036/1036 pass** (baseline on clean origin/main c8f4dea also fully green — no pre-existing failures).

## Benchmarks (acceptance)

2000-entity ruby swarm (integrate + bounce per tick), bgfx desktop, ReleaseFast, two-point method ((T(2200 ticks) − T(200 ticks))/2000, min of 3 reps, `--headless --uncapped`), on the `ruby-swarm{,-fast,-batch}` rigs:

| Rig | Before (prototype engine + prototype scripting) | After (this PR + scripting PR) | RFC reference |
|---|---:|---:|---:|
| naive (`e.get`/`e.set`, JSON) — engine 2.5.0 baseline | 5.37 ms/tick | — (path unchanged) | 5.40 ms |
| fast (packed `into:`) | 4.93 ms/tick | **4.91 ms/tick** | 4.97 ms |
| batch (`batch_get`/`batch_set`) | 0.60 ms/tick | **0.61 ms/tick** | 0.61 ms |

No regressions — the port + hardening (int-refusal pre-pass, exact-size guard) costs nothing measurable.

**Round-2 re-measure** (after the read-modify-write batch_set + preflight): batch **0.649 ms/tick** at 2000 entities (was 0.605 — **+7.2%**, the per-entity component fetch + the preflight sizing walk; within the agreed <10% envelope), packed `into:` 4.90 ms/tick (unchanged). Still **8.3× over naive**. Batch = **8.8× over naive**. (Naive baseline was measured with scripting pinned to its origin/main. Round-1 update: the scripting branch now degrades on pre-v1.3 hosts via a comptime engine-module probe — see the capability-detection section of the scripting PR.)

Refs labelle-toolkit/labelle-scripting#41

https://claude.ai/code/session_011szWvquoss1yNX7KWSKCaM

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-engine/pr/781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787008222&installation_id=146340424&pr_number=781&repository=labelle-toolkit%2Flabelle-engine&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-engine%2Fpull%2F781&signature=30a6d2b0c4001b477b40a7a4f1193527c57ecd0329d9c0adac0287ca6befd3f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

