### PR TITLE
RFC: declarative, event-driven sprite animation

### DIFF
--- a/RFC-EVENT-DRIVEN-ANIMATION.md
+++ b/RFC-EVENT-DRIVEN-ANIMATION.md
@@ -2,8 +2,8 @@
 
 ## Summary
 
-Four incremental changes that let sprite animations be authored as **prefab
-data** instead of per-game driver scripts:
+Five incremental changes that let sprite animations be authored as **prefab
+data** instead of per-game driver scripts, and unify how they pause:
 
 1. **Drive animations by default** — retire the one-line opt-in every game
    copies (`00_sprite_animation_driver.zig`).
@@ -14,6 +14,10 @@ data** instead of per-game driver scripts:
 4. **Named + crossing-accurate frame markers** — `"emit footstep at frame
    3"`, firing a *named* game event (not a generic frame-index event) and
    never dropped by a `dt` spike.
+5. **Unify pause on the time scale** — Unity-style: pause zeroes the scaled
+   game clock and everything scaled freezes for free; a per-animation
+   `scaled | unscaled` update mode keeps menu/UI animations running. Removes
+   the separate `sprite_animations_paused` flag and per-script pause checks.
 
 Together they make animations **fully symmetric event participants** —
 triggered *by* events and emitting *named* events at specific frames — so the
@@ -171,6 +175,59 @@ this right is what makes the feature replace scripts instead of adding footguns.
   marker path should use crossing detection so a footstep/hit never silently
   drops. Keep the legacy `event_frames` field working (landed-on) for compat.
 
+### 5. Unify pause on the time scale (scaled / unscaled update mode)
+
+Pause is the piece that makes §1 fully clean — and it's currently fragmented.
+Today the engine has **three** overlapping pause concepts, and the game adds a
+fourth:
+
+- `time_scale` → `scaled_dt = dt * time_scale` (`game/loop_mixin.zig:26`).
+- a separate `paused` flag (#465): `isPaused() = paused OR time_scale==0`
+  (`loop_mixin.zig:197`), halts the tick independently.
+- `sprite_animations_paused` — a flag *just* for `SpriteAnimation`
+  (`loop_mixin.zig:86` gates on `!sprite_animations_paused and scaled_dt != 0`).
+- flying-platform's own `GamePaused` singleton, which every custom animation
+  script (`worker_animation`, `ship_animation`, …) checks via
+  `pause_state.isPaused`.
+
+The kicker: a `time_scale == 0` pause **already** zeroes `scaled_dt`, which
+**already** freezes `SpriteAnimation` — so `sprite_animations_paused` is largely
+redundant, and the per-script `GamePaused` checks re-implement "am I paused"
+everywhere. Every animated thing has to know about pause independently.
+
+**How Unity 3D does it** (the target model): one global knob, `Time.timeScale`.
+Pause = `timeScale = 0`; everything reading **scaled** time freezes for free —
+movement (`Time.deltaTime`), the Animator (Update Mode `Normal`), physics,
+particles. Things that must keep moving during pause opt into **unscaled** time:
+`Time.unscaledDeltaTime`, or Animator Update Mode `Unscaled Time` (menus, UI).
+One time scale + a per-system scaled/unscaled choice — no per-system pause flag.
+
+**Proposal — collapse labelle onto the time scale, exactly like Unity:**
+
+1. **Pause = zero the scaled game clock.** `isPaused` ⇒ `scaled_dt == 0` as the
+   single source of truth. flying-platform's `GamePaused` *sets* that (or the
+   engine `paused` flag zeroes the effective game dt), instead of being a
+   parallel mechanism.
+2. **Systems advance on scaled `dt`.** Expose `game.dt()` (scaled) vs
+   `game.realDt()` (unscaled). Anything using scaled dt — `SpriteAnimation`
+   *and* the custom worker/ship animators — freezes on pause with **zero
+   pause-aware code**, deleting the per-script `pause_state.isPaused` early-outs.
+3. **Per-animation update mode** = Unity's Animator UpdateMode:
+   `SpriteAnimation.update: scaled | unscaled` (default `scaled`). Menu spinners
+   / pause-screen effects set `unscaled` and keep running while the game freezes.
+
+**Removes:** the `sprite_animations_paused` flag, the `setSpriteAnimationsPaused`
+wiring in `97_pause_menu.zig`, and the copy-pasted `isPaused` checks in every
+animation script. Pause becomes "set timeScale 0"; `scaled` things freeze,
+`unscaled` things don't. This generalizes beyond animation to *all* time-based
+systems, and it's what lets §1's "drive by default" ship without a leftover
+pause flag.
+
+**Compat:** `unscaled` defaults to off (today's behavior — everything is
+effectively scaled). Keep `setSpriteAnimationsPaused` as a deprecated shim that
+maps to a pause of the animation subsystem's scaled clock, so callers don't
+break during migration.
+
 ## The combined model
 
 Put §3 and §4 together and animations become event-symmetric, entirely in data:
