### PR TITLE
feat: own the dynamic ChildrenComponent lifecycle (no MAX_CHILDREN cap)

### DIFF
--- a/src/game.zig
+++ b/src/game.zig
@@ -482,6 +482,10 @@ pub fn GameConfigWithYAxis(
             renderer: RenderImpl,
             sprite_cache: atlas_mod.SpriteCache,
             nested_entity_arena: std.heap.ArenaAllocator,
+            /// Retained so `deinit` can free heap-owning components (the
+            /// `ChildrenComponent` ArrayLists) before the ECS is torn down —
+            /// the backend drops components by value with no destructor.
+            allocator: std.mem.Allocator,
 
             pub fn init(allocator: std.mem.Allocator) World {
                 return .{
@@ -489,10 +493,21 @@ pub fn GameConfigWithYAxis(
                     .renderer = RenderImpl.init(allocator),
                     .sprite_cache = atlas_mod.SpriteCache.init(allocator),
                     .nested_entity_arena = std.heap.ArenaAllocator.init(allocator),
+                    .allocator = allocator,
                 };
             }
 
             pub fn deinit(self: *World) void {
+                // Free every `ChildrenComponent`'s backing allocation before
+                // the ECS wipe drops the components by value (no destructor)
+                // — otherwise the child lists leak on final teardown.
+                {
+                    var v = self.ecs_backend.view(.{Children}, .{});
+                    defer v.deinit();
+                    while (v.next()) |e| {
+                        if (self.ecs_backend.getComponent(e, Children)) |cc| cc.deinit(self.allocator);
+                    }
+                }
                 self.nested_entity_arena.deinit();
                 self.sprite_cache.deinit();
                 self.renderer.deinit();

--- a/src/game/components_mixin.zig
+++ b/src/game/components_mixin.zig
@@ -192,6 +192,12 @@ pub fn Mixin(comptime Game: type) type {
         // ── Generic Component Access ──────────────────────────────
 
         pub fn addComponent(self: *Game, entity: Entity, component: anytype) void {
+            // `Children` owns a heap list; overwriting it by value would leak
+            // the old allocation. The engine manages it via setParent/destroy,
+            // but this is a public path — free any existing one first.
+            if (@TypeOf(component) == Children) {
+                if (self.ecs_backend.getComponent(entity, Children)) |old| old.deinit(self.allocator);
+            }
             self.ecs_backend.addComponent(entity, component);
             // Tag-set membership may have changed — invalidate rosters
             // (#653). Over-invalidation on a re-add is safe: it just
@@ -207,6 +213,11 @@ pub fn Mixin(comptime Game: type) type {
         pub fn setComponent(self: *Game, entity: Entity, component: anytype) void {
             const T = @TypeOf(component);
             const is_update = self.ecs_backend.hasComponent(entity, T);
+            // Overwriting a `Children` by value would leak its old heap list
+            // (see `addComponent`) — free it first on a genuine replace.
+            if (T == Children and is_update) {
+                if (self.ecs_backend.getComponent(entity, Children)) |old| old.deinit(self.allocator);
+            }
             self.ecs_backend.addComponent(entity, component);
             // A genuine add changes tag-set membership; an in-place
             // update does not — only invalidate rosters in the former
@@ -268,6 +279,11 @@ pub fn Mixin(comptime Game: type) type {
         pub fn removeComponent(self: *Game, entity: Entity, comptime T: type) void {
             if (@typeInfo(T) == .@"struct" and @hasDecl(T, "onRemove")) {
                 T.onRemove(ComponentPayload{ .entity_id = @intCast(entity), .game_ptr = @ptrCast(self) });
+            }
+            // Free `Children`'s heap list before the by-value drop — the
+            // engine strips it via detach/destroy, but this is a public path.
+            if (T == Children) {
+                if (self.ecs_backend.getComponent(entity, Children)) |old| old.deinit(self.allocator);
             }
             self.ecs_backend.removeComponent(entity, T);
             // Tag-set membership changed — invalidate rosters (#653).

--- a/src/game/components_mixin.zig
+++ b/src/game/components_mixin.zig
@@ -104,10 +104,10 @@ pub fn Mixin(comptime Game: type) type {
             });
 
             if (self.ecs_backend.getComponent(parent_entity, Children)) |children_comp| {
-                children_comp.addChild(child);
+                children_comp.addChild(self.allocator, child);
             } else {
                 var new_children = Children{};
-                new_children.addChild(child);
+                new_children.addChild(self.allocator, child);
                 self.ecs_backend.addComponent(parent_entity, new_children);
             }
 

--- a/src/game/entity_mixin.zig
+++ b/src/game/entity_mixin.zig
@@ -229,21 +229,27 @@ pub fn Mixin(comptime Game: type) type {
 
         pub fn destroyEntity(self: *Game, entity: Entity) void {
             if (self.ecs_backend.getComponent(entity, Children)) |children_comp| {
-                // Cascade over a by-value snapshot of the children list.
-                // Each child's destroy unlinks it from THIS live list via
-                // `detachFromParent` (a swap-remove), so iterating the
-                // live slice would shrink and reorder it under the loop —
-                // skipping children and double-destroying swap remnants.
-                // The snapshot (a 16-slot inline array, cheap stack copy)
-                // also shields the walk from `entity_destroyed` hooks
-                // re-parenting into this list mid-cascade, and from the
-                // component pool reshuffling under the held pointer while
-                // descendants' own `Children` components are removed.
-                const children_snapshot = children_comp.*;
-                for (children_snapshot.getChildren()) |child| {
+                // Cascade over an INDEPENDENT copy of the child ids. Each
+                // child's destroy unlinks it from THIS live list via
+                // `detachFromParent` (a swap-remove), and the list's backing
+                // allocation is freed just below — so iterating the live
+                // buffer, or a shallow struct copy that shares it (the list
+                // is now a heap-backed `ArrayList`, not an inline buffer),
+                // would read shrunk / reordered / freed memory. Copy the ids
+                // onto their own allocation first. This also shields the walk
+                // from `entity_destroyed` hooks re-parenting into this list
+                // and from the component pool reshuffling mid-cascade.
+                const kids = self.allocator.dupe(Entity, children_comp.getChildren()) catch @panic("OOM: destroyEntity children snapshot");
+                defer self.allocator.free(kids);
+                for (kids) |child| {
                     destroyEntity(self, child);
                 }
             }
+            // Free this entity's own `Children` backing allocation before the
+            // backend drops the component by value (the ECS runs no
+            // destructor). Re-fetch: the cascade above may have relocated the
+            // Children pool under any pointer held before it.
+            if (self.ecs_backend.getComponent(entity, Children)) |cc| cc.deinit(self.allocator);
             // Preview telemetry emits BEFORE the actual destroy so any
             // editor-side consumer can still introspect the entity from
             // a `getComponent` style API while reacting to the frame.
@@ -278,6 +284,12 @@ pub fn Mixin(comptime Game: type) type {
             // already be destroyed — `detachFromParent` guards with
             // `entityExists` before touching the parent's list.
             self.detachFromParent(entity);
+            // Free this entity's own `Children` backing allocation. This
+            // variant leaves the listed children ALIVE (its contract), but
+            // the `Children` component itself dies with the entity, so its
+            // ArrayList must be freed or it leaks (the ECS runs no
+            // destructor).
+            if (self.ecs_backend.getComponent(entity, Children)) |cc| cc.deinit(self.allocator);
             untrackSceneEntity(self, entity);
             self.active_world.sprite_cache.invalidate(@intCast(entity));
             self.renderer.untrackEntity(entity);

--- a/src/game/entity_mixin.zig
+++ b/src/game/entity_mixin.zig
@@ -245,14 +245,12 @@ pub fn Mixin(comptime Game: type) type {
                     destroyEntity(self, child);
                 }
             }
-            // Free this entity's own `Children` backing allocation before the
-            // backend drops the component by value (the ECS runs no
-            // destructor). Re-fetch: the cascade above may have relocated the
-            // Children pool under any pointer held before it.
-            if (self.ecs_backend.getComponent(entity, Children)) |cc| cc.deinit(self.allocator);
             // Preview telemetry emits BEFORE the actual destroy so any
             // editor-side consumer can still introspect the entity from
-            // a `getComponent` style API while reacting to the frame.
+            // a `getComponent` style API while reacting to the frame — so the
+            // `Children` free below must stay AFTER this: freeing the list
+            // first would hand a preview `getChildren` a slice into a freed
+            // allocation.
             if (self.preview) |*p| p.emitEntityDestroyed(@intCast(entity)) catch {};
             // #701 — unlink from the parent's `Children` before the
             // backend destroy (after it, the `Parent` component is
@@ -266,6 +264,12 @@ pub fn Mixin(comptime Game: type) type {
             self.active_world.sprite_cache.invalidate(@intCast(entity));
             self.renderer.untrackEntity(entity);
             self.releaseTilemap(entity);
+            // Free this entity's own `Children` backing allocation just before
+            // the backend drops the component by value (the ECS runs no
+            // destructor). Kept here — after the preview telemetry above — so
+            // a preview `getChildren` never reads a freed list. Re-fetch: the
+            // cascade may have relocated the Children pool under an old pointer.
+            if (self.ecs_backend.getComponent(entity, Children)) |cc| cc.deinit(self.allocator);
             self.ecs_backend.destroyEntity(entity);
             self.bumpRoster();
             recordTombstone(self, entity);

--- a/src/game/world_mixin.zig
+++ b/src/game/world_mixin.zig
@@ -122,6 +122,20 @@ pub fn Mixin(comptime Game: type) type {
             // Free per-entity particle sims for the same reason (#750): the
             // ECS wipe invalidates every emitter entity id in the side-table.
             self.clearParticleSystems();
+            // Free every `ChildrenComponent`'s backing allocation before the
+            // ECS is torn down: the backend drops components by value with no
+            // destructor, so their heap-backed child lists would otherwise
+            // leak on every scene swap / load. Entities already destroyed via
+            // destroyEntity[Only] freed theirs; this catches the survivors the
+            // wipe is about to drop.
+            {
+                const Children = Game.ChildrenComp;
+                var v = self.active_world.ecs_backend.view(.{Children}, .{});
+                defer v.deinit();
+                while (v.next()) |e| {
+                    if (self.active_world.ecs_backend.getComponent(e, Children)) |cc| cc.deinit(self.allocator);
+                }
+            }
             self.active_world.ecs_backend.deinit();
             _ = self.active_world.nested_entity_arena.reset(.retain_capacity);
 

--- a/src/jsonc/scene_loader/nested_spawn.zig
+++ b/src/jsonc/scene_loader/nested_spawn.zig
@@ -367,10 +367,10 @@ pub fn NestedSpawn(comptime GameType: type, comptime Components: type, comptime 
                 for (ids) |child_id| {
                     const child_entity: Entity = @intCast(child_id);
                     if (game.ecs_backend.getComponent(parent_entity, ChildrenComp)) |children_comp| {
-                        children_comp.addChild(child_entity);
+                        children_comp.addChild(game.allocator, child_entity);
                     } else {
                         var new_children = ChildrenComp{};
-                        new_children.addChild(child_entity);
+                        new_children.addChild(game.allocator, child_entity);
                         game.ecs_backend.addComponent(parent_entity, new_children);
                     }
                 }

--- a/test/destroy_unlink_test.zig
+++ b/test/destroy_unlink_test.zig
@@ -53,6 +53,37 @@ test "#701: destroying a child unlinks it from the parent's Children" {
     try testing.expectEqual(@as(usize, 0), game.entityCount());
 }
 
+test "#797: direct removeComponent / set / add of Children don't leak the list" {
+    // The generic component API is a public path that bypasses the hierarchy
+    // choke points: removing or overwriting a `Children` by value would drop
+    // its heap list without freeing it. `game.deinit` runs under
+    // `testing.allocator`, so any leaked child-list allocation fails here.
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    const Children = Game.ChildrenComp;
+
+    const parent = game.createEntity();
+    var i: usize = 0;
+    while (i < 20) : (i += 1) game.setParent(game.createEntity(), parent, .{});
+    try testing.expectEqual(@as(usize, 20), game.getChildren(parent).len);
+
+    // Direct generic removal must free the backing list.
+    game.removeComponent(parent, Children);
+    try testing.expect(!game.hasComponent(parent, Children));
+
+    // setComponent overwrite must free the replaced list.
+    i = 0;
+    while (i < 20) : (i += 1) game.setParent(game.createEntity(), parent, .{});
+    game.setComponent(parent, Children{});
+    try testing.expectEqual(@as(usize, 0), game.getChildren(parent).len);
+
+    // addComponent overwrite must free the replaced list.
+    i = 0;
+    while (i < 20) : (i += 1) game.setParent(game.createEntity(), parent, .{});
+    game.addComponent(parent, Children{});
+    try testing.expectEqual(@as(usize, 0), game.getChildren(parent).len);
+}
+
 test "#701: destroying the middle child leaves the siblings listed" {
     var game = Game.init(testing.allocator);
     defer game.deinit();

--- a/test/destroy_unlink_test.zig
+++ b/test/destroy_unlink_test.zig
@@ -221,13 +221,15 @@ test "#701: repeated child destroys don't leak Children slots" {
     var game = Game.init(testing.allocator);
     defer game.deinit();
 
-    // Consequence 3 of the bug: MAX_CHILDREN slots with silent drop in
-    // addChild — every leaked stale id permanently consumed a slot, so
-    // after enough destroys new children silently failed to register.
+    // Consequence 3 of the bug: a leaked stale id used to linger in the
+    // parent's child list after each destroy. With dynamic children there's
+    // no cap, so this instead pins that repeated parent+destroy cycles leave
+    // the list correct (each destroy unlinks the child) and leak nothing —
+    // `testing.allocator` (via `game.deinit`) fails the test on any leaked
+    // child-list allocation. Loop well past the old 16 cap.
     const parent = game.createEntity();
-    const max = Game.ChildrenComp.MAX_CHILDREN;
     var i: usize = 0;
-    while (i < max + 4) : (i += 1) {
+    while (i < 40) : (i += 1) {
         const child = game.createEntity();
         game.setParent(child, parent, .{});
         game.destroyEntity(child);


### PR DESCRIPTION
## What

Pairs with **labelle-core#65** (dynamic `ChildrenComponent` — ArrayList-backed, no `MAX_CHILDREN`). The ECS backends store components by value and run no destructors, so the engine — which exclusively manages the hierarchy — owns the child-list heap lifecycle at every choke point:

- **`setParent` / nested-prefab spawn** thread `game.allocator` into `addChild`.
- **`destroyEntity`** copies child ids onto an **independent** allocation before the cascade — the old shallow struct snapshot (`children_comp.*`) would now alias, and outlive the free of, the heap-backed list — then frees the entity's own list (re-fetched, since the cascade can relocate the pool).
- **`destroyEntityOnly`** frees the dying entity's list (its children stay alive).
- **`resetEcsBackend`** and **`World.deinit`** free every `ChildrenComponent` before the ECS wipe drops them by value. `World` now retains its allocator for the teardown free.

Removes the silent-drop-past-16 orphaning of slot-heavy rooms/workstations (consumer #657).

## Verification

The engine test suite runs under the DebugAllocator's **leak detector**. A first cut that missed the `World.deinit` free was caught by the prefab-with-children tests; with all choke points covered the full suite passes leak-free. `#701`'s repeated-destroy test is re-pinned to the dynamic model (no more `MAX_CHILDREN`).

## Depends on

**labelle-core#65 — merge that first.** This engine build compiles against core's new `addChild(allocator, …)` / `deinit(allocator)` API; CI here is red until core main carries the change.

https://claude.ai/code/session_011szWvquoss1yNX7KWSKCaM

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-engine/pr/797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787454015&installation_model_id=427192&pr_number=797&repository=labelle-toolkit%2Flabelle-engine&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-engine%2Fpull%2F797&signature=293a2a313f7579a73b6c7030966585bef1a9d380137a90d10cba9df2c718b473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->