### PR TITLE
feat: make destroyEntity cascade panic-safe against already-dead descendants

### DIFF
--- a/src/game/entity_mixin.zig
+++ b/src/game/entity_mixin.zig
@@ -264,6 +264,17 @@ pub fn Mixin(comptime Game: type) type {
                     destroyEntity(self, child);
                 }
             }
+            // Re-check liveness after the cascade. The entry guard only proved
+            // `entity` was alive at the START; a child's synchronous
+            // `entity_destroyed` hook can call back into the Game and destroy
+            // THIS entity mid-cascade (e.g. a teardown hook that removes an
+            // owner/room when one of its children dies). If it did, the entity
+            // has already run its full destroy — including freeing its own
+            // `Children` allocation — so the tail below (preview, the
+            // `Children` free, backend destroy, tombstone, hooks) must NOT run
+            // again on a dead id or it double-frees / re-emits. (`kids` is our
+            // independent dupe, freed by the defer above regardless.)
+            if (!self.ecs_backend.entityExists(entity)) return;
             // Preview telemetry emits BEFORE the actual destroy so any
             // editor-side consumer can still introspect the entity from
             // a `getComponent` style API while reacting to the frame — so the

--- a/src/game/entity_mixin.zig
+++ b/src/game/entity_mixin.zig
@@ -228,6 +228,25 @@ pub fn Mixin(comptime Game: type) type {
         }
 
         pub fn destroyEntity(self: *Game, entity: Entity) void {
+            // Idempotence guard — make the cascade panic-safe against an
+            // already-dead descendant. The cascade below recurses over a
+            // by-value snapshot of child ids (`kids`), and by the time the
+            // walk reaches a given id that entity may already be gone:
+            //   • a consumer destroyed some entities first, then cascades a
+            //     surviving ancestor (flying-platform room teardown);
+            //   • the same entity is reachable twice in the walk (a child
+            //     that appears under two parents, or a re-parent remnant);
+            //   • a sibling's `entity_destroyed` hook destroyed it mid-cascade.
+            // Every step past this point (backend `destroyEntity`, the
+            // `Children` ArrayList free, `detachFromParent`, tombstone,
+            // hooks, preview telemetry) assumes a LIVE entity — re-running
+            // them on a dead id double-frees the heap-backed `Children`
+            // list, re-emits `entity_destroyed`, and traps the backend
+            // destroy on sparse-set backends. A dead entity already ran its
+            // own full teardown (including freeing its `Children` list), so
+            // bailing here is a leak-free no-op. `entityExists` is the same
+            // liveness oracle `detachFromParent` trusts.
+            if (!self.ecs_backend.entityExists(entity)) return;
             if (self.ecs_backend.getComponent(entity, Children)) |children_comp| {
                 // Cascade over an INDEPENDENT copy of the child ids. Each
                 // child's destroy unlinks it from THIS live list via
@@ -279,6 +298,23 @@ pub fn Mixin(comptime Game: type) type {
         }
 
         pub fn destroyEntityOnly(self: *Game, entity: Entity) void {
+            // Idempotence guard — mirror `destroyEntity` so both public
+            // destroy entry points are safe no-ops on a dead id.
+            //
+            // Reasoning on whether this is *needed*: unlike `destroyEntity`,
+            // this variant does NOT cascade, so a single call never re-hits
+            // an entity of its own accord, and its main caller (the scene
+            // drain) pops each tracked entity exactly once and dedups via
+            // `untrackSceneEntity`. So under today's callers it wouldn't
+            // trap. It's added anyway because (1) it's a public API and a
+            // consumer that double-destroys — or destroys an entity that a
+            // prior `destroyEntity` cascade already reaped — must get the
+            // same idempotent behaviour rather than a double-free of the
+            // `Children` list + duplicate hooks, and (2) equal guarantees on
+            // both entry points remove a footgun when code switches between
+            // them. It does NOT change the contract: the listed children
+            // still stay alive; a dead entity simply has nothing left to do.
+            if (!self.ecs_backend.entityExists(entity)) return;
             if (self.preview) |*p| p.emitEntityDestroyed(@intCast(entity)) catch {};
             // #701 — same parent-unlink as `destroyEntity`. This variant
             // deliberately leaves the entity's own children alive (its

--- a/test/destroy_unlink_test.zig
+++ b/test/destroy_unlink_test.zig
@@ -248,6 +248,146 @@ test "#701: re-parent then destroy touches only the current parent's list" {
     try testing.expect(game.ecs_backend.entityExists(p2));
 }
 
+// ── Cascade panic-safety against already-dead descendants ───────────────
+//
+// A consumer (flying-platform room teardown) wants to cascade-destroy an
+// ancestor AFTER having already destroyed some of its descendants directly.
+// Before the idempotence guard the cascade re-hit those dead ids: it
+// double-freed the heap-backed `Children` list, re-emitted
+// `entity_destroyed`, and trapped the backend destroy. These tests pin that
+// re-hitting a dead entity anywhere in the walk is a leak-free no-op
+// (`testing.allocator` via `game.deinit` fails on any leaked child list).
+
+test "cascade: destroying a subtree whose child was already destroyed is a safe no-op" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const parent = game.createEntity();
+    const child_a = game.createEntity();
+    const child_b = game.createEntity();
+    game.setParent(child_a, parent, .{});
+    game.setParent(child_b, parent, .{});
+
+    // Consumer destroys one child up front (it unlinks from parent's list).
+    game.destroyEntity(child_a);
+    try testing.expect(!game.ecs_backend.entityExists(child_a));
+
+    // Now cascade the ancestor. child_a is already dead — the cascade must
+    // NOT re-hit it (double-free / trap). The rest is still cleaned up.
+    game.destroyEntity(parent);
+
+    try testing.expect(!game.ecs_backend.entityExists(parent));
+    try testing.expect(!game.ecs_backend.entityExists(child_b));
+    try testing.expectEqual(@as(usize, 0), game.entityCount());
+}
+
+test "cascade: a grandchild destroyed before its parent's cascade is skipped" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    // G → M → L. Kill the leaf first, then cascade the grandparent: the
+    // walk descends G → M → L and must early-return on the dead L.
+    const grandparent = game.createEntity();
+    const middle = game.createEntity();
+    const leaf = game.createEntity();
+    game.setParent(middle, grandparent, .{});
+    game.setParent(leaf, middle, .{});
+
+    game.destroyEntity(leaf);
+    try testing.expect(!game.ecs_backend.entityExists(leaf));
+    // Middle survives (only the leaf died) and its list is now empty.
+    try testing.expect(game.ecs_backend.entityExists(middle));
+    try testing.expectEqual(@as(usize, 0), game.getChildren(middle).len);
+
+    // Cascade the whole remaining tree — the dead leaf must not re-trap.
+    game.destroyEntity(grandparent);
+
+    try testing.expect(!game.ecs_backend.entityExists(grandparent));
+    try testing.expect(!game.ecs_backend.entityExists(middle));
+    try testing.expectEqual(@as(usize, 0), game.entityCount());
+}
+
+test "cascade: destroying an already-dead entity directly is a no-op" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const bystander = game.createEntity();
+    const entity = game.createEntity();
+
+    game.destroyEntity(entity);
+    try testing.expect(!game.ecs_backend.entityExists(entity));
+    const count_after_first = game.entityCount();
+
+    // A second destroy of the same id must not re-emit hooks, double-free,
+    // or disturb the count / the bystander.
+    game.destroyEntity(entity);
+    try testing.expectEqual(count_after_first, game.entityCount());
+    try testing.expect(game.ecs_backend.entityExists(bystander));
+}
+
+test "cascade: an already-destroyed subtree with grandchildren does not double-free" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    // parent → mid (→ leaf), and a sibling under parent. Destroy `mid`
+    // (cascading leaf) up front, THEN cascade parent. The parent's walk
+    // reaches the dead `mid`, which must be skipped whole — its already-
+    // freed `Children` list must not be freed again.
+    const parent = game.createEntity();
+    const mid = game.createEntity();
+    const leaf = game.createEntity();
+    const sibling = game.createEntity();
+    game.setParent(mid, parent, .{});
+    game.setParent(leaf, mid, .{});
+    game.setParent(sibling, parent, .{});
+
+    game.destroyEntity(mid);
+    try testing.expect(!game.ecs_backend.entityExists(mid));
+    try testing.expect(!game.ecs_backend.entityExists(leaf)); // cascaded
+
+    game.destroyEntity(parent);
+    try testing.expect(!game.ecs_backend.entityExists(parent));
+    try testing.expect(!game.ecs_backend.entityExists(sibling));
+    try testing.expectEqual(@as(usize, 0), game.entityCount());
+}
+
+test "cascade: a normal (all-live) destroy still cleans up and keeps entityCount correct" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const keep_a = game.createEntity();
+    const keep_b = game.createEntity();
+    const parent = game.createEntity();
+    var kids: [3]Entity = undefined;
+    for (&kids) |*k| {
+        k.* = game.createEntity();
+        game.setParent(k.*, parent, .{});
+    }
+    try testing.expectEqual(@as(usize, 6), game.entityCount());
+
+    game.destroyEntity(parent);
+
+    try testing.expect(!game.ecs_backend.entityExists(parent));
+    for (kids) |k| try testing.expect(!game.ecs_backend.entityExists(k));
+    // Unrelated entities untouched; count reflects exactly the 4 removed.
+    try testing.expect(game.ecs_backend.entityExists(keep_a));
+    try testing.expect(game.ecs_backend.entityExists(keep_b));
+    try testing.expectEqual(@as(usize, 2), game.entityCount());
+}
+
+test "destroyEntityOnly: destroying an already-dead entity is a no-op" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    const entity = game.createEntity();
+    game.destroyEntityOnly(entity);
+    const count_after = game.entityCount();
+
+    // Idempotent second call — no double-free, no duplicate hooks.
+    game.destroyEntityOnly(entity);
+    try testing.expectEqual(count_after, game.entityCount());
+}
+
 test "#701: repeated child destroys don't leak Children slots" {
     var game = Game.init(testing.allocator);
     defer game.deinit();


### PR DESCRIPTION
## What

`game.destroyEntity` cascades over a by-value snapshot of child ids, but a descendant can already be dead by the time the walk reaches it:
- a consumer destroyed some entities first, then cascades a surviving ancestor (the flying-platform room teardown case);
- the same id is reachable twice in the walk (a re-parent remnant / a child under two parents);
- a sibling's `entity_destroyed` hook killed it mid-cascade.

Every step past the recursion — backend destroy, the heap-backed `Children` `ArrayList` free, `detachFromParent`, tombstone, hooks, preview telemetry — would then double-free / re-emit / trap on a dead id. That's precisely why downstream games use a hand-rolled non-cascading teardown (`destroyEntityOnly` + explicit id-array walking) instead of just cascading.

## Fix

An idempotence guard — `if (!self.ecs_backend.entityExists(entity)) return;` — as the **first statement** of both public destroy entry points (`destroyEntity`, and for parity `destroyEntityOnly`). `entityExists` is the alive-set oracle `detachFromParent` already trusts; a dead entity has already freed its own `Children` allocation, so bailing is a leak-free no-op. No change to `destroyEntityOnly`'s contract (listed children still stay alive).

## Why it matters

Lets a consumer (flying-platform's `31_drain_pass` room teardown) drop the non-cascading `destroyEntityOnly` + id-array walk and just `destroyEntity` the room — which in turn makes the `reapOrphans` fish/critter backstops genuinely removable (parenting now means the cascade cleans them up).

## Tests

`test/destroy_unlink_test.zig` (+6): subtree with a pre-destroyed child, grandchild destroyed before its ancestor's cascade, direct double-destroy, an already-dead subtree with grandchildren (no double-free), a normal all-live destroy, and `destroyEntityOnly` on a dead entity. All under `testing.allocator` (leak = fail). `zig build test` green.

https://claude.ai/code/session_011szWvquoss1yNX7KWSKCaM

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-engine/pr/798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787494811&installation_model_id=427192&pr_number=798&repository=labelle-toolkit%2Flabelle-engine&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-engine%2Fpull%2F798&signature=2ff097e39ea78d2db67ba7077e5500a5d874750f0c655e2ba83529c87a38a2a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->