@@ -242,4 +299,7 @@ Independent, shippable in order:
 1. §2 frame-range shorthand — smallest, immediate authoring win, zero risk.
 2. §4 named + crossing-accurate markers — additive; upgrades #625.
 3. §3 event-triggered playback + targeting — the main feature.
-4. §1 default-on driver — the breaking-default cleanup, batched into a major.
+4. §5 pause unification (scaled/unscaled update mode) — the cross-cutting
+   cleanup; deprecate `sprite_animations_paused` and the per-script checks.
+5. §1 default-on driver — the breaking-default cleanup; batch with §5 into a
+   major (both remove leftover flags/boilerplate).

--- a/RFC-EVENT-DRIVEN-ANIMATION.md
+++ b/RFC-EVENT-DRIVEN-ANIMATION.md
@@ -1,0 +1,245 @@
+# RFC: Declarative, event-driven sprite animation
+
+## Summary
+
+Four incremental changes that let sprite animations be authored as **prefab
+data** instead of per-game driver scripts:
+
+1. **Drive animations by default** — retire the one-line opt-in every game
+   copies (`00_sprite_animation_driver.zig`).
+2. **Frame-range shorthand** — declare `sewer_machine_0001..0010` without
+   listing all ten filenames.
+3. **Event-triggered playback** — `"play once on event X"`, `"loop on event
+   Y"`, `"stop on event Z"`, declared on the animation.
+4. **Named + crossing-accurate frame markers** — `"emit footstep at frame
+   3"`, firing a *named* game event (not a generic frame-index event) and
+   never dropped by a `dt` spike.
+
+Together they make animations **fully symmetric event participants** —
+triggered *by* events and emitting *named* events at specific frames — so the
+common cases need no `*_animation.zig` script at all.
+
+## Motivation
+
+Today, "make this sprite animate in response to the game" means writing a
+per-feature Zig script. flying-platform alone carries ~10 of them:
+`33_wc_animation.zig`, `worker_animation.zig`, `08_sleep_animation.zig`,
+`bandit_animation.zig`, `ship_animation.zig`, `17_status_overlay.zig`,
+`34_bowel_overlay.zig`, the kitchen smoke/sink overlay component + script,
+`condenser_gate.zig`, … A large fraction of these are literally *"when
+state/event X happens, play clip A once or on loop; when Y, stop."*
+
+That's boilerplate the engine can absorb. The animation machinery is already
+engine-side; what's missing is a **declarative binding** between the game's
+event bus and animation playback — in both directions.
+
+This also directly serves the toolkit's "Packs" / LLM-authoring goal: adding
+an animated prop should be one prefab entry, not a component **plus** a script.
+
+## Background: what already exists
+
+Grounding the proposal in the current code (`labelle-engine/src`):
+
+- **`SpriteAnimation`** (`sprite_animation.zig:51`) — a `.transient` component
+  with `frames: []const []const u8`, `fps`, `mode: .loop | .once | .ping_pong`,
+  `speed`, and `event_frames: []const u16`. It auto-plays on spawn.
+- **The engine already advances it.** `game/loop_mixin.zig:86` ticks every
+  `SpriteAnimation` on the time-scaled `dt`, gated on
+  `drive_sprite_animations and !sprite_animations_paused and scaled_dt != 0`.
+- **The flag defaults off.** `game.zig:723` (`drive_sprite_animations: bool =
+  false`) — *"Off by default so existing projects that still drive animation
+  from a script don't double-advance."* Hence every game copies a one-line
+  `setDriveSpriteAnimations(true)` at boot.
+- **Animations already EMIT events** (`animation_events.zig`): `engine__anim_
+  complete` (once clips), `engine__anim_frame` (from `event_frames`, "landed
+  on" semantics — v1 can miss a frame on a `dt` spike), `engine__anim_loop`.
+  Delivered through the buffered event bus (`game.emit`).
+- **`AnimationDef`** (`animation_def.zig`) — a richer clip/variant system with
+  `TransitionRule { from: ?u8, to: u8, via: u8 }` and **crossing-accurate**
+  markers via beat iteration.
+- **Components already SUBSCRIBE to events** — the events-as-spine pattern the
+  packs use (custom `events/*.zig` folding into `GameEvents`).
+
+So animations already *produce* events and the bus already *routes* them; what
+does not exist is animations *consuming* events declaratively, or emitting
+*named* ones.
+
+## Proposal
+
+### 1. Drive sprite animations by default
+
+The advance is already in the engine; the only game-side artifact is flipping
+the opt-in. Make it unnecessary:
+
+- **Default `drive_sprite_animations = true`.** The tick only iterates
+  `SpriteAnimation` components — zero cost for games with none.
+- The one thing this can break is a game *still* running the deprecated
+  legacy `sprite_animation_tick` script (double-advance). Those get an
+  explicit **opt-out** (`setDriveSpriteAnimations(false)`), and are expected to
+  migrate. Consider a comptime alternative: the assembler enables the flag when
+  the `SpriteAnimation` component is present in the registry and no legacy tick
+  script is discovered — "if you use the component, it's driven."
+- **Result:** `00_sprite_animation_driver.zig` disappears from every game.
+
+Because it changes a default, land it behind the next engine **major**, or gate
+on a project-config `animation.autodrive` that defaults on for new scaffolds.
+
+### 2. Frame-range shorthand
+
+Authoring an N-frame clip should not mean typing N filenames. Extend the
+`SpriteAnimation` prefab deserializer to accept a pattern as an alternative to
+`frames`:
+
+```jsonc
+"SpriteAnimation": {
+  "frames_pattern": "sewer/sewer_machine/sewer_machine_%04d",
+  "from": 1, "to": 10,
+  "fps": 8, "mode": "loop"
+}
+```
+
+- Expands to `..._0001.png … _0010.png` at load, interning the same strings
+  `frames` would have.
+- `frames` (explicit list) stays valid and takes precedence; `frames_pattern`
+  is sugar. `%0Nd` width comes from the pattern; `.png` is appended if absent.
+- Pure load-time expansion — no runtime cost, no change to the component's
+  runtime shape.
+
+### 3. Event-triggered playback
+
+Let an animation declare which events start/stop it and how. New optional
+`triggers` on the animation component (or a sibling `AnimationTriggers`
+component if we want to keep `SpriteAnimation` save-shape frozen):
+
+```jsonc
+"SpriteAnimation": {
+  "frames_pattern": "sewer/sewer_machine/sewer_machine_%04d", "from": 1, "to": 10, "fps": 8,
+  "start": "dormant",              // don't auto-play on spawn
+  "triggers": [
+    { "on": "sewer__machine_on",  "play": "loop" },
+    { "on": "sewer__machine_off", "action": "stop" },
+    { "on": "sewer__pulse",       "play": "once" }
+  ]
+}
+```
+
+Vocabulary:
+
+- `play`: `once` | `loop` | `ping_pong` — (re)start the clip in that mode.
+- `action`: `stop` | `pause` | `resume` | `restart`.
+- `start`: `playing` (today's behavior, default) | `dormant` (wait for a
+  trigger) — so triggered props don't run until their event arrives.
+
+This is resolved by the same driver that already advances animations; it reads
+the frame's event buffer and applies matching triggers before advancing.
+
+#### Entity targeting (the crux)
+
+Events are global; a `machine_on` must start *the machine in the room that
+turned on*, not every sewer. This is the real design decision, not the syntax.
+Two rules, pick one (or support both):
+
+- **Self-scoped (default):** an animation reacts only to events emitted *about
+  its own entity* (or an ancestor — the room). The event carries an entity id;
+  the trigger matches when that id is the animation's entity or a parent. This
+  mirrors exactly what the imperative scripts do today (walk `parent → child by
+  sprite_name`).
+- **Broadcast (opt-in):** `{ "on": "...", "scope": "any" }` reacts to the event
+  regardless of target — for genuinely global cues (a day/night tint pulse).
+
+Recommendation: **self-scoped by default**, `scope: "any"` to opt out. Getting
+this right is what makes the feature replace scripts instead of adding footguns.
+
+### 4. Named + crossing-accurate frame markers
+
+`event_frames` already fires at frames, but fires one *generic*
+`engine__anim_frame` carrying the index — so every consumer filters `if (frame
+== 3)`. Let the marker name the event it emits:
+
+```jsonc
+"markers": [
+  { "frame": 3, "emit": "footstep" },
+  { "frame": 7, "emit": "sewer__splash" }
+]
+```
+
+- Emits the *named* event through `game.emit`, carrying the animation's entity
+  as target (so consumers can scope it, same as §3).
+- **Crossing-accurate by default.** `SpriteAnimation.event_frames` is v1
+  "landed-on" (a lag spike past frame 3 misses it, per its own doc comment);
+  `AnimationDef` already does crossing-accurate via beat iteration. The named-
+  marker path should use crossing detection so a footstep/hit never silently
+  drops. Keep the legacy `event_frames` field working (landed-on) for compat.
+
+## The combined model
+
+Put §3 and §4 together and animations become event-symmetric, entirely in data:
+
+```
+game event ──trigger (§3)──▶  [ animation clip ]  ──marker (§4)──▶ named game event
+                                    ▲     │
+                          AnimationDef transitions (existing)
+```
+
+- **In:** "play once / loop / stop on event X" (declarative — new)
+- **Out:** "emit `footstep` at frame N" (marker — exists, upgraded to named +
+  crossing-accurate)
+- **Sequencing:** `AnimationDef` `TransitionRule` for state cases (existing)
+
+Add §1 (default-on) and §2 (shorthand) and authoring an animated prop goes from
+"a component **plus** a script" to a single prefab entry.
+
+## What this does NOT replace
+
+Be honest about the ceiling. Event-triggers + markers cover *"play/stop a clip
+on an event, and emit cues."* They do **not** replace true state machines that
+choose direction/target frame from current runtime state — e.g.
+`33_wc_animation.zig` plays the door **forward or reverse depending on the
+current frame** and flips a screen colour. Those belong in `AnimationDef`
+transitions (`from → to via`); the trigger just *requests* a target clip and the
+transition table decides the path. The RFC composes with that system, it does
+not duplicate it. Worker locomotion, death, and status overlays that derive the
+clip from continuous component state also stay script/`AnimationDef`-driven.
+
+Rough estimate on flying-platform: of the ~10 `*_animation.zig` scripts, the
+machine/smoke/overlay/gate family (~half) collapses to prefab data; the
+worker/wc/state-machine family stays but shrinks (markers replace their manual
+frame bookkeeping).
+
+## Compatibility & migration
+
+- **§2 / §3 / §4** are strictly additive (new optional fields / a new sibling
+  component). Existing prefabs are untouched.
+- **§1** changes a default → next major, or a `animation.autodrive` project
+  flag defaulting on for new scaffolds, off for pre-existing ones until they
+  drop their legacy tick script.
+- Keep `event_frames` (landed-on) as a deprecated alias of the new named-marker
+  path so #625 consumers don't break.
+
+## Open questions
+
+1. **Component boundary:** extend `SpriteAnimation` (it's `.transient`, so no
+   save-shape cost) vs. a separate `AnimationTriggers` / `AnimationMarkers`
+   sibling? Separate keeps each concern small and lets `AnimationDef` reuse the
+   trigger/marker parsers.
+2. **Targeting default:** self-scoped vs. broadcast — confirm self-scoped is the
+   right default and specify how the "about my entity/ancestor" match reads the
+   event payload.
+3. **Trigger → AnimationDef bridge:** for `AnimationDef` entities, does a
+   trigger name a *clip* (letting transitions handle the `via`), or a raw
+   frame range? Naming a clip is the composable answer.
+4. **Marker payload:** do named markers carry extra data (a `value` field) or
+   just the entity + event name? Start with entity + name; add payload if a
+   consumer needs it.
+5. **Dedup / re-trigger semantics:** if `machine_on` fires while already
+   looping, is it a no-op or a restart? Propose no-op for `loop`, restart for
+   `once`.
+
+## Rollout
+
+Independent, shippable in order:
+
+1. §2 frame-range shorthand — smallest, immediate authoring win, zero risk.
+2. §4 named + crossing-accurate markers — additive; upgrades #625.
+3. §3 event-triggered playback + targeting — the main feature.
+4. §1 default-on driver — the breaking-default cleanup, batched into a major.


### PR DESCRIPTION
Adds `RFC-EVENT-DRIVEN-ANIMATION.md` — a design doc (no code) for making sprite animations authorable as **prefab data** instead of per-game driver scripts.

## The four pieces (independent, shippable in order)
1. **Drive animations by default** — the advance is already engine-side (`loop_mixin.zig:86`); `drive_sprite_animations` just defaults off (`game.zig:723`), so every game copies a one-line `setDriveSpriteAnimations(true)`. Flip the default (or comptime auto-enable when the component is registered); retires `00_sprite_animation_driver.zig`.
2. **Frame-range shorthand** — `"frames_pattern": ".../sewer_machine_%04d", "from": 1, "to": 10` instead of listing every filename. Load-time sugar, additive.
3. **Event-triggered playback** — `"triggers": [{ "on": "machine_on", "play": "loop" }, ...]` on the animation, with a full section on the real hard part: **entity targeting** (self-scoped by default vs broadcast).
4. **Named + crossing-accurate markers** — upgrade `SpriteAnimation.event_frames` (#625, generic + "landed-on") to emit **named** events (`{ "frame": 3, "emit": "footstep" }`) with crossing detection so a `dt` spike never drops one.

## Why
~10 `*_animation.zig` scripts in flying-platform are "when event X, play clip A once/loop; when Y, stop." That's boilerplate the engine can absorb. Animations already *emit* events and the bus already routes them — this closes the loop so they *consume* events declaratively too, in both directions.

Composes with `AnimationDef` `TransitionRule` (state-machine cases like the wc door stay there) rather than duplicating it. See the RFC for the combined model, "what this does NOT replace", compat/migration, and 5 open questions.

Opening for discussion — not requesting merge of any implementation yet.

https://claude.ai/code/session_011szWvquoss1yNX7KWSKCaM

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-engine/pr/793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787168145&installation_model_id=427192&pr_number=793&repository=labelle-toolkit%2Flabelle-engine&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-engine%2Fpull%2F793&signature=61adf94567a1589bb1fc99094656a0337012e45650c2f0496fd8094b24356691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->