### PR TITLE
feat(#771): render the in-game UI-kit DrawList — renderer loop + font pipeline

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -203,6 +203,12 @@ pub fn build(b: *std.Build) void {
         // plugin render callback (the seam `labelle-spine` submits skinned
         // meshes through).
         "test/render_mesh_test.zig",
+        // In-game UI-kit DrawList renderer loop + font pipeline (#771):
+        // the engine consumer of labelle-gui `ui_kit`'s backend-agnostic
+        // DrawList — UV→pixel src mapping, glyph-run text pass, focus ring,
+        // command conversion, and the full `bakeUiFont` + submit/render
+        // integration through a recording renderer + mock font backend.
+        "test/ui_draw_list_test.zig",
         // labelle-studio Play mode (Phase 3) — wasm editor control
         // surface: bind/dispatch vtable, pause/step tick gating, scene
         // digest JSON (+ truncation validity), camera override state

--- a/src/atlas.zig
+++ b/src/atlas.zig
@@ -56,6 +56,11 @@ pub const FindSpriteResult = struct {
     texture_id: u32,
     texture_scale_x: f32 = 1.0,
     texture_scale_y: f32 = 1.0,
+    /// The owning atlas's logical dims (`meta.size`), null when the JSON
+    /// omitted a meta block. Used by #771's `resolveUiFrame` to normalise a
+    /// frame's UV without a renderer texture query. See `RuntimeAtlas`.
+    atlas_logical_width: ?u32 = null,
+    atlas_logical_height: ?u32 = null,
 };
 
 /// Compile-time atlas from a .zon frame definition.
@@ -146,6 +151,16 @@ pub const RuntimeAtlas = struct {
     /// nothing forces uniform scaling.
     texture_scale_x: f32 = 1.0,
     texture_scale_y: f32 = 1.0,
+    /// Logical atlas dims from the JSON's `meta.size` (null when the JSON
+    /// omitted a meta block, e.g. comptime atlases). Retained — unlike the
+    /// transient `AtlasMeta` — so screen-space consumers (the in-game
+    /// UI-kit `resolveUiFrame`, #771) can derive a frame's normalised UV
+    /// (`logical_rect / logical_dims`) without a renderer texture query.
+    /// That query returns null for catalog-uploaded atlases (they bypass
+    /// the renderer side-table), so the retained logical dims are the only
+    /// path that resolves UVs for both the legacy and streaming loads.
+    logical_width: ?u32 = null,
+    logical_height: ?u32 = null,
     /// Lazy-load state. When non-null, the atlas's JSON has been parsed
     /// into `sprites` but the PNG hasn't been decoded yet. Calling
     /// `Game.loadAtlasIfNeeded(name)` decodes the bytes, uploads the
@@ -428,6 +443,8 @@ pub const TextureManager = struct {
                     .texture_id = atlas.texture_id,
                     .texture_scale_x = atlas.texture_scale_x,
                     .texture_scale_y = atlas.texture_scale_y,
+                    .atlas_logical_width = atlas.logical_width,
+                    .atlas_logical_height = atlas.logical_height,
                 };
             }
         }
@@ -624,6 +641,11 @@ fn parseTexturePackerJsonContent(
 /// missing or zero the scale stays at `1.0` — preserving legacy
 /// behavior for callers that don't track texture dims.
 fn applyTextureScale(atlas: *RuntimeAtlas, meta: AtlasMeta, actual_dims: ?TextureManager.TextureDims) void {
+    // Retain the authored logical dims regardless of whether actual texture
+    // dims are known — the catalog upload path passes `null` actual_dims but
+    // still has `meta.size`, and #771's `resolveUiFrame` needs these.
+    atlas.logical_width = meta.logical_width;
+    atlas.logical_height = meta.logical_height;
     const dims = actual_dims orelse return;
     if (meta.logical_width) |lw| {
         if (lw > 0 and dims.width > 0) {

--- a/src/game.zig
+++ b/src/game.zig
@@ -1260,6 +1260,7 @@ pub fn GameConfigWithYAxis(
         pub const bakeUiFont = UiKitMixin.bakeUiFont;
         pub const uiFont = UiKitMixin.uiFont;
         pub const resolveUiFrame = UiKitMixin.resolveUiFrame;
+        pub const reuploadUiFonts = UiKitMixin.reuploadUiFonts;
 
         // ── Offscreen render targets / transport mirror (mixin) ──
         /// Render a scene into a texture instead of the screen, then draw that

--- a/src/game.zig
+++ b/src/game.zig
@@ -40,6 +40,8 @@ const video_mixin = @import("game/video_mixin.zig");
 const gui_mixin = @import("game/gui_mixin.zig");
 const gizmo_mixin = @import("game/gizmo_mixin.zig");
 const mesh_mixin = @import("game/mesh_mixin.zig");
+const ui_kit_mixin = @import("game/ui_kit_mixin.zig");
+const ui_draw_list_mod = @import("ui_draw_list.zig");
 const render_target_mixin = @import("game/render_target_mixin.zig");
 const post_fx_mixin = @import("game/post_fx_mixin.zig");
 const scene_mixin = @import("game/scene_mixin.zig");
@@ -389,6 +391,7 @@ pub fn GameConfigWithYAxis(
         const GuiMixin = gui_mixin.Mixin(Self);
         const GizmoMixin = gizmo_mixin.Mixin(Self);
         const MeshMixin = mesh_mixin.Mixin(Self);
+        const UiKitMixin = ui_kit_mixin.Mixin(Self);
         const RenderTargetMixin = render_target_mixin.Mixin(Self);
         const PostFxMixin = post_fx_mixin.Mixin(Self);
         const SceneMixin = scene_mixin.Mixin(Self);
@@ -955,6 +958,14 @@ pub fn GameConfigWithYAxis(
         gizmos_enabled: bool = true,
         gizmo_state: gizmo_draws_mod.GizmoState(Entity),
 
+        // In-game UI kit (issue #771). Per-frame draw commands submitted by
+        // game code (`submitUiDrawList`), drained + drawn in `render()` after
+        // the world pass and before gizmos; baked fonts retained across
+        // frames for the renderer's text pass + the kit's FontResolver.
+        ui_draw_list: std.ArrayListUnmanaged(ui_draw_list_mod.UiDrawCmd) = .empty,
+        ui_render_opts: ui_draw_list_mod.UiRenderOptions = .{},
+        ui_fonts: ui_draw_list_mod.UiFontStore = .empty,
+
         // Debug-only: tombstone ring buffer (#420)
         tombstones: if (is_debug) [tombstone_size]?TombstoneEntry else void =
             if (is_debug) [_]?TombstoneEntry{null} ** tombstone_size else {},
@@ -1241,6 +1252,14 @@ pub fn GameConfigWithYAxis(
         /// on renderers/backends that don't declare it. Plugins call this from
         /// a `Systems.renderMeshes(game)` callback (see `SystemRegistry`).
         pub const drawMesh = MeshMixin.drawMesh;
+
+        // ── In-game UI kit (issue #771) ──
+        pub const submitUiDrawList = UiKitMixin.submitUiDrawList;
+        pub const renderSubmittedUi = UiKitMixin.renderSubmittedUi;
+        pub const clearSubmittedUi = UiKitMixin.clearSubmittedUi;
+        pub const bakeUiFont = UiKitMixin.bakeUiFont;
+        pub const uiFont = UiKitMixin.uiFont;
+        pub const resolveUiFrame = UiKitMixin.resolveUiFrame;
 
         // ── Offscreen render targets / transport mirror (mixin) ──
         /// Render a scene into a texture instead of the screen, then draw that

--- a/src/game/lifecycle_mixin.zig
+++ b/src/game/lifecycle_mixin.zig
@@ -100,6 +100,11 @@ pub fn Mixin(comptime Game: type) type {
             self.active_world.deinit();
             self.allocator.destroy(self.active_world);
             self.gizmo_state.deinit(self.allocator);
+            // In-game UI kit (#771): free any commands submitted after the
+            // last render() drain, then the retained baked-font tables.
+            self.clearSubmittedUi();
+            self.ui_draw_list.deinit(self.allocator);
+            self.ui_fonts.deinit(self.allocator);
             self.scenes.deinit();
             self.jsonc_scenes.deinit();
             // Sprite-based asset inference (#563): free the reverse index and

--- a/src/game/lifecycle_mixin.zig
+++ b/src/game/lifecycle_mixin.zig
@@ -355,6 +355,11 @@ pub fn Mixin(comptime Game: type) type {
         pub fn surfaceRestored(self: *Game) void {
             self.assets.reenqueueGpuResident();
             forcePumpCurrentScene(self);
+            // In-game UI-kit font atlases (#771) are uploaded directly through
+            // the renderer, not the catalog, so the re-enqueue above misses
+            // them — re-upload from their retained RGBA here or `text_line`s
+            // would sample a stale, destroyed GPU handle after resume.
+            self.reuploadUiFonts();
             std.log.info("surface_restored: re-enqueued + pumped to ready", .{});
             // Engine `Events` dual-emit (#578).
             self.emitEngineEvent("engine__surface_restored", .{});

--- a/src/game/loop_mixin.zig
+++ b/src/game/loop_mixin.zig
@@ -324,6 +324,15 @@ pub fn Mixin(comptime Game: type) type {
                     @import("../particles_tick.zig").render(self);
                 }
             }
+            // In-game UI kit (issue #771). Composite the submitted UI
+            // DrawList OVER the world sprite pass + particles, and UNDER
+            // gizmos (debug overlays stay on top). Screen-space, no camera
+            // transform. Outside the post-load gate: UI is submitted fresh
+            // each frame by game code, never restored/gated. A no-op when
+            // nothing was submitted or the renderer lacks the screen-quad
+            // seam. Drains the retained commands.
+            self.renderSubmittedUi();
+
             self.renderGizmos();
             self.clearGizmos();
         }

--- a/src/game/ui_kit_mixin.zig
+++ b/src/game/ui_kit_mixin.zig
@@ -1,0 +1,297 @@
+//! UI-kit mixin — the Game methods behind the DrawList renderer loop
+//! (issue #771; see `src/ui_draw_list.zig` for the contract rationale).
+//!
+//! Frame shape (mirrors how gizmos work):
+//!
+//!   1. During update, game code builds/updates its `ui_kit` tree, runs the
+//!      kit's `render.build(...)`, and calls
+//!      `game.submitUiDrawList(list.items, opts)`. The engine converts +
+//!      retains the commands (text slices are duped, so the source list may
+//!      be freed immediately after submit).
+//!   2. `render()` (loop_mixin) draws the retained commands AFTER the world
+//!      sprite pass + particles and BEFORE gizmos — UI composites over the
+//!      world, debug overlays stay on top — then clears them. Submitting is
+//!      per-frame: nothing submitted → nothing drawn.
+//!
+//! Drawing goes through two labelle-gfx screen-space primitives —
+//! `drawScreenTexture` / `drawScreenRect` — both thin forwarders over the
+//! *required* backend-contract decls `drawTexturePro` / `drawRectangleRec`,
+//! so the path is backend-agnostic by construction. Both are `@hasDecl`
+//! gated here: on an older gfx (or the stub renderer) submit/draw are
+//! silent no-ops, same stance as `drawMesh`.
+//!
+//! Font pipeline (`bakeUiFont`): TTF/OTF bytes → the injected
+//! `FontBackend.decode` (stb_truetype on the backend, pure CPU) → the 8-bit
+//! coverage atlas is expanded to white-RGBA and uploaded through the
+//! renderer's `createTextureFromPixels` (required `uploadTexture` decl
+//! underneath) → glyph/codepoint/kern tables are RETAINED engine-side in
+//! `game.ui_fonts`. That retention is the piece the catalog's font path
+//! doesn't do (it hands tables to the backend and frees them) — and it is
+//! exactly what the kit's `FontResolver` needs: `uiFont(name)` exposes the
+//! tables for game-side glue to wrap in a `ui_kit.font.FontMetrics`
+//! (identity slice casts, four scalar copies).
+const std = @import("std");
+const ui_draw_list = @import("../ui_draw_list.zig");
+const assets_mod = @import("../assets/mod.zig");
+const font_loader = assets_mod.font_loader;
+
+/// Returns the UI-kit mixin for a given Game type.
+pub fn Mixin(comptime Game: type) type {
+    return struct {
+        const UiDrawCmd = ui_draw_list.UiDrawCmd;
+        const UiRect = ui_draw_list.UiRect;
+        const UiRgba8 = ui_draw_list.UiRgba8;
+
+        fn rendererCanDrawUi(comptime Renderer: type) bool {
+            return @hasDecl(Renderer, "drawScreenTexture") and
+                @hasDecl(Renderer, "drawScreenRect");
+        }
+
+        /// Submit a UI-kit DrawList for this frame. `cmds` is a slice of
+        /// kit-shaped `DrawCmd` unions (pass `draw_list.items` from
+        /// `ui_kit.render.build`, or any structurally matching union —
+        /// see `ui_draw_list.convertCommand`). Unknown command tags are
+        /// skipped. Text slices are duped; the caller may free the list
+        /// right after this returns.
+        ///
+        /// Multiple submits in one frame accumulate (drawn in submit
+        /// order); the LAST submit's `opts` win. Everything drains at the
+        /// next `render()`. No-op (drops the commands) when the renderer
+        /// lacks the screen-quad seam.
+        pub fn submitUiDrawList(
+            self: *Game,
+            cmds: anytype,
+            opts: ui_draw_list.UiRenderOptions,
+        ) void {
+            if (comptime !rendererCanDrawUi(@TypeOf(self.renderer.*))) return;
+            // Free the prior frame/submit's owned default-font dupe before the
+            // struct copy overwrites the pointer (multiple submits per frame).
+            if (self.ui_render_opts.default_font.len > 0) {
+                self.allocator.free(self.ui_render_opts.default_font);
+            }
+            self.ui_render_opts = opts;
+            self.ui_render_opts.default_font = "";
+            if (opts.default_font.len > 0) {
+                // Dupe: the caller's option slice has no lifetime contract.
+                if (self.allocator.dupe(u8, opts.default_font)) |owned| {
+                    self.ui_render_opts.default_font = owned;
+                } else |_| {}
+            }
+            for (cmds) |cmd| {
+                const converted = ui_draw_list.convertCommand(cmd) orelse continue;
+                const retained: UiDrawCmd = switch (converted) {
+                    .text_line => |line| blk: {
+                        const content = self.allocator.dupe(u8, line.content) catch continue;
+                        const font_name = self.allocator.dupe(u8, line.font_name) catch {
+                            self.allocator.free(content);
+                            continue;
+                        };
+                        var owned = line;
+                        owned.content = content;
+                        owned.font_name = font_name;
+                        break :blk .{ .text_line = owned };
+                    },
+                    else => converted,
+                };
+                self.ui_draw_list.append(self.allocator, retained) catch {
+                    // Allocation pressure: drop the command, free any dupes.
+                    freeCmd(self, retained);
+                };
+            }
+        }
+
+        /// Draw + drain the retained commands. Called by `render()` in
+        /// loop_mixin — after world/particles, before gizmos.
+        pub fn renderSubmittedUi(self: *Game) void {
+            const Renderer = @TypeOf(self.renderer.*);
+            if (comptime !rendererCanDrawUi(Renderer)) return;
+            if (self.ui_draw_list.items.len == 0) return;
+
+            const Sink = struct {
+                renderer: *Renderer,
+                pub fn drawTexturedQuad(
+                    sink: @This(),
+                    texture_id: u32,
+                    src: UiRect,
+                    dst: UiRect,
+                    tint: UiRgba8,
+                ) void {
+                    sink.renderer.drawScreenTexture(
+                        texture_id,
+                        src.x,
+                        src.y,
+                        src.w,
+                        src.h,
+                        dst.x,
+                        dst.y,
+                        dst.w,
+                        dst.h,
+                        tint.r,
+                        tint.g,
+                        tint.b,
+                        tint.a,
+                    );
+                }
+                pub fn drawSolidRect(sink: @This(), dst: UiRect, color: UiRgba8) void {
+                    sink.renderer.drawScreenRect(
+                        dst.x,
+                        dst.y,
+                        dst.w,
+                        dst.h,
+                        color.r,
+                        color.g,
+                        color.b,
+                        color.a,
+                    );
+                }
+            };
+
+            ui_draw_list.renderCommands(
+                Sink{ .renderer = self.renderer },
+                &self.ui_fonts,
+                self.ui_draw_list.items,
+                self.ui_render_opts,
+            );
+            clearSubmittedUi(self);
+        }
+
+        /// Free retained command dupes + reset the list. Also called from
+        /// `deinit` for commands submitted after the last `render()`.
+        pub fn clearSubmittedUi(self: *Game) void {
+            for (self.ui_draw_list.items) |cmd| freeCmd(self, cmd);
+            self.ui_draw_list.clearRetainingCapacity();
+            if (self.ui_render_opts.default_font.len > 0) {
+                self.allocator.free(self.ui_render_opts.default_font);
+                self.ui_render_opts.default_font = "";
+            }
+        }
+
+        fn freeCmd(self: *Game, cmd: UiDrawCmd) void {
+            switch (cmd) {
+                .text_line => |line| {
+                    self.allocator.free(line.content);
+                    self.allocator.free(line.font_name);
+                },
+                else => {},
+            }
+        }
+
+        /// Rasterise a TTF/OTF into a baked UI font under `name`:
+        /// `FontBackend.decode` (RFC-FONT-LOADER; stb_truetype CPU bake on
+        /// the injected backend) → white-RGBA atlas texture via the
+        /// renderer's `createTextureFromPixels` → glyph tables retained in
+        /// `game.ui_fonts` for both the engine's `text_line` drawing and
+        /// the kit's `FontResolver` (via `uiFont`).
+        ///
+        /// `file_type` is "ttf"/"otf". `data` is borrowed for the call.
+        /// Errors: `error.FontBackendNotInitialized` (no injected backend
+        /// — e.g. headless tests without a mock), `error.Unsupported` (the
+        /// renderer lacks `createTextureFromPixels`, i.e. pre-#771 gfx),
+        /// plus whatever the backend's decode raises on malformed bytes.
+        ///
+        /// Baked fonts live for the Game lifetime (tables freed at
+        /// `deinit`; the GPU texture is torn down with the renderer).
+        /// Re-baking an existing `name` replaces the tables.
+        pub fn bakeUiFont(
+            self: *Game,
+            name: []const u8,
+            file_type: [:0]const u8,
+            data: []const u8,
+            params: font_loader.FontBakeParams,
+        ) !void {
+            const Renderer = @TypeOf(self.renderer.*);
+            if (comptime !@hasDecl(Renderer, "createTextureFromPixels")) {
+                return error.Unsupported;
+            }
+            const backend = font_loader.currentBackend() orelse
+                return error.FontBackendNotInitialized;
+
+            const decoded = try backend.decode(file_type, data, params, self.allocator);
+            // Bitmap is consumed here; tables are retained (ownership moves
+            // into the store on success).
+            defer self.allocator.free(decoded.bitmap);
+            errdefer {
+                self.allocator.free(decoded.glyphs);
+                self.allocator.free(decoded.codepoint_index);
+                self.allocator.free(decoded.kerning);
+            }
+
+            // Expand the 8-bit coverage atlas to straight-alpha white RGBA:
+            // draws through the ordinary textured-quad pipeline on every
+            // backend (no R8 sampler support needed) and tints with the
+            // text color at draw time.
+            const pixel_count = @as(usize, decoded.width) * @as(usize, decoded.height);
+            const rgba = try self.allocator.alloc(u8, pixel_count * 4);
+            defer self.allocator.free(rgba);
+            for (decoded.bitmap[0..pixel_count], 0..) |alpha, i| {
+                rgba[i * 4 + 0] = 255;
+                rgba[i * 4 + 1] = 255;
+                rgba[i * 4 + 2] = 255;
+                rgba[i * 4 + 3] = alpha;
+            }
+
+            const texture_id: u32 = try self.renderer.createTextureFromPixels(
+                decoded.width,
+                decoded.height,
+                rgba,
+            );
+
+            try self.ui_fonts.put(self.allocator, name, .{
+                .texture_id = texture_id,
+                .atlas_width = decoded.width,
+                .atlas_height = decoded.height,
+                .glyphs = decoded.glyphs,
+                .codepoint_index = decoded.codepoint_index,
+                .kerning = decoded.kerning,
+                .pixel_height = params.pixel_height,
+                .ascent = decoded.ascent,
+                .descent = decoded.descent,
+                .line_gap = decoded.line_gap,
+                .line_height = decoded.line_height,
+            });
+        }
+
+        /// Baked-font lookup — the engine half of the kit's `FontResolver`.
+        /// Game-side glue wraps the returned tables in a
+        /// `ui_kit.font.FontMetrics` (slice casts + scalar copies).
+        pub fn uiFont(self: *const Game, name: []const u8) ?*const ui_draw_list.BakedUiFont {
+            return self.ui_fonts.get(name);
+        }
+
+        /// Resolve an atlas sprite frame for the UI kit — the engine half
+        /// of the kit's `FrameResolver`. Wraps `findSprite` + the
+        /// renderer's texture dims into normalised UVs.
+        ///
+        /// Returns null when the sprite is unknown, its atlas texture dims
+        /// can't be queried, or the frame is 90°-rotated in the atlas (the
+        /// kit's `UvRect` cannot express rotation — v1 limitation; pack UI
+        /// themes with rotation disabled).
+        pub fn resolveUiFrame(self: *Game, sprite_name: []const u8) ?ui_draw_list.ResolvedUiFrame {
+            const found = self.findSprite(sprite_name) orelse return null;
+            if (found.sprite.rotated) return null;
+            const dims = self.queryTextureDims(found.texture_id) orelse return null;
+            if (dims.width == 0 or dims.height == 0) return null;
+            const aw: f32 = @floatFromInt(dims.width);
+            const ah: f32 = @floatFromInt(dims.height);
+            // Physical atlas footprint: logical grid × texture_scale (same
+            // mapping `resolveAtlasSprites` applies for sprite draws).
+            const px = @as(f32, @floatFromInt(found.sprite.x)) * found.texture_scale_x;
+            const py = @as(f32, @floatFromInt(found.sprite.y)) * found.texture_scale_y;
+            const pw = @as(f32, @floatFromInt(found.sprite.width)) * found.texture_scale_x;
+            const ph = @as(f32, @floatFromInt(found.sprite.height)) * found.texture_scale_y;
+            return .{
+                .uv = .{
+                    .u0 = px / aw,
+                    .v0 = py / ah,
+                    .u1 = (px + pw) / aw,
+                    .v1 = (py + ph) / ah,
+                },
+                .frame_w = @floatFromInt(found.sprite.getWidth()),
+                .frame_h = @floatFromInt(found.sprite.getHeight()),
+                .texture_id = found.texture_id,
+                .atlas_width = aw,
+                .atlas_height = ah,
+            };
+        }
+    };
+}

--- a/src/game/ui_kit_mixin.zig
+++ b/src/game/ui_kit_mixin.zig
@@ -207,8 +207,8 @@ pub fn Mixin(comptime Game: type) type {
                 return error.FontBackendNotInitialized;
 
             const decoded = try backend.decode(file_type, data, params, self.allocator);
-            // Bitmap is consumed here; tables are retained (ownership moves
-            // into the store on success).
+            // Bitmap is consumed here; tables + the expanded RGBA are retained
+            // (ownership moves into the store on success).
             defer self.allocator.free(decoded.bitmap);
             errdefer {
                 self.allocator.free(decoded.glyphs);
@@ -219,10 +219,11 @@ pub fn Mixin(comptime Game: type) type {
             // Expand the 8-bit coverage atlas to straight-alpha white RGBA:
             // draws through the ordinary textured-quad pipeline on every
             // backend (no R8 sampler support needed) and tints with the
-            // text color at draw time.
+            // text color at draw time. RETAINED (not a scratch buffer) so a
+            // GPU surface loss can re-upload it without re-baking.
             const pixel_count = @as(usize, decoded.width) * @as(usize, decoded.height);
             const rgba = try self.allocator.alloc(u8, pixel_count * 4);
-            defer self.allocator.free(rgba);
+            errdefer self.allocator.free(rgba);
             for (decoded.bitmap[0..pixel_count], 0..) |alpha, i| {
                 rgba[i * 4 + 0] = 255;
                 rgba[i * 4 + 1] = 255;
@@ -240,6 +241,7 @@ pub fn Mixin(comptime Game: type) type {
                 .texture_id = texture_id,
                 .atlas_width = decoded.width,
                 .atlas_height = decoded.height,
+                .atlas_rgba = rgba,
                 .glyphs = decoded.glyphs,
                 .codepoint_index = decoded.codepoint_index,
                 .kerning = decoded.kerning,
@@ -251,6 +253,28 @@ pub fn Mixin(comptime Game: type) type {
             });
         }
 
+        /// Re-upload every retained UI font atlas after a GPU surface loss
+        /// (Android TERM_WINDOW destroys all textures). Called from
+        /// `surfaceRestored` alongside the asset catalog / atlas manager
+        /// re-upload: `bakeUiFont` retains the expanded RGBA, so this mints a
+        /// fresh `texture_id` per font from the kept pixels — no re-decode.
+        /// A no-op (and a silent skip per font) when the renderer lacks the
+        /// upload seam. Errors are swallowed per font so one failure can't
+        /// abort the whole restore.
+        pub fn reuploadUiFonts(self: *Game) void {
+            const Renderer = @TypeOf(self.renderer.*);
+            if (comptime !@hasDecl(Renderer, "createTextureFromPixels")) return;
+            var it = self.ui_fonts.fonts.valueIterator();
+            while (it.next()) |font| {
+                const new_id = self.renderer.createTextureFromPixels(
+                    font.atlas_width,
+                    font.atlas_height,
+                    font.atlas_rgba,
+                ) catch continue;
+                font.texture_id = new_id;
+            }
+        }
+
         /// Baked-font lookup — the engine half of the kit's `FontResolver`.
         /// Game-side glue wraps the returned tables in a
         /// `ui_kit.font.FontMetrics` (slice casts + scalar copies).
@@ -259,38 +283,57 @@ pub fn Mixin(comptime Game: type) type {
         }
 
         /// Resolve an atlas sprite frame for the UI kit — the engine half
-        /// of the kit's `FrameResolver`. Wraps `findSprite` + the
-        /// renderer's texture dims into normalised UVs.
+        /// of the kit's `FrameResolver`.
         ///
-        /// Returns null when the sprite is unknown, its atlas texture dims
-        /// can't be queried, or the frame is 90°-rotated in the atlas (the
-        /// kit's `UvRect` cannot express rotation — v1 limitation; pack UI
-        /// themes with rotation disabled).
+        /// UVs are derived from the atlas's LOGICAL dims (`meta.size`,
+        /// retained on the `RuntimeAtlas`), NOT a renderer texture query:
+        ///
+        ///   uv = logical_rect / logical_dims
+        ///
+        /// The `texture_scale` factor (logical→physical) cancels — physical
+        /// footprint (`logical_rect × scale`) over physical texture dims
+        /// (`logical_dims × scale`) reduces to `logical_rect / logical_dims`.
+        /// This resolves frames for CATALOG-loaded atlases too: those bypass
+        /// the renderer texture side-table, so `getTextureInfo` returns null,
+        /// but their logical dims come straight from the manifest JSON — the
+        /// streaming path this API targets (#771 review, P1). It also avoids
+        /// the `TextureId`-vs-`u32` mismatch that a `getTextureInfo` call
+        /// would hit (the atlas manager's `texture_id` is a normalised `u32`,
+        /// not the renderer's native handle).
+        ///
+        /// `atlas_width`/`atlas_height` return the PHYSICAL texture pixel
+        /// dims (`logical × texture_scale`) — what `renderCommands` needs to
+        /// map the normalised UV into a `drawTexturePro` pixel source rect.
+        ///
+        /// Returns null when the sprite is unknown, the frame is 90°-rotated
+        /// (the kit's `UvRect` can't express rotation — pack UI themes with
+        /// rotation off), or the atlas JSON omitted `meta.size` (no logical
+        /// dims → UI theme atlases must ship a meta block).
         pub fn resolveUiFrame(self: *Game, sprite_name: []const u8) ?ui_draw_list.ResolvedUiFrame {
             const found = self.findSprite(sprite_name) orelse return null;
             if (found.sprite.rotated) return null;
-            const dims = self.queryTextureDims(found.texture_id) orelse return null;
-            if (dims.width == 0 or dims.height == 0) return null;
-            const aw: f32 = @floatFromInt(dims.width);
-            const ah: f32 = @floatFromInt(dims.height);
-            // Physical atlas footprint: logical grid × texture_scale (same
-            // mapping `resolveAtlasSprites` applies for sprite draws).
-            const px = @as(f32, @floatFromInt(found.sprite.x)) * found.texture_scale_x;
-            const py = @as(f32, @floatFromInt(found.sprite.y)) * found.texture_scale_y;
-            const pw = @as(f32, @floatFromInt(found.sprite.width)) * found.texture_scale_x;
-            const ph = @as(f32, @floatFromInt(found.sprite.height)) * found.texture_scale_y;
+            const lw = found.atlas_logical_width orelse return null;
+            const lh = found.atlas_logical_height orelse return null;
+            if (lw == 0 or lh == 0) return null;
+            const lwf: f32 = @floatFromInt(lw);
+            const lhf: f32 = @floatFromInt(lh);
+            const sx: f32 = @floatFromInt(found.sprite.x);
+            const sy: f32 = @floatFromInt(found.sprite.y);
+            const sw: f32 = @floatFromInt(found.sprite.width);
+            const sh: f32 = @floatFromInt(found.sprite.height);
             return .{
                 .uv = .{
-                    .u0 = px / aw,
-                    .v0 = py / ah,
-                    .u1 = (px + pw) / aw,
-                    .v1 = (py + ph) / ah,
+                    .u0 = sx / lwf,
+                    .v0 = sy / lhf,
+                    .u1 = (sx + sw) / lwf,
+                    .v1 = (sy + sh) / lhf,
                 },
                 .frame_w = @floatFromInt(found.sprite.getWidth()),
                 .frame_h = @floatFromInt(found.sprite.getHeight()),
                 .texture_id = found.texture_id,
-                .atlas_width = aw,
-                .atlas_height = ah,
+                // Physical texture dims = logical × per-axis scale.
+                .atlas_width = lwf * found.texture_scale_x,
+                .atlas_height = lhf * found.texture_scale_y,
             };
         }
     };

--- a/src/root.zig
+++ b/src/root.zig
@@ -180,6 +180,24 @@ pub const FontBakeParams = assets_mod.font_loader.FontBakeParams;
 pub const CodepointRange = assets_mod.font_loader.CodepointRange;
 pub const DecodedFont = assets_mod.font_loader.DecodedFont;
 
+// ── In-game UI kit DrawList renderer (issue #771) ──
+// The engine side of the labelle-gui `ui_kit` DrawList seam: converts the
+// kit's `DrawCmd`s into engine commands and issues screen-space draw calls,
+// plus the baked-font store the renderer's text pass and the kit's
+// `FontResolver` share. See `src/ui_draw_list.zig` and
+// `src/game/ui_kit_mixin.zig`.
+const ui_draw_list_mod = @import("ui_draw_list.zig");
+pub const UiDrawCmd = ui_draw_list_mod.UiDrawCmd;
+pub const UiRect = ui_draw_list_mod.UiRect;
+pub const UiRgba8 = ui_draw_list_mod.UiRgba8;
+pub const UiUvRect = ui_draw_list_mod.UiUvRect;
+pub const UiRenderOptions = ui_draw_list_mod.UiRenderOptions;
+pub const UiFontStore = ui_draw_list_mod.UiFontStore;
+pub const BakedUiFont = ui_draw_list_mod.BakedUiFont;
+pub const ResolvedUiFrame = ui_draw_list_mod.ResolvedUiFrame;
+pub const convertUiDrawCommand = ui_draw_list_mod.convertCommand;
+pub const renderUiCommands = ui_draw_list_mod.renderCommands;
+
 // ── GUI ──
 pub const GuiInterface = gui_mod.GuiInterface;
 pub const StubGui = gui_mod.StubGui;

--- a/src/ui_draw_list.zig
+++ b/src/ui_draw_list.zig
@@ -89,6 +89,10 @@ pub const UiDrawCmd = union(enum) {
 };
 
 fn quantColor(v: f32) u8 {
+    // `@intFromFloat` panics on NaN in Debug/ReleaseSafe. A UI color can go
+    // NaN through a 0/0 in layout/animation math — treat it as 0 (fully
+    // transparent / black component) rather than crash the game.
+    if (std.math.isNan(v)) return 0;
     const clamped = @max(0.0, @min(1.0, v));
     return @intFromFloat(@round(clamped * 255.0));
 }
@@ -164,9 +168,18 @@ pub fn convertCommand(cmd: anytype) ?UiDrawCmd {
 /// them straight off this struct.
 pub const BakedUiFont = struct {
     /// Renderer texture handle (`u32`, the engine-wide texture id shape).
+    /// Re-minted by `reuploadUiFonts` after a GPU surface loss.
     texture_id: u32,
     atlas_width: u32,
     atlas_height: u32,
+
+    /// The expanded white-RGBA atlas pixels (`atlas_width*atlas_height*4`),
+    /// owned. Retained — NOT freed after the initial upload — so the atlas
+    /// can be re-uploaded verbatim after an Android GPU surface loss
+    /// (TERM_WINDOW destroys every texture). The bitmap→RGBA expansion and
+    /// stb_truetype bake are the expensive parts; keeping the small RGBA
+    /// buffer trades ~atlas_bytes of RAM for a decode-free restore.
+    atlas_rgba: []u8,
 
     /// Dense glyph table, addressed via `codepoint_index`. Owned.
     glyphs: []font_types.Glyph,
@@ -210,6 +223,7 @@ pub const BakedUiFont = struct {
         allocator.free(self.glyphs);
         allocator.free(self.codepoint_index);
         allocator.free(self.kerning);
+        allocator.free(self.atlas_rgba);
     }
 };
 
@@ -287,8 +301,11 @@ pub const ResolvedUiFrame = struct {
 pub const UiRenderOptions = struct {
     /// Renderer texture id of the theme atlas every `textured_quad`'s UV
     /// rect indexes into (the kit's FrameResolver resolved against ONE
-    /// host-known atlas). `0` = unknown → textured quads are skipped.
-    atlas_texture: u32 = 0,
+    /// host-known atlas). `null` = unknown → textured quads are skipped.
+    /// Optional (not a `0` sentinel): `0` is a VALID texture handle on some
+    /// backends (bgfx can bind an atlas at handle 0), so treating it as
+    /// "missing" would drop every themed quad — see #771 review.
+    atlas_texture: ?u32 = null,
     /// Pixel dims of that atlas texture — needed to turn the kit's
     /// normalised UVs into the pixel-space source rects the backend's
     /// `drawTexturePro` takes. `0` → textured quads are skipped.
@@ -325,7 +342,7 @@ pub fn renderCommands(
 ) void {
     for (cmds) |cmd| switch (cmd) {
         .textured_quad => |q| {
-            if (opts.atlas_texture == 0) continue;
+            const tex = opts.atlas_texture orelse continue;
             if (opts.atlas_width <= 0 or opts.atlas_height <= 0) continue;
             const src: UiRect = .{
                 .x = q.uv.u0 * opts.atlas_width,
@@ -333,7 +350,7 @@ pub fn renderCommands(
                 .w = (q.uv.u1 - q.uv.u0) * opts.atlas_width,
                 .h = (q.uv.v1 - q.uv.v0) * opts.atlas_height,
             };
-            sink.drawTexturedQuad(opts.atlas_texture, src, q.dst, q.tint);
+            sink.drawTexturedQuad(tex, src, q.dst, q.tint);
         },
         .solid_quad => |q| sink.drawSolidRect(q.dst, q.color),
         .text_line => |line| drawTextLine(sink, fonts, line, opts),
@@ -368,6 +385,14 @@ fn drawTextLine(
         const gi = font.glyphIndex(cp) orelse continue;
         if (gi >= font.glyphs.len) continue;
         const g = font.glyphs[gi];
+        // Guard corrupt glyph metrics: a malformed font with `u1 < u0` or
+        // `v1 < v0` would underflow the unsigned subtraction and panic in
+        // Debug/ReleaseSafe. Skip the degenerate glyph — the pen still
+        // advances below so the rest of the line stays aligned.
+        if (g.u1 < g.u0 or g.v1 < g.v0) {
+            pen_x += g.advance * scale;
+            continue;
+        }
         const gw: f32 = @floatFromInt(@as(u32, g.u1) - @as(u32, g.u0));
         const gh: f32 = @floatFromInt(@as(u32, g.v1) - @as(u32, g.v0));
         if (gw > 0 and gh > 0) {

--- a/src/ui_draw_list.zig
+++ b/src/ui_draw_list.zig
@@ -1,0 +1,400 @@
+//! UI-kit DrawList consumer (issue #771).
+//!
+//! The in-game UI kit (labelle-gui `src/ui_kit/render.zig`, issue
+//! labelle-gui#214) walks its retained widget tree into a flat,
+//! GPU-agnostic `DrawList` of `DrawCmd`s: 9-slice `textured_quad`s,
+//! `solid_quad` fallbacks, wrapped `text_line`s, and a `focus_highlight`
+//! ring. That DrawList is the single cross-repo seam between the kit and
+//! any renderer — this module is the *engine* side of that seam.
+//!
+//! ## Why the engine re-declares the command shape
+//!
+//! The engine cannot import labelle-gui (it would drag the whole editor
+//! build into every game), so — exactly like the `Glyph`/`CodepointEntry`/
+//! `KernPair` extern structs canonicalised in labelle-core — the command
+//! shape is mirrored structurally. `convertCommand` accepts *any* union
+//! whose tags/fields match the kit contract (duck-typed via `inline else`),
+//! so a game passes `ui_kit.render.DrawList.items` straight in; unknown
+//! tags are ignored at comptime, keeping the seam forward-compatible.
+//!
+//! ## Coordinate space
+//!
+//! Kit rects are SCREEN space: top-left origin, +y down, pixels — the same
+//! convention as `drawRenderTarget` composites. Commands are drawn exactly
+//! as given, with no camera transform and no y-axis flip; the renderer's
+//! screen-quad primitives (`drawScreenTexture` / `drawScreenRect`,
+//! labelle-gfx) already treat coordinates that way.
+//!
+//! ## Fonts
+//!
+//! `text_line` carries a font *name*, not glyphs — glyph drawing is the
+//! renderer's job (the kit only measures/wraps). `UiFontStore` holds the
+//! baked-atlas fonts the engine rasterised (see `bakeUiFont` in
+//! `game/ui_kit_mixin.zig`): the glyph/codepoint/kern tables (labelle-core
+//! extern layout — the same tables a `ui_kit.font.FontMetrics` borrows via
+//! identity `@ptrCast`) plus the RGBA-expanded atlas texture. The walk here
+//! reproduces the kit's pen advance (kern-then-advance, unbaked glyphs
+//! advance 0) so drawn glyphs land exactly where the kit measured them.
+
+const std = @import("std");
+const font_types = @import("font_types");
+
+// ─── Geometry / color ──────────────────────────────────────────────────────
+
+/// Screen-space rectangle: top-left origin, +y down, pixels. Mirrors the
+/// kit's `Rect { x, y, w, h }`.
+pub const UiRect = struct {
+    x: f32 = 0,
+    y: f32 = 0,
+    w: f32 = 0,
+    h: f32 = 0,
+};
+
+/// 8-bit straight-alpha RGBA — the renderer boundary quantisation of the
+/// kit's f32 `Color` (matching `ui_kit.Color.toU8`).
+pub const UiRgba8 = struct {
+    r: u8 = 255,
+    g: u8 = 255,
+    b: u8 = 255,
+    a: u8 = 255,
+};
+
+/// Normalised (0..1) UV sub-rect into the theme atlas texture. Mirrors the
+/// kit's `UvRect`.
+pub const UiUvRect = struct {
+    u0: f32 = 0,
+    v0: f32 = 0,
+    u1: f32 = 1,
+    v1: f32 = 1,
+};
+
+// ─── Commands (engine-internal, converted from the kit's DrawCmd) ──────────
+
+/// One retained draw command. Field-for-field the kit's `DrawCmd` payloads
+/// with colors quantised to `UiRgba8`; `text_line` slices are owned by the
+/// submitting game (duped by `submitUiDrawList`, freed after the draw).
+pub const UiDrawCmd = union(enum) {
+    textured_quad: struct { dst: UiRect, uv: UiUvRect, tint: UiRgba8 },
+    solid_quad: struct { dst: UiRect, color: UiRgba8 },
+    text_line: struct {
+        dst: UiRect,
+        content: []const u8,
+        color: UiRgba8,
+        size_px: f32,
+        font_name: []const u8,
+    },
+    /// The kit's `focus_highlight` minus the `ElementId` (the engine draws
+    /// the ring; identity is a kit concern).
+    focus_rect: struct { rect: UiRect },
+};
+
+fn quantColor(v: f32) u8 {
+    const clamped = @max(0.0, @min(1.0, v));
+    return @intFromFloat(@round(clamped * 255.0));
+}
+
+fn toRgba8(color: anytype) UiRgba8 {
+    return .{
+        .r = quantColor(color.r),
+        .g = quantColor(color.g),
+        .b = quantColor(color.b),
+        .a = quantColor(color.a),
+    };
+}
+
+fn toUiRect(rect: anytype) UiRect {
+    return .{ .x = rect.x, .y = rect.y, .w = rect.w, .h = rect.h };
+}
+
+/// Convert one kit-shaped `DrawCmd` (any union whose tag names/payload
+/// fields match the labelle-gui ui_kit contract) into the engine's
+/// `UiDrawCmd`. Returns `null` for tags the engine does not know — the
+/// caller skips them, so a newer kit keeps working against an older engine.
+///
+/// NOTE: `text_line` slices are borrowed from the input command here;
+/// `submitUiDrawList` dupes them before retaining.
+pub fn convertCommand(cmd: anytype) ?UiDrawCmd {
+    switch (cmd) {
+        inline else => |payload, tag| {
+            const name = @tagName(tag);
+            if (comptime std.mem.eql(u8, name, "textured_quad")) {
+                return .{ .textured_quad = .{
+                    .dst = toUiRect(payload.dst),
+                    .uv = .{
+                        .u0 = payload.uv.u0,
+                        .v0 = payload.uv.v0,
+                        .u1 = payload.uv.u1,
+                        .v1 = payload.uv.v1,
+                    },
+                    .tint = toRgba8(payload.tint),
+                } };
+            } else if (comptime std.mem.eql(u8, name, "solid_quad")) {
+                return .{ .solid_quad = .{
+                    .dst = toUiRect(payload.dst),
+                    .color = toRgba8(payload.color),
+                } };
+            } else if (comptime std.mem.eql(u8, name, "text_line")) {
+                return .{ .text_line = .{
+                    .dst = toUiRect(payload.dst),
+                    .content = payload.content,
+                    .color = toRgba8(payload.color),
+                    .size_px = payload.size_px,
+                    .font_name = payload.font_name,
+                } };
+            } else if (comptime std.mem.eql(u8, name, "focus_highlight")) {
+                return .{ .focus_rect = .{ .rect = toUiRect(payload.rect) } };
+            } else {
+                return null;
+            }
+        },
+    }
+}
+
+// ─── Baked UI fonts ────────────────────────────────────────────────────────
+
+/// One rasterised font: the baked glyph tables (labelle-core extern layout,
+/// pixel-space UV rects into the atlas) plus the atlas texture the engine
+/// uploaded (RGBA-expanded, so it draws through the ordinary textured-quad
+/// path and tints with the text color).
+///
+/// The three table slices are exactly what a `ui_kit.font.FontMetrics`
+/// wants: `glyphs`/`codepoint_index`/`kerning` reinterpret across the repo
+/// boundary as an identity `@ptrCast` (RFC-FONT-LOADER §3), the four
+/// scalars copy. Game-side glue building the kit's `FontResolver` reads
+/// them straight off this struct.
+pub const BakedUiFont = struct {
+    /// Renderer texture handle (`u32`, the engine-wide texture id shape).
+    texture_id: u32,
+    atlas_width: u32,
+    atlas_height: u32,
+
+    /// Dense glyph table, addressed via `codepoint_index`. Owned.
+    glyphs: []font_types.Glyph,
+    /// codepoint → glyph index, sorted ascending by codepoint. Owned.
+    codepoint_index: []const font_types.CodepointEntry,
+    /// Sparse GPOS kern pairs; empty when the face has none. Owned.
+    kerning: []const font_types.KernPair,
+
+    /// Pixel size the tables were baked at; advances scale by
+    /// `size_px / pixel_height` at draw time.
+    pixel_height: f32,
+    ascent: f32,
+    descent: f32, // negative (below baseline)
+    line_gap: f32,
+    line_height: f32,
+
+    /// Glyph index for `codepoint` via binary search, or null if unbaked.
+    pub fn glyphIndex(self: *const BakedUiFont, codepoint: u21) ?u32 {
+        var lo: usize = 0;
+        var hi: usize = self.codepoint_index.len;
+        const key: u32 = codepoint;
+        while (lo < hi) {
+            const mid = lo + (hi - lo) / 2;
+            const c = self.codepoint_index[mid].codepoint;
+            if (c == key) return self.codepoint_index[mid].glyph_index;
+            if (c < key) lo = mid + 1 else hi = mid;
+        }
+        return null;
+    }
+
+    /// Kern adjustment (baked px) between `left` then `right`; 0 when the
+    /// pair is not in the table. Mirrors `ui_kit.font.FontMetrics.bakedKern`.
+    pub fn kern(self: *const BakedUiFont, left: u21, right: u21) f32 {
+        for (self.kerning) |k| {
+            if (k.first == @as(u32, left) and k.second == @as(u32, right)) return k.advance;
+        }
+        return 0;
+    }
+
+    pub fn deinit(self: *BakedUiFont, allocator: std.mem.Allocator) void {
+        allocator.free(self.glyphs);
+        allocator.free(self.codepoint_index);
+        allocator.free(self.kerning);
+    }
+};
+
+/// Name → baked font. Unmanaged (allocator passed per call) so the Game
+/// field default-initialises. Keys are duped/owned.
+pub const UiFontStore = struct {
+    fonts: std.StringHashMapUnmanaged(BakedUiFont) = .empty,
+
+    pub const empty: UiFontStore = .{};
+
+    /// Insert (or replace) a baked font under `name`. Takes ownership of
+    /// the font's table slices; dupes the name. On replace the previous
+    /// tables are freed — the previous *texture* is not (the renderer owns
+    /// GPU teardown; see `bakeUiFont` docs).
+    pub fn put(
+        self: *UiFontStore,
+        allocator: std.mem.Allocator,
+        name: []const u8,
+        font: BakedUiFont,
+    ) !void {
+        const gop = try self.fonts.getOrPut(allocator, name);
+        if (gop.found_existing) {
+            gop.value_ptr.deinit(allocator);
+        } else {
+            const owned_name = allocator.dupe(u8, name) catch |err| {
+                _ = self.fonts.remove(name);
+                return err;
+            };
+            gop.key_ptr.* = owned_name;
+        }
+        gop.value_ptr.* = font;
+    }
+
+    pub fn get(self: *const UiFontStore, name: []const u8) ?*const BakedUiFont {
+        return self.fonts.getPtr(name);
+    }
+
+    pub fn count(self: *const UiFontStore) usize {
+        return self.fonts.count();
+    }
+
+    pub fn deinit(self: *UiFontStore, allocator: std.mem.Allocator) void {
+        var it = self.fonts.iterator();
+        while (it.next()) |entry| {
+            allocator.free(entry.key_ptr.*);
+            entry.value_ptr.deinit(allocator);
+        }
+        self.fonts.deinit(allocator);
+    }
+};
+
+// ─── Frame resolution (the kit's FrameResolver, engine side) ───────────────
+
+/// An atlas sprite frame resolved for the UI kit: everything the game-side
+/// glue needs to (a) answer the kit's `FrameResolver` (`uv` + `frame_px`)
+/// and (b) fill `UiRenderOptions` (`texture_id` + atlas dims) for the draw.
+/// Produced by `game.resolveUiFrame(name)` from the loaded atlas data.
+pub const ResolvedUiFrame = struct {
+    /// Normalised UV sub-rect of the frame inside its atlas texture.
+    uv: UiUvRect,
+    /// Source frame size in (logical) pixels — what the kit needs to map a
+    /// panel's pixel border into UV space for the 9-slice.
+    frame_w: f32,
+    frame_h: f32,
+    /// Renderer texture id of the atlas the frame lives in.
+    texture_id: u32,
+    /// Pixel dims of that atlas texture.
+    atlas_width: f32,
+    atlas_height: f32,
+};
+
+// ─── Render options ────────────────────────────────────────────────────────
+
+/// Per-submission context the DrawList itself does not carry.
+pub const UiRenderOptions = struct {
+    /// Renderer texture id of the theme atlas every `textured_quad`'s UV
+    /// rect indexes into (the kit's FrameResolver resolved against ONE
+    /// host-known atlas). `0` = unknown → textured quads are skipped.
+    atlas_texture: u32 = 0,
+    /// Pixel dims of that atlas texture — needed to turn the kit's
+    /// normalised UVs into the pixel-space source rects the backend's
+    /// `drawTexturePro` takes. `0` → textured quads are skipped.
+    atlas_width: f32 = 0,
+    atlas_height: f32 = 0,
+    /// Store name used when a `text_line.font_name` is empty (the kit's
+    /// "default font"). Empty + empty name → the line is skipped.
+    default_font: []const u8 = "",
+    /// Focus-ring styling for `focus_highlight` commands.
+    focus_color: UiRgba8 = .{ .r = 255, .g = 200, .b = 60, .a = 255 },
+    focus_thickness: f32 = 2,
+};
+
+// ─── The renderer loop ─────────────────────────────────────────────────────
+
+/// Walk `cmds` in order (painter's order — the kit emits parents first) and
+/// issue draw calls on `sink`. `sink` is any type providing:
+///
+///   fn drawTexturedQuad(sink, texture_id: u32, src_px: UiRect, dst: UiRect, tint: UiRgba8) void
+///   fn drawSolidRect(sink, dst: UiRect, color: UiRgba8) void
+///
+/// (`src_px` is in texture pixels, matching the backend `drawTexturePro`
+/// source-rect convention.) The Game mixin adapts the renderer's screen-quad
+/// primitives to this sink; tests record calls.
+///
+/// Unresolvable work degrades, never errors: quads without a known atlas
+/// and text without a baked font are skipped — mirroring the kit's own
+/// "mis-authored themes stay visible, not fatal" stance.
+pub fn renderCommands(
+    sink: anytype,
+    fonts: *const UiFontStore,
+    cmds: []const UiDrawCmd,
+    opts: UiRenderOptions,
+) void {
+    for (cmds) |cmd| switch (cmd) {
+        .textured_quad => |q| {
+            if (opts.atlas_texture == 0) continue;
+            if (opts.atlas_width <= 0 or opts.atlas_height <= 0) continue;
+            const src: UiRect = .{
+                .x = q.uv.u0 * opts.atlas_width,
+                .y = q.uv.v0 * opts.atlas_height,
+                .w = (q.uv.u1 - q.uv.u0) * opts.atlas_width,
+                .h = (q.uv.v1 - q.uv.v0) * opts.atlas_height,
+            };
+            sink.drawTexturedQuad(opts.atlas_texture, src, q.dst, q.tint);
+        },
+        .solid_quad => |q| sink.drawSolidRect(q.dst, q.color),
+        .text_line => |line| drawTextLine(sink, fonts, line, opts),
+        .focus_rect => |f| drawFocusRing(sink, f.rect, opts),
+    };
+}
+
+fn drawTextLine(
+    sink: anytype,
+    fonts: *const UiFontStore,
+    line: anytype,
+    opts: UiRenderOptions,
+) void {
+    const name = if (line.font_name.len > 0) line.font_name else opts.default_font;
+    if (name.len == 0) return;
+    const font = fonts.get(name) orelse return;
+
+    const scale: f32 = if (font.pixel_height > 0) line.size_px / font.pixel_height else 1.0;
+    // The kit hands `dst.y` as the line's TOP; glyph rects hang off the
+    // baseline (stbtt `yoff` is negative-up from it).
+    const baseline_y = line.dst.y + font.ascent * scale;
+
+    const view = std.unicode.Utf8View.init(line.content) catch return;
+    var it = view.iterator();
+    var pen_x = line.dst.x;
+    var prev: ?u21 = null;
+    while (it.nextCodepoint()) |cp| {
+        // Pen walk mirrors `ui_kit.text.measure`: kern between the pair,
+        // then the glyph's advance; unbaked codepoints advance 0.
+        if (prev) |p| pen_x += font.kern(p, cp) * scale;
+        prev = cp;
+        const gi = font.glyphIndex(cp) orelse continue;
+        if (gi >= font.glyphs.len) continue;
+        const g = font.glyphs[gi];
+        const gw: f32 = @floatFromInt(@as(u32, g.u1) - @as(u32, g.u0));
+        const gh: f32 = @floatFromInt(@as(u32, g.v1) - @as(u32, g.v0));
+        if (gw > 0 and gh > 0) {
+            sink.drawTexturedQuad(font.texture_id, .{
+                .x = @floatFromInt(g.u0),
+                .y = @floatFromInt(g.v0),
+                .w = gw,
+                .h = gh,
+            }, .{
+                .x = pen_x + g.xoff * scale,
+                .y = baseline_y + g.yoff * scale,
+                .w = gw * scale,
+                .h = gh * scale,
+            }, line.color);
+        }
+        pen_x += g.advance * scale;
+    }
+}
+
+fn drawFocusRing(sink: anytype, rect: UiRect, opts: UiRenderOptions) void {
+    const t = opts.focus_thickness;
+    if (t <= 0 or rect.w <= 0 or rect.h <= 0) return;
+    const c = opts.focus_color;
+    // Four edge strips drawn OUTSIDE the rect — `drawRectangleLinesEx` is an
+    // optional backend decl, four solid rects are universal.
+    sink.drawSolidRect(.{ .x = rect.x - t, .y = rect.y - t, .w = rect.w + 2 * t, .h = t }, c);
+    sink.drawSolidRect(.{ .x = rect.x - t, .y = rect.y + rect.h, .w = rect.w + 2 * t, .h = t }, c);
+    sink.drawSolidRect(.{ .x = rect.x - t, .y = rect.y, .w = t, .h = rect.h }, c);
+    sink.drawSolidRect(.{ .x = rect.x + rect.w, .y = rect.y, .w = t, .h = rect.h }, c);
+}

--- a/test/ui_draw_list_test.zig
+++ b/test/ui_draw_list_test.zig
@@ -65,6 +65,7 @@ fn fixtureFont() BakedUiFont {
         .texture_id = 99,
         .atlas_width = 16,
         .atlas_height = 10,
+        .atlas_rgba = &.{}, // fixture: no reupload path exercised here.
         .glyphs = @constCast(glyphs),
         .codepoint_index = cps,
         .kerning = kern,
@@ -211,6 +212,82 @@ test "focus_rect emits four edge strips around the rect" {
     };
     engine.renderUiCommands(RecordingSink{ .tex = &tex, .rect = &rect, .alloc = testing.allocator }, &fonts, &cmds, .{ .focus_thickness = 2 });
     try testing.expectEqual(@as(usize, 4), rect.items.len);
+}
+
+test "textured_quad still draws when the atlas is bound at handle 0" {
+    var tex: std.ArrayListUnmanaged(TexCall) = .empty;
+    var rect: std.ArrayListUnmanaged(RectCall) = .empty;
+    defer tex.deinit(testing.allocator);
+    defer rect.deinit(testing.allocator);
+    var fonts: UiFontStore = .empty;
+    const cmds = [_]UiDrawCmd{
+        .{ .textured_quad = .{ .dst = .{ .w = 10, .h = 10 }, .uv = .{ .u1 = 1, .v1 = 1 }, .tint = .{} } },
+    };
+    // atlas_texture = 0 is a VALID handle (bgfx), not "missing".
+    engine.renderUiCommands(
+        RecordingSink{ .tex = &tex, .rect = &rect, .alloc = testing.allocator },
+        &fonts,
+        &cmds,
+        .{ .atlas_texture = 0, .atlas_width = 64, .atlas_height = 64 },
+    );
+    try testing.expectEqual(@as(usize, 1), tex.items.len);
+    try testing.expectEqual(@as(u32, 0), tex.items[0].tex);
+}
+
+test "NaN color components quantise to 0 instead of panicking" {
+    // A 0/0 in layout can produce a NaN color; convertCommand must not crash.
+    const nan = std.math.nan(f32);
+    const converted = engine.convertUiDrawCommand(KitDrawCmd{
+        .solid_quad = .{ .dst = .{ .x = 0, .y = 0, .w = 1, .h = 1 }, .color = .{ .r = nan, .g = 0.5, .b = nan, .a = 1 } },
+    }).?;
+    try testing.expectEqual(@as(u8, 0), converted.solid_quad.color.r);
+    try testing.expectEqual(@as(u8, 128), converted.solid_quad.color.g);
+    try testing.expectEqual(@as(u8, 0), converted.solid_quad.color.b);
+    try testing.expectEqual(@as(u8, 255), converted.solid_quad.color.a);
+}
+
+test "corrupt glyph metrics (u1<u0) are skipped without underflow-panicking" {
+    var tex: std.ArrayListUnmanaged(TexCall) = .empty;
+    var rect: std.ArrayListUnmanaged(RectCall) = .empty;
+    defer tex.deinit(testing.allocator);
+    defer rect.deinit(testing.allocator);
+
+    // A font whose only glyph 'X' has inverted UV (u1 < u0) — a malformed
+    // bake. It must be skipped, not underflow-panic; the good glyph 'i'
+    // after it still draws, proving the pen kept advancing.
+    const glyphs = &[_]engine.Glyph{
+        .{ .u0 = 10, .v0 = 0, .u1 = 2, .v1 = 10, .xoff = 0, .yoff = -8, .advance = 6 }, // 'X' corrupt
+        .{ .u0 = 0, .v0 = 0, .u1 = 4, .v1 = 10, .xoff = 0, .yoff = -8, .advance = 4 }, // 'i' good
+    };
+    const cps = &[_]engine.CodepointEntry{
+        .{ .codepoint = 'X', .glyph_index = 0 },
+        .{ .codepoint = 'i', .glyph_index = 1 },
+    };
+    var fonts: UiFontStore = .empty;
+    try fonts.fonts.put(testing.allocator, "bad", .{
+        .texture_id = 99,
+        .atlas_width = 16,
+        .atlas_height = 10,
+        .atlas_rgba = &.{},
+        .glyphs = @constCast(glyphs),
+        .codepoint_index = cps,
+        .kerning = &.{},
+        .pixel_height = 10,
+        .ascent = 8,
+        .descent = -2,
+        .line_gap = 0,
+        .line_height = 10,
+    });
+    defer fonts.fonts.deinit(testing.allocator);
+
+    const cmds = [_]UiDrawCmd{
+        .{ .text_line = .{ .dst = .{ .x = 0, .y = 0, .w = 100, .h = 10 }, .content = "Xi", .color = .{}, .size_px = 10, .font_name = "bad" } },
+    };
+    engine.renderUiCommands(RecordingSink{ .tex = &tex, .rect = &rect, .alloc = testing.allocator }, &fonts, &cmds, .{});
+    // 'X' skipped, 'i' drawn → exactly one glyph quad.
+    try testing.expectEqual(@as(usize, 1), tex.items.len);
+    // 'i' sits at pen 0 + advance('X')=6 (the corrupt glyph still advanced).
+    try testing.expectApproxEqAbs(@as(f32, 6), tex.items[0].dst.x, 0.001);
 }
 
 // ─── convertUiDrawCommand ──────────────────────────────────────────────────
@@ -445,6 +522,66 @@ test "multiple submits in one frame accumulate without leaking the default-font 
     game.render();
     // Both panels accumulated (submit order).
     try testing.expectEqual(@as(usize, 2), game.renderer.rect_calls.items.len);
+}
+
+test "resolveUiFrame derives UVs from logical dims (catalog-atlas path, no renderer query)" {
+    const RGame = RecordingGame();
+    var game = RGame.init(testing.allocator);
+    defer game.deinit();
+
+    // Simulate a CATALOG-loaded atlas: seed the atlas manager directly with
+    // a sprite + logical dims + a texture handle, WITHOUT a renderer
+    // side-table entry (catalog uploads bypass it). resolveUiFrame must still
+    // resolve — the pre-fix code queried getTextureInfo and got null here.
+    const mgr = game.getTextureManager();
+    const atlas = try mgr.addAtlas("theme");
+    atlas.texture_id = 0; // bound at handle 0 — also the #1 case.
+    atlas.logical_width = 256;
+    atlas.logical_height = 128;
+    atlas.texture_scale_x = 1.0;
+    atlas.texture_scale_y = 1.0;
+    try atlas.addSprite("panel_bg", .{ .x = 64, .y = 32, .width = 32, .height = 16 });
+
+    const frame = game.resolveUiFrame("panel_bg").?;
+    // uv = logical_rect / logical_dims.
+    try testing.expectApproxEqAbs(@as(f32, 64.0 / 256.0), frame.uv.u0, 0.0001);
+    try testing.expectApproxEqAbs(@as(f32, 32.0 / 128.0), frame.uv.v0, 0.0001);
+    try testing.expectApproxEqAbs(@as(f32, 96.0 / 256.0), frame.uv.u1, 0.0001);
+    try testing.expectApproxEqAbs(@as(f32, 48.0 / 128.0), frame.uv.v1, 0.0001);
+    // physical atlas dims = logical × scale (scale 1 here).
+    try testing.expectApproxEqAbs(@as(f32, 256), frame.atlas_width, 0.001);
+    try testing.expectApproxEqAbs(@as(f32, 128), frame.atlas_height, 0.001);
+    try testing.expectEqual(@as(u32, 0), frame.texture_id);
+}
+
+test "resolveUiFrame returns null when the atlas JSON omitted meta.size" {
+    const RGame = RecordingGame();
+    var game = RGame.init(testing.allocator);
+    defer game.deinit();
+    const mgr = game.getTextureManager();
+    const atlas = try mgr.addAtlas("nometa");
+    // logical_width/height left null (comptime atlas / no meta block).
+    try atlas.addSprite("x", .{ .x = 0, .y = 0, .width = 8, .height = 8 });
+    try testing.expect(game.resolveUiFrame("x") == null);
+}
+
+test "reuploadUiFonts re-mints texture ids from the retained RGBA after surface loss" {
+    const RGame = RecordingGame();
+    var game = RGame.init(testing.allocator);
+    defer game.deinit();
+
+    font_loader.setBackend(MockFontBackend.backend);
+    defer font_loader.clearBackend();
+    try game.bakeUiFont("body", "ttf", "x", .{ .pixel_height = 2 });
+
+    const before = game.uiFont("body").?.texture_id;
+    // Simulate the GPU surface loss/restore re-upload.
+    game.reuploadUiFonts();
+    const after = game.uiFont("body").?.texture_id;
+    // A fresh handle was minted (RecordingRender increments), proving the
+    // retained RGBA drove a real re-upload rather than a stale handle.
+    try testing.expect(after != before);
+    try testing.expect(after >= 1000);
 }
 
 test "submit + render draws the UI DrawList after the world pass, then drains" {

--- a/test/ui_draw_list_test.zig
+++ b/test/ui_draw_list_test.zig
@@ -1,0 +1,484 @@
+//! In-game UI-kit DrawList renderer loop + font pipeline (issue #771).
+//!
+//! Three layers, all headless:
+//!   1. `ui_draw_list.renderCommands` against a recording sink — proves
+//!      textured_quad UV→pixel-src mapping, solid_quad passthrough, the
+//!      text_line glyph walk (kern + per-glyph advance + size scaling +
+//!      baseline placement), and focus_rect → four edge strips.
+//!   2. `convertUiDrawCommand` — a kit-shaped `DrawCmd` union converts +
+//!      quantises correctly, and unknown tags are dropped.
+//!   3. Full Game integration: a recording renderer with the screen-quad
+//!      seam + a mock FontBackend. `bakeUiFont` rasterises through the
+//!      backend and retains tables; `submitUiDrawList` + `render()` draw
+//!      the commands in painter order after the world pass.
+
+const std = @import("std");
+const testing = std.testing;
+
+const engine = @import("engine");
+const core = @import("labelle-core");
+const font_loader = engine.FontLoader;
+
+const UiDrawCmd = engine.UiDrawCmd;
+const UiRect = engine.UiRect;
+const UiRgba8 = engine.UiRgba8;
+const UiFontStore = engine.UiFontStore;
+const BakedUiFont = engine.BakedUiFont;
+const UiRenderOptions = engine.UiRenderOptions;
+
+// ─── A recording sink for the pure renderer loop ───────────────────────────
+
+const TexCall = struct { tex: u32, src: UiRect, dst: UiRect, tint: UiRgba8 };
+const RectCall = struct { dst: UiRect, color: UiRgba8 };
+
+const RecordingSink = struct {
+    tex: *std.ArrayListUnmanaged(TexCall),
+    rect: *std.ArrayListUnmanaged(RectCall),
+    alloc: std.mem.Allocator,
+
+    pub fn drawTexturedQuad(self: RecordingSink, tex: u32, src: UiRect, dst: UiRect, tint: UiRgba8) void {
+        self.tex.append(self.alloc, .{ .tex = tex, .src = src, .dst = dst, .tint = tint }) catch {};
+    }
+    pub fn drawSolidRect(self: RecordingSink, dst: UiRect, color: UiRgba8) void {
+        self.rect.append(self.alloc, .{ .dst = dst, .color = color }) catch {};
+    }
+};
+
+// A 10px-baked proportional fixture: 'i' advance 4, 'W' advance 12, with a
+// W→i kern of -3. Glyph pixel rects are non-degenerate so they draw.
+fn fixtureFont() BakedUiFont {
+    // NOTE: these three slices are `const` fixtures — the Game-owned store
+    // frees its tables, but here we build the store manually and never
+    // deinit it, so static slices are fine (no alloc to leak).
+    const glyphs = &[_]engine.Glyph{
+        .{ .u0 = 0, .v0 = 0, .u1 = 4, .v1 = 10, .xoff = 0, .yoff = -8, .advance = 4 }, // 'i'
+        .{ .u0 = 4, .v0 = 0, .u1 = 16, .v1 = 10, .xoff = 0, .yoff = -8, .advance = 12 }, // 'W'
+    };
+    const cps = &[_]engine.CodepointEntry{
+        .{ .codepoint = 'W', .glyph_index = 1 },
+        .{ .codepoint = 'i', .glyph_index = 0 },
+    };
+    const kern = &[_]engine.KernPair{
+        .{ .first = 'W', .second = 'i', .advance = -3 },
+    };
+    return .{
+        .texture_id = 99,
+        .atlas_width = 16,
+        .atlas_height = 10,
+        .glyphs = @constCast(glyphs),
+        .codepoint_index = cps,
+        .kerning = kern,
+        .pixel_height = 10,
+        .ascent = 8,
+        .descent = -2,
+        .line_gap = 0,
+        .line_height = 10,
+    };
+}
+
+test "textured_quad maps normalised UV to pixel source rect against the atlas" {
+    var tex: std.ArrayListUnmanaged(TexCall) = .empty;
+    var rect: std.ArrayListUnmanaged(RectCall) = .empty;
+    defer tex.deinit(testing.allocator);
+    defer rect.deinit(testing.allocator);
+    var fonts: UiFontStore = .empty;
+
+    const cmds = [_]UiDrawCmd{
+        .{ .textured_quad = .{
+            .dst = .{ .x = 100, .y = 50, .w = 64, .h = 64 },
+            .uv = .{ .u0 = 0.25, .v0 = 0.5, .u1 = 0.75, .v1 = 1.0 },
+            .tint = .{ .r = 200, .g = 100, .b = 50, .a = 255 },
+        } },
+    };
+    engine.renderUiCommands(
+        RecordingSink{ .tex = &tex, .rect = &rect, .alloc = testing.allocator },
+        &fonts,
+        &cmds,
+        .{ .atlas_texture = 7, .atlas_width = 256, .atlas_height = 128 },
+    );
+
+    try testing.expectEqual(@as(usize, 1), tex.items.len);
+    const c = tex.items[0];
+    try testing.expectEqual(@as(u32, 7), c.tex);
+    // src = uv * atlas dims: x=0.25*256=64, y=0.5*128=64, w=0.5*256=128, h=0.5*128=64
+    try testing.expectApproxEqAbs(@as(f32, 64), c.src.x, 0.001);
+    try testing.expectApproxEqAbs(@as(f32, 64), c.src.y, 0.001);
+    try testing.expectApproxEqAbs(@as(f32, 128), c.src.w, 0.001);
+    try testing.expectApproxEqAbs(@as(f32, 64), c.src.h, 0.001);
+    // dst passes through unchanged.
+    try testing.expectApproxEqAbs(@as(f32, 100), c.dst.x, 0.001);
+    try testing.expectEqual(@as(u8, 200), c.tint.r);
+}
+
+test "textured_quad without a known atlas is skipped (degrade, not crash)" {
+    var tex: std.ArrayListUnmanaged(TexCall) = .empty;
+    var rect: std.ArrayListUnmanaged(RectCall) = .empty;
+    defer tex.deinit(testing.allocator);
+    defer rect.deinit(testing.allocator);
+    var fonts: UiFontStore = .empty;
+    const cmds = [_]UiDrawCmd{
+        .{ .textured_quad = .{ .dst = .{ .w = 10, .h = 10 }, .uv = .{}, .tint = .{} } },
+    };
+    // atlas_texture defaults to 0 → unknown.
+    engine.renderUiCommands(RecordingSink{ .tex = &tex, .rect = &rect, .alloc = testing.allocator }, &fonts, &cmds, .{});
+    try testing.expectEqual(@as(usize, 0), tex.items.len);
+}
+
+test "solid_quad forwards dst + color verbatim" {
+    var tex: std.ArrayListUnmanaged(TexCall) = .empty;
+    var rect: std.ArrayListUnmanaged(RectCall) = .empty;
+    defer tex.deinit(testing.allocator);
+    defer rect.deinit(testing.allocator);
+    var fonts: UiFontStore = .empty;
+    const cmds = [_]UiDrawCmd{
+        .{ .solid_quad = .{ .dst = .{ .x = 5, .y = 6, .w = 7, .h = 8 }, .color = .{ .r = 1, .g = 2, .b = 3, .a = 4 } } },
+    };
+    engine.renderUiCommands(RecordingSink{ .tex = &tex, .rect = &rect, .alloc = testing.allocator }, &fonts, &cmds, .{});
+    try testing.expectEqual(@as(usize, 1), rect.items.len);
+    try testing.expectEqual(@as(f32, 7), rect.items[0].dst.w);
+    try testing.expectEqual(@as(u8, 3), rect.items[0].color.b);
+}
+
+test "text_line walks glyphs with kerning, advance, scale, and baseline" {
+    var tex: std.ArrayListUnmanaged(TexCall) = .empty;
+    var rect: std.ArrayListUnmanaged(RectCall) = .empty;
+    defer tex.deinit(testing.allocator);
+    defer rect.deinit(testing.allocator);
+
+    var fonts: UiFontStore = .empty;
+    // Manually seed the store (no alloc — static fixture tables).
+    try fonts.fonts.put(testing.allocator, "ui", fixtureFont());
+    defer fonts.fonts.deinit(testing.allocator);
+
+    // "Wi" at size 20 (2× the baked 10px). Baseline = dst.y + ascent*scale
+    // = 30 + 8*2 = 46. First glyph 'W' at pen 100; second 'i' pen =
+    // 100 + advance(W)*2 + kern(W,i)*2 = 100 + 24 - 6 = 118.
+    const cmds = [_]UiDrawCmd{
+        .{ .text_line = .{
+            .dst = .{ .x = 100, .y = 30, .w = 200, .h = 20 },
+            .content = "Wi",
+            .color = .{ .r = 255, .g = 255, .b = 255, .a = 255 },
+            .size_px = 20,
+            .font_name = "ui",
+        } },
+    };
+    engine.renderUiCommands(RecordingSink{ .tex = &tex, .rect = &rect, .alloc = testing.allocator }, &fonts, &cmds, .{});
+
+    try testing.expectEqual(@as(usize, 2), tex.items.len);
+    // Both glyphs sample the FONT atlas texture (99), not the theme atlas.
+    try testing.expectEqual(@as(u32, 99), tex.items[0].tex);
+    // 'W' src rect = its atlas pixel rect (4,0)-(16,10) → x=4 w=12 h=10.
+    try testing.expectApproxEqAbs(@as(f32, 4), tex.items[0].src.x, 0.001);
+    try testing.expectApproxEqAbs(@as(f32, 12), tex.items[0].src.w, 0.001);
+    // 'W' dst: pen 100 + xoff(0), baseline 46 + yoff(-8)*2 = 30; scaled size 12*2=24 wide.
+    try testing.expectApproxEqAbs(@as(f32, 100), tex.items[0].dst.x, 0.001);
+    try testing.expectApproxEqAbs(@as(f32, 30), tex.items[0].dst.y, 0.001);
+    try testing.expectApproxEqAbs(@as(f32, 24), tex.items[0].dst.w, 0.001);
+    // 'i' dst.x = 118 (advance + kern applied).
+    try testing.expectApproxEqAbs(@as(f32, 118), tex.items[1].dst.x, 0.001);
+}
+
+test "text_line falls back to the default font when its font_name is empty" {
+    var tex: std.ArrayListUnmanaged(TexCall) = .empty;
+    var rect: std.ArrayListUnmanaged(RectCall) = .empty;
+    defer tex.deinit(testing.allocator);
+    defer rect.deinit(testing.allocator);
+    var fonts: UiFontStore = .empty;
+    try fonts.fonts.put(testing.allocator, "ui", fixtureFont());
+    defer fonts.fonts.deinit(testing.allocator);
+
+    const cmds = [_]UiDrawCmd{
+        .{ .text_line = .{ .dst = .{ .x = 0, .y = 0, .w = 50, .h = 10 }, .content = "i", .color = .{}, .size_px = 10, .font_name = "" } },
+    };
+    // default_font resolves the empty name.
+    engine.renderUiCommands(RecordingSink{ .tex = &tex, .rect = &rect, .alloc = testing.allocator }, &fonts, &cmds, .{ .default_font = "ui" });
+    try testing.expectEqual(@as(usize, 1), tex.items.len);
+
+    // With no default font, the line is skipped.
+    tex.clearRetainingCapacity();
+    engine.renderUiCommands(RecordingSink{ .tex = &tex, .rect = &rect, .alloc = testing.allocator }, &fonts, &cmds, .{});
+    try testing.expectEqual(@as(usize, 0), tex.items.len);
+}
+
+test "focus_rect emits four edge strips around the rect" {
+    var tex: std.ArrayListUnmanaged(TexCall) = .empty;
+    var rect: std.ArrayListUnmanaged(RectCall) = .empty;
+    defer tex.deinit(testing.allocator);
+    defer rect.deinit(testing.allocator);
+    var fonts: UiFontStore = .empty;
+    const cmds = [_]UiDrawCmd{
+        .{ .focus_rect = .{ .rect = .{ .x = 50, .y = 50, .w = 40, .h = 20 } } },
+    };
+    engine.renderUiCommands(RecordingSink{ .tex = &tex, .rect = &rect, .alloc = testing.allocator }, &fonts, &cmds, .{ .focus_thickness = 2 });
+    try testing.expectEqual(@as(usize, 4), rect.items.len);
+}
+
+// ─── convertUiDrawCommand ──────────────────────────────────────────────────
+
+// A kit-shaped DrawCmd: structurally identical tag names + payload fields to
+// labelle-gui `ui_kit.render.DrawCmd`, so `convertUiDrawCommand` accepts it.
+const KitColor = struct { r: f32, g: f32, b: f32, a: f32 };
+const KitRect = struct { x: f32, y: f32, w: f32, h: f32 };
+const KitUv = struct { u0: f32, v0: f32, u1: f32, v1: f32 };
+const KitDrawCmd = union(enum) {
+    textured_quad: struct { dst: KitRect, uv: KitUv, tint: KitColor },
+    solid_quad: struct { dst: KitRect, color: KitColor },
+    text_line: struct { dst: KitRect, content: []const u8, color: KitColor, size_px: f32, font_name: []const u8 },
+    focus_highlight: struct { id: u32, rect: KitRect },
+};
+
+test "convertUiDrawCommand quantises f32 colors and maps every known tag" {
+    const solid = engine.convertUiDrawCommand(KitDrawCmd{
+        .solid_quad = .{ .dst = .{ .x = 1, .y = 2, .w = 3, .h = 4 }, .color = .{ .r = 1.0, .g = 0.5, .b = 0.0, .a = 1.0 } },
+    }).?;
+    try testing.expect(solid == .solid_quad);
+    try testing.expectEqual(@as(u8, 255), solid.solid_quad.color.r);
+    try testing.expectEqual(@as(u8, 128), solid.solid_quad.color.g); // round(0.5*255)=128
+    try testing.expectEqual(@as(u8, 0), solid.solid_quad.color.b);
+
+    const focus = engine.convertUiDrawCommand(KitDrawCmd{ .focus_highlight = .{ .id = 5, .rect = .{ .x = 0, .y = 0, .w = 9, .h = 9 } } }).?;
+    try testing.expect(focus == .focus_rect);
+
+    const text = engine.convertUiDrawCommand(KitDrawCmd{
+        .text_line = .{ .dst = .{ .x = 0, .y = 0, .w = 0, .h = 0 }, .content = "hi", .color = .{ .r = 1, .g = 1, .b = 1, .a = 1 }, .size_px = 12, .font_name = "f" },
+    }).?;
+    try testing.expectEqualStrings("hi", text.text_line.content);
+}
+
+test "convertUiDrawCommand returns null for unknown tags" {
+    const Unknown = union(enum) { mystery: struct { x: f32 } };
+    try testing.expect(engine.convertUiDrawCommand(Unknown{ .mystery = .{ .x = 1 } }) == null);
+}
+
+// ─── Full Game integration ─────────────────────────────────────────────────
+
+fn RecordingRender(comptime Entity: type) type {
+    return struct {
+        const Self = @This();
+
+        pub const Sprite = struct {
+            sprite_name: []const u8 = "",
+            visible: bool = true,
+            z_index: i16 = 0,
+            layer: enum { default } = .default,
+        };
+        pub const Shape = struct {
+            shape: union(enum) { rectangle: struct { width: f32 = 10, height: f32 = 10 } } = .{ .rectangle = .{} },
+            color: struct { r: u8 = 255, g: u8 = 255, b: u8 = 255, a: u8 = 255 } = .{},
+            visible: bool = true,
+            z_index: i16 = 0,
+            layer: enum { default } = .default,
+        };
+
+        render_count: usize = 0,
+        tex_calls: std.ArrayListUnmanaged(TexCall) = .empty,
+        rect_calls: std.ArrayListUnmanaged(RectCall) = .empty,
+        /// True when a screen draw landed after render() — proves UI is in
+        /// the render phase, over the world.
+        first_ui_after_render: ?bool = null,
+        next_texture: u32 = 1000,
+        alloc: std.mem.Allocator = undefined,
+
+        pub fn init(allocator: std.mem.Allocator) Self {
+            return .{ .alloc = allocator };
+        }
+        pub fn deinit(self: *Self) void {
+            self.tex_calls.deinit(self.alloc);
+            self.rect_calls.deinit(self.alloc);
+        }
+
+        pub fn trackEntity(_: *Self, _: Entity, _: core.render.VisualType) void {}
+        pub fn untrackEntity(_: *Self, _: Entity) void {}
+        pub fn markPositionDirty(_: *Self, _: Entity) void {}
+        pub fn markPositionDirtyWithChildren(_: *Self, comptime _: type, _: anytype, _: Entity) void {}
+        pub fn updateHierarchyFlag(_: *Self, _: Entity, _: bool) void {}
+        pub fn markVisualDirty(_: *Self, _: Entity) void {}
+        pub fn sync(_: *Self, comptime _: type, _: anytype) void {}
+        pub fn setScreenHeight(_: *Self, _: f32) void {}
+        pub fn renderGizmoDraws(_: *Self, _: []const core.gizmos.GizmoDraw) void {}
+        pub fn hasEntity(_: *const Self, _: Entity) bool {
+            return false;
+        }
+        pub fn render(self: *Self) void {
+            self.render_count += 1;
+        }
+        pub fn clear(self: *Self) void {
+            self.render_count = 0;
+        }
+
+        // ── The #771 screen-space seam ──
+        pub fn createTextureFromPixels(self: *Self, w: u32, h: u32, pixels: []const u8) !u32 {
+            std.debug.assert(pixels.len == @as(usize, w) * @as(usize, h) * 4);
+            const id = self.next_texture;
+            self.next_texture += 1;
+            return id;
+        }
+        pub fn drawScreenTexture(
+            self: *Self,
+            tex: u32,
+            sx: f32,
+            sy: f32,
+            sw: f32,
+            sh: f32,
+            dx: f32,
+            dy: f32,
+            dw: f32,
+            dh: f32,
+            r: u8,
+            g: u8,
+            b: u8,
+            a: u8,
+        ) void {
+            if (self.first_ui_after_render == null) self.first_ui_after_render = self.render_count > 0;
+            self.tex_calls.append(self.alloc, .{
+                .tex = tex,
+                .src = .{ .x = sx, .y = sy, .w = sw, .h = sh },
+                .dst = .{ .x = dx, .y = dy, .w = dw, .h = dh },
+                .tint = .{ .r = r, .g = g, .b = b, .a = a },
+            }) catch {};
+        }
+        pub fn drawScreenRect(self: *Self, dx: f32, dy: f32, dw: f32, dh: f32, r: u8, g: u8, b: u8, a: u8) void {
+            if (self.first_ui_after_render == null) self.first_ui_after_render = self.render_count > 0;
+            self.rect_calls.append(self.alloc, .{
+                .dst = .{ .x = dx, .y = dy, .w = dw, .h = dh },
+                .color = .{ .r = r, .g = g, .b = b, .a = a },
+            }) catch {};
+        }
+    };
+}
+
+const EmptyComponents = struct {
+    pub fn has(comptime _: []const u8) bool {
+        return false;
+    }
+    pub fn names() []const []const u8 {
+        return &.{};
+    }
+};
+
+fn RecordingGame() type {
+    return engine.GameConfig(
+        RecordingRender(u32),
+        engine.MockEcsBackend(u32),
+        engine.StubInput,
+        engine.StubAudio,
+        engine.StubVideo,
+        engine.StubGui,
+        void,
+        engine.StubLogSink,
+        EmptyComponents,
+        &.{},
+        void,
+    );
+}
+
+// Mock font backend: bakes a 2×2 alpha atlas + a 1-glyph 'A' table, all
+// allocator-owned (so the GPA catches leaks / double-frees).
+const MockFontBackend = struct {
+    fn decode(file_type: [:0]const u8, data: []const u8, params: font_loader.FontBakeParams, allocator: std.mem.Allocator) anyerror!engine.DecodedFont {
+        _ = file_type;
+        _ = data;
+        _ = params;
+        const bitmap = try allocator.alloc(u8, 4);
+        @memset(bitmap, 0xAA);
+        const glyphs = try allocator.alloc(engine.Glyph, 1);
+        glyphs[0] = .{ .u0 = 0, .v0 = 0, .u1 = 2, .v1 = 2, .xoff = 0, .yoff = -2, .advance = 3 };
+        const cps = try allocator.alloc(engine.CodepointEntry, 1);
+        cps[0] = .{ .codepoint = 'A', .glyph_index = 0 };
+        const kern = try allocator.alloc(engine.KernPair, 0);
+        return .{
+            .bitmap = bitmap,
+            .width = 2,
+            .height = 2,
+            .glyphs = glyphs,
+            .codepoint_index = cps,
+            .ascent = 2,
+            .descent = 0,
+            .line_gap = 0,
+            .line_height = 2,
+            .kerning = kern,
+        };
+    }
+    // upload/unload are unused by bakeUiFont (it uploads through the
+    // renderer directly) but the FontBackend struct requires them.
+    fn upload(_: engine.DecodedFont) anyerror!engine.FontId {
+        return engine.FontId.invalid;
+    }
+    fn unload(_: engine.FontId) void {}
+
+    const backend: font_loader.FontBackend = .{ .decode = decode, .upload = upload, .unload = unload };
+};
+
+test "bakeUiFont rasterises through the backend and retains glyph tables" {
+    const RGame = RecordingGame();
+    var game = RGame.init(testing.allocator);
+    defer game.deinit();
+
+    font_loader.setBackend(MockFontBackend.backend);
+    defer font_loader.clearBackend();
+
+    try game.bakeUiFont("body", "ttf", "fake-ttf-bytes", .{ .pixel_height = 16 });
+
+    const f = game.uiFont("body").?;
+    try testing.expectEqual(@as(usize, 1), f.glyphs.len);
+    try testing.expectEqual(@as(f32, 16), f.pixel_height);
+    try testing.expectEqual(@as(?u32, 0), f.glyphIndex('A'));
+    try testing.expect(f.glyphIndex('Z') == null);
+    // The renderer minted a texture id for the expanded RGBA atlas.
+    try testing.expect(f.texture_id >= 1000);
+}
+
+test "multiple submits in one frame accumulate without leaking the default-font dupe" {
+    const RGame = RecordingGame();
+    var game = RGame.init(testing.allocator);
+    defer game.deinit(); // GPA (testing.allocator) fails the test on any leak.
+
+    const a = [_]KitDrawCmd{
+        .{ .solid_quad = .{ .dst = .{ .x = 0, .y = 0, .w = 5, .h = 5 }, .color = .{ .r = 1, .g = 0, .b = 0, .a = 1 } } },
+    };
+    const b = [_]KitDrawCmd{
+        .{ .solid_quad = .{ .dst = .{ .x = 5, .y = 5, .w = 5, .h = 5 }, .color = .{ .r = 0, .g = 1, .b = 0, .a = 1 } } },
+    };
+    // Two submits, each carrying an owned default_font dupe.
+    game.submitUiDrawList(&a, .{ .default_font = "one" });
+    game.submitUiDrawList(&b, .{ .default_font = "two" });
+    game.render();
+    // Both panels accumulated (submit order).
+    try testing.expectEqual(@as(usize, 2), game.renderer.rect_calls.items.len);
+}
+
+test "submit + render draws the UI DrawList after the world pass, then drains" {
+    const RGame = RecordingGame();
+    var game = RGame.init(testing.allocator);
+    defer game.deinit();
+
+    font_loader.setBackend(MockFontBackend.backend);
+    defer font_loader.clearBackend();
+    try game.bakeUiFont("body", "ttf", "x", .{ .pixel_height = 2 });
+
+    // A kit-shaped DrawList: a solid panel fallback, a focused button ring,
+    // and a text line — the shapes `ui_kit.render.build` emits.
+    const cmds = [_]KitDrawCmd{
+        .{ .solid_quad = .{ .dst = .{ .x = 10, .y = 10, .w = 100, .h = 40 }, .color = .{ .r = 0.2, .g = 0.2, .b = 0.3, .a = 1 } } },
+        .{ .text_line = .{ .dst = .{ .x = 20, .y = 15, .w = 80, .h = 10 }, .content = "A", .color = .{ .r = 1, .g = 1, .b = 1, .a = 1 }, .size_px = 2, .font_name = "body" } },
+        .{ .focus_highlight = .{ .id = 1, .rect = .{ .x = 10, .y = 10, .w = 100, .h = 40 } } },
+    };
+    game.submitUiDrawList(&cmds, .{ .default_font = "body" });
+
+    // Mirror the generated frame: world pass, then the engine drains UI.
+    game.render();
+
+    const r = game.renderer;
+    // Panel solid (1) + focus ring (4 strips) = 5 rect calls.
+    try testing.expectEqual(@as(usize, 5), r.rect_calls.items.len);
+    // One glyph ('A') textured.
+    try testing.expectEqual(@as(usize, 1), r.tex_calls.items.len);
+    // UI drew after the world render().
+    try testing.expectEqual(@as(?bool, true), r.first_ui_after_render);
+    // Drained: a second render() with no submit draws nothing new.
+    r.rect_calls.clearRetainingCapacity();
+    r.tex_calls.clearRetainingCapacity();
+    game.render();
+    try testing.expectEqual(@as(usize, 0), r.rect_calls.items.len);
+    try testing.expectEqual(@as(usize, 0), r.tex_calls.items.len);
+}


### PR DESCRIPTION
Follow-up to labelle-gui#214 (gui #215/#216). The engine now consumes labelle-gui `ui_kit`'s backend-agnostic **DrawList** — the single cross-repo seam a renderer maps to draw calls.

## What the DrawList contract turned out to be

`ui_kit.render.build(tree, opts)` walks a laid-out retained widget tree into a flat, GPU-type-free `DrawList` of `DrawCmd`s (painter's order, parents first):

- **`textured_quad`** `{ dst: Rect, uv: UvRect, tint: Color }` — 9-slice panel cells (from an atlas frame the host resolves) + images.
- **`solid_quad`** `{ dst, color }` — the panel fallback when a sprite frame doesn't resolve (mis-authored themes stay visible).
- **`text_line`** `{ dst, content, color, size_px, font_name }` — one per wrapped line; **glyphs are NOT rasterized in the kit** — it only measures/wraps and hands the renderer the line + font name.
- **`focus_highlight`** `{ id, rect }` — the focus ring for the focused button.

Two host callbacks parameterize `build`: a **`FrameResolver`** (sprite name → atlas UV, engine wraps the asset catalog / editor wraps `atlas.Index`) and a **`FontResolver`** (font name → proportional `FontMetrics`, whose `Glyph`/`CodepointEntry`/`KernPair` tables are byte-identical to labelle-core so a loaded font casts across the repo boundary as an identity `@ptrCast`).

## Engine side (this PR)

- **`src/ui_draw_list.zig`** — `convertCommand` duck-types any kit-shaped `DrawCmd` union (structural match → games pass `list.items` straight in; unknown tags skipped for forward-compat). `renderCommands` walks the converted list on a duck-typed sink: UV→pixel-src mapping for textured quads, a glyph-run text pass that reproduces the kit's kern-then-advance pen (size scaling + baseline placement), and the focus ring as four edge strips. `UiFontStore`/`BakedUiFont` retain the baked glyph tables + atlas texture.
- **`src/game/ui_kit_mixin.zig`** — the Game API: `submitUiDrawList` (convert + retain, dupes text slices), `renderSubmittedUi` (draw + drain — called in `render()` after the world/particles pass, before gizmos, screen-space, no camera transform), `bakeUiFont`, `uiFont` / `resolveUiFrame` (engine halves of the kit's resolvers). All drawing goes through the renderer's `drawScreenTexture` / `drawScreenRect` / `createTextureFromPixels` seam, `@hasDecl`-gated so an older gfx or the stub renderer is a silent no-op.
- Wired into `Game`, the frame loop, `deinit`, `root.zig`, and `test/ui_draw_list_test.zig`.

**Backend PR:** labelle-gfx#311 adds those three screen-space primitives (thin forwarders over the required `drawTexturePro`/`drawRectangleRec`/`uploadTexture` contract decls → backend-agnostic).

## The font story

Rasterization **reuses the existing Phase-4 `FontBackend` seam** (RFC-FONT-LOADER; stb_truetype on the raylib/sokol backends) rather than adding a new rasterizer. `bakeUiFont` drives `FontBackend.decode`, expands the 8-bit coverage atlas to white-RGBA (so it draws through the ordinary textured-quad path and tints with the text color on every backend), uploads via the renderer, and **retains the glyph tables engine-side** — the piece the catalog font path doesn't do (it hands tables to the backend and frees them), and exactly what the kit's FontResolver needs.

## Evidence

`zig build test` — **1055/1055 green**. `test/ui_draw_list_test.zig` (11 tests) drives the renderer loop end-to-end headlessly: UV→pixel mapping, the glyph pen walk (kern + advance + size scale + baseline, asserted to the pixel), focus ring, command conversion + quantization, and a full **bake → submit → render** integration through a recording renderer + a mock `FontBackend` — asserting the exact draw calls land, in painter order, after the world pass, and drain each frame.

## Slice vs full

This is the **renderer loop + font pipeline slice**, proven headless. Not yet done (filed as follow-ups):
1. An on-GPU demo example (a game importing `ui_kit`, building a Tree, calling `submitUiDrawList`) + `LABELLE_SCREENSHOT_PATH` screenshot — needs assembler wiring to expose `ui_kit` as a game dependency.
2. The editor `atlas.Index` FrameResolver preview (labelle-gui side).
3. The acceptance criteria: FP's build menu rebuilt on the kit + a theme-pack swap.

`Refs #771` (not `Closes`) — the renderer loop + font rasterization land here; the demo + editor preview + FP acceptance remain.

https://claude.ai/code/session_011szWvquoss1yNX7KWSKCaM

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-engine/pr/786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787073367&installation_id=146340424&pr_number=786&repository=labelle-toolkit%2Flabelle-engine&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-engine%2Fpull%2F786&signature=b349ef8adabef9f79dcbfeabad911fc2b7440ac941c5f16a9b5af705fd7153b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->