### PR TITLE
feat: game-facing per-entity material authoring (setMaterial + Material component) (#789)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -156,6 +156,7 @@ pub fn build(b: *std.Build) void {
         "test/collect_entities_test.zig",
         "test/entities_with_roster_test.zig",
         "test/set_sprite_flip_test.zig",
+        "test/set_material_test.zig",
         "test/video_component_test.zig",
         "test/camera_viewport_test.zig",
         "test/camera_viewport_seed_test.zig",

--- a/src/game.zig
+++ b/src/game.zig
@@ -1091,6 +1091,8 @@ pub fn GameConfigWithYAxis(
         pub const removeText = Visuals.removeText;
         pub const setZIndex = Visuals.setZIndex;
         pub const setSpriteFlip = Visuals.setSpriteFlip;
+        pub const setMaterial = Visuals.setMaterial;
+        pub const clearMaterial = Visuals.clearMaterial;
 
         // ── Tilemap (mixin, T2 Phase 2) ──────────────────────────
         pub const addTilemap = TilemapMixin.addTilemap;

--- a/src/game/visuals.zig
+++ b/src/game/visuals.zig
@@ -1,6 +1,14 @@
 /// Visuals mixin — sprite, shape, text, icon, and gizmo management + z-index.
+const std = @import("std");
 const core = @import("labelle-core");
 const Position = core.Position;
+
+/// Curated per-entity material effect + uniforms (labelle-gfx#305). Sourced
+/// from `labelle-core` so the engine, the renderer plugin's `Sprite.material`
+/// field, and game code all name ONE nominal type (gfx re-exports the same
+/// `backend_contract.Material`). Re-exported at the module root as
+/// `engine.Material`. See `setMaterial` / `clearMaterial` below.
+const Material = core.backend_contract.Material;
 
 /// Returns the visual management mixin for a given Game type.
 pub fn Mixin(comptime Game: type) type {
@@ -120,6 +128,56 @@ pub fn Mixin(comptime Game: type) type {
             if (sprite.flip_x == flip_x) return;
             sprite.flip_x = flip_x;
             self.renderer.markVisualDirty(entity);
+        }
+
+        /// Apply a curated per-entity material effect (flash / palette_swap /
+        /// dissolve / outline — labelle-gfx#305) to a sprite entity, then mark
+        /// its visuals dirty so the renderer picks up the change on the next
+        /// sync.
+        ///
+        /// The runtime mirror of the declarative `.Sprite = .{ .material = … }`
+        /// scene/prefab authoring path: material rides INLINE on the sprite
+        /// component (exactly like `tint` / `flip_x`), so there is no separate
+        /// `Material` component to register — this setter and the scene loader's
+        /// generic field coercion feed the very same `Sprite.material` field.
+        ///
+        /// Bundles the `sprite.material = m` + `renderer.markVisualDirty(entity)`
+        /// pair (forgetting the dirty-mark leaves the visual stale — the same
+        /// silent bug `setSpriteFlip` was created to prevent). Short-circuits
+        /// when the material already matches, avoiding a wasted dirty-mark and
+        /// the batch-breaking material re-submit it would provoke.
+        ///
+        /// GRACEFUL DEGRADE — two layers, no crash on either:
+        ///  1. Comptime: a no-op on renderers whose `Sprite` carries no
+        ///     `material` field (`StubRender`, mock renderers, and gfx builds
+        ///     predating the material seam). The `@hasField` guard short-circuits
+        ///     before any field access, so the setter is safe to call uniformly.
+        ///  2. Runtime: on a backend that lacks the specific effect's shader,
+        ///     the renderer's `materialSupported` gate draws the plain sprite
+        ///     (`labelle-gfx#305`). Setting an unsupported material never
+        ///     crashes — it simply has no visible effect on that backend.
+        ///
+        /// Returns silently if the entity has no `Sprite` component — callers
+        /// that need to assert presence should `getComponent` themselves first
+        /// (matches `setSpriteFlip` / `setZIndex`).
+        pub fn setMaterial(self: *Game, entity: Entity, material: Material) void {
+            if (comptime !@hasField(Sprite, "material")) return;
+            self.assertEntityAlive(entity, "setMaterial");
+            const sprite = self.ecs_backend.getComponent(entity, Sprite) orelse return;
+            if (std.meta.eql(sprite.material, material)) return;
+            sprite.material = material;
+            self.renderer.markVisualDirty(entity);
+        }
+
+        /// Remove any material effect from a sprite entity, restoring the plain
+        /// (fast-path, fully batchable) sprite draw. Equivalent to
+        /// `setMaterial(entity, .{})` — `Material.effect == .none` is the
+        /// no-material default that never touches the renderer's material path.
+        ///
+        /// Same graceful-degrade + missing-`Sprite` + short-circuit semantics as
+        /// `setMaterial`.
+        pub fn clearMaterial(self: *Game, entity: Entity) void {
+            self.setMaterial(entity, .{});
         }
     };
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -220,6 +220,21 @@ pub const ValueState = gui_runtime_state_mod.ValueState;
 pub const FormBinder = form_binder_mod.FormBinder;
 pub const GuiEvent = form_binder_mod.GuiEvent;
 
+// ── Material seam (per-entity curated shader effects, labelle-gfx#305) ──
+//
+// The game-facing authoring types for the material seam. `Material` rides
+// INLINE on the renderer plugin's `Sprite` component (like `tint` / `flip_x`),
+// so there is no separate ECS component — games author it declaratively as
+// `.Sprite = .{ .material = .{ .effect = .flash, .uniforms = .{ … } } }` in a
+// scene/prefab `.zon`, or at runtime via `game.setMaterial(entity, .{ … })` /
+// `game.clearMaterial(entity)` (see `src/game/visuals.zig`). Sourced from
+// `labelle-core` so the engine, gfx's `Sprite.material`, and game code all name
+// the one nominal `backend_contract.Material` type. A backend lacking a given
+// effect's shader draws the plain sprite (graceful degrade, never a crash).
+pub const Material = core.backend_contract.Material;
+pub const MaterialEffect = core.backend_contract.MaterialEffect;
+pub const MaterialUniforms = core.backend_contract.MaterialUniforms;
+
 // ── Core Utilities ──
 pub const SparseSet = sparse_set_mod.SparseSet;
 pub const separateComponents = query_mod.separateComponents;

--- a/test/set_material_test.zig
+++ b/test/set_material_test.zig
@@ -1,0 +1,309 @@
+//! `Game.setMaterial` / `Game.clearMaterial` — the game-facing per-entity
+//! material authoring surface for the labelle-gfx#305 curated shader effects
+//! (flash / palette_swap / dissolve / outline).
+//!
+//! Background: the material seam is renderer-complete — the `Material` value
+//! type lives in `labelle-core` (`backend_contract.Material`), gfx carries it
+//! INLINE on `SpriteVisual.material`, and the bgfx backend renders the full
+//! curated set (with `materialSupported` graceful degrade). But before this the
+//! engine exposed NO way for a game to SET a material on a sprite entity — no
+//! `Sprite.material` authoring, no `setMaterial` API. This closes that gap by
+//! mirroring `setSpriteFlip`: material rides on the sprite component like
+//! `tint` / `flip_x`, so the runtime setter and the declarative
+//! `.Sprite = .{ .material = … }` scene path feed the same field.
+//!
+//! Coverage:
+//! - happy path: `setMaterial` writes `sprite.material` AND bumps
+//!   `markVisualDirty` exactly once.
+//! - idempotent: setting the material the sprite already has short-circuits —
+//!   neither write nor dirty-mark fires (a wasted material re-submit breaks the
+//!   backend's draw batch, so the short-circuit is load-bearing).
+//! - `clearMaterial`: resets to `.effect == .none` (the plain-sprite fast path)
+//!   and marks dirty.
+//! - declarative parity: a material authored INLINE on the `addSprite` literal
+//!   (the runtime mirror of `.Sprite = .{ .material = … }` in a `.zon`) lands on
+//!   the component with no setter call — proving the field-on-Sprite authoring
+//!   surface, not a separate component.
+//! - missing-Sprite: the setter returns silently rather than panicking.
+//! - comptime no-op: a renderer whose `Sprite` lacks a `material` field
+//!   (StubRender, older gfx, custom mocks) still compiles and runs the setter as
+//!   a no-op — the `@hasField` guard catches it before any field access.
+//!
+//! Uses a local `MaterialRenderer` (mirroring `set_sprite_flip_test`'s
+//! `FlipRenderer`): its `Sprite` carries a real `material` field plus a
+//! `markVisualDirty` counter, keeping this PR engine-only.
+
+const std = @import("std");
+const testing = std.testing;
+const core = @import("labelle-core");
+const engine = @import("engine");
+
+const Material = core.backend_contract.Material;
+const MockEcs = core.MockEcsBackend(u32);
+
+/// Minimal renderer with exactly the bits `setMaterial` touches: a
+/// `Sprite.material` field to mutate (the same nominal
+/// `backend_contract.Material` gfx carries on `SpriteVisual`) and a
+/// `markVisualDirty` that increments a test-observable counter.
+fn MaterialRenderer(comptime Entity: type) type {
+    return struct {
+        const Self = @This();
+
+        pub const Sprite = struct {
+            sprite_name: []const u8 = "",
+            visible: bool = true,
+            z_index: i16 = 0,
+            material: Material = .{},
+            layer: enum { default } = .default,
+        };
+
+        pub const Shape = struct {
+            visible: bool = true,
+            z_index: i16 = 0,
+            layer: enum { default } = .default,
+        };
+
+        visual_dirty_count: usize = 0,
+
+        pub fn init(_: std.mem.Allocator) Self {
+            return .{};
+        }
+        pub fn deinit(_: *Self) void {}
+        pub fn trackEntity(_: *Self, _: Entity, _: core.VisualType) void {}
+        pub fn untrackEntity(_: *Self, _: Entity) void {}
+        pub fn markPositionDirty(_: *Self, _: Entity) void {}
+        pub fn markPositionDirtyWithChildren(_: *Self, comptime _: type, _: anytype, _: Entity) void {}
+        pub fn updateHierarchyFlag(_: *Self, _: Entity, _: bool) void {}
+        pub fn markVisualDirty(self: *Self, _: Entity) void {
+            self.visual_dirty_count += 1;
+        }
+        pub fn sync(_: *Self, comptime _: type, _: anytype) void {}
+        pub fn render(_: *Self) void {}
+        pub fn setScreenHeight(_: *Self, _: f32) void {}
+        pub fn clear(_: *Self) void {}
+        pub fn renderGizmoDraws(_: *Self, _: []const core.GizmoDraw) void {}
+        pub fn hasEntity(_: *const Self, _: Entity) bool {
+            return false;
+        }
+    };
+}
+
+const EmptyComponents = struct {
+    pub fn has(comptime _: []const u8) bool {
+        return false;
+    }
+    pub fn names() []const []const u8 {
+        return &.{};
+    }
+};
+
+const TestGame = engine.GameConfig(
+    MaterialRenderer(MockEcs.Entity),
+    MockEcs,
+    engine.StubInput,
+    engine.StubAudio,
+    engine.StubVideo,
+    engine.StubGui,
+    void,
+    engine.StubLogSink,
+    EmptyComponents,
+    &.{},
+    void,
+);
+
+const Sprite = TestGame.SpriteComp;
+
+const flash_red: Material = .{
+    .effect = .flash,
+    .uniforms = .{ .r = 1, .g = 0, .b = 0, .a = 1, .scalar0 = 0.6 },
+};
+
+test "setMaterial: writes material and marks visual dirty" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const entity = game.createEntity();
+    game.addSprite(entity, .{ .sprite_name = "worker" });
+
+    // Baseline: a fresh sprite defaults to the no-material fast path.
+    const sprite0 = game.getComponent(entity, Sprite).?;
+    try testing.expectEqual(core.backend_contract.MaterialEffect.none, sprite0.material.effect);
+
+    const dirty_before = game.renderer.visual_dirty_count;
+
+    game.setMaterial(entity, flash_red);
+
+    const sprite = game.getComponent(entity, Sprite).?;
+    try testing.expectEqual(core.backend_contract.MaterialEffect.flash, sprite.material.effect);
+    try testing.expectEqual(@as(f32, 0.6), sprite.material.uniforms.scalar0);
+    try testing.expectEqual(dirty_before + 1, game.renderer.visual_dirty_count);
+}
+
+test "setMaterial: no-op when material already matches (no dirty-mark)" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const entity = game.createEntity();
+    game.addSprite(entity, .{ .sprite_name = "worker", .material = flash_red });
+
+    const dirty_before = game.renderer.visual_dirty_count;
+
+    // Same value → short-circuit. A material re-submit breaks the backend draw
+    // batch, so a naive "always write + always mark" would waste a resync.
+    game.setMaterial(entity, flash_red);
+
+    const sprite = game.getComponent(entity, Sprite).?;
+    try testing.expectEqual(core.backend_contract.MaterialEffect.flash, sprite.material.effect);
+    try testing.expectEqual(dirty_before, game.renderer.visual_dirty_count);
+}
+
+test "clearMaterial: resets to .none fast path and marks dirty" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const entity = game.createEntity();
+    game.addSprite(entity, .{ .sprite_name = "worker", .material = flash_red });
+
+    const dirty_before = game.renderer.visual_dirty_count;
+
+    game.clearMaterial(entity);
+
+    const sprite = game.getComponent(entity, Sprite).?;
+    try testing.expectEqual(core.backend_contract.MaterialEffect.none, sprite.material.effect);
+    try testing.expectEqual(dirty_before + 1, game.renderer.visual_dirty_count);
+}
+
+test "clearMaterial: no-op when already unmaterialed (no dirty-mark)" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const entity = game.createEntity();
+    game.addSprite(entity, .{ .sprite_name = "worker" });
+
+    const dirty_before = game.renderer.visual_dirty_count;
+
+    game.clearMaterial(entity);
+
+    try testing.expectEqual(dirty_before, game.renderer.visual_dirty_count);
+}
+
+test "declarative: material authored inline on the sprite component lands with no setter" {
+    // The runtime mirror of `.Sprite = .{ .material = … }` in a scene/prefab
+    // `.zon`: because material rides on the sprite component (not a separate
+    // ECS component), authoring it on the `addSprite` literal is sufficient —
+    // no `setMaterial` call, no component registration.
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    const entity = game.createEntity();
+    game.addSprite(entity, .{
+        .sprite_name = "hero",
+        .material = .{ .effect = .outline, .uniforms = .{ .scalar0 = 2.0 } },
+    });
+
+    const sprite = game.getComponent(entity, Sprite).?;
+    try testing.expectEqual(core.backend_contract.MaterialEffect.outline, sprite.material.effect);
+    try testing.expectEqual(@as(f32, 2.0), sprite.material.uniforms.scalar0);
+}
+
+test "setMaterial: entity without Sprite returns silently" {
+    var game = TestGame.init(testing.allocator);
+    defer game.deinit();
+
+    // No `addSprite` — the entity has no Sprite component.
+    const entity = game.createEntity();
+
+    const dirty_before = game.renderer.visual_dirty_count;
+
+    game.setMaterial(entity, flash_red);
+    game.clearMaterial(entity);
+
+    try testing.expectEqual(dirty_before, game.renderer.visual_dirty_count);
+}
+
+test "engine re-exports name the same nominal Material type as core" {
+    // `engine.Material` must be the very type gfx carries on `Sprite.material`,
+    // so a game can write `engine.Material{ … }` and hand it straight to
+    // `setMaterial` / a `.zon`.
+    try testing.expect(engine.Material == core.backend_contract.Material);
+    try testing.expect(engine.MaterialEffect == core.backend_contract.MaterialEffect);
+    try testing.expect(engine.MaterialUniforms == core.backend_contract.MaterialUniforms);
+}
+
+/// Renderer whose `Sprite` has no `material` field — exercises the
+/// `comptime @hasField(Sprite, "material")` guard. Mirror of `MaterialRenderer`
+/// minus the field (StubRender / older gfx / custom mocks).
+fn NoMaterialRenderer(comptime Entity: type) type {
+    return struct {
+        const Self = @This();
+
+        pub const Sprite = struct {
+            sprite_name: []const u8 = "",
+            visible: bool = true,
+            z_index: i16 = 0,
+            layer: enum { default } = .default,
+        };
+
+        pub const Shape = struct {
+            visible: bool = true,
+            z_index: i16 = 0,
+            layer: enum { default } = .default,
+        };
+
+        visual_dirty_count: usize = 0,
+
+        pub fn init(_: std.mem.Allocator) Self {
+            return .{};
+        }
+        pub fn deinit(_: *Self) void {}
+        pub fn trackEntity(_: *Self, _: Entity, _: core.VisualType) void {}
+        pub fn untrackEntity(_: *Self, _: Entity) void {}
+        pub fn markPositionDirty(_: *Self, _: Entity) void {}
+        pub fn markPositionDirtyWithChildren(_: *Self, comptime _: type, _: anytype, _: Entity) void {}
+        pub fn updateHierarchyFlag(_: *Self, _: Entity, _: bool) void {}
+        pub fn markVisualDirty(self: *Self, _: Entity) void {
+            self.visual_dirty_count += 1;
+        }
+        pub fn sync(_: *Self, comptime _: type, _: anytype) void {}
+        pub fn render(_: *Self) void {}
+        pub fn setScreenHeight(_: *Self, _: f32) void {}
+        pub fn clear(_: *Self) void {}
+        pub fn renderGizmoDraws(_: *Self, _: []const core.GizmoDraw) void {}
+        pub fn hasEntity(_: *const Self, _: Entity) bool {
+            return false;
+        }
+    };
+}
+
+const NoMaterialGame = engine.GameConfig(
+    NoMaterialRenderer(MockEcs.Entity),
+    MockEcs,
+    engine.StubInput,
+    engine.StubAudio,
+    engine.StubVideo,
+    engine.StubGui,
+    void,
+    engine.StubLogSink,
+    EmptyComponents,
+    &.{},
+    void,
+);
+
+test "setMaterial: comptime no-op when Sprite has no material field" {
+    var game = NoMaterialGame.init(testing.allocator);
+    defer game.deinit();
+
+    const entity = game.createEntity();
+    game.addSprite(entity, .{ .sprite_name = "worker" });
+
+    const dirty_before = game.renderer.visual_dirty_count;
+
+    // The point is the *compile*: a renderer whose Sprite has no `material`
+    // (StubRender, older gfx, custom mocks) must still call setMaterial /
+    // clearMaterial without a type error. The `@hasField` guard short-circuits
+    // before any field access; at runtime dirty-count stays at zero.
+    game.setMaterial(entity, flash_red);
+    game.clearMaterial(entity);
+
+    try testing.expectEqual(dirty_before, game.renderer.visual_dirty_count);
+}


