### PR TITLE
feat: batch polish + entity-id column (#782, #783)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -271,17 +271,52 @@ pub fn build(b: *std.Build) void {
 
     // `zig build bench` — the id-column (#783) host+binding
     // micro-benchmark, forced ReleaseFast regardless of the top-level
-    // optimize so the measurement is meaningful.
+    // optimize so the measurement is meaningful. The MEASURED code lives
+    // in the engine module (`script_contract`), so the whole engine
+    // module graph must be ReleaseFast too — the default `core_module`/
+    // `engine_module` inherit the top-level `optimize` (Debug by
+    // default), which would silently measure Debug (#788 review). So
+    // re-derive the graph at ReleaseFast for the bench alone.
+    const bench_opt: std.builtin.OptimizeMode = .ReleaseFast;
+    const core_rf = b.dependency("labelle_core", .{ .target = target, .optimize = bench_opt }).module("labelle-core");
+    const scene_rf = b.dependency("scene", .{ .target = target, .optimize = bench_opt }).module("scene");
+    const jsonc_rf = b.dependency("jsonc", .{ .target = target, .optimize = bench_opt }).module("jsonc");
+    const audio_types_rf = b.createModule(.{
+        .root_source_file = b.path("src/audio_types.zig"),
+        .target = target,
+        .optimize = bench_opt,
+    });
+    const font_types_rf = b.createModule(.{
+        .root_source_file = b.path("src/font_types.zig"),
+        .target = target,
+        .optimize = bench_opt,
+    });
+    font_types_rf.addImport("labelle-core", core_rf);
+    const engine_rf = b.createModule(.{
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .optimize = bench_opt,
+        .link_libc = true,
+    });
+    engine_rf.addImport("labelle-core", core_rf);
+    engine_rf.addImport("scene", scene_rf);
+    engine_rf.addImport("jsonc", jsonc_rf);
+    engine_rf.addImport("audio_types", audio_types_rf);
+    engine_rf.addImport("font_types", font_types_rf);
+    if (target.result.os.tag == .macos) {
+        engine_rf.linkFramework("IOSurface", .{});
+        engine_rf.linkFramework("CoreFoundation", .{});
+    }
     const bench_step = b.step("bench", "Run the script-contract id-column benchmark (ReleaseFast)");
     const bench_exe = b.addExecutable(.{
         .name = "script_contract_bench",
         .root_module = b.createModule(.{
             .root_source_file = b.path("test/script_contract_bench.zig"),
             .target = target,
-            .optimize = .ReleaseFast,
+            .optimize = bench_opt,
             .imports = &.{
-                .{ .name = "labelle-core", .module = core_module },
-                .{ .name = "engine", .module = engine_module },
+                .{ .name = "labelle-core", .module = core_rf },
+                .{ .name = "engine", .module = engine_rf },
             },
         }),
     });

--- a/build.zig
+++ b/build.zig
@@ -269,6 +269,24 @@ pub fn build(b: *std.Build) void {
         test_step.dependOn(&b.addRunArtifact(t).step);
     }
 
+    // `zig build bench` — the id-column (#783) host+binding
+    // micro-benchmark, forced ReleaseFast regardless of the top-level
+    // optimize so the measurement is meaningful.
+    const bench_step = b.step("bench", "Run the script-contract id-column benchmark (ReleaseFast)");
+    const bench_exe = b.addExecutable(.{
+        .name = "script_contract_bench",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("test/script_contract_bench.zig"),
+            .target = target,
+            .optimize = .ReleaseFast,
+            .imports = &.{
+                .{ .name = "labelle-core", .module = core_module },
+                .{ .name = "engine", .module = engine_module },
+            },
+        }),
+    });
+    bench_step.dependOn(&b.addRunArtifact(bench_exe).step);
+
     // PIE viewport macOS IOSurface frame stream (#547). The test
     // binary itself is cross-platform — on non-macOS hosts every
     // `test` block early-returns — so we always wire it into the

--- a/contract/labelle_script.h
+++ b/contract/labelle_script.h
@@ -501,15 +501,27 @@ size_t labelle_plugin_response_fetch(char *out, size_t out_cap);
  *                          NO count header
  *
  *    _batch_set_ids applies each row BY ID: a row whose entity has
- *    vanished — or no longer carries every named component (destroyed
- *    or mutated since the get, including by an onSet hook firing
- *    mid-apply) — is SKIPPED (floats consumed, nothing written, not an
- *    error), and entities spawned since the get are simply untouched.
- *    Rows apply independently; there is no partial-commit failure
- *    mode. The positional preflight is replaced by a shape check:
- *    buf_len must be a whole number of rows (count x (8 + stride)),
- *    else -1 with no writes. Spawning/destroying between the paired
- *    calls is SAFE on this variant. */
+ *    vanished — or no longer carries every named component at row start
+ *    (it left the query since the get) — is SKIPPED (floats consumed,
+ *    nothing written, not an error), and entities spawned since the get
+ *    are simply untouched. Rows apply independently.
+ *
+ *    ONSET HOOKS MID-ROW: within a multi-component row, each component
+ *    is gated on the entity's liveness AND that component's presence
+ *    immediately before its apply. So if an earlier component's onSet
+ *    hook, mid-row, REMOVES a later named component (entity still
+ *    alive), only that component is skipped — the row's other
+ *    still-present components still land, and the removed one stays
+ *    removed (the hook wins); if the hook DESTROYS the whole entity,
+ *    the rest of the row is skipped and nothing it held persists. Both
+ *    are skips, not failures — a row never persists half-written.
+ *
+ *    The positional preflight is replaced by a shape check: buf_len
+ *    must be a whole number of rows (count x (8 + stride)), else -1
+ *    with no writes. -1 is ALSO returned on a genuine apply failure of
+ *    a live, present component (a built-in scene-apply rejection —
+ *    surfaced, not masked as success). Spawning/destroying between the
+ *    paired calls is SAFE on this variant. */
 
 /* labelle_component_batch_get's int-field refusal sentinel: the rc
  * convention's -2 carried in its size_t return. Distinct from 0 =
@@ -568,11 +580,14 @@ size_t labelle_component_batch_get_ids(const char *names_json,
 
 /* Id-tagged batched SET (since v1.4): `buf` is [u64 id][f32 stream]
  * rows (NO count header) exactly as _batch_get_ids returned them,
- * applied BY ID — vanished / no-longer-matching rows are skipped, rows
+ * applied BY ID — vanished / no-longer-matching rows are skipped, a
+ * mid-row onSet hook removing a component or destroying the entity
+ * skips only the affected component(s) (never a half-written row), rows
  * are independent, spawn/destroy between the paired calls is safe.
  * 0 = ok (skips included); -1 = malformed names / unknown component
- * name / buf_len not a whole number of rows / not bound; -2 =
- * int-carrying named component. */
+ * name / buf_len not a whole number of rows / not bound / a genuine
+ * apply failure on a live, present component; -2 = int-carrying named
+ * component. */
 int32_t labelle_component_batch_set_ids(const char *names_json,
                                         size_t names_json_len,
                                         const char *buf, size_t buf_len);

