### PR TITLE
fix(PackView): raise comptime branch quota for the allow-list build

### DIFF
--- a/scene/src/component.zig
+++ b/scene/src/component.zig
@@ -418,6 +418,14 @@ pub fn PackView(comptime FullRegistry: type, comptime own_names: []const []const
     // comptime block, whose temporary array goes out of scope with the block.
     const Holder = struct {
         const allowed = blk: {
+            // Building the allow-list is O(own_names × globals): the dedup
+            // loop below runs `nameAllowed` (a linear scan over `globals`)
+            // once per own component. With enough global components a pack's
+            // own-name loop overruns the default 1000 backwards-branch budget
+            // (a game hit it at the 10th global). Raise the ceiling well
+            // above any realistic registry so registering more components
+            // can't trip it — this is a comptime-only bound, free at runtime.
+            @setEvalBranchQuota(1_000_000);
             const globals = globalNames(FullRegistry);
             var buf: [globals.len + own_names.len][]const u8 = undefined;
             var n: usize = 0;


### PR DESCRIPTION
## Problem

`PackView`'s allow-list construction is O(own_names × globals): the dedup loop runs `nameAllowed` (a linear scan over the global component names) once per own component. With enough global components a pack's own-name loop overruns Zig's default 1000 backwards-branch budget — a downstream game hit it when a registry crossed **10 global components**:

```
scene/src/component.zig:430:33: error: evaluation exceeded 1000 backwards branches
```

So simply registering more components could break the build.

## Fix

`@setEvalBranchQuota(1_000_000)` at the top of the allow-list `blk` — a comptime-only bound (free at runtime, no API change) that scales past any realistic registry size.

## Backport

Also shipped as **v1.83.1** (tag off `v1.83.0`) to unblock a consumer pinned to the 1.x line.

https://claude.ai/code/session_011szWvquoss1yNX7KWSKCaM

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-engine/pr/796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787451599&installation_model_id=427192&pr_number=796&repository=labelle-toolkit%2Flabelle-engine&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-engine%2Fpull%2F796&signature=2a38237e0756e6bfef5b4d6aff910bd2c9c263004f0dcb77aec8b99dd75f39f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->