### PR DESCRIPTION
## What

Adds the **game-facing authoring surface** for the labelle-gfx#305 curated material effects (`flash` / `palette_swap` / `dissolve` / `outline`). The seam was renderer-complete — the `Material` value type lives in labelle-core (`backend_contract.Material`), gfx carries it inline on `SpriteVisual.material`, and the bgfx backend renders the full curated set with `materialSupported` graceful degrade — but the engine exposed **no way for a game to set a material on a sprite entity**. This closes that gap (the exact evidence in #789: the assembler material-demo couldn't flash/dissolve an individual sprite because no engine API existed).

## Design — field-on-Sprite, not a separate component

Material rides **inline on the sprite component** (like `tint` / `flip_x`), *not* a separate ECS `Material` component. Rationale:

- `SpriteVisual` already carries `material` inline — the game-facing component is the natural mirror.
- Matches the existing visual-prop pattern (`setSpriteFlip` mutates a `Sprite` field + `markVisualDirty`).
- **Declarative authoring is free**: `.Sprite = .{ .material = .{ .effect = .flash, .uniforms = .{ … } } }` in a scene/prefab `.zon` falls out of the loader's existing generic field coercion — no new component registration, no new sync path, no assembler codegen change.

## Changes

- **`Game.setMaterial(entity, Material)` / `Game.clearMaterial(entity)`** (`src/game/visuals.zig`, wired in `game.zig`), mirroring `setSpriteFlip`: mutate `sprite.material` + `markVisualDirty`, short-circuit on no-change (a material re-submit breaks the backend's draw batch, so the short-circuit is load-bearing).
- **Two-layer graceful degrade** — setting an unsupported material never crashes:
  1. *Comptime*: no-op on renderers whose `Sprite` lacks a `material` field (`@hasField` guard — `StubRender`, mocks, gfx builds predating the seam).
  2. *Runtime*: on a backend missing the effect's shader, `materialSupported` draws the plain sprite (labelle-gfx#305).
- **`engine.Material` / `MaterialEffect` / `MaterialUniforms`** re-exports (from `core.backend_contract`) so games and `.zon` name the one nominal type.
- **`test/set_material_test.zig`** — 9 tests: write+dirty, idempotent no-dirty, `clearMaterial` reset, declarative inline-on-component parity, missing-`Sprite` silent, re-export type identity, and the comptime no-material-field degrade.

`zig build` + `zig build test` green.

## Verification

- **Engine unit tests** prove `setMaterial` writes `sprite.material` + marks dirty, `clearMaterial` resets to the `.none` fast path, and the whole surface no-op-degrades on a renderer without the field.
- **GPU render proof**: the bgfx `material_effects` committed golden (bgfx `material_golden` headless harness) renders the full curated set — red `flash`, rainbow `palette_swap`, orange-edged `dissolve`, green `outline`, plus a plain control. This is the `drawTextureProMaterial` output engine `setMaterial` feeds once the material reaches `SpriteVisual.material`.

Chain: `setMaterial` → `Sprite.material` (engine test) → `toVisual` → `SpriteVisual.material` → `drawTextureProMaterial` → GPU pixels (golden).

## Companion follow-up (gfx#305 tail — required for end-to-end)

gfx's game-facing `SpriteComponent` (= `RenderImpl.Sprite`, what `setMaterial` writes) still needs a `material: Material = .{}` field + one `.material = self.material` line in `toVisual()` so the component-side material reaches `SpriteVisual.material`. The render-internal `SpriteVisual` + the bgfx shaders are already done on the gfx#305 branch (`fix/305-postfx-renderwithlayerhooks`). Until that lands, the engine setter is correctly a comptime no-op on the released gfx. The end-to-end assembler material-demo (assembler#645) consumes engine#789 + that gfx completion.

Refs #789

https://claude.ai/code/session_011szWvquoss1yNX7KWSKCaM

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-engine/pr/790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787089699&installation_id=146340424&pr_number=790&repository=labelle-toolkit%2Flabelle-engine&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-engine%2Fpull%2F790&signature=e6eced1b874c668281329e5eba038dc9ca238bc5ac1b74101a3fb8c800a1ff71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->