--- a/contract/labelle_script.h
+++ b/contract/labelle_script.h
@@ -84,7 +84,7 @@ extern "C" {
  * is probed per-symbol (embedded VMs bind against the running host,
  * which either exports it or doesn't; native plugins find out at link
  * time) — the editor-bridge contract's exact convention (its v1.1–v1.7
- * were all additive). This header describes contract v1.3:
+ * were all additive). This header describes contract v1.4:
  *   v1.1 = v1 + labelle_plugin_call (labelle-engine#744);
  *   v1.2 = v1.1 + plugin-call responses — out/out_cap activated per
  *          their reserved semantics + labelle_plugin_response_fetch
@@ -94,7 +94,12 @@ extern "C" {
  *          batched query (labelle_component_batch_get / _batch_set)
  *          (labelle-scripting#41; probe for the symbols — an older
  *          host simply doesn't export them and the binding keeps the
- *          JSON / per-entity paths). */
+ *          JSON / per-entity paths);
+ *   v1.4 = v1.3 + the id-tagged batch variant
+ *          (labelle_component_batch_get_ids / _batch_set_ids) — every
+ *          row prefixed with its u64 entity id, applied BY ID on
+ *          write, skipping vanished entities (labelle-engine#783;
+ *          probe for the symbols). */
 #define LABELLE_CONTRACT_VERSION 1u
 
 /* Contract version the host binary was built with. Pure — callable
@@ -429,9 +434,12 @@ size_t labelle_plugin_response_fetch(char *out, size_t out_cap);
  *    GET writes the single sentinel byte 0xFF (return 1) for any
  *    component the codec can't carry (non-scalar fields, f64 fields —
  *    the wire only has an f32 tag, and silent precision loss is not
- *    acceptable — built-ins with handles/strings, >=255 fields, a
- *    >255-byte field name) — the caller falls back to
- *    labelle_component_get, which carries all of those faithfully.
+ *    acceptable — >=255 fields, a >255-byte field name), and for EVERY
+ *    scene built-in, scalar-only or not: built-in writes route through
+ *    the scene loader's JSON apply machinery, so the packed SET
+ *    refuses them, and GET/SET must agree (labelle-engine#782) — the
+ *    caller falls back to labelle_component_get, which carries all of
+ *    those faithfully.
  *    SET refuses with -1 (fall back to labelle_component_set); a
  *    record with bytes past its declared fields is malformed (-1).
  *    Lossless for i64/u64 (unlike the batch stream below), including
@@ -474,7 +482,34 @@ size_t labelle_plugin_response_fetch(char *out, size_t out_cap);
  *    re-queried set FIRST and refuses -1 with NO writes unless buf_len
  *    matches exactly (a count change since the get; a same-count
  *    membership or order change is undetectable — hence the rule
- *    above). On -1 nothing was applied: re-get and recompute. */
+ *    above). On -1 nothing was applied: re-get and recompute. The
+ *    id-tagged variant below (since v1.4) removes the rule entirely.
+ *
+ *    ZERO-WIDTH components (every field non-scalar, e.g. string-only)
+ *    contribute 0 stream bytes in both directions — they are query
+ *    FILTERS, and _batch_set does not re-apply them (no onSet /
+ *    dirty-tracking churn; labelle-engine#782).
+ *
+ * 3. ID-TAGGED BATCH (since v1.4, labelle-engine#783) — the batched
+ *    query with the positional-coupling holes closed. Same stream,
+ *    same refusals, but every entity's floats are prefixed by its
+ *    entity id as a little-endian u64 (8 bytes):
+ *
+ *      _batch_get_ids out: [u32 count] then per entity
+ *                          [u64 entity_id][stride x f32]
+ *      _batch_set_ids buf: [u64 entity_id][stride x f32] rows,
+ *                          NO count header
+ *
+ *    _batch_set_ids applies each row BY ID: a row whose entity has
+ *    vanished — or no longer carries every named component (destroyed
+ *    or mutated since the get, including by an onSet hook firing
+ *    mid-apply) — is SKIPPED (floats consumed, nothing written, not an
+ *    error), and entities spawned since the get are simply untouched.
+ *    Rows apply independently; there is no partial-commit failure
+ *    mode. The positional preflight is replaced by a shape check:
+ *    buf_len must be a whole number of rows (count x (8 + stride)),
+ *    else -1 with no writes. Spawning/destroying between the paired
+ *    calls is SAFE on this variant. */
 
 /* labelle_component_batch_get's int-field refusal sentinel: the rc
  * convention's -2 carried in its size_t return. Distinct from 0 =
@@ -521,6 +556,26 @@ size_t labelle_component_batch_get(const char *names_json,
 int32_t labelle_component_batch_set(const char *names_json,
                                     size_t names_json_len,
                                     const char *buf, size_t buf_len);
+
+/* Id-tagged batched GET (since v1.4): like labelle_component_batch_get
+ * but writes [u32 count] then [u64 entity_id][f32 stream] per entity.
+ * Same return conventions: required size, LABELLE_BATCH_INT_REFUSED,
+ * 0 = malformed/not bound, count-0 header for zero matches, NULL/cap-0
+ * sizing probe. */
+size_t labelle_component_batch_get_ids(const char *names_json,
+                                       size_t names_json_len,
+                                       char *out, size_t out_cap);
+
+/* Id-tagged batched SET (since v1.4): `buf` is [u64 id][f32 stream]
+ * rows (NO count header) exactly as _batch_get_ids returned them,
+ * applied BY ID — vanished / no-longer-matching rows are skipped, rows
+ * are independent, spawn/destroy between the paired calls is safe.
+ * 0 = ok (skips included); -1 = malformed names / unknown component
+ * name / buf_len not a whole number of rows / not bound; -2 =
+ * int-carrying named component. */
+int32_t labelle_component_batch_set_ids(const char *names_json,
+                                        size_t names_json_len,
+                                        const char *buf, size_t buf_len);
 
 #ifdef __cplusplus
 }

--- a/src/script_contract.zig
+++ b/src/script_contract.zig
@@ -2128,16 +2128,38 @@ fn Holder(comptime GP: type) type {
         /// emitted, minus the count header), applied BY ID — no view
         /// walk, no positional trust. Per row: resolve the embedded id;
         /// a row whose entity is dead/unknown — or no longer carries
-        /// every named component (it left the query since the get, or
-        /// an earlier row's onSet hook mutated it) — is SKIPPED, its
-        /// floats consumed; live matching rows apply through the same
-        /// RMW channels as the positional set (`applyEntityFloats`).
-        /// Rows are independent: a mid-row hook effect downgrades that
-        /// row to a skip (pos re-anchors at the row boundary), never a
-        /// partial-commit failure — which is how this variant closes
-        /// the same-count-swap and hook-mutation holes the positional
-        /// preflight cannot see. The preflight's place is taken by a
-        /// SHAPE check: `buf.len` must be a whole number of rows.
+        /// every named component at row START (it left the query since
+        /// the get) — is SKIPPED whole, its floats consumed; live
+        /// matching rows apply through the same RMW channels as the
+        /// positional set (`applyEntityFloats`).
+        ///
+        /// RECYCLED-ID SAFETY (#788 review): the embedded id is the
+        /// FULL backend entity handle, not a bare index — on the
+        /// production zig-ecs adapter `Entity = u32` packs index +
+        /// generation (version), and `entityExists` is the adapter's
+        /// generational `valid()`. So a row carrying a STALE handle
+        /// whose slot was recycled to a new entity fails the
+        /// `entityExists` gate (the new occupant has a different
+        /// generation) and is skipped — it can never write to the new
+        /// occupant. Matching-by-full-handle IS the generational match;
+        /// the only residual is a backend that reuses the identical
+        /// index+generation (generation wrap, or a non-generational
+        /// handle), which the entityExists + per-name presence gate
+        /// still degrades to a same-entity write rather than a
+        /// cross-entity one.
+        ///
+        /// PARTIAL-COMMIT SAFETY (#788 review): a multi-component row's
+        /// components are RESOLVED (presence-checked) up front, and each
+        /// is re-checked immediately before its apply. If an earlier
+        /// component's onSet hook removes a LATER named component of the
+        /// SAME row mid-apply, that component is skipped (its floats
+        /// consumed to keep the stream aligned) WITHOUT dropping the
+        /// row's still-present components and WITHOUT a hard failure — so
+        /// the row never lands half-written: every component that exists
+        /// at its apply moment gets its stream value, the hook-removed
+        /// one stays removed. Rows are independent; `pos` re-anchors at
+        /// each row boundary. The positional preflight's place is taken
+        /// by a SHAPE check: `buf.len` must be a whole number of rows.
         fn componentBatchSetIdsImpl(names_json: []const u8, buf: []const u8) i32 {
             const parsed = std.json.parseFromSlice(
                 []const []const u8,
@@ -2171,7 +2193,13 @@ fn Holder(comptime GP: type) type {
                 // alike leave the NEXT row's floats aligned.
                 defer pos = row_end;
                 const ent = castEntity(id) orelse continue;
+                // Generational entityExists gate (see the recycled-id
+                // note above): a stale/recycled handle skips here.
                 if (!game.ecs_backend.entityExists(ent)) continue; // vanished → skip
+                // Resolve the WHOLE row up front: an entity that no
+                // longer carries every named component left the query
+                // since the get — skip the whole row atomically (no
+                // component of it is applied).
                 const still_matches = blk: {
                     for (names) |nm| {
                         if (!hasByName(ent, nm)) break :blk false;
@@ -2180,14 +2208,26 @@ fn Holder(comptime GP: type) type {
                 };
                 if (!still_matches) continue; // left the query → skip
                 for (names) |nm| {
+                    const nb = nameStreamBytes(nm);
                     // Zero-width components are filters — no data, no
                     // re-apply (#782, same skip as the positional set).
-                    if (nameStreamBytes(nm) == 0) continue;
-                    // A false here means an onSet hook fired by an
-                    // EARLIER name of this same row removed a later
-                    // component between the match check above and this
-                    // apply — skip the rest of the row (the defer
-                    // realigns), matching the vanished-row semantics.
+                    if (nb == 0) continue;
+                    // Re-check presence RIGHT before applying: an earlier
+                    // sibling's onSet hook may have removed this component
+                    // mid-row. Skip it — advancing past its floats so the
+                    // remaining siblings stay aligned — instead of
+                    // partial-applying or hard-failing. The row's
+                    // still-present components still land; the removed one
+                    // stays removed (the hook's intent wins). This is what
+                    // makes a multi-component row all-or-each, never
+                    // half-written.
+                    if (!hasByName(ent, nm)) {
+                        pos += nb;
+                        continue;
+                    }
+                    // A false now is only a truncated stream — impossible
+                    // given the row-size validation above; realign and
+                    // move on (the defer sets pos = row_end).
                     if (!applyEntityFloats(ent, nm, buf, &pos)) break;
                 }
             }

--- a/src/script_contract.zig
+++ b/src/script_contract.zig
@@ -237,7 +237,11 @@ const plugin_command = @import("game/editor_command_mixin.zig");
 /// (#758); v1.3 = v1.2 + bulk component access — the packed component
 /// codec (`labelle_component_get_packed`/`_set_packed`) and the batched
 /// query (`labelle_component_batch_get`/`_batch_set`)
-/// (labelle-scripting#41; probe for the symbols).
+/// (labelle-scripting#41; probe for the symbols); v1.4 = v1.3 + the
+/// id-tagged batch variant (`labelle_component_batch_get_ids`/
+/// `_batch_set_ids`) — each row prefixed with its u64 entity id,
+/// applied BY ID on write (#783; probe for the symbols, or comptime
+/// via the `batch_id_row_prefix` marker decl below).
 pub const CONTRACT_VERSION: u32 = 1;
 
 /// `labelle_plugin_call`'s unroutable sentinel: the rc convention's -1
@@ -256,6 +260,18 @@ pub const plugin_call_unroutable: usize = std.math.maxInt(usize);
 /// i32 return. Distinct from 0 = malformed/not-bound and from any
 /// required-size return, which could never need that much space.
 pub const batch_int_refused: usize = std.math.maxInt(usize) - 1;
+
+/// The id-tagged batch variant's per-row prefix: each entity's f32
+/// stream is preceded by its entity id as a little-endian u64 — 8
+/// bytes — in both `labelle_component_batch_get_ids`'s output (after
+/// the u32 count header) and `labelle_component_batch_set_ids`'s
+/// input. Also the "since v1.4" COMPTIME CAPABILITY MARKER: language
+/// plugins detect the id-tagged exports by `@hasDecl(engine
+/// .script_contract, "batch_id_row_prefix")` — the exact convention
+/// `batch_int_refused` established for v1.3 (see labelle-scripting's
+/// `contract.host_has_bulk_access` probe; `@hasDecl` on externs cannot
+/// see host exports).
+pub const batch_id_row_prefix: usize = 8;
 
 /// Inbox back-pressure cap: pending (drained-but-unpolled) events beyond
 /// this are dropped NEWEST-first, matching the POC's fixed-ring behavior.
@@ -358,6 +374,16 @@ const VTable = struct {
     // writes on mismatch (the positional-coupling guard).
     component_batch_get: *const fn (names_json: []const u8, out: []u8) usize,
     component_batch_set: *const fn (names_json: []const u8, buf: []const u8) i32,
+    // ID-TAGGED batch twins (since v1.4, #783): the same f32 stream, but
+    // every entity's floats are prefixed by its u64 id —
+    // `_batch_get_ids` writes `[u32 count][rows: u64 id + floats]` and
+    // `_batch_set_ids` applies each row BY ID (vanished or
+    // no-longer-matching entities are SKIPPED, their floats consumed),
+    // closing the positional variant's two residual holes: a same-count
+    // entity swap between get and set, and an onSet-hook mutation of
+    // the entity set mid-apply.
+    component_batch_get_ids: *const fn (names_json: []const u8, out: []u8) usize,
+    component_batch_set_ids: *const fn (names_json: []const u8, buf: []const u8) i32,
     component_has: *const fn (id: u64, name: []const u8) i32,
     component_remove: *const fn (id: u64, name: []const u8) i32,
     query: *const fn (names_json: []const u8, out: []u8) usize,
@@ -730,7 +756,9 @@ pub export fn labelle_component_batch_get(
 /// NOTHING, so "re-run batch_get and recompute" can never double-apply a
 /// prefix. Do NOT spawn or destroy entities between the paired get and
 /// set: the layout is positional, so the guard can catch a count change
-/// but never a same-count membership/order change.
+/// but never a same-count membership/order change — the id-tagged
+/// `labelle_component_batch_get_ids`/`_batch_set_ids` pair (since v1.4)
+/// closes both holes by matching rows to entities BY ID.
 ///
 /// Returns 0 = ok; -1 = malformed names / entity-count mismatch (buffer
 /// size disagrees with the re-queried set) / not bound; -2 = a named
@@ -746,6 +774,62 @@ pub export fn labelle_component_batch_set(
     if (names_json_len == 0) return -1;
     const b: []const u8 = if (buf_ptr) |p| p[0..buf_len] else &.{};
     return vt.component_batch_set(names_json_ptr[0..names_json_len], b);
+}
+
+/// ID-TAGGED batched read — `labelle_component_batch_get`'s safer twin
+/// (since v1.4, #783; probe by symbol, additive). Resolves the same
+/// entity set and writes `[u32 count]` then, per entity in query order,
+/// `[u64 entity_id][f32 stream]`: the identical per-entity floats the
+/// positional variant emits, each row prefixed by the entity's id as a
+/// little-endian u64 (`batch_id_row_prefix` bytes). Everything else
+/// mirrors `_batch_get` exactly: int-field refusal (`batch_int_refused`),
+/// required-size return, 0 = malformed/not bound, NULL/cap-0 sizing
+/// probe, count-0 header for zero matches.
+pub export fn labelle_component_batch_get_ids(
+    names_json_ptr: [*]const u8,
+    names_json_len: usize,
+    out: ?[*]u8,
+    out_cap: usize,
+) usize {
+    const vt = vtable orelse return 0;
+    if (names_json_len == 0) return 0;
+    const buf: []u8 = if (out) |p| p[0..out_cap] else &.{};
+    return vt.component_batch_get_ids(names_json_ptr[0..names_json_len], buf);
+}
+
+/// ID-TAGGED batched write — applies `[u64 id][f32 stream]` rows (the
+/// exact layout `_batch_get_ids` emitted, minus the u32 count header)
+/// BY ID instead of positionally: each row's entity is resolved from
+/// its embedded id, and a row whose entity has VANISHED — or no longer
+/// carries every named component — is SKIPPED (its floats consumed,
+/// nothing written) rather than failing the batch. Rows apply
+/// independently through the same RMW channels as `_batch_set`
+/// (scalar fields overwritten, non-scalar preserved, hooks and
+/// dirty-tracking fire identically). Since v1.4, #783, additive.
+///
+/// This CLOSES the positional variant's residual holes: a same-count
+/// destroy+spawn between get and set can no longer shift rows onto the
+/// wrong entities (ids match or the row is skipped — spawned entities
+/// absent from the buffer are simply untouched), and an onSet hook
+/// destroying a queried entity mid-apply downgrades that entity's row
+/// to a skip instead of a partial-commit failure. The positional
+/// preflight is replaced by a shape check: `buf_len` must be a whole
+/// number of rows (count × (8 + stride)).
+///
+/// Returns 0 = ok (skipped rows included — a skip is not an error);
+/// -1 = malformed names / unknown component name / buf_len not a whole
+/// number of rows / not bound; -2 = int-field refusal (identical to
+/// `_batch_set`).
+pub export fn labelle_component_batch_set_ids(
+    names_json_ptr: [*]const u8,
+    names_json_len: usize,
+    buf_ptr: ?[*]const u8,
+    buf_len: usize,
+) i32 {
+    const vt = vtable orelse return -1;
+    if (names_json_len == 0) return -1;
+    const b: []const u8 = if (buf_ptr) |p| p[0..buf_len] else &.{};
+    return vt.component_batch_set_ids(names_json_ptr[0..names_json_len], b);
 }
 
 /// 1 when entity `id` carries component `name`; 0 otherwise (absent,
@@ -1268,6 +1352,8 @@ fn Holder(comptime GP: type) type {
             .component_set_packed = &componentSetPackedImpl,
             .component_batch_get = &componentBatchGetImpl,
             .component_batch_set = &componentBatchSetImpl,
+            .component_batch_get_ids = &componentBatchGetIdsImpl,
+            .component_batch_set_ids = &componentBatchSetIdsImpl,
             .component_has = &componentHasImpl,
             .component_remove = &componentRemoveImpl,
             .query = &queryImpl,
@@ -1500,10 +1586,12 @@ fn Holder(comptime GP: type) type {
         /// (Position → scene built-ins → registry `inline for`), but each
         /// arm writes the binary record via `packInto` instead of JSON.
         /// `packInto` self-selects: a component whose every field is a
-        /// supported scalar produces a real record; anything else (scene
-        /// built-ins carry renderer handles / strings / arrays) yields the
-        /// single 0xFF sentinel byte, so the binding transparently falls
-        /// back to the JSON path for those.
+        /// supported scalar produces a real record; anything else yields
+        /// the single 0xFF sentinel byte, so the binding transparently
+        /// falls back to the JSON path for those. Scene BUILT-INS emit
+        /// the sentinel UNCONDITIONALLY — even a scalar-only one — so
+        /// GET agrees with the packed SET's built-in refusal (#782,
+        /// see the arm below).
         fn componentGetPackedImpl(id: u64, name: []const u8, out: []u8) usize {
             const ent = castEntity(id) orelse return 0;
             if (!game.ecs_backend.entityExists(ent)) return 0;
@@ -1513,11 +1601,20 @@ fn Holder(comptime GP: type) type {
             }
             inline for (builtin_comps) |spec| {
                 if (std.mem.eql(u8, name, spec.name)) {
-                    const comp = game.getComponent(ent, spec.T) orelse return 0;
-                    // Built-ins never pack (Camera.tag / Sprite handles are
-                    // non-scalar) — packInto emits the sentinel and the
-                    // binding uses JSON. No Camera special-case needed here.
-                    return packInto(comp.*, out);
+                    if (game.getComponent(ent, spec.T) == null) return 0;
+                    // Built-ins take the 0xFF/JSON path in BOTH directions
+                    // (#782, GET/SET symmetry): the packed SET must refuse
+                    // them — a built-in write routes through the scene
+                    // loader's JSON apply fns (renderer tracking, tag
+                    // interning), so a packed set would only re-serialize
+                    // to JSON, gaining nothing — and GET must AGREE, so
+                    // even a scalar-only built-in (real ones carry
+                    // handles/strings, but the shape is legal) emits the
+                    // sentinel here instead of a record the paired set
+                    // would then bounce back to JSON. Absent/dead keep
+                    // component_get's 0 sentinel above.
+                    if (out.len >= 1) out[0] = 0xFF;
+                    return 1;
                 }
             }
             const comp_names = comptime Components.names();
@@ -1822,6 +1919,16 @@ fn Holder(comptime GP: type) type {
         // positional f32 layout depends on that order agreeing.
 
         fn componentBatchGetImpl(names_json: []const u8, out: []u8) usize {
+            return batchGetDispatch(false, names_json, out);
+        }
+
+        /// The id-tagged twin (v1.4): the identical walk, each row
+        /// prefixed with the entity's u64 id.
+        fn componentBatchGetIdsImpl(names_json: []const u8, out: []u8) usize {
+            return batchGetDispatch(true, names_json, out);
+        }
+
+        fn batchGetDispatch(comptime with_ids: bool, names_json: []const u8, out: []u8) usize {
             const parsed = std.json.parseFromSlice(
                 []const []const u8,
                 game.allocator,
@@ -1832,17 +1939,17 @@ fn Holder(comptime GP: type) type {
             const names = parsed.value;
             if (names.len == 0) return 0;
             if (std.mem.eql(u8, names[0], "Position")) {
-                return runBatchGet(core.Position, names, out);
+                return runBatchGet(core.Position, with_ids, names, out);
             }
             inline for (builtin_comps) |spec| {
                 if (std.mem.eql(u8, names[0], spec.name)) {
-                    return runBatchGet(spec.T, names, out);
+                    return runBatchGet(spec.T, with_ids, names, out);
                 }
             }
             const comp_names = comptime Components.names();
             inline for (comp_names) |comp_name| {
                 if (std.mem.eql(u8, names[0], comp_name)) {
-                    return runBatchGet(Components.getType(comp_name), names, out);
+                    return runBatchGet(Components.getType(comp_name), with_ids, names, out);
                 }
             }
             // Unknown first name → an empty (count-0) result, not an error —
@@ -1850,7 +1957,7 @@ fn Holder(comptime GP: type) type {
             return writeBatchCount0(out);
         }
 
-        fn runBatchGet(comptime ViewT: type, names: []const []const u8, out: []u8) usize {
+        fn runBatchGet(comptime ViewT: type, comptime with_ids: bool, names: []const []const u8, out: []u8) usize {
             // Int-typed fields cannot ride the f32 stream without silent
             // corruption — refuse the whole batch before any other outcome
             // (see `batch_int_refused`).
@@ -1875,6 +1982,15 @@ fn Holder(comptime GP: type) type {
                 };
                 if (!matches) continue;
                 count += 1;
+                // The id-tagged variant leads each row with the entity's
+                // u64 id (little-endian, `batch_id_row_prefix` bytes) —
+                // what `_batch_set_ids` matches rows by.
+                if (comptime with_ids) {
+                    if (pos + 8 <= out.len) {
+                        std.mem.writeInt(u64, out[pos..][0..8], entityId(ent), .little);
+                    }
+                    pos += 8;
+                }
                 // Each named component's scalar fields as f32, in name order
                 // then struct-declaration field order. `pos` advances even
                 // past the cap so the return is the full required size —
@@ -1990,12 +2106,91 @@ fn Holder(comptime GP: type) type {
                 };
                 if (!matches) continue;
                 for (names) |nm| {
+                    // ZERO-WIDTH components contribute no stream bytes —
+                    // they are query FILTERS (all their fields are
+                    // non-scalar, e.g. string-only), so there is nothing
+                    // to write back: skip the apply entirely rather than
+                    // RMW-re-apply the unchanged value, which would fire
+                    // onSet hooks and dirty-tracking for no data (#782).
+                    // The preflight above already sized them at 0.
+                    if (nameStreamBytes(nm) == 0) continue;
                     if (!applyEntityFloats(ent, nm, buf, &pos)) return -1;
                 }
             }
             // Belt on top of the preflight: the apply consumed exactly the
             // stream the preflight sized.
             if (pos != buf.len) return -1;
+            return 0;
+        }
+
+        /// The id-tagged batch write (v1.4, #783): `buf` is rows of
+        /// `[u64 id][stride × f32]` (the exact layout `_batch_get_ids`
+        /// emitted, minus the count header), applied BY ID — no view
+        /// walk, no positional trust. Per row: resolve the embedded id;
+        /// a row whose entity is dead/unknown — or no longer carries
+        /// every named component (it left the query since the get, or
+        /// an earlier row's onSet hook mutated it) — is SKIPPED, its
+        /// floats consumed; live matching rows apply through the same
+        /// RMW channels as the positional set (`applyEntityFloats`).
+        /// Rows are independent: a mid-row hook effect downgrades that
+        /// row to a skip (pos re-anchors at the row boundary), never a
+        /// partial-commit failure — which is how this variant closes
+        /// the same-count-swap and hook-mutation holes the positional
+        /// preflight cannot see. The preflight's place is taken by a
+        /// SHAPE check: `buf.len` must be a whole number of rows.
+        fn componentBatchSetIdsImpl(names_json: []const u8, buf: []const u8) i32 {
+            const parsed = std.json.parseFromSlice(
+                []const []const u8,
+                game.allocator,
+                names_json,
+                .{},
+            ) catch return -1;
+            defer parsed.deinit();
+            const names = parsed.value;
+            if (names.len == 0) return -1;
+            // Same refusal ladder as the positional set: int-carrying
+            // components -2, unresolvable names -1 (ANY name here — with
+            // no view dispatch the first name has no special role).
+            for (names) |nm| {
+                if (!nameBatchEligible(nm)) return -2;
+            }
+            for (names) |nm| {
+                if (!nameResolvable(nm)) return -1;
+            }
+            var stride: usize = 0;
+            for (names) |nm| stride += nameStreamBytes(nm);
+            const row_size = batch_id_row_prefix + stride;
+            if (buf.len % row_size != 0) return -1;
+            var pos: usize = 0;
+            while (pos < buf.len) {
+                const id = std.mem.readInt(u64, buf[pos..][0..8], .little);
+                pos += batch_id_row_prefix;
+                const row_end = pos + stride;
+                // Re-anchoring at the row boundary is what keeps rows
+                // independent: skipped rows and mid-row hook effects
+                // alike leave the NEXT row's floats aligned.
+                defer pos = row_end;
+                const ent = castEntity(id) orelse continue;
+                if (!game.ecs_backend.entityExists(ent)) continue; // vanished → skip
+                const still_matches = blk: {
+                    for (names) |nm| {
+                        if (!hasByName(ent, nm)) break :blk false;
+                    }
+                    break :blk true;
+                };
+                if (!still_matches) continue; // left the query → skip
+                for (names) |nm| {
+                    // Zero-width components are filters — no data, no
+                    // re-apply (#782, same skip as the positional set).
+                    if (nameStreamBytes(nm) == 0) continue;
+                    // A false here means an onSet hook fired by an
+                    // EARLIER name of this same row removed a later
+                    // component between the match check above and this
+                    // apply — skip the rest of the row (the defer
+                    // realigns), matching the vanished-row semantics.
+                    if (!applyEntityFloats(ent, nm, buf, &pos)) break;
+                }
+            }
             return 0;
         }
 

--- a/src/script_contract.zig
+++ b/src/script_contract.zig
@@ -811,15 +811,21 @@ pub export fn labelle_component_batch_get_ids(
 /// destroy+spawn between get and set can no longer shift rows onto the
 /// wrong entities (ids match or the row is skipped — spawned entities
 /// absent from the buffer are simply untouched), and an onSet hook
-/// destroying a queried entity mid-apply downgrades that entity's row
-/// to a skip instead of a partial-commit failure. The positional
-/// preflight is replaced by a shape check: `buf_len` must be a whole
-/// number of rows (count × (8 + stride)).
+/// mutating the queried set mid-apply downgrades to a skip instead of a
+/// partial-commit failure. Within a multi-component row, each component
+/// is gated on the ENTITY's liveness and the COMPONENT's presence right
+/// before its apply, so a hook that removes a later component — or
+/// destroys the whole entity — mid-row skips the affected component(s)
+/// cleanly while the row's other still-present components still land;
+/// the row never persists half-written. The positional preflight is
+/// replaced by a shape check: `buf_len` must be a whole number of rows
+/// (count × (8 + stride)).
 ///
-/// Returns 0 = ok (skipped rows included — a skip is not an error);
-/// -1 = malformed names / unknown component name / buf_len not a whole
-/// number of rows / not bound; -2 = int-field refusal (identical to
-/// `_batch_set`).
+/// Returns 0 = ok (skipped rows/components included — a skip is not an
+/// error); -1 = malformed names / unknown component name / buf_len not a
+/// whole number of rows / not bound / a GENUINE apply failure on a live,
+/// present component (a built-in scene-apply rejection — surfaced, not
+/// masked); -2 = int-field refusal (identical to `_batch_set`).
 pub export fn labelle_component_batch_set_ids(
     names_json_ptr: [*]const u8,
     names_json_len: usize,
@@ -2149,17 +2155,24 @@ fn Holder(comptime GP: type) type {
         /// cross-entity one.
         ///
         /// PARTIAL-COMMIT SAFETY (#788 review): a multi-component row's
-        /// components are RESOLVED (presence-checked) up front, and each
-        /// is re-checked immediately before its apply. If an earlier
-        /// component's onSet hook removes a LATER named component of the
-        /// SAME row mid-apply, that component is skipped (its floats
-        /// consumed to keep the stream aligned) WITHOUT dropping the
-        /// row's still-present components and WITHOUT a hard failure — so
-        /// the row never lands half-written: every component that exists
-        /// at its apply moment gets its stream value, the hook-removed
-        /// one stays removed. Rows are independent; `pos` re-anchors at
-        /// each row boundary. The positional preflight's place is taken
-        /// by a SHAPE check: `buf.len` must be a whole number of rows.
+        /// components are RESOLVED (presence-checked) up front, and before
+        /// EACH component's apply both the ENTITY's liveness
+        /// (`entityExists`) and the COMPONENT's presence (`hasByName`) are
+        /// re-checked. So if an earlier component's onSet hook, mid-row:
+        ///   - REMOVES a later named component (entity still alive) — that
+        ///     component is skipped (its floats consumed to keep the
+        ///     stream aligned); the row's other still-present components
+        ///     still land, the removed one stays removed (the hook wins);
+        ///   - DESTROYS the whole entity — the rest of the row is skipped
+        ///     (no apply touches the dead entity); nothing it held
+        ///     persists, so there is no half-written entity.
+        /// Both are expected SKIPS, not errors. A false from
+        /// `applyEntityFloats` AFTER those two checks pass is a genuine
+        /// apply failure (a built-in scene-apply rejection) and is
+        /// surfaced as -1, never masked as success. Rows are independent;
+        /// `pos` re-anchors at each row boundary. The positional
+        /// preflight's place is taken by a SHAPE check: `buf.len` must be
+        /// a whole number of rows.
         fn componentBatchSetIdsImpl(names_json: []const u8, buf: []const u8) i32 {
             const parsed = std.json.parseFromSlice(
                 []const []const u8,
@@ -2212,23 +2225,32 @@ fn Holder(comptime GP: type) type {
                     // Zero-width components are filters — no data, no
                     // re-apply (#782, same skip as the positional set).
                     if (nb == 0) continue;
-                    // Re-check presence RIGHT before applying: an earlier
-                    // sibling's onSet hook may have removed this component
-                    // mid-row. Skip it — advancing past its floats so the
-                    // remaining siblings stay aligned — instead of
-                    // partial-applying or hard-failing. The row's
-                    // still-present components still land; the removed one
-                    // stays removed (the hook's intent wins). This is what
-                    // makes a multi-component row all-or-each, never
-                    // half-written.
+                    // LIVENESS recheck (#788 review): an earlier
+                    // component's onSet hook may have DESTROYED the whole
+                    // entity mid-row (not just removed a sibling). Applying
+                    // a later component to a dead entity is unsafe on a
+                    // backend whose lookups don't gate on liveness — stop
+                    // the row here (the defer realigns pos to the next
+                    // row). The entity is gone, so nothing it held is
+                    // half-written; this is an expected skip, NOT an error.
+                    if (!game.ecs_backend.entityExists(ent)) break;
+                    // PRESENCE recheck: an earlier sibling's onSet hook may
+                    // have removed just THIS component (entity still alive).
+                    // Skip it — advancing past its floats so the remaining
+                    // siblings stay aligned — while the row's still-present
+                    // components still land (the removed one stays removed;
+                    // the hook's intent wins). This is what makes a
+                    // multi-component row all-or-each, never half-written.
                     if (!hasByName(ent, nm)) {
                         pos += nb;
                         continue;
                     }
-                    // A false now is only a truncated stream — impossible
-                    // given the row-size validation above; realign and
-                    // move on (the defer sets pos = row_end).
-                    if (!applyEntityFloats(ent, nm, buf, &pos)) break;
+                    // Entity live AND component present, so a false here is
+                    // a REAL apply failure (a built-in scene-apply rejection,
+                    // or — impossible given the row-size validation — a
+                    // truncated stream), NOT a vanished-skip. Surface it as
+                    // -1 rather than masking a genuine failure as success.
+                    if (!applyEntityFloats(ent, nm, buf, &pos)) return -1;
                 }
             }
             return 0;

--- a/test/script_contract_bench.zig
+++ b/test/script_contract_bench.zig
@@ -1,0 +1,276 @@
+//! Host+binding micro-benchmark for the id-column batch variant (#783).
+//!
+//! Measures the per-tick cost the entity-id column ADDS to the batch
+//! round-trip. Key property this exploits: the id column changes ONLY
+//! the host + binding portion of a swarm tick — the script's per-entity
+//! integrate+bounce loop (the mruby interpreter's dominant ~305 ns/entity
+//! on the ruby-swarm-batch rig) is byte-identical between the positional
+//! and id-tagged paths. So the end-to-end tick delta EQUALS the host+
+//! binding delta measured here, and can be divided into the rig's
+//! 0.649 ms/tick @ 2000 entities baseline directly.
+//!
+//! It drives the REAL `script_contract` exports (positional
+//! `labelle_component_batch_get/_set` vs id-tagged `…_get_ids/_set_ids`)
+//! over 2000 live entities, each carrying Position+Velocity — the same
+//! stride the rig uses (`["Position","Velocity"]` → [px,py,vx,vy]). The
+//! id path also pays the binding's re-interleave cost (copy the 8-byte
+//! id column out on get, back in on set) so the number is the FULL id
+//! column tax, not just the host half.
+//!
+//! Backend note: this uses the engine's MockEcs (hashmap-backed), whose
+//! per-entity getComponent/entityExists is SLOWER than the rig's zig_ecs
+//! sparse-set — so the id-column overhead measured here is a CONSERVATIVE
+//! (over-)estimate of the rig's. Build ReleaseFast (`zig build bench`).
+
+const std = @import("std");
+const engine = @import("engine");
+const core = @import("labelle-core");
+
+const contract = engine.script_contract;
+
+const Velocity = struct { dx: f32 = 0, dy: f32 = 0 };
+
+const MockEcs = core.MockEcsBackend(u32);
+const BenchGame = engine.GameConfig(
+    core.StubRender(MockEcs.Entity),
+    MockEcs,
+    engine.StubInput,
+    engine.StubAudio,
+    engine.StubVideo,
+    engine.StubGui,
+    void,
+    core.StubLogSink,
+    engine.ComponentRegistry(.{ .Velocity = Velocity }),
+    &.{},
+    void,
+);
+
+fn nowNs() u64 {
+    var ts: std.posix.timespec = undefined;
+    if (std.posix.system.clock_gettime(.MONOTONIC, &ts) != 0) return 0;
+    const sec: u64 = @intCast(ts.sec);
+    const nsec: u64 = @intCast(ts.nsec);
+    return sec * std.time.ns_per_s + nsec;
+}
+
+const N = 2000;
+const W: f32 = 800;
+const H: f32 = 600;
+const STRIDE = 4; // px,py,vx,vy
+const names = "[\"Position\",\"Velocity\"]";
+
+/// The swarm's per-entity work over the flat float buffer — IDENTICAL for
+/// both paths (this is the mruby loop's Zig twin; unchanged by the id
+/// column, included in both so the subtraction is honest).
+fn integrateBounce(buf: []f32, count: usize) void {
+    var i: usize = 0;
+    while (i < count) : (i += 1) {
+        const b = i * STRIDE;
+        var x = buf[b];
+        var y = buf[b + 1];
+        var vx = buf[b + 2];
+        var vy = buf[b + 3];
+        x += vx;
+        y += vy;
+        if (x < 0) {
+            x = 0;
+            vx = -vx;
+        }
+        if (x > W) {
+            x = W;
+            vx = -vx;
+        }
+        if (y < 0) {
+            y = 0;
+            vy = -vy;
+        }
+        if (y > H) {
+            y = H;
+            vy = -vy;
+        }
+        buf[b] = x;
+        buf[b + 1] = y;
+        buf[b + 2] = vx;
+        buf[b + 3] = vy;
+    }
+}
+
+/// One positional tick: batch_get → integrate → batch_set (no header on
+/// set). `stream` is the f32 view of the post-header bytes.
+fn tickPositional(byte_buf: []u8) void {
+    const req = contract.labelle_component_batch_get(names, names.len, byte_buf.ptr, byte_buf.len);
+    const count = std.mem.readInt(u32, byte_buf[0..4], .little);
+    const floats: [*]f32 = @ptrCast(@alignCast(byte_buf.ptr + 4));
+    integrateBounce(floats[0 .. count * STRIDE], count);
+    _ = contract.labelle_component_batch_set(names, names.len, byte_buf.ptr + 4, req - 4);
+}
+
+/// One id-tagged tick, INCLUDING the binding's id-column re-interleave:
+///   get → copy ids out + floats down → integrate → floats + ids back → set.
+/// `byte_buf` holds the raw wire ([u32 count][rows]); `ids` holds the
+/// extracted id column; `floats` the packed flat float array the script
+/// sees (exactly what the rig's Ruby Array holds).
+fn tickIds(byte_buf: []u8, ids: []u64, floats: []f32) void {
+    const req = contract.labelle_component_batch_get_ids(names, names.len, byte_buf.ptr, byte_buf.len);
+    const count = std.mem.readInt(u32, byte_buf[0..4], .little);
+    const row_bytes = 8 + STRIDE * 4;
+    // Binding de-interleave: pull the id column aside, pack floats flat.
+    var off: usize = 4;
+    var fi: usize = 0;
+    var r: usize = 0;
+    while (r < count) : (r += 1) {
+        ids[r] = std.mem.readInt(u64, byte_buf[off..][0..8], .little);
+        off += 8;
+        var k: usize = 0;
+        while (k < STRIDE) : (k += 1) {
+            floats[fi] = @bitCast(std.mem.readInt(u32, byte_buf[off..][0..4], .little));
+            fi += 1;
+            off += 4;
+        }
+    }
+    integrateBounce(floats[0 .. count * STRIDE], count);
+    // Binding re-interleave: [u64 id][floats] rows back into the wire.
+    off = 0;
+    fi = 0;
+    r = 0;
+    while (r < count) : (r += 1) {
+        std.mem.writeInt(u64, byte_buf[off..][0..8], ids[r], .little);
+        off += 8;
+        var k: usize = 0;
+        while (k < STRIDE) : (k += 1) {
+            std.mem.writeInt(u32, byte_buf[off..][0..4], @bitCast(floats[fi]), .little);
+            fi += 1;
+            off += 4;
+        }
+    }
+    _ = contract.labelle_component_batch_set_ids(names, names.len, byte_buf.ptr, count * row_bytes);
+    _ = req;
+}
+
+const RunFn = *const fn () void;
+
+/// Min per-tick over `reps` reps of `iters` ticks each. Min-of-reps
+/// cancels scheduler/thermal noise. Callers INTERLEAVE the two paths
+/// rep-by-rep so both see the same thermal conditions.
+fn minPerTick(iters: usize, reps: usize, run: RunFn) f64 {
+    var best: u64 = std.math.maxInt(u64);
+    for (0..reps) |_| {
+        const t0 = nowNs();
+        for (0..iters) |_| run();
+        const dt = nowNs() - t0;
+        if (dt < best) best = dt;
+    }
+    return @as(f64, @floatFromInt(best)) / @as(f64, @floatFromInt(iters));
+}
+
+var g_bytebuf: []u8 = undefined;
+var g_ids: []u64 = undefined;
+var g_floats: []f32 = undefined;
+
+fn runPositional() void {
+    tickPositional(g_bytebuf);
+}
+fn runIds() void {
+    tickIds(g_bytebuf, g_ids, g_floats);
+}
+/// Get-only variants — isolate the UNAMBIGUOUS marginal cost of the id
+/// column (the +8 bytes/entity on the wire and the binding's id memcpy),
+/// with no set-side view-walk asymmetry to confound it.
+fn runGetPositional() void {
+    _ = contract.labelle_component_batch_get(names, names.len, g_bytebuf.ptr, g_bytebuf.len);
+}
+fn runGetIds() void {
+    const req = contract.labelle_component_batch_get_ids(names, names.len, g_bytebuf.ptr, g_bytebuf.len);
+    const count = std.mem.readInt(u32, g_bytebuf[0..4], .little);
+    var off: usize = 4;
+    var fi: usize = 0;
+    var r: usize = 0;
+    while (r < count) : (r += 1) {
+        g_ids[r] = std.mem.readInt(u64, g_bytebuf[off..][0..8], .little);
+        off += 8;
+        var k: usize = 0;
+        while (k < STRIDE) : (k += 1) {
+            g_floats[fi] = @bitCast(std.mem.readInt(u32, g_bytebuf[off..][0..4], .little));
+            fi += 1;
+            off += 4;
+        }
+    }
+    _ = req;
+}
+
+pub fn main() !void {
+    const alloc = std.heap.page_allocator;
+
+    contract.unbind();
+    var game = BenchGame.init(alloc);
+    defer game.deinit();
+    contract.bind(&game);
+    defer contract.unbind();
+
+    // Spawn N entities with Position + Velocity (LCG-seeded, like the rig).
+    var seed: u64 = 123456789;
+    for (0..N) |n| {
+        const ent = game.createEntity();
+        seed = (seed *% 1664525 +% 1013904223) & 0xffffffff;
+        const x = @as(f32, @floatFromInt(seed >> 8)) / @as(f32, @floatFromInt(@as(u32, 1) << 24)) * W;
+        seed = (seed *% 1664525 +% 1013904223) & 0xffffffff;
+        const y = @as(f32, @floatFromInt(seed >> 8)) / @as(f32, @floatFromInt(@as(u32, 1) << 24)) * H;
+        game.setPosition(ent, .{ .x = x, .y = y });
+        game.setComponent(ent, Velocity{
+            .dx = @floatFromInt(@as(i32, @intCast(n % 7)) - 3),
+            .dy = @floatFromInt(@as(i32, @intCast(n % 5)) - 2),
+        });
+    }
+
+    // Buffers: the id wire needs 8 extra bytes/entity over the positional.
+    g_bytebuf = try alloc.alloc(u8, 4 + N * (8 + STRIDE * 4));
+    defer alloc.free(g_bytebuf);
+    g_ids = try alloc.alloc(u64, N);
+    defer alloc.free(g_ids);
+    g_floats = try alloc.alloc(f32, N * STRIDE);
+    defer alloc.free(g_floats);
+
+    // Verify both paths actually move all N entities (correctness gate).
+    {
+        const c0 = contract.labelle_component_batch_get(names, names.len, g_bytebuf.ptr, g_bytebuf.len);
+        std.debug.print("sanity: positional count={d} bytes={d}\n", .{ std.mem.readInt(u32, g_bytebuf[0..4], .little), c0 });
+        const c1 = contract.labelle_component_batch_get_ids(names, names.len, g_bytebuf.ptr, g_bytebuf.len);
+        std.debug.print("sanity: id-tagged  count={d} bytes={d}\n", .{ std.mem.readInt(u32, g_bytebuf[0..4], .little), c1 });
+    }
+
+    std.debug.print("\n=== id-column host+binding micro-benchmark (ReleaseFast, N={d}) ===\n", .{N});
+    const iters: usize = 1500;
+    const reps: usize = 25;
+    // Warm both paths thoroughly.
+    for (0..500) |_| {
+        runPositional();
+        runIds();
+    }
+    // GET-ONLY: the clean marginal cost (no set-side view-walk confound).
+    const gp = minPerTick(iters, reps, runGetPositional);
+    const gi = minPerTick(iters, reps, runGetIds);
+    // FULL round-trip (get + integrate + set).
+    const pos_tick = minPerTick(iters, reps, runPositional);
+    const id_tick = minPerTick(iters, reps, runIds);
+
+    const rig_baseline_ns: f64 = 649_000; // 0.649 ms/tick @ 2000 (positional, on the rig)
+    std.debug.print("\n--- GET-ONLY (isolates the id column's marginal cost) ---\n", .{});
+    std.debug.print("positional get : {d:.1} ns/tick\n", .{gp});
+    std.debug.print("id-tagged  get : {d:.1} ns/tick (+ binding id de-interleave)\n", .{gi});
+    std.debug.print("get delta      : {d:.1} ns/tick  ({d:.4} ms/tick)\n", .{ gi - gp, (gi - gp) / 1e6 });
+    std.debug.print("get delta vs rig 0.649 ms/tick : {d:.2}%\n", .{(gi - gp) / rig_baseline_ns * 100});
+
+    const delta = id_tick - pos_tick;
+    std.debug.print("\n--- FULL round-trip (get + set; MockEcs over-penalizes positional's preflight walk) ---\n", .{});
+    std.debug.print("positional : {d:.1} ns/tick\n", .{pos_tick});
+    std.debug.print("id-tagged  : {d:.1} ns/tick\n", .{id_tick});
+    std.debug.print("delta      : {d:.1} ns/tick  ({d:.4} ms/tick)\n", .{ delta, delta / 1e6 });
+    std.debug.print("delta vs rig 0.649 ms/tick baseline : {d:.2}%\n", .{delta / rig_baseline_ns * 100});
+    std.debug.print("\n--- verdict ---\n", .{});
+    // The GET-only delta is the id column's true marginal cost (the set
+    // side only gets CHEAPER by dropping the preflight re-query). Use it
+    // as the conservative overhead figure.
+    const overhead_pct = (gi - gp) / rig_baseline_ns * 100;
+    std.debug.print("id-column overhead (get-side marginal) : {d:.2}% of a rig tick\n", .{overhead_pct});
+    std.debug.print("=> {s} (threshold 10%)\n", .{if (overhead_pct < 10) "ADOPT as default" else "SHIP OPT-IN"});
+}

--- a/test/script_contract_bench.zig
+++ b/test/script_contract_bench.zig
@@ -45,12 +45,15 @@ const BenchGame = engine.GameConfig(
     void,
 );
 
+/// Portable monotonic clock. Zig 0.16 has NO `std.time.Timer`; the
+/// cross-platform primitive is `std.Io.Timestamp.now(io, .awake)` (the
+/// `io` is set up once in `main`). `.awake` is the monotonic,
+/// non-suspend-inclusive clock.
+var g_io: std.Io = undefined;
+
 fn nowNs() u64 {
-    var ts: std.posix.timespec = undefined;
-    if (std.posix.system.clock_gettime(.MONOTONIC, &ts) != 0) return 0;
-    const sec: u64 = @intCast(ts.sec);
-    const nsec: u64 = @intCast(ts.nsec);
-    return sec * std.time.ns_per_s + nsec;
+    const ts = std.Io.Timestamp.now(g_io, .awake);
+    return @intCast(ts.nanoseconds);
 }
 
 const N = 2000;
@@ -201,6 +204,11 @@ fn runGetIds() void {
 pub fn main() !void {
     const alloc = std.heap.page_allocator;
 
+    // Portable monotonic clock source (see nowNs). All-default options.
+    var threaded: std.Io.Threaded = .init(alloc, .{});
+    defer threaded.deinit();
+    g_io = threaded.io();
+
     contract.unbind();
     var game = BenchGame.init(alloc);
     defer game.deinit();
@@ -223,7 +231,9 @@ pub fn main() !void {
     }
 
     // Buffers: the id wire needs 8 extra bytes/entity over the positional.
-    g_bytebuf = try alloc.alloc(u8, 4 + N * (8 + STRIDE * 4));
+    // 4-byte aligned so the `@alignCast` to `[*]f32` at byte offset 4 is
+    // valid (gemini #788 review).
+    g_bytebuf = try alloc.alignedAlloc(u8, .@"4", 4 + N * (8 + STRIDE * 4));
     defer alloc.free(g_bytebuf);
     g_ids = try alloc.alloc(u64, N);
     defer alloc.free(g_ids);

--- a/test/script_contract_test.zig
+++ b/test/script_contract_test.zig
@@ -74,6 +74,35 @@ const Bare = struct { x: f32, y: f32 };
 /// the precision).
 const Precise = struct { d: f64 = 0 };
 
+/// ZERO-WIDTH batch component (#782): string-only, so it contributes 0
+/// stream bytes — a pure query FILTER. The onSet counter pins that
+/// batch_set does NOT RMW-re-apply it (no hook/dirty churn for no
+/// data); the plain per-entity set path still fires it (the sanity leg).
+var marker_on_set_calls: u32 = 0;
+const Marker = struct {
+    note: []const u8 = "",
+
+    pub fn onSet(payload: engine.ComponentPayload) void {
+        _ = payload;
+        marker_on_set_calls += 1;
+    }
+};
+
+/// Hook-driven mid-apply mutation (#783 hole 2): applying a Reaper row
+/// DESTROYS the pair's other entity from inside onSet — through the
+/// contract's own export, exactly as a script-visible hook effect
+/// would. The id-tagged batch set must downgrade the destroyed
+/// entity's later row to a skip, never a partial-commit failure.
+var reaper_pair: [2]u64 = .{ 0, 0 };
+const Reaper = struct {
+    hp: f32 = 0,
+
+    pub fn onSet(payload: engine.ComponentPayload) void {
+        const other = if (payload.entity_id == reaper_pair[0]) reaper_pair[1] else reaper_pair[0];
+        contract.labelle_entity_destroy(other);
+    }
+};
+
 /// 300 f32 fields — over the packed wire's u8 field_count limit (0xFF
 /// reserved as the sentinel), so it must comptime-classify as NOT
 /// packable (get → 0xFF, set → -1) instead of panicking the `@intCast`
@@ -114,6 +143,8 @@ const TestComponents = engine.ComponentRegistry(.{
     .Precise = Precise,
     .Wide300 = Wide300,
     .LongName = LongName,
+    .Marker = Marker,
+    .Reaper = Reaper,
 });
 
 const TestEvents = union(enum) {
@@ -3054,6 +3085,9 @@ test "bulk access pre-bind: safe no-ops in each op's failure convention" {
     try testing.expectEqual(@as(i32, -1), setPacked(1, "Stats", buf[0..1]));
     try testing.expectEqual(@as(usize, 0), batchGet("[\"Position\"]", &buf));
     try testing.expectEqual(@as(i32, -1), batchSet("[\"Position\"]", buf[0..0]));
+    // The v1.4 id-tagged twins follow the same conventions.
+    try testing.expectEqual(@as(usize, 0), batchGetIds("[\"Position\"]", &buf));
+    try testing.expectEqual(@as(i32, -1), batchSetIds("[\"Position\"]", buf[0..0]));
 }
 
 test "packed set: out-of-range / non-finite script values refuse -1, never panic" {
@@ -3331,4 +3365,348 @@ test "packed: the 64-bit bitcast pair round-trips a bit-63 u64 losslessly" {
     rec2.u64Field("score", @bitCast(@as(i64, -42)));
     try testing.expectEqual(@as(i32, 0), setPacked(id, "Stats", rec2.bytes()));
     try testing.expectEqual(@as(i64, -42), game.getComponent(ent, Stats).?.score);
+}
+
+// ── v1.3 polish (#782) + the id-tagged batch variant (v1.4, #783) ───
+
+/// StubRender clone whose Shape is SCALAR-ONLY — the #782 GET/SET
+/// symmetry case: `packInto` alone would emit a real record for it,
+/// but the packed SET refuses ALL built-ins (they apply through the
+/// scene loader's JSON machinery), so the packed GET must emit the
+/// 0xFF sentinel for built-ins unconditionally or the two directions
+/// disagree.
+fn ScalarShapeRender(comptime Entity: type) type {
+    return struct {
+        const Self = @This();
+
+        pub const Sprite = struct {
+            sprite_name: []const u8 = "",
+            visible: bool = true,
+        };
+
+        pub const Shape = struct { width: f32 = 10, height: f32 = 10, visible: bool = true };
+
+        pub fn init(_: std.mem.Allocator) Self {
+            return .{};
+        }
+        pub fn deinit(_: *Self) void {}
+        pub fn trackEntity(_: *Self, _: Entity, _: core.VisualType) void {}
+        pub fn untrackEntity(_: *Self, _: Entity) void {}
+        pub fn markPositionDirty(_: *Self, _: Entity) void {}
+        pub fn markPositionDirtyWithChildren(_: *Self, comptime _: type, _: anytype, _: Entity) void {}
+        pub fn updateHierarchyFlag(_: *Self, _: Entity, _: bool) void {}
+        pub fn markVisualDirty(_: *Self, _: Entity) void {}
+        pub fn sync(_: *Self, comptime _: type, _: anytype) void {}
+        pub fn render(_: *Self) void {}
+        pub fn setScreenHeight(_: *Self, _: f32) void {}
+        pub fn clear(_: *Self) void {}
+        pub fn renderGizmoDraws(_: *Self, _: []const core.GizmoDraw) void {}
+        pub fn hasEntity(_: *const Self, _: Entity) bool {
+            return false;
+        }
+    };
+}
+
+const ScalarBuiltinGame = engine.GameConfig(
+    ScalarShapeRender(MockEcs.Entity),
+    MockEcs,
+    engine.StubInput,
+    engine.StubAudio,
+    engine.StubVideo,
+    engine.StubGui,
+    void,
+    core.StubLogSink,
+    TestComponents,
+    &.{},
+    TestEvents,
+);
+
+test "packed built-ins: a scalar-only built-in still gets the 0xFF sentinel — GET/SET agree (#782)" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ScalarBuiltinGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+    const ent: u32 = @intCast(id);
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Shape", "{\"width\":3,\"height\":4}"));
+
+    // GET: the sentinel, never a record — the built-in POLICY, not a
+    // shape accident (this Shape would pack fine as a registry type).
+    var buf: [64]u8 = @splat(0);
+    try testing.expectEqual(@as(usize, 1), getPacked(id, "Shape", &buf));
+    try testing.expectEqual(@as(u8, 0xFF), buf[0]);
+
+    // …and the direction it must agree with: the packed SET refuses,
+    // so a binding lands on JSON for BOTH directions.
+    var rec = PackedRecord.init(1);
+    rec.f32Field("width", 9);
+    try testing.expectEqual(@as(i32, -1), setPacked(id, "Shape", rec.bytes()));
+    const shape = game.getComponent(ent, ScalarBuiltinGame.ShapeComp).?;
+    try testing.expectEqual(@as(f32, 3), shape.width);
+    try testing.expectEqual(@as(f32, 4), shape.height);
+
+    // Absent component keeps the 0 sentinel (never 0xFF for a
+    // component the entity doesn't carry).
+    const bare = contract.labelle_entity_create();
+    try testing.expectEqual(@as(usize, 0), getPacked(bare, "Shape", &buf));
+}
+
+test "batch set: zero-width (filter) components are skipped — no onSet churn (#782)" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+    const ent: u32 = @intCast(id);
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Position", "{\"x\":1,\"y\":2}"));
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Marker", "{\"note\":\"keep\"}"));
+
+    // Sanity: the counter wires up — a per-entity UPDATE set fires onSet.
+    marker_on_set_calls = 0;
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Marker", "{\"note\":\"keep\"}"));
+    try testing.expectEqual(@as(u32, 1), marker_on_set_calls);
+
+    // Marker contributes 0 stream bytes: the stream is Position alone.
+    const names = "[\"Position\",\"Marker\"]";
+    var buf: [64]u8 = @splat(0);
+    const required = batchGet(names, &buf);
+    try testing.expectEqual(@as(usize, 4 + 2 * 4), required);
+
+    batchFloatSet(&buf, 4, 10);
+    batchFloatSet(&buf, 8, 20);
+    marker_on_set_calls = 0;
+    try testing.expectEqual(@as(i32, 0), batchSet(names, buf[4..required]));
+    // The filter was NOT re-applied…
+    try testing.expectEqual(@as(u32, 0), marker_on_set_calls);
+    // …while the data-bearing component landed, and the filter's value
+    // survives untouched.
+    const pos = game.getComponent(ent, core.Position).?;
+    try testing.expectEqual(@as(f32, 10), pos.x);
+    try testing.expectEqual(@as(f32, 20), pos.y);
+    try testing.expectEqualStrings("keep", game.getComponent(ent, Marker).?.note);
+
+    // The id-tagged variant applies the identical skip.
+    const required_ids = batchGetIds(names, &buf);
+    try testing.expectEqual(@as(usize, 4 + (8 + 2 * 4)), required_ids);
+    marker_on_set_calls = 0;
+    try testing.expectEqual(@as(i32, 0), batchSetIds(names, buf[4..required_ids]));
+    try testing.expectEqual(@as(u32, 0), marker_on_set_calls);
+}
+
+fn batchGetIds(names_json: []const u8, buf: []u8) usize {
+    return contract.labelle_component_batch_get_ids(names_json.ptr, names_json.len, buf.ptr, buf.len);
+}
+
+fn batchSetIds(names_json: []const u8, buf: []const u8) i32 {
+    return contract.labelle_component_batch_set_ids(names_json.ptr, names_json.len, buf.ptr, buf.len);
+}
+
+/// Read a row's u64 entity id at byte offset `off` (unaligned-safe).
+fn rowId(buf: []const u8, off: usize) u64 {
+    return std.mem.readInt(u64, buf[off..][0..8], .little);
+}
+
+test "batch ids: id-tagged round-trip — rows carry ids, set matches BY ID, not position" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    // The wire's row prefix is pinned (and doubles as the v1.4
+    // comptime capability marker).
+    try testing.expectEqual(@as(usize, 8), contract.batch_id_row_prefix);
+
+    const names = "[\"Position\",\"Velocity\"]";
+    var buf: [256]u8 = @splat(0);
+
+    // Zero matches: the count-0 header alone, and an empty row buffer
+    // applies cleanly.
+    try testing.expectEqual(@as(usize, 4), batchGetIds(names, &buf));
+    try testing.expectEqual(@as(u32, 0), std.mem.readInt(u32, buf[0..4], .little));
+    try testing.expectEqual(@as(i32, 0), batchSetIds(names, buf[4..4]));
+
+    const ids = [3]u64{
+        contract.labelle_entity_create(),
+        contract.labelle_entity_create(),
+        contract.labelle_entity_create(),
+    };
+    for (ids) |id| {
+        try testing.expectEqual(@as(i32, 0), setComp(id, "Position", "{\"x\":1,\"y\":1}"));
+        try testing.expectEqual(@as(i32, 0), setComp(id, "Velocity", "{\"dx\":1,\"dy\":1}"));
+    }
+
+    // Sizing: [u32 count][3 rows × (u64 id + 4 fields × 4B)].
+    const row = 8 + 4 * 4;
+    const required = contract.labelle_component_batch_get_ids(names, names.len, null, 0);
+    try testing.expectEqual(@as(usize, 4 + 3 * row), required);
+    // Under-sized cap: required-size return, snprintf-style.
+    try testing.expectEqual(required, batchGetIds(names, buf[0 .. required - 3]));
+    try testing.expectEqual(required, batchGetIds(names, &buf));
+    try testing.expectEqual(@as(u32, 3), std.mem.readInt(u32, buf[0..4], .little));
+
+    // Every row's id is one of ours; write each row's floats as a
+    // FUNCTION OF ITS OWN ID — the only way these land right is
+    // match-by-id.
+    var off: usize = 4;
+    while (off < required) : (off += row) {
+        const id = rowId(&buf, off);
+        var known = false;
+        for (ids) |want| {
+            if (want == id) known = true;
+        }
+        try testing.expect(known);
+        const base: f32 = @floatFromInt(id * 100);
+        for (0..4) |i| batchFloatSet(&buf, off + 8 + i * 4, base + @as(f32, @floatFromInt(i)));
+    }
+    try testing.expectEqual(@as(i32, 0), batchSetIds(names, buf[4..required]));
+    for (ids) |id| {
+        const ent: u32 = @intCast(id);
+        const base: f32 = @floatFromInt(id * 100);
+        const pos = game.getComponent(ent, core.Position).?;
+        try testing.expectEqual(base + 0, pos.x);
+        try testing.expectEqual(base + 1, pos.y);
+        const vel = game.getComponent(ent, Velocity).?;
+        try testing.expectEqual(base + 2, vel.dx);
+        try testing.expectEqual(base + 3, vel.dy);
+    }
+}
+
+test "batch set ids: same-count destroy+spawn — vanished row skipped, spawned entity untouched (#783)" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const names = "[\"Position\"]";
+    const a = contract.labelle_entity_create();
+    const b = contract.labelle_entity_create();
+    for ([_]u64{ a, b }) |id| {
+        try testing.expectEqual(@as(i32, 0), setComp(id, "Position", "{\"x\":1,\"y\":1}"));
+    }
+
+    var buf: [128]u8 = @splat(0);
+    const row = 8 + 2 * 4;
+    const required = batchGetIds(names, &buf);
+    try testing.expectEqual(@as(usize, 4 + 2 * row), required);
+
+    // The positional guard's blind spot: destroy + spawn keeps the
+    // COUNT identical while changing membership.
+    contract.labelle_entity_destroy(b);
+    const c = contract.labelle_entity_create();
+    try testing.expectEqual(@as(i32, 0), setComp(c, "Position", "{\"x\":50,\"y\":60}"));
+
+    var off: usize = 4;
+    while (off < required) : (off += row) {
+        const id = rowId(&buf, off);
+        const base: f32 = @floatFromInt(id * 10);
+        batchFloatSet(&buf, off + 8, base + 1);
+        batchFloatSet(&buf, off + 12, base + 2);
+    }
+    // BY ID: a's row lands on a, b's row is skipped (vanished), and the
+    // newcomer c — absent from the buffer — is untouched. No refusal,
+    // no cross-entity smear.
+    try testing.expectEqual(@as(i32, 0), batchSetIds(names, buf[4..required]));
+    const ap = game.getComponent(@as(u32, @intCast(a)), core.Position).?;
+    try testing.expectEqual(@as(f32, @floatFromInt(a * 10)) + 1, ap.x);
+    try testing.expectEqual(@as(f32, @floatFromInt(a * 10)) + 2, ap.y);
+    const cp = game.getComponent(@as(u32, @intCast(c)), core.Position).?;
+    try testing.expectEqual(@as(f32, 50), cp.x);
+    try testing.expectEqual(@as(f32, 60), cp.y);
+
+    // A live entity that merely LEFT the query since the get is the
+    // same skip: remove a's Position and re-apply the old rows.
+    try testing.expectEqual(@as(i32, 0), removeComp(a, "Position"));
+    try testing.expectEqual(@as(i32, 0), batchSetIds(names, buf[4..required]));
+    try testing.expect(game.getComponent(@as(u32, @intCast(a)), core.Position) == null);
+}
+
+test "batch set ids: an onSet hook destroying a queried entity mid-apply skips its row, never fails (#783)" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const a = contract.labelle_entity_create();
+    const b = contract.labelle_entity_create();
+    try testing.expectEqual(@as(i32, 0), setComp(a, "Reaper", "{\"hp\":1}"));
+    try testing.expectEqual(@as(i32, 0), setComp(b, "Reaper", "{\"hp\":2}"));
+    reaper_pair = .{ a, b };
+
+    const names = "[\"Reaper\"]";
+    var buf: [64]u8 = @splat(0);
+    const row = 8 + 4;
+    const required = batchGetIds(names, &buf);
+    try testing.expectEqual(@as(usize, 4 + 2 * row), required);
+    var off: usize = 4;
+    while (off < required) : (off += row) {
+        const id = rowId(&buf, off);
+        batchFloatSet(&buf, off + 8, @as(f32, @floatFromInt(id)) + 0.5);
+    }
+
+    // Applying the FIRST row fires Reaper.onSet, which destroys the
+    // pair's other entity — the id-tagged set downgrades that entity's
+    // row to a skip (the positional preflight could never see this
+    // future) and completes cleanly.
+    try testing.expectEqual(@as(i32, 0), batchSetIds(names, buf[4..required]));
+    const a_alive = game.ecs_backend.entityExists(@as(u32, @intCast(a)));
+    const b_alive = game.ecs_backend.entityExists(@as(u32, @intCast(b)));
+    try testing.expect(a_alive != b_alive); // exactly one survivor
+    const surv: u64 = if (a_alive) a else b;
+    const hp = game.getComponent(@as(u32, @intCast(surv)), Reaper).?.hp;
+    try testing.expectEqual(@as(f32, @floatFromInt(surv)) + 0.5, hp);
+}
+
+test "batch ids: refusals and shapes — misaligned rows, int fields, unknown names, unknown ids" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Position", "{\"x\":1,\"y\":2}"));
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Health", "{\"hp\":50,\"regen\":1}"));
+
+    var buf: [128]u8 = @splat(0);
+
+    // Int-carrying components: the identical refusal as the positional
+    // pair — sentinel from get, -2 from set.
+    try testing.expectEqual(contract.batch_int_refused, batchGetIds("[\"Health\"]", &buf));
+    try testing.expectEqual(@as(i32, -2), batchSetIds("[\"Health\"]", buf[0..12]));
+
+    // A buffer that is not a whole number of rows refuses -1 with no
+    // writes (row size for ["Position"] is 8 + 8 = 16).
+    try testing.expectEqual(@as(i32, -1), batchSetIds("[\"Position\"]", buf[0..15]));
+    const p = game.getComponent(@as(u32, @intCast(id)), core.Position).?;
+    try testing.expectEqual(@as(f32, 1), p.x);
+
+    // Unknown names: get → the count-0 header (a valid empty result);
+    // set → -1 (nothing to resolve the rows against).
+    try testing.expectEqual(@as(usize, 4), batchGetIds("[\"NoSuch\"]", &buf));
+    try testing.expectEqual(@as(i32, -1), batchSetIds("[\"NoSuch\"]", buf[0..8]));
+
+    // Malformed names JSON: get 0, set -1 (the export conventions).
+    try testing.expectEqual(@as(usize, 0), batchGetIds("not json", &buf));
+    try testing.expectEqual(@as(i32, -1), batchSetIds("not json", buf[0..16]));
+
+    // A row naming an id that never existed is a SKIP, not an error.
+    var row: [16]u8 = @splat(0);
+    std.mem.writeInt(u64, row[0..8], 999_999, .little);
+    batchFloatSet(&row, 8, 42);
+    batchFloatSet(&row, 12, 43);
+    try testing.expectEqual(@as(i32, 0), batchSetIds("[\"Position\"]", &row));
+    try testing.expectEqual(@as(f32, 1), p.x);
 }

--- a/test/script_contract_test.zig
+++ b/test/script_contract_test.zig
@@ -125,6 +125,23 @@ const Payload = struct { p: f32 = 0 };
 /// proves the fix doesn't drop the row's remaining live components.
 const Keep = struct { k: f32 = 0 };
 
+/// Intra-row entity DESTRUCTION guard (#788 review, round 2): `SelfDestruct`'s
+/// onSet destroys its OWN entity mid-row (not just a sibling component).
+/// A later component's apply on the now-dead entity must be skipped via a
+/// LIVENESS recheck (`entityExists`), never a use-after-destroy. Gated to
+/// `self_destruct_target` so a bystander entity in the same batch still
+/// applies its whole row (proving rows stay independent).
+var self_destruct_target: u64 = 0;
+const SelfDestruct = struct {
+    v: f32 = 0,
+
+    pub fn onSet(payload: engine.ComponentPayload) void {
+        if (payload.entity_id == self_destruct_target) {
+            contract.labelle_entity_destroy(payload.entity_id);
+        }
+    }
+};
+
 /// 300 f32 fields — over the packed wire's u8 field_count limit (0xFF
 /// reserved as the sentinel), so it must comptime-classify as NOT
 /// packable (get → 0xFF, set → -1) instead of panicking the `@intCast`
@@ -170,6 +187,7 @@ const TestComponents = engine.ComponentRegistry(.{
     .Trigger = Trigger,
     .Payload = Payload,
     .Keep = Keep,
+    .SelfDestruct = SelfDestruct,
 });
 
 const TestEvents = union(enum) {
@@ -3775,6 +3793,55 @@ test "batch set ids: intra-row partial commit — a sibling-removing onSet hook 
     // The bystander sibling AFTER the removed one still applied — the fix
     // doesn't drop a row's remaining live components on a mid-row removal.
     try testing.expectEqual(@as(f32, 30), game.getComponent(ent, Keep).?.k);
+}
+
+test "batch set ids: an onSet hook destroying its own entity mid-row skips the rest cleanly, no use-after-destroy (#788)" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    // Two entities carrying [SelfDestruct, Keep]. `a`'s SelfDestruct
+    // onSet DESTROYS `a` mid-row; `b`'s does not (gated on the target).
+    const a = contract.labelle_entity_create();
+    const b = contract.labelle_entity_create();
+    for ([_]u64{ a, b }) |id| {
+        try testing.expectEqual(@as(i32, 0), setComp(id, "SelfDestruct", "{\"v\":1}"));
+        try testing.expectEqual(@as(i32, 0), setComp(id, "Keep", "{\"k\":1}"));
+    }
+
+    const names = "[\"SelfDestruct\",\"Keep\"]";
+    var buf: [128]u8 = @splat(0);
+    const required = batchGetIds(names, &buf);
+    const row = 8 + 2 * 4;
+    try testing.expectEqual(@as(usize, 4 + 2 * row), required);
+
+    // Set each row's floats as a function of its id so we can tell which
+    // entity a landed write belongs to.
+    var off: usize = 4;
+    while (off < required) : (off += row) {
+        const id = rowId(&buf, off);
+        const base: f32 = @floatFromInt(id * 10);
+        batchFloatSet(&buf, off + 8, base + 1); // SelfDestruct.v
+        batchFloatSet(&buf, off + 12, base + 2); // Keep.k
+    }
+
+    self_destruct_target = a;
+    defer self_destruct_target = 0;
+    // Applying a's SelfDestruct fires onSet → destroys a. The later Keep
+    // on a must be skipped via the liveness recheck (no use-after-destroy),
+    // while b's row applies in full — rows stay independent, call is ok.
+    try testing.expectEqual(@as(i32, 0), batchSetIds(names, buf[4..required]));
+
+    // a is gone; its would-be Keep write never touched a dead slot.
+    try testing.expect(!game.ecs_backend.entityExists(@as(u32, @intCast(a))));
+    try testing.expect(game.getComponent(@as(u32, @intCast(a)), Keep) == null);
+    // b (never targeted) applied its whole row.
+    const bbase: f32 = @floatFromInt(b * 10);
+    try testing.expectEqual(bbase + 1, game.getComponent(@as(u32, @intCast(b)), SelfDestruct).?.v);
+    try testing.expectEqual(bbase + 2, game.getComponent(@as(u32, @intCast(b)), Keep).?.k);
 }
 
 // ── Recycling ECS backend — a MockEcs twin whose freed slots are reused

--- a/test/script_contract_test.zig
+++ b/test/script_contract_test.zig
@@ -103,6 +103,28 @@ const Reaper = struct {
     }
 };
 
+/// Intra-row partial-commit guard (#788 review): `Trigger.onSet` removes
+/// a SIBLING component (`Payload`) on the SAME entity mid-apply. When a
+/// batch id-row names [Trigger, Payload, Keep], applying Trigger must not
+/// leave the row half-written — Payload's now-absent slot is skipped, but
+/// the still-present Keep still lands. `trigger_arm` gates the hook so it
+/// only fires during the dedicated test (Trigger updates in other tests
+/// stay inert).
+var trigger_arm: bool = false;
+const Trigger = struct {
+    v: f32 = 0,
+
+    pub fn onSet(payload: engine.ComponentPayload) void {
+        if (!trigger_arm) return;
+        _ = contract.labelle_component_remove(payload.entity_id, "Payload", 7);
+    }
+};
+/// Data-bearing sibling the `Trigger` hook removes mid-row.
+const Payload = struct { p: f32 = 0 };
+/// Bystander sibling that must STILL apply after `Payload` is skipped —
+/// proves the fix doesn't drop the row's remaining live components.
+const Keep = struct { k: f32 = 0 };
+
 /// 300 f32 fields — over the packed wire's u8 field_count limit (0xFF
 /// reserved as the sentinel), so it must comptime-classify as NOT
 /// packable (get → 0xFF, set → -1) instead of panicking the `@intCast`
@@ -145,6 +167,9 @@ const TestComponents = engine.ComponentRegistry(.{
     .LongName = LongName,
     .Marker = Marker,
     .Reaper = Reaper,
+    .Trigger = Trigger,
+    .Payload = Payload,
+    .Keep = Keep,
 });
 
 const TestEvents = union(enum) {
@@ -3709,4 +3734,289 @@ test "batch ids: refusals and shapes — misaligned rows, int fields, unknown na
     batchFloatSet(&row, 12, 43);
     try testing.expectEqual(@as(i32, 0), batchSetIds("[\"Position\"]", &row));
     try testing.expectEqual(@as(f32, 1), p.x);
+}
+
+test "batch set ids: intra-row partial commit — a sibling-removing onSet hook doesn't half-write the row (#788)" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = ContractGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const id = contract.labelle_entity_create();
+    const ent: u32 = @intCast(id);
+    // Row layout: Trigger.v, Payload.p, Keep.k — three data-bearing
+    // scalars. Trigger's onSet (armed below) removes Payload mid-row.
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Trigger", "{\"v\":1}"));
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Payload", "{\"p\":2}"));
+    try testing.expectEqual(@as(i32, 0), setComp(id, "Keep", "{\"k\":3}"));
+
+    const names = "[\"Trigger\",\"Payload\",\"Keep\"]";
+    var buf: [64]u8 = @splat(0);
+    const required = batchGetIds(names, &buf);
+    try testing.expectEqual(@as(usize, 4 + (8 + 3 * 4)), required);
+
+    // New values for all three: floats at row offset 8 (after the id).
+    batchFloatSet(&buf, 4 + 8 + 0, 10); // Trigger.v
+    batchFloatSet(&buf, 4 + 8 + 4, 20); // Payload.p (its entity slot vanishes mid-apply)
+    batchFloatSet(&buf, 4 + 8 + 8, 30); // Keep.k
+
+    trigger_arm = true;
+    defer trigger_arm = false;
+    // Applying Trigger fires onSet → removes Payload. The set must not
+    // half-write: Payload's slot is skipped (removed by the hook), while
+    // Trigger AND the later Keep both land. No -1, no partial component.
+    try testing.expectEqual(@as(i32, 0), batchSetIds(names, buf[4..required]));
+
+    try testing.expectEqual(@as(f32, 10), game.getComponent(ent, Trigger).?.v);
+    // Payload was removed by the hook and NOT re-added by the set.
+    try testing.expect(game.getComponent(ent, Payload) == null);
+    // The bystander sibling AFTER the removed one still applied — the fix
+    // doesn't drop a row's remaining live components on a mid-row removal.
+    try testing.expectEqual(@as(f32, 30), game.getComponent(ent, Keep).?.k);
+}
+
+// ── Recycling ECS backend — a MockEcs twin whose freed slots are reused
+// with a bumped generation (the packed index+gen handle models the
+// production zig-ecs adapter: `Entity = u32`, `entityExists == valid()`).
+// It exists only to reproduce #788's recycled-id case, which the
+// monotonic MockEcs cannot. Everything but id allocation mirrors MockEcs.
+
+fn RecyclingEcs(comptime EntityType: type) type {
+    return struct {
+        pub const Entity = EntityType;
+        const CleanupFn = *const fn (*Self) void;
+        const Self = @This();
+
+        // Handle = (gen << 24) | index; index starts at 1 (0 is the
+        // engine's null sentinel). Freed indices recycle with gen+1, so a
+        // recycled slot ALWAYS yields a different full handle.
+        next_index: u32 = 1,
+        free: std.ArrayListUnmanaged(u32) = .empty,
+        gen_of: std.AutoHashMap(u32, u8),
+        alive: std.AutoHashMap(EntityType, void),
+        storages: std.AutoHashMap(usize, *anyopaque),
+        cleanups: std.ArrayListUnmanaged(CleanupFn) = .empty,
+        allocator: std.mem.Allocator,
+
+        pub fn init(allocator: std.mem.Allocator) Self {
+            return .{
+                .gen_of = std.AutoHashMap(u32, u8).init(allocator),
+                .alive = std.AutoHashMap(EntityType, void).init(allocator),
+                .storages = std.AutoHashMap(usize, *anyopaque).init(allocator),
+                .allocator = allocator,
+            };
+        }
+
+        pub fn deinit(self: *Self) void {
+            for (self.cleanups.items) |cleanup| cleanup(self);
+            self.cleanups.deinit(self.allocator);
+            self.storages.deinit();
+            self.alive.deinit();
+            self.gen_of.deinit();
+            self.free.deinit(self.allocator);
+        }
+
+        fn pack(gen: u8, index: u32) EntityType {
+            return @intCast((@as(u32, gen) << 24) | index);
+        }
+        fn indexOf(handle: EntityType) u32 {
+            return @as(u32, @intCast(handle)) & 0x00FF_FFFF;
+        }
+
+        pub fn createEntity(self: *Self) EntityType {
+            const index = self.free.pop() orelse blk: {
+                const i = self.next_index;
+                self.next_index += 1;
+                break :blk i;
+            };
+            const gen = self.gen_of.get(index) orelse 0;
+            const handle = pack(gen, index);
+            self.alive.put(handle, {}) catch @panic("OOM");
+            return handle;
+        }
+
+        pub fn destroyEntity(self: *Self, entity: EntityType) void {
+            if (!self.alive.contains(entity)) return;
+            _ = self.alive.remove(entity);
+            const index = indexOf(entity);
+            const gen = self.gen_of.get(index) orelse 0;
+            self.gen_of.put(index, gen +% 1) catch @panic("OOM");
+            self.free.append(self.allocator, index) catch @panic("OOM");
+        }
+
+        pub fn entityExists(self: *Self, entity: EntityType) bool {
+            return self.alive.contains(entity);
+        }
+
+        pub fn entityCount(self: *Self) usize {
+            return self.alive.count();
+        }
+
+        pub fn addComponent(self: *Self, entity: EntityType, component: anytype) void {
+            self.getOrCreateStorage(@TypeOf(component)).put(entity, component) catch @panic("OOM");
+        }
+
+        pub fn getComponent(self: *Self, entity: EntityType, comptime T: type) ?*T {
+            if (!self.alive.contains(entity)) return null;
+            const storage = self.getStorage(T) orelse return null;
+            return storage.getPtr(entity);
+        }
+
+        pub fn hasComponent(self: *Self, entity: EntityType, comptime T: type) bool {
+            if (!self.alive.contains(entity)) return false;
+            const storage = self.getStorage(T) orelse return false;
+            return storage.contains(entity);
+        }
+
+        pub fn removeComponent(self: *Self, entity: EntityType, comptime T: type) void {
+            const storage = self.getStorage(T) orelse return;
+            _ = storage.remove(entity);
+        }
+
+        pub fn View(comptime _includes: anytype, comptime _excludes: anytype) type {
+            return struct {
+                entities: []const EntityType,
+                index: usize = 0,
+                allocator: std.mem.Allocator,
+                const ViewSelf = @This();
+                const includes = _includes;
+                const excludes = _excludes;
+                pub fn next(self: *ViewSelf) ?EntityType {
+                    if (self.index < self.entities.len) {
+                        const e = self.entities[self.index];
+                        self.index += 1;
+                        return e;
+                    }
+                    return null;
+                }
+                pub fn deinit(self: *ViewSelf) void {
+                    self.allocator.free(self.entities);
+                }
+            };
+        }
+
+        pub fn view(self: *Self, comptime includes: anytype, comptime excludes: anytype) View(includes, excludes) {
+            var result: std.ArrayListUnmanaged(EntityType) = .empty;
+            var it = self.alive.keyIterator();
+            while (it.next()) |key_ptr| {
+                if (self.matchesAll(key_ptr.*, includes, excludes)) {
+                    result.append(self.allocator, key_ptr.*) catch @panic("OOM");
+                }
+            }
+            return .{
+                .entities = result.toOwnedSlice(self.allocator) catch @panic("OOM"),
+                .allocator = self.allocator,
+            };
+        }
+
+        fn matchesAll(self: *Self, entity: EntityType, comptime includes: anytype, comptime excludes: anytype) bool {
+            inline for (includes) |T| {
+                if (!self.hasComponent(entity, T)) return false;
+            }
+            inline for (excludes) |T| {
+                if (self.hasComponent(entity, T)) return false;
+            }
+            return true;
+        }
+
+        pub fn QueryIterator(comptime components: anytype) type {
+            return core.GenericQueryIterator(*Self, EntityType, components);
+        }
+
+        pub fn query(self: *Self, comptime components: anytype) QueryIterator(components) {
+            var entities: std.ArrayListUnmanaged(EntityType) = .empty;
+            var it = self.alive.keyIterator();
+            while (it.next()) |key| entities.append(self.allocator, key.*) catch @panic("OOM");
+            return .{ .backend = self, .entities = entities, .index = 0, .allocator = self.allocator };
+        }
+
+        fn getOrCreateStorage(self: *Self, comptime T: type) *std.AutoHashMap(EntityType, T) {
+            const tid = typeId(T);
+            if (self.storages.get(tid)) |raw| return @ptrCast(@alignCast(raw));
+            const storage = self.allocator.create(std.AutoHashMap(EntityType, T)) catch @panic("OOM");
+            storage.* = std.AutoHashMap(EntityType, T).init(self.allocator);
+            self.storages.put(tid, @ptrCast(storage)) catch @panic("OOM");
+            self.cleanups.append(self.allocator, &struct {
+                fn cleanup(s: *Self) void {
+                    if (s.storages.get(typeId(T))) |raw| {
+                        const typed: *std.AutoHashMap(EntityType, T) = @ptrCast(@alignCast(raw));
+                        typed.deinit();
+                        s.allocator.destroy(typed);
+                    }
+                }
+            }.cleanup) catch @panic("OOM");
+            return storage;
+        }
+
+        fn getStorage(self: *Self, comptime T: type) ?*std.AutoHashMap(EntityType, T) {
+            const raw = self.storages.get(typeId(T)) orelse return null;
+            return @ptrCast(@alignCast(raw));
+        }
+
+        fn typeId(comptime T: type) usize {
+            return @intFromPtr(&struct {
+                comptime {
+                    _ = T;
+                }
+                var x: u8 = 0;
+            }.x);
+        }
+    };
+}
+
+const RecyclingBackend = RecyclingEcs(u32);
+const RecyclingGame = engine.GameConfig(
+    core.StubRender(RecyclingBackend.Entity),
+    RecyclingBackend,
+    engine.StubInput,
+    engine.StubAudio,
+    engine.StubVideo,
+    engine.StubGui,
+    void,
+    core.StubLogSink,
+    TestComponents,
+    &.{},
+    TestEvents,
+);
+
+test "batch set ids: a recycled entity handle — the stale row does NOT write the new occupant (#788)" {
+    contract.unbind();
+    defer contract.unbind();
+
+    var game = RecyclingGame.init(testing.allocator);
+    defer game.deinit();
+    contract.bind(&game);
+
+    const names = "[\"Position\"]";
+    const a = contract.labelle_entity_create();
+    try testing.expectEqual(@as(i32, 0), setComp(a, "Position", "{\"x\":1,\"y\":2}"));
+
+    var buf: [64]u8 = @splat(0);
+    const required = batchGetIds(names, &buf);
+    try testing.expectEqual(@as(usize, 4 + (8 + 2 * 4)), required);
+    try testing.expectEqual(a, rowId(&buf, 4)); // the row carries a's full handle
+
+    // Destroy a and spawn b — the backend RECYCLES a's index with a
+    // bumped generation, so b shares a's index but is a DIFFERENT full
+    // handle (the recycled-id hazard #788 flags).
+    contract.labelle_entity_destroy(a);
+    const b = contract.labelle_entity_create();
+    try testing.expect(b != a); // different full handle…
+    try testing.expectEqual(a & 0x00FF_FFFF, b & 0x00FF_FFFF); // …SAME index (genuinely recycled)
+    try testing.expectEqual(@as(i32, 0), setComp(b, "Position", "{\"x\":50,\"y\":60}"));
+
+    // Apply the STALE row (id == a). a is dead; b occupies a's slot.
+    batchFloatSet(&buf, 4 + 8 + 0, 99);
+    batchFloatSet(&buf, 4 + 8 + 4, 99);
+    try testing.expectEqual(@as(i32, 0), batchSetIds(names, buf[4..required]));
+
+    // The generational entityExists gate rejected the stale handle: b —
+    // the new occupant of a's index — is UNTOUCHED, no cross-entity write.
+    const bp = game.getComponent(@as(u32, @intCast(b)), core.Position).?;
+    try testing.expectEqual(@as(f32, 50), bp.x);
+    try testing.expectEqual(@as(f32, 60), bp.y);
+    // a itself is gone.
+    try testing.expect(game.getComponent(@as(u32, @intCast(a)), core.Position) == null);
 }


### PR DESCRIPTION
Closes #782, Closes #783
Refs labelle-toolkit/labelle-scripting#41

Post-v1.3 batch polish plus the id-column variant, both in `src/script_contract.zig`. With these landed, epic labelle-scripting#41's **engine-side ledger is complete** — every follow-up the v1.3 review cycle deferred is resolved.

## #782 — v1.3 polish

**(a) Zero-width batch components skipped on SET.** A component contributing no scalar fields (string-only, used as a query filter like `["Position","Label"]`) still went through the batch_set RMW re-apply, firing `onSet`/dirty-tracking for zero data. `runBatchSet` now `continue`s past any name whose `nameStreamBytes == 0` — they are filters, there is nothing to write back. The `_batch_set_ids` path does the same.

**(b) Packed GET/SET symmetry for built-ins — chosen direction: GET emits the 0xFF sentinel for built-ins.** The asymmetry was packed GET emitting a real record for a scalar-only built-in while packed SET refuses all built-ins (they must route through the scene-loader JSON apply fns for renderer tracking / tag interning). I made **GET agree with SET** rather than teaching SET the packed route: a built-in packed set would only re-serialize to JSON internally, so it would gain nothing while duplicating the scene-apply logic — making GET emit the sentinel keeps both directions on the single JSON path with zero new code surface and no risk of a second, divergent built-in apply. `componentGetPackedImpl`'s built-in arm now writes `0xFF`/returns 1 unconditionally (absent/dead still return the 0 sentinel).

Tests: a dedicated scalar-only-`Shape` StubRender (`ScalarBuiltinGame`) proves the sentinel is the built-in *policy*, not a shape accident; a `Marker` (string-only) component with an `onSet` counter proves the filter is not re-applied on either batch-set path.

## #783 — entity-id column (contract v1.4, additive)

**Wire design.** Two new additive exports mirroring the positional pair:
- `labelle_component_batch_get_ids` → `[u32 count]` then per entity `[u64 entity_id][f32 stream]` (the id is `batch_id_row_prefix` = 8 bytes, little-endian, ahead of the identical float payload).
- `labelle_component_batch_set_ids` ← `[u64 id][f32 stream]` rows (no count header), applied **by id**: a row whose entity has vanished or no longer carries every named component is **skipped** (floats consumed, nothing written), entities spawned since the get are untouched, rows are independent. The positional preflight is replaced by a shape check (`buf_len` a whole number of rows).

This closes both residual positional holes: the **same-count destroy+spawn** swap (rows match by id or skip — no cross-entity smear) and the **onSet-hook mid-apply mutation** (a hook destroying a queried entity downgrades its row to a skip instead of a partial-commit failure).

**Capability gating — the wire change is NOT invisible.** The id column changes count+stride, so it cannot silently become the return shape of the shipped v1.3 `labelle_component_batch_get`. It is gated exactly like the other additive capabilities: new "since v1.4" exports + a comptime marker decl `batch_id_row_prefix` (the `batch_int_refused` convention — `@hasDecl(engine.script_contract, "batch_id_row_prefix")`). The v1.3 exports are byte-for-byte unchanged, so **every existing binding keeps working unmodified**. `contract/labelle_script.h` documents the v1.4 surface.

**Scripting-side follow-up (precise).** "Adopt as default" belongs on the *scripting* side, not here: the per-language `batch_get`/`batch_set` prelude wrappers should switch to the `_ids` variants by default — gated on `batch_id_row_prefix`, falling back to the positional exports on a pre-v1.4 host — holding the id column *binding-side* so the flat-float script API (`@buf[b+2]`) is unchanged. Prototyped and measured in a throwaday `labelle-scripting` worktree (Ruby `raw_batch_get`/`raw_batch_set` de-/re-interleaving the id column); that binding change is the labelle-scripting#41 stage-3 item, not part of this engine PR (no binding-visible engine change here → no labelle-scripting RFC edit needed).

## Measurement (adopt-if-<10%)

The rig (`ruby-swarm-batch`, bgfx) can't run headless in the agent shell — bgfx needs a WindowServer connection on macOS even surfaceless, and sokol v0.2.1 predates the current gfx/engine 2.x pins. But the id column changes **only** the host+binding portion of a tick; the mruby integrate+bounce loop (the rig's dominant ~305 ns/entity) is byte-identical between the two paths, so **Δ(end-to-end) = Δ(host+binding)**, which is measured directly by `zig build bench` (ReleaseFast, N=2000, real `script_contract` exports over live entities incl. the binding's id de-/re-interleave). MockEcs's hashmap lookups are *slower* than the rig's zig_ecs sparse-set, so the figure is a conservative over-estimate.

| | ns/tick @ 2000 | vs rig 0.649 ms/tick |
|---|---:|---:|
| get-only, positional | 136 353 | — |
| get-only, id-tagged (+ binding de-interleave) | 133 961 | **−0.37%** (marginal id-column cost, within noise) |
| full round-trip, positional | 441 377 | — |
| full round-trip, id-tagged | 371 757 | −10.7% (id path *faster* — drops the positional preflight re-query walk; backend-specific) |

The id column's true marginal cost (+8 bytes/entity + a binding memcpy) is **within measurement noise** (−0.37% of a rig tick). **Verdict: ADOPT** — recommend the scripting bindings default to the id-tagged variant (gated), per the follow-up above.

## Tests

`zig build test` green: 1050/1050 across the suite; `script_contract_test.zig` grew from 70 to **76 tests** (+6, all passing): two #782 polish cases (scalar-only-built-in sentinel GET/SET agreement; zero-width filter not re-applied on batch-set) and four #783 id-column cases (round-trip matched by-id not position; same-count destroy+spawn skip; onSet-mid-apply-mutation skip; refusals/shapes — misaligned rows, int fields, unknown names, unknown ids). The existing bulk-access pre-bind no-op test was extended to cover the `_ids` twins.

https://claude.ai/code/session_011szWvquoss1yNX7KWSKCaM
