### PR TITLE
feat: SET-side f64 packed value tag (tag 4) for float→int precision (since v1.3)

### DIFF
--- a/contract/labelle_script.h
+++ b/contract/labelle_script.h
@@ -452,6 +452,12 @@ size_t labelle_plugin_response_fetch(char *out, size_t out_cap);
  *    emits tag 3, the binding bitcasts to its signed integer, SET
  *    re-emits tag 1, the host bitcasts back. Narrower int fields keep
  *    the range-checked refusal (-1 on overflow — never clamped).
+ *    A BOOL field accepts ONLY the bool tag (2): every numeric tag
+ *    (0/1/3/4) targeting a bool field is type confusion and refuses
+ *    (-1 -> JSON fallback), so a number mis-addressing a bool field
+ *    surfaces rather than silently collapsing to true/false. The
+ *    reverse — a bool tag widening into a number field (true/false ->
+ *    1/0) — is allowed (total, lossless, unambiguous).
  *
  * 2. BATCHED QUERY — one call moves ALL matching entities' scalar
  *    component data as a flat f32 stream, collapsing the 4-per-entity

--- a/contract/labelle_script.h
+++ b/contract/labelle_script.h
@@ -425,6 +425,16 @@ size_t labelle_plugin_response_fetch(char *out, size_t out_cap);
  *      repeat field_count times:
  *        [u8 name_len][name bytes][u8 tag][value bytes]
  *      tag: 0=f32(4B)  1=i64(8B)  2=bool(1B)  3=u64(8B)
+ *           4=f64(8B, SET-side only — since v1.3)
+ *
+ *    GET emits only tags 0..3. The binding may SET tag 4 for a float
+ *    that would lose precision through f32's 24-bit mantissa (a Float
+ *    destined for an int field past 2^24) — the host coerces it at
+ *    full f64 precision (float->int exact, under the same range
+ *    refusal). A pre-tag-4 host reads tag 4 as an unknown tag and
+ *    refuses (-1); the binding then falls back to labelle_component_set
+ *    (JSON), which carries the f64 faithfully. Additive, no version
+ *    bump.
  *
  *    GET writes the single sentinel byte 0xFF (return 1) for any
  *    component the codec can't carry (non-scalar fields, f64 fields —

