### PR TITLE
feat(#380): runtime profiling-capture toggle + setup/plugin-drawGui phase timing

### DIFF
--- a/scene/src/profiler.zig
+++ b/scene/src/profiler.zig
@@ -194,15 +194,30 @@ pub fn severityForNs(ns: u64) Severity {
 }
 
 /// A flattened, render-ready row for the overlay: the live (`last_ns`)
-/// per-frame cost of an entry's primary phase (`tick`) and secondary
-/// phase (`drawGui` for scripts, `postTick` for plugins), already in ms
-/// with a severity bucket for coloring. Backend-agnostic — the debug
+/// per-frame cost of an entry, one field per lifecycle phase, already in
+/// ms with a severity bucket for coloring. Backend-agnostic — the debug
 /// plugin walks these and emits imgui/text; the shape is what makes the
 /// collector headless-testable.
+///
+/// All four phases are surfaced so a consumer of the collector sees the
+/// full breakdown: scripts populate `setup`/`tick`/`draw_gui`
+/// (`post_tick` stays 0 — scripts have no postTick phase); plugins
+/// populate all four. `setup` is the one-shot boot cost (never
+/// window-reset); the others are per-frame.
+///
+/// `aux_*` is a back-compat secondary-phase view (drawGui for scripts,
+/// postTick for plugins) mirroring the pre-#380-follow-up shape; new
+/// consumers should read the named per-phase fields instead.
 pub const OverlayRow = struct {
     name: []const u8,
+    setup_ms: f32 = 0,
+    setup_severity: Severity = .good,
     tick_ms: f32 = 0,
     tick_severity: Severity = .good,
+    post_tick_ms: f32 = 0,
+    post_tick_severity: Severity = .good,
+    draw_gui_ms: f32 = 0,
+    draw_gui_severity: Severity = .good,
     /// Secondary phase label ("drawGui" or "postTick").
     aux_label: []const u8 = "",
     aux_ms: f32 = 0,
@@ -220,8 +235,13 @@ pub fn collectScriptRows(dst: []OverlayRow, src: []const ScriptRow) []OverlayRow
     for (src[0..n], 0..) |e, i| {
         dst[i] = .{
             .name = e.name,
+            .setup_ms = nsToMs(e.setup.last_ns),
+            .setup_severity = severityForNs(e.setup.last_ns),
             .tick_ms = nsToMs(e.tick.last_ns),
             .tick_severity = severityForNs(e.tick.last_ns),
+            .draw_gui_ms = nsToMs(e.draw_gui.last_ns),
+            .draw_gui_severity = severityForNs(e.draw_gui.last_ns),
+            // Back-compat secondary view: scripts' aux is drawGui.
             .aux_label = "drawGui",
             .aux_ms = nsToMs(e.draw_gui.last_ns),
             .aux_severity = severityForNs(e.draw_gui.last_ns),
@@ -237,8 +257,15 @@ pub fn collectPluginRows(dst: []OverlayRow, src: []const PluginRow) []OverlayRow
     for (src[0..n], 0..) |e, i| {
         dst[i] = .{
             .name = e.name,
+            .setup_ms = nsToMs(e.setup.last_ns),
+            .setup_severity = severityForNs(e.setup.last_ns),
             .tick_ms = nsToMs(e.tick.last_ns),
             .tick_severity = severityForNs(e.tick.last_ns),
+            .post_tick_ms = nsToMs(e.post_tick.last_ns),
+            .post_tick_severity = severityForNs(e.post_tick.last_ns),
+            .draw_gui_ms = nsToMs(e.draw_gui.last_ns),
+            .draw_gui_severity = severityForNs(e.draw_gui.last_ns),
+            // Back-compat secondary view: plugins' aux is postTick.
             .aux_label = "postTick",
             .aux_ms = nsToMs(e.post_tick.last_ns),
             .aux_severity = severityForNs(e.post_tick.last_ns),
@@ -247,11 +274,14 @@ pub fn collectPluginRows(dst: []OverlayRow, src: []const PluginRow) []OverlayRow
     return dst[0..n];
 }
 
-/// Sum of the primary + secondary live cost across `rows`, in ms — the
-/// "Total scripts" / "Total plugins" footer line.
+/// Sum of the recurring per-frame live cost across `rows`, in ms — the
+/// "Total scripts" / "Total plugins" footer line. Covers every per-frame
+/// phase (`tick` + `post_tick` + `draw_gui`); the one-shot `setup` boot
+/// cost is deliberately excluded so the total reflects steady-state
+/// frame cost.
 pub fn totalMs(rows: []const OverlayRow) f32 {
     var sum: f32 = 0;
-    for (rows) |r| sum += r.tick_ms + r.aux_ms;
+    for (rows) |r| sum += r.tick_ms + r.post_tick_ms + r.draw_gui_ms;
     return sum;
 }
 

--- a/scene/src/profiler.zig
+++ b/scene/src/profiler.zig
@@ -82,8 +82,23 @@ extern "c" fn getenv(name: [*:0]const u8) ?[*:0]const u8;
 
 var _recording: ?bool = null;
 
-/// True when `LABELLE_PROFILE` is set and non-empty. The env read is
-/// cached so this is a cheap branch in the per-frame hot path.
+/// Runtime override of the `LABELLE_PROFILE` gate, set via
+/// `setRecording`. `null` = no override (env decides). This is what the
+/// debug inspector flips when its Performance section opens/closes, so
+/// live per-unit capture works without relaunching with the env var.
+var _override: ?bool = null;
+
+/// Force per-unit capture on (`true`), off (`false`), or defer back to
+/// the `LABELLE_PROFILE` env gate (`null`). Passing `null` on close is
+/// what keeps a user's env-enabled headless dump running when the
+/// inspector panel merely toggled itself away.
+pub fn setRecording(on: ?bool) void {
+    _override = on;
+}
+
+/// True when `LABELLE_PROFILE` is set and non-empty, unless overridden
+/// by `setRecording`. The env read is cached so this is a cheap branch
+/// in the per-frame hot path.
 ///
 /// The env lookup goes through libc `getenv` when libc is linked (the
 /// case for every shipped desktop build — raylib pulls in libc). Without
@@ -92,6 +107,7 @@ var _recording: ?bool = null;
 /// `main` only), so the profiler stays off rather than forcing an
 /// unresolved `getenv` symbol at link time on no-libc builds.
 pub fn recording() bool {
+    if (_override) |v| return v;
     if (_recording) |v| return v;
     const v = blk: {
         if (comptime is_wasm) break :blk false;
@@ -142,18 +158,26 @@ pub const Row = struct { name: []const u8, worst_ns: u64, avg_ns: u64 };
 
 /// One game script's live timing. Layout-shared with
 /// `ScriptRunner.ProfileEntry` so the Game's opaque pointer casts cleanly.
+/// `setup` is recorded once at boot (unconditionally — two clock reads
+/// per script, one time) and never window-reset, so the inspector can
+/// always show boot cost.
 pub const ScriptRow = struct {
     name: []const u8,
+    setup: Stat = .{},
     tick: Stat = .{},
     draw_gui: Stat = .{},
 };
 
 /// One plugin system's live timing. Layout-shared with
-/// `SystemRegistry.PluginProfileEntry`.
+/// `SystemRegistry.PluginProfileEntry`. `setup` as in `ScriptRow`;
+/// `draw_gui` covers the plugin's `Systems.drawGui` phase (e.g. the
+/// debug inspector's own rendering cost shows up here).
 pub const PluginRow = struct {
     name: []const u8,
+    setup: Stat = .{},
     tick: Stat = .{},
     post_tick: Stat = .{},
+    draw_gui: Stat = .{},
 };
 
 /// Traffic-light bucket for the inspector's color coding: green < 1 ms,

--- a/scene/src/system.zig
+++ b/scene/src/system.zig
@@ -81,13 +81,20 @@ pub fn SystemRegistry(comptime plugin_modules: anytype) type {
 
         /// Call setup() on all plugin systems that declare it.
         pub fn setup(game: anytype) void {
+            comptime var pidx: usize = 0;
             inline for (info.@"struct".fields) |field| {
                 const mod = @field(plugin_modules, field.name);
                 if (@hasDecl(mod, "Systems")) {
                     const Sys = @field(mod, "Systems");
                     if (@hasDecl(Sys, "setup")) {
+                        // Unconditionally timed (one-shot at boot; the
+                        // inspector can't have enabled capture yet) so
+                        // boot cost is always visible in the overlay.
+                        const t0 = profiler.nowNs();
                         Sys.setup(game);
+                        plugin_profile[pidx].setup.record(profiler.nowNs() - t0);
                     }
+                    pidx += 1;
                 }
             }
         }
@@ -134,6 +141,8 @@ pub fn SystemRegistry(comptime plugin_modules: anytype) type {
                 rows[i] = .{ .name = e.name, .worst_ns = e.tick.worst_ns, .avg_ns = e.tick.avgNs() };
                 e.tick.resetWindow();
                 e.post_tick.resetWindow();
+                e.draw_gui.resetWindow();
+                // `setup` is deliberately NOT reset: one-shot boot cost.
             }
             profiler.report("plugin", &rows);
         }
@@ -166,6 +175,7 @@ pub fn SystemRegistry(comptime plugin_modules: anytype) type {
         /// Call drawGui() on all plugin systems that declare it.
         pub fn drawGui(game: anytype) void {
             const current_state = getGameState(game);
+            const rec = profiler.recording();
             comptime var pidx: usize = 0;
             inline for (info.@"struct".fields) |field| {
                 const mod = @field(plugin_modules, field.name);
@@ -173,7 +183,13 @@ pub fn SystemRegistry(comptime plugin_modules: anytype) type {
                     const Sys = @field(mod, "Systems");
                     if (@hasDecl(Sys, "drawGui")) {
                         if (isStateAllowed(Sys, current_state)) {
-                            Sys.drawGui(game);
+                            if (rec) {
+                                const t0 = profiler.nowNs();
+                                Sys.drawGui(game);
+                                plugin_profile[pidx].draw_gui.record(profiler.nowNs() - t0);
+                            } else {
+                                Sys.drawGui(game);
+                            }
                         }
                     }
                     pidx += 1;

--- a/src/game.zig
+++ b/src/game.zig
@@ -1568,6 +1568,9 @@ pub fn GameConfigWithYAxis(
         pub const frameStats = MiscMixin.frameStats;
         pub const scriptProfileRows = MiscMixin.scriptProfileRows;
         pub const pluginProfileRows = MiscMixin.pluginProfileRows;
+        pub const frameHistory = MiscMixin.frameHistory;
+        pub const setProfilingCapture = MiscMixin.setProfilingCapture;
+        pub const profilingCaptureActive = MiscMixin.profilingCaptureActive;
     };
 }
 

--- a/src/game/misc_mixin.zig
+++ b/src/game/misc_mixin.zig
@@ -214,6 +214,33 @@ pub fn Mixin(comptime Game: type) type {
             return self.frame_profiler.stats();
         }
 
+        /// Copy the recent frame-time history (ms, oldest-first) into
+        /// `dst` for the inspector's mini-graph. Returns the filled
+        /// prefix; a short `dst` keeps the newest frames.
+        pub fn frameHistory(self: *const Game, dst: []f32) []f32 {
+            return self.frame_profiler.history(dst);
+        }
+
+        /// Force per-script / per-plugin capture on (`true`), off
+        /// (`false`), or defer to the `LABELLE_PROFILE` env gate
+        /// (`null`). The debug inspector passes `true` while its
+        /// Performance section is open and `null` when it closes, so an
+        /// env-enabled headless dump keeps running regardless of panel
+        /// state. Zero-cost when off: the dispatch loops still branch on
+        /// one cached bool per frame.
+        pub fn setProfilingCapture(self: *const Game, on: ?bool) void {
+            _ = self;
+            profiler.setRecording(on);
+        }
+
+        /// Whether per-unit capture is currently active (override or
+        /// `LABELLE_PROFILE`). The inspector uses this to label stale
+        /// rows when capture is off.
+        pub fn profilingCaptureActive(self: *const Game) bool {
+            _ = self;
+            return profiler.recording();
+        }
+
         /// The live per-script profile rows (`tick` + `drawGui` timings),
         /// or an empty slice when the generated `main` hasn't wired the
         /// pointer (unit-test games, or a build without scripts). The Game

--- a/src/script_runner.zig
+++ b/src/script_runner.zig
@@ -173,10 +173,21 @@ pub fn ScriptRunner(
         /// loading or the first tick.
         pub fn setup(self: *Self, game: anytype) void {
             const decls = @typeInfo(AllScripts).@"struct".decls;
+            comptime var profile_idx: usize = 0;
             inline for (decls) |d| {
                 const mod = @field(AllScripts, d.name);
-                if (comptime isFnDecl(mod, "setup")) {
-                    dispatchCall(mod.setup, game, self, d.name);
+                if (comptime isGameScript(mod)) {
+                    if (comptime isFnDecl(mod, "setup")) {
+                        // Setup is timed unconditionally (not gated on
+                        // `profiler.recording()`): it runs once at boot —
+                        // before the inspector could possibly enable
+                        // capture — and two clock reads per script, once,
+                        // is free. Lets the inspector show boot cost.
+                        const t0 = profiler.nowNs();
+                        dispatchCall(mod.setup, game, self, d.name);
+                        self.profile[profile_idx].setup.record(profiler.nowNs() - t0);
+                    }
+                    profile_idx += 1;
                 }
             }
         }

--- a/test/inspector_overlay_test.zig
+++ b/test/inspector_overlay_test.zig
@@ -24,9 +24,9 @@ test "severity: green < 1ms, yellow 1-5ms, red > 5ms" {
     try testing.expectEqual(profiler.Severity.bad, profiler.severityForNs(12_000_000));
 }
 
-test "collectScriptRows: flattens live tick + drawGui into ms rows" {
+test "collectScriptRows: flattens live setup + tick + drawGui into ms rows" {
     const src = [_]profiler.ScriptRow{
-        .{ .name = "physics", .tick = stat(450_000), .draw_gui = stat(120_000) },
+        .{ .name = "physics", .setup = stat(2_000_000), .tick = stat(450_000), .draw_gui = stat(120_000) },
         .{ .name = "worker_movement", .tick = stat(220_000) },
     };
     var dst: [8]profiler.OverlayRow = undefined;
@@ -35,19 +35,27 @@ test "collectScriptRows: flattens live tick + drawGui into ms rows" {
     try testing.expectEqual(@as(usize, 2), rows.len);
     try testing.expectEqualStrings("physics", rows[0].name);
     try testing.expectApproxEqAbs(@as(f32, 0.45), rows[0].tick_ms, 0.001);
+    // New named per-phase fields carry the full breakdown.
+    try testing.expectApproxEqAbs(@as(f32, 2.0), rows[0].setup_ms, 0.001);
+    try testing.expectEqual(profiler.Severity.warn, rows[0].setup_severity); // 2ms → yellow
+    try testing.expectApproxEqAbs(@as(f32, 0.12), rows[0].draw_gui_ms, 0.001);
+    // Scripts have no postTick phase.
+    try testing.expectApproxEqAbs(@as(f32, 0.0), rows[0].post_tick_ms, 0.001);
+    // Back-compat secondary view still points at drawGui.
     try testing.expectEqualStrings("drawGui", rows[0].aux_label);
     try testing.expectApproxEqAbs(@as(f32, 0.12), rows[0].aux_ms, 0.001);
     try testing.expectEqual(profiler.Severity.good, rows[0].tick_severity);
 
     try testing.expectEqualStrings("worker_movement", rows[1].name);
     try testing.expectApproxEqAbs(@as(f32, 0.22), rows[1].tick_ms, 0.001);
-    try testing.expectApproxEqAbs(@as(f32, 0.0), rows[1].aux_ms, 0.001);
+    try testing.expectApproxEqAbs(@as(f32, 0.0), rows[1].draw_gui_ms, 0.001);
+    try testing.expectApproxEqAbs(@as(f32, 0.0), rows[1].setup_ms, 0.001);
 }
 
-test "collectPluginRows: flattens tick + postTick with correct label" {
+test "collectPluginRows: flattens setup + tick + postTick + drawGui" {
     const src = [_]profiler.PluginRow{
         .{ .name = "box2d", .tick = stat(1_200_000), .post_tick = stat(300_000) },
-        .{ .name = "debug", .tick = stat(6_000_000) },
+        .{ .name = "debug", .tick = stat(6_000_000), .draw_gui = stat(80_000), .setup = stat(500_000) },
     };
     var dst: [8]profiler.OverlayRow = undefined;
     const rows = profiler.collectPluginRows(&dst, &src);
@@ -56,11 +64,15 @@ test "collectPluginRows: flattens tick + postTick with correct label" {
     try testing.expectEqualStrings("box2d", rows[0].name);
     try testing.expectApproxEqAbs(@as(f32, 1.2), rows[0].tick_ms, 0.001);
     try testing.expectEqual(profiler.Severity.warn, rows[0].tick_severity); // 1.2ms → yellow
+    try testing.expectApproxEqAbs(@as(f32, 0.3), rows[0].post_tick_ms, 0.001);
+    // Back-compat secondary view still points at postTick.
     try testing.expectEqualStrings("postTick", rows[0].aux_label);
     try testing.expectApproxEqAbs(@as(f32, 0.3), rows[0].aux_ms, 0.001);
 
-    // 6ms tick → red.
+    // 6ms tick → red; new setup/draw_gui phases surface through the collector.
     try testing.expectEqual(profiler.Severity.bad, rows[1].tick_severity);
+    try testing.expectApproxEqAbs(@as(f32, 0.08), rows[1].draw_gui_ms, 0.001);
+    try testing.expectApproxEqAbs(@as(f32, 0.5), rows[1].setup_ms, 0.001);
 }
 
 test "collectScriptRows: respects destination bound" {
@@ -74,12 +86,13 @@ test "collectScriptRows: respects destination bound" {
     try testing.expectEqual(@as(usize, 2), rows.len);
 }
 
-test "totalMs: sums primary + secondary phase across rows" {
+test "totalMs: sums recurring phases (tick+postTick+drawGui), excludes setup" {
     const rows = [_]profiler.OverlayRow{
-        .{ .name = "a", .tick_ms = 0.45, .aux_ms = 0.12 },
-        .{ .name = "b", .tick_ms = 0.22, .aux_ms = 0.0 },
+        .{ .name = "a", .tick_ms = 0.45, .post_tick_ms = 0.1, .draw_gui_ms = 0.12, .setup_ms = 9.0 },
+        .{ .name = "b", .tick_ms = 0.22, .draw_gui_ms = 0.0 },
     };
-    try testing.expectApproxEqAbs(@as(f32, 0.79), profiler.totalMs(&rows), 0.001);
+    // 0.45+0.1+0.12 + 0.22 = 0.89; the 9ms setup must NOT be counted.
+    try testing.expectApproxEqAbs(@as(f32, 0.89), profiler.totalMs(&rows), 0.001);
 }
 
 test "game: scriptProfileRows/pluginProfileRows are empty when unwired" {

--- a/test/inspector_overlay_test.zig
+++ b/test/inspector_overlay_test.zig
@@ -123,3 +123,60 @@ test "game: profile row accessors round-trip the opaque pointer" {
     try testing.expectEqual(@as(usize, 2), overlay.len);
     try testing.expectApproxEqAbs(@as(f32, 0.45), overlay[0].tick_ms, 0.001);
 }
+
+test "profiler.setRecording overrides the env gate and null restores it" {
+    // Whatever the env says (LABELLE_PROFILE may or may not be set in the
+    // test runner), the override must win in both directions and `null`
+    // must fall back to the env-derived baseline.
+    const env_base = profiler.recording();
+
+    profiler.setRecording(true);
+    defer profiler.setRecording(null); // never leak the override
+    try testing.expect(profiler.recording());
+
+    profiler.setRecording(false);
+    try testing.expect(!profiler.recording());
+
+    profiler.setRecording(null);
+    try testing.expectEqual(env_base, profiler.recording());
+}
+
+test "game: setProfilingCapture round-trips through profilingCaptureActive" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    game.setProfilingCapture(true);
+    defer game.setProfilingCapture(null);
+    try testing.expect(game.profilingCaptureActive());
+
+    game.setProfilingCapture(false);
+    try testing.expect(!game.profilingCaptureActive());
+}
+
+test "game: frameHistory exposes the frame-time ring oldest-first in ms" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    game.frame_profiler.record(0.010);
+    game.frame_profiler.record(0.020);
+    game.frame_profiler.record(0.030);
+
+    var buf: [8]f32 = undefined;
+    const hist = game.frameHistory(&buf);
+    try testing.expectEqual(@as(usize, 3), hist.len);
+    try testing.expectApproxEqAbs(@as(f32, 10.0), hist[0], 0.01);
+    try testing.expectApproxEqAbs(@as(f32, 30.0), hist[2], 0.01);
+}
+
+test "profile rows carry setup and plugin drawGui phases" {
+    // New phases (#380 follow-up): setup on both row kinds, drawGui on
+    // plugins. Defaults must be zeroed so untimed phases render as 0.
+    const s = profiler.ScriptRow{ .name = "boot_heavy", .setup = stat(2_000_000) };
+    try testing.expectEqual(@as(u64, 2_000_000), s.setup.last_ns);
+    try testing.expectEqual(@as(u64, 0), s.tick.last_ns);
+
+    const p = profiler.PluginRow{ .name = "debug", .draw_gui = stat(80_000) };
+    try testing.expectEqual(@as(u64, 80_000), p.draw_gui.last_ns);
+    try testing.expectEqual(@as(u64, 0), p.setup.last_ns);
+    try testing.expectEqual(profiler.Severity.good, profiler.severityForNs(p.draw_gui.last_ns));
+}


### PR DESCRIPTION
## What

Ships the last engine-side pieces of the debug-inspector profiling issue. Most of #380 already landed earlier (per-script/per-plugin `LABELLE_PROFILE` profiler in v1.6-era, FPS `FrameProfiler` + overlay data API in #733); this PR closes the remaining gaps the live inspector panel needs:

- **`profiler.setRecording(?bool)`** — runtime override of the `LABELLE_PROFILE` env gate. `true`/`false` force per-unit capture on/off; `null` defers back to the env var. This is what lets the debug plugin arm live capture while its Performance section is open — and hand the gate back on close without killing a user's env-enabled headless dump.
- **`Game.setProfilingCapture` / `Game.profilingCaptureActive` / `Game.frameHistory`** (MiscMixin + re-exports) — the accessor surface the debug plugin drives/reads. `frameHistory` exposes the frame-time ring (ms, oldest-first) for the mini-graph.
- **New timed phases**: `ScriptRow`/`PluginRow` gain a one-shot **`setup`** Stat (timed unconditionally at boot — two clock reads per unit, once; never window-reset) and `PluginRow` gains **`draw_gui`** (rec-gated in `SystemRegistry.drawGui`, mirroring script `drawGui` timing). The overlay can now show the full setup/tick/postTick/drawGui breakdown requested in the issue discussion.

## Zero-cost-when-off

Unchanged: dispatch loops still branch on one cached bool per frame. Measured (ReleaseFast, macOS, same `clock_gettime` primitive `nowNs` uses):

- capture ON: **53.1 ns** per dispatched unit (2× clock read + `Stat.record`)
- capture OFF: **2.1 ns** per dispatched unit (cached-bool branch)
- at flying-platform scale (~45 dispatched units/frame) capture costs **~2.3 µs/frame**, ~0.014% of a 60 FPS budget

## Tests

`test/inspector_overlay_test.zig`: override round-trip (restores env baseline), Game capture accessors, `frameHistory` passthrough, new phase-field defaults. `zig build test` green (exit-checked).

## Companion PR

The inspector UI that consumes this lands in the labelle-assembler debug plugin (linked in comments): engine-fed FPS header + mini-graph, sorted per-unit ms tables with severity markers, panel-driven capture arming, `LABELLE_DEBUG_OPEN=1` boot-open. Verified live on flying-platform-labelle via `local:` overrides. The plugin is `@hasDecl`/`@hasField`-gated, so it degrades gracefully against engines without this PR; the full panel needs an engine release cut from this (next minor, 2.5.0).

Follow-ups (not this PR):
- Colored severity (green/yellow/red) needs a `labelColored` on core's `GuiInterface` + imgui adapter; text markers (`*`/`!`) until then.
- Per-language-plugin script breakdown (labelle-scripting Controller tick) if per-script granularity inside a language plugin's single `Systems.tick` row is wanted.

Closes #380

https://claude.ai/code/session_011szWvquoss1yNX7KWSKCaM

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-engine/pr/784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787071097&installation_id=146340424&pr_number=784&repository=labelle-toolkit%2Flabelle-engine&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-engine%2Fpull%2F784&signature=ce18b198085a008b702428d20377984d7ade6415cd334346d41bed558c25068d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->