--- a/src/script_contract.zig
+++ b/src/script_contract.zig
@@ -2522,6 +2522,17 @@ fn safeFloatToInt(comptime T: type, f: f64) ?T {
 /// field): the value is script-supplied, so the host must never panic on
 /// it, and must not silently clamp/zero it either — the JSON path
 /// surfaces the value faithfully (or refuses it visibly).
+///
+/// BOOL-FIELD RULE (asymmetric on purpose): a bool field accepts ONLY
+/// the bool tag (2). Every NUMERIC tag (f32/i64/u64/f64) targeting a
+/// bool field is a type error — a script value of the wrong kind
+/// mis-addressing the field (e.g. `alive = 16_777_217.0`) — and REFUSES
+/// (null → -1), so the JSON path surfaces the real value or its parse
+/// error instead of silently collapsing it to true/false (which would
+/// discard the value entirely). The reverse — a bool tag WIDENING into a
+/// number field (true/false → 1/0) — stays allowed: it is total,
+/// lossless and unambiguous, the documented write-side mirror.
+/// Narrowing a number to a bool is none of those, hence the asymmetry.
 fn coercePacked(comptime T: type, tag: u8, bytes: []const u8) ?T {
     return switch (@typeInfo(T)) {
         .float => switch (tag) {
@@ -2571,11 +2582,12 @@ fn coercePacked(comptime T: type, tag: u8, bytes: []const u8) ?T {
             4 => safeFloatToInt(T, @as(f64, @bitCast(std.mem.readInt(u64, bytes[0..8], .little)))),
             else => null,
         },
+        // A bool field accepts ONLY the bool tag — every numeric tag
+        // (0/1/3/4) is type confusion and refuses (see the fn doc's
+        // BOOL-FIELD RULE). No silent number→bool collapse in EITHER
+        // direction; the JSON fallback surfaces the real value/error.
         .bool => switch (tag) {
             2 => bytes[0] != 0,
-            1 => std.mem.readInt(i64, bytes[0..8], .little) != 0,
-            3 => std.mem.readInt(u64, bytes[0..8], .little) != 0,
-            4 => @as(f64, @bitCast(std.mem.readInt(u64, bytes[0..8], .little))) != 0,
             else => null,
         },
         else => unreachable,

--- a/src/script_contract.zig
+++ b/src/script_contract.zig
@@ -2306,6 +2306,13 @@ fn Holder(comptime GP: type) type {
         ///   [u8 field_count]                (0xFF = "not packable")
         ///   repeat: [u8 name_len][name][u8 type_tag][value bytes]
         ///   type_tag: 0=f32(4B) 1=i64(8B) 2=bool(1B) 3=u64(8B)
+        ///             4=f64(8B, SET-side only — since v1.3)
+        /// GET emits only tags 0..3; the binding may SET tag 4 for a
+        /// float that would lose precision through f32's mantissa (a
+        /// Float destined for an int field past 2^24) — the host coerces
+        /// it at full f64 precision. A pre-tag-4 host reads tag 4 as an
+        /// unknown tag and refuses (-1), the binding then falls back to
+        /// JSON (which carries the f64 faithfully).
         ///
         /// Same required-size / all-or-nothing contract as `stringifyInto`
         /// (a counting pass sizes first). A struct with ANY non-scalar
@@ -2443,6 +2450,11 @@ fn packedTagSize(tag: u8) ?usize {
         1 => 8, // i64
         2 => 1, // bool
         3 => 8, // u64
+        4 => 8, // f64 — SET-side only (since v1.3): full-precision floats
+        // so a script Float destined for an int field lands exactly past
+        // f32's 24-bit mantissa. GET never emits it (f64 *fields* stay
+        // non-packable / 0xFF). An unknown tag stays null → applyPacked
+        // refuses (-1) and the binding falls back to JSON.
         else => null,
     };
 }
@@ -2482,9 +2494,9 @@ fn writePackedValue(comptime T: type, val: T, out: []u8) usize {
 /// bounds are the exact powers of two 2^bits / ±2^(bits-1) — always
 /// representable in f64, unlike maxInt(T) itself, whose f64 rounding
 /// would re-admit the panicking boundary value for 64-bit targets.
-fn safeFloatToInt(comptime T: type, f: f32) ?T {
+fn safeFloatToInt(comptime T: type, f: f64) ?T {
     if (!std.math.isFinite(f)) return null;
-    const t: f64 = @trunc(@as(f64, f));
+    const t: f64 = @trunc(f);
     const info = @typeInfo(T).int;
     // Degenerate 0-bit ints hold only 0 (and i0's bits-1 would underflow
     // the shift below).
@@ -2519,6 +2531,12 @@ fn coercePacked(comptime T: type, tag: u8, bytes: []const u8) ?T {
             1 => @floatFromInt(std.mem.readInt(i64, bytes[0..8], .little)),
             2 => if (bytes[0] != 0) 1 else 0,
             3 => @floatFromInt(std.mem.readInt(u64, bytes[0..8], .little)),
+            // f64 tag (SET-side, since v1.3): @floatCast narrows to the
+            // field's real float width (f32 fields aren't packable-f64,
+            // but an f32-declared field receiving an f64 tag narrows the
+            // same way JSON would parse-then-narrow — a defined
+            // conversion).
+            4 => @floatCast(@as(f64, @bitCast(std.mem.readInt(u64, bytes[0..8], .little)))),
             else => null,
         },
         .int => |ti| switch (tag) {
@@ -2546,12 +2564,18 @@ fn coercePacked(comptime T: type, tag: u8, bytes: []const u8) ?T {
                 }
                 break :blk std.math.cast(T, v);
             },
+            // f64 tag (SET-side, since v1.3): the whole point — a float
+            // beyond f32's 24-bit mantissa reaches an int field EXACTLY
+            // (16_777_217.0 no longer rounds), refusing (null) only on
+            // NaN/Inf/out-of-range, never clamping.
+            4 => safeFloatToInt(T, @as(f64, @bitCast(std.mem.readInt(u64, bytes[0..8], .little)))),
             else => null,
         },
         .bool => switch (tag) {
             2 => bytes[0] != 0,
             1 => std.mem.readInt(i64, bytes[0..8], .little) != 0,
             3 => std.mem.readInt(u64, bytes[0..8], .little) != 0,
+            4 => @as(f64, @bitCast(std.mem.readInt(u64, bytes[0..8], .little))) != 0,
             else => null,
         },
         else => unreachable,

--- a/test/script_contract_test.zig
+++ b/test/script_contract_test.zig
@@ -3173,6 +3173,68 @@ test "packed set: the SET-side f64 tag (v1.3) reaches int fields past f32 precis
     try testing.expectEqual(@as(f32, 0.1), game.getComponent(ent, Velocity).?.dx);
 }
 
+test "packed set: a bool field accepts ONLY the bool tag; every numeric tag refuses" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+    const ent: u32 = @intCast(id);
+    // Flag = { on: bool, weight: f32 }. Seed a known state.
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Flag", "{\"on\":true,\"weight\":9}"));
+
+    // The bool tag (2) is the ONLY tag a bool field accepts — true and
+    // false both round-trip.
+    var t = PackedRecord.init(1);
+    t.boolField("on", false);
+    try testing.expectEqual(@as(i32, 0), setPacked(id, "Flag", t.bytes()));
+    try testing.expect(!game.getComponent(ent, Flag).?.on);
+    var t2 = PackedRecord.init(1);
+    t2.boolField("on", true);
+    try testing.expectEqual(@as(i32, 0), setPacked(id, "Flag", t2.bytes()));
+    try testing.expect(game.getComponent(ent, Flag).?.on);
+
+    // Every NUMERIC tag targeting the bool `on` field REFUSES (-1) —
+    // type confusion (`alive = 1` / `= 16_777_217.0`) is surfaced, not
+    // silently collapsed to true. Reset to a known `on:true` before each
+    // so a wrongly-accepted coercion would be visible AND the field is
+    // left untouched by the refusal.
+    const NumberTag = union(enum) { i64: i64, u64: u64, f32: f32, f64: f64 };
+    inline for ([_]NumberTag{
+        .{ .i64 = 1 }, // a truthy int — the old silent 1→true path
+        .{ .i64 = 0 }, // a falsy int — would have flipped it to false
+        .{ .u64 = 1 },
+        .{ .f32 = 1.0 },
+        .{ .f64 = 16_777_217.0 }, // codex's type-confusion example
+    }) |nt| {
+        try testing.expectEqual(@as(i32, 0), setComp(id, "Flag", "{\"on\":true,\"weight\":9}"));
+        var rec = PackedRecord.init(1);
+        switch (nt) {
+            .i64 => |v| rec.i64Field("on", v),
+            .u64 => |v| rec.u64Field("on", v),
+            .f32 => |v| rec.f32Field("on", v),
+            .f64 => |v| rec.f64Field("on", v),
+        }
+        try testing.expectEqual(@as(i32, -1), setPacked(id, "Flag", rec.bytes()));
+        // Refused → entity untouched (the JSON fallback owns the value).
+        try testing.expect(game.getComponent(ent, Flag).?.on);
+    }
+
+    // The REVERSE stays allowed: a bool tag WIDENS into a number field
+    // (true/false → 1/0) — the documented, lossless, unambiguous mirror.
+    var w = PackedRecord.init(1);
+    w.boolField("weight", true);
+    try testing.expectEqual(@as(i32, 0), setPacked(id, "Flag", w.bytes()));
+    try testing.expectEqual(@as(f32, 1), game.getComponent(ent, Flag).?.weight);
+    var w0 = PackedRecord.init(1);
+    w0.boolField("weight", false);
+    try testing.expectEqual(@as(i32, 0), setPacked(id, "Flag", w0.bytes()));
+    try testing.expectEqual(@as(f32, 0), game.getComponent(ent, Flag).?.weight);
+}
+
 test "batch set: NaN in the stream is defined behavior (float lands, bool reads true), no panic" {
     contract.unbind();
     defer contract.unbind();

--- a/test/script_contract_test.zig
+++ b/test/script_contract_test.zig
@@ -2758,6 +2758,15 @@ const PackedRecord = struct {
         self.len += 9;
     }
 
+    /// The SET-side f64 tag (4, since v1.3): a binding writes it for a
+    /// float that would lose precision through f32's mantissa.
+    fn f64Field(self: *PackedRecord, n: []const u8, v: f64) void {
+        self.name(n);
+        self.buf[self.len] = 4;
+        std.mem.writeInt(u64, self.buf[self.len + 1 ..][0..8], @bitCast(v), .little);
+        self.len += 9;
+    }
+
     fn bytes(self: *const PackedRecord) []const u8 {
         return self.buf[0..self.len];
     }
@@ -3107,6 +3116,61 @@ test "packed set: out-of-range / non-finite script values refuse -1, never panic
     const applied = game.getComponent(ent, Tiny).?;
     try testing.expectEqual(@as(u8, 200), applied.b);
     try testing.expectEqual(@as(i32, 42), applied.w);
+}
+
+test "packed set: the SET-side f64 tag (v1.3) reaches int fields past f32 precision, exactly" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+    const ent: u32 = @intCast(id);
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Tiny", "{\"b\":0,\"w\":0}"));
+
+    // 16_777_217 (2^24 + 1) is the first integer f32 cannot hold: the
+    // f32 tag rounds it to 16_777_216 BEFORE the host sees it. The f64
+    // tag carries it whole, and coercePacked lands it in the i32 field
+    // EXACTLY — the precision fix's whole point (#45).
+    var exact = PackedRecord.init(2);
+    exact.i64Field("b", 1);
+    exact.f64Field("w", 16_777_217.0);
+    try testing.expectEqual(@as(i32, 0), setPacked(id, "Tiny", exact.bytes()));
+    const applied = game.getComponent(ent, Tiny).?;
+    try testing.expectEqual(@as(i32, 16_777_217), applied.w);
+
+    // The old f32 tag would have rounded to 16_777_216 — prove the wire
+    // difference is real (this is what the binding avoids by sending 4).
+    var lossy = PackedRecord.init(1);
+    lossy.f32Field("w", 16_777_217.0);
+    try testing.expectEqual(@as(i32, 0), setPacked(id, "Tiny", lossy.bytes()));
+    try testing.expectEqual(@as(i32, 16_777_216), game.getComponent(ent, Tiny).?.w);
+
+    // f64 tag keeps the SAME refusal discipline as f32: NaN / Inf /
+    // out-of-range refuse (-1, entity untouched), never clamp or panic.
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Tiny", "{\"b\":5,\"w\":5}"));
+    inline for ([_]f64{
+        std.math.nan(f64),
+        std.math.inf(f64),
+        1e100, // finite but far past i32 range
+        -1e100,
+    }) |bad| {
+        var rec = PackedRecord.init(1);
+        rec.f64Field("w", bad);
+        try testing.expectEqual(@as(i32, -1), setPacked(id, "Tiny", rec.bytes()));
+    }
+    const untouched = game.getComponent(ent, Tiny).?;
+    try testing.expectEqual(@as(i32, 5), untouched.w);
+
+    // A finite f64 into an f32 FIELD narrows the field's width (defined,
+    // like the JSON parse-then-narrow route). Velocity.dx is f32.
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Velocity", "{\"dx\":0,\"dy\":0}"));
+    var flt = PackedRecord.init(1);
+    flt.f64Field("dx", 0.1); // f32 cannot hold 0.1 exactly — nearest f32 lands
+    try testing.expectEqual(@as(i32, 0), setPacked(id, "Velocity", flt.bytes()));
+    try testing.expectEqual(@as(f32, 0.1), game.getComponent(ent, Velocity).?.dx);
 }
 
 test "batch set: NaN in the stream is defined behavior (float lands, bool reads true), no panic" {


### PR DESCRIPTION
## What

Adds value **tag 4 = f64(8B)** to the packed component **SET** codec (SET-side only). A language binding tags a float that would lose precision through the f32 tag's 24-bit mantissa — a script `Float` destined for an int field past 2^24 (e.g. `16_777_217.0`) — with tag 4 instead of tag 0. The host coerces it at full f64 precision: float→int **exact**, under the same range/finiteness refusal as every other tag (never clamps, never panics).

`GET` stays f32-only — f64 *fields* remain non-packable (0xFF/JSON), where there is no precision to lose.

## Why

The engine half of **labelle-scripting#45(c)**. Before this, a binding tagging a `Float` as f32 silently rounded values past 2^24 before the host saw them, while the JSON path carried the same value exactly. The scripting bindings now emit tag 4 for such values.

## Compatibility — additive, no version bump

An older host reads tag 4 as an unknown tag and refuses (`-1`); the binding then falls back to `labelle_component_set` (JSON), which carries the f64 faithfully. So the scripting side is **correct standalone** — this change only lets the packed *fast path* preserve the precision too (one FFI round-trip saved). Marked "since v1.3" in the wire-format docs.

## Changes

- `packedTagSize`: `4 => 8`
- `coercePacked`: tag-4 arms for float / int / bool targets
- `safeFloatToInt`: generalized `f32` → `f64` param (it already widened to f64 internally; the one f32 caller coerces implicitly)
- `contract/labelle_script.h` + `script_contract.zig` doc: tag 4 documented SET-side
- New test: `packed set: the SET-side f64 tag (v1.3) reaches int fields past f32 precision, exactly` (exact round-trip, the f32-tag lossy contrast, NaN/Inf/out-of-range refusal, f64→f32-field narrow)

Full `zig build test` green.

Refs #41, labelle-toolkit/labelle-scripting#45

https://claude.ai/code/session_011szWvquoss1yNX7KWSKCaM

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-engine/pr/785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787073073&installation_id=146340424&pr_number=785&repository=labelle-toolkit%2Flabelle-engine&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-engine%2Fpull%2F785&signature=d331b6e9287cde589587b9d20e0bba41ea4b42c02bf200b5c5940394cda17116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->