### PR TITLE
feat(scenes): `@ref`-targeted overrides on prefab references (#801)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -91,6 +91,7 @@ pub fn build(b: *std.Build) void {
         "test/save_load_mixin_test.zig",
         "test/jsonc/bridge_leak_test.zig",
         "test/jsonc/nested_lifecycle_test.zig",
+        "test/jsonc/target_overrides_test.zig",
         // C2 — a project-registered component named `Tilemap` must win over
         // the engine built-in in the scene loader (no silent shadowing).
         "test/jsonc/tilemap_precedence_test.zig",

--- a/src/jsonc/scene_loader/entity_walker.zig
+++ b/src/jsonc/scene_loader/entity_walker.zig
@@ -17,6 +17,9 @@ const Position = core.Position;
 const prefab_cache_mod = @import("../prefab_cache.zig");
 const PrefabCache = prefab_cache_mod.PrefabCache;
 const uf = @import("../unified_format.zig");
+const to = @import("../target_overrides.zig");
+const tree_walker = @import("../tree_walker.zig");
+const cycle_detect = @import("cycle_detect.zig");
 const ref_resolver_mod = @import("../ref_resolver.zig");
 const component_apply_mod = @import("../component_apply.zig");
 const on_ready_mod = @import("../on_ready.zig");
@@ -37,7 +40,15 @@ pub fn EntityWalker(comptime GameType: type, comptime Components: type, comptime
         /// applies components with `@ref` strings replaced by `0`
         /// (patched in pass 2). When `ref_ctx` is null, follows the
         /// original single-pass path.
-        pub fn loadEntityInternal(game: *GameType, entity_val: Value, prefab_cache: *PrefabCache, depth: usize, parent_offset: Position, ref_ctx: ?*RefContext) Self.LoadEntityError!Entity {
+        ///
+        /// `inherited_targets` is the chain of enclosing references'
+        /// `@`-target patches (#801): when this entry sits inside a
+        /// prefab body whose reference declared `"@name"` overrides,
+        /// a matching entry-level `ref` folds those patches into this
+        /// entity's own patch (outermost author wins). The entry's own
+        /// `@` keys extend the chain for its body. Top-level scene
+        /// entries pass `null`.
+        pub fn loadEntityInternal(game: *GameType, entity_val: Value, prefab_cache: *PrefabCache, depth: usize, parent_offset: Position, ref_ctx: ?*RefContext, inherited_targets: ?*to.TargetCtx) Self.LoadEntityError!Entity {
             if (depth > Self.MAX_DEPTH) return error.IncludeDepthExceeded;
             const entity_obj = entity_val.asObject() orelse return error.InvalidFormat;
 
@@ -104,9 +115,62 @@ pub fn EntityWalker(comptime GameType: type, comptime Components: type, comptime
             // For a reference entry this is the `overrides` patch;
             // for an inline entry, its own `components`. The flat
             // form (RFC #596) synthesizes the view from the entity's
-            // PascalCase keys; the wrapped form returns the existing
-            // Object verbatim.
-            const scene_components = try uf.entityPatch(entity_obj, merge_arena.allocator(), game.log);
+            // PascalCase + `@` keys; the wrapped form returns the
+            // existing Object verbatim.
+            const raw_patch = try uf.entityPatch(entity_obj, merge_arena.allocator(), game.log);
+
+            // ── `@`-target overrides (#801) ─────────────────────
+            // Partition the patch: bare component keys patch THIS
+            // entity; `@name` keys patch ref-named entities inside
+            // the referenced prefab's body.
+            const parts = try to.splitPatch(raw_patch, merge_arena.allocator());
+            if (parts.targets != null and !is_reference) {
+                game.log.err(
+                    "[target-override] `@` keys are only valid on a prefab reference (#801) — an inline entity authors its nested entries directly, so put the override on the entry itself.",
+                    .{},
+                );
+                return error.InvalidFormat;
+            }
+
+            // This entry's effective ref: entry-level `ref` wins,
+            // else the referenced prefab root's `ref` — the same
+            // precedence ref registration uses.
+            const own_ref: ?[]const u8 = entity_obj.getString("ref") orelse
+                if (prefab_obj_opt) |pobj| uf.rootObject(pobj).getString("ref") else null;
+
+            // Fold enclosing references' matching `@` patches onto
+            // this entity's own patch, outermost author last (wins).
+            const fold = try to.foldMatches(inherited_targets, own_ref, parts.components, merge_arena.allocator());
+            const scene_components = fold.patch;
+
+            // RFC #562 `null`-removal is scoped to reference
+            // `overrides` — and (#801) to any patch a `@` target
+            // contributed, so a scene can remove a component from a
+            // nested inline entity too.
+            const removal_active = is_reference or fold.matched;
+
+            // This entry's own `@` targets extend the chain for its
+            // prefab body. Accounting (every target must match) is
+            // checked once the body finishes loading, below.
+            const own_targets: ?*to.TargetCtx = try to.buildCtx(
+                parts.targets,
+                entity_obj.getString("prefab") orelse "<inline>",
+                inherited_targets,
+                merge_arena.allocator(),
+                game.log,
+            );
+            const child_targets = own_targets orelse inherited_targets;
+
+            // #801's original trap, made loud: a bare override key
+            // the prefab root doesn't declare is legal (it ADDS a
+            // component to the root) — but when an entity nested in
+            // the prefab's body carries that component, the author
+            // almost certainly meant to target it. Checked over the
+            // PRE-fold patch so components a matched `@` target
+            // deliberately added never trigger it.
+            if (is_reference) {
+                warnOverrideOnlyNestedComponents(game, entity_obj, parts.components, prefab_components, prefab_cache);
+            }
 
             // Create entity — destroy on error to prevent orphans.
             const entity = game.createEntity();
@@ -120,9 +184,7 @@ pub fn EntityWalker(comptime GameType: type, comptime Components: type, comptime
             // own RefContext).
             if (ref_ctx) |rctx| {
                 const entity_id: u64 = @intCast(entity);
-                const ref_name = entity_obj.getString("ref") orelse
-                    if (prefab_obj_opt) |pobj| uf.rootObject(pobj).getString("ref") else null;
-                if (ref_name) |rn| {
+                if (own_ref) |rn| {
                     if (try rctx.ref_map.fetchPut(rn, entity_id)) |existing| {
                         game.log.warn("[SceneRef] Duplicate ref '{s}' (entities {d} and {d})", .{ rn, existing.value, entity_id });
                     }
@@ -155,7 +217,7 @@ pub fn EntityWalker(comptime GameType: type, comptime Components: type, comptime
             const effective_overrides: ?[]?Value = if (scene_components) |sc| blk: {
                 const slice = try merge_arena.allocator().alloc(?Value, sc.entries.len);
                 for (sc.entries, 0..) |entry, i| {
-                    if (is_reference and entry.value == .null_value) {
+                    if (removal_active and entry.value == .null_value) {
                         slice[i] = null;
                     } else {
                         slice[i] = try uf.mergedOverride(prefab_components, entry.key, entry.value, merge_arena.allocator());
@@ -180,8 +242,16 @@ pub fn EntityWalker(comptime GameType: type, comptime Components: type, comptime
             }
 
             // Apply prefab components the override did not touch.
+            // `@` keys on a prefab ROOT are not applied — a target
+            // key only means something on a *reference* (#801). Skip
+            // visibly rather than let the unknown-component path
+            // mislabel it.
             if (prefab_components) |pc| {
                 for (pc.entries) |entry| {
+                    if (uf.isTargetKey(entry.key)) {
+                        warnPrefabRootTarget(game, entity_obj, entry.key);
+                        continue;
+                    }
                     if (!applied.contains(entry.key)) {
                         try ApplyHelpers.applyComponentWithRefs(game, entity, entry.key, entry.value, parent_offset, ref_ctx);
                     }
@@ -200,20 +270,23 @@ pub fn EntityWalker(comptime GameType: type, comptime Components: type, comptime
             if (scene_components) |sc| {
                 for (sc.entries, 0..) |entry, i| {
                     const effective = effective_overrides.?[i] orelse continue;
-                    try Self.spawnAndLinkNestedEntities(game, entity, entry.key, effective, entity_pos, prefab_cache, depth, ref_ctx);
+                    try Self.spawnAndLinkNestedEntities(game, entity, entry.key, effective, entity_pos, prefab_cache, depth, ref_ctx, child_targets);
                 }
             }
             if (prefab_components) |pc| {
                 for (pc.entries) |entry| {
+                    if (uf.isTargetKey(entry.key)) continue; // warned in the apply pass
                     if (!applied.contains(entry.key)) {
-                        try Self.spawnAndLinkNestedEntities(game, entity, entry.key, entry.value, entity_pos, prefab_cache, depth, ref_ctx);
+                        try Self.spawnAndLinkNestedEntities(game, entity, entry.key, entry.value, entity_pos, prefab_cache, depth, ref_ctx, child_targets);
                     }
                 }
             }
 
             // Fire onReady for all applied components (after entity
-            // is fully assembled).
-            OnReadyHelpers.fireOnReadyAll(game, entity, scene_components, prefab_components, &applied, is_reference);
+            // is fully assembled). `removal_active` widens the "null
+            // means removed, fire no hook" rule to patches a `@`
+            // target contributed (#801).
+            OnReadyHelpers.fireOnReadyAll(game, entity, scene_components, prefab_components, &applied, removal_active);
 
             // Process children recursively (prefab children +
             // entity-level children).
@@ -239,9 +312,17 @@ pub fn EntityWalker(comptime GameType: type, comptime Components: type, comptime
             // between top-level entities still work as before.
             if (prefab_children) |children| {
                 for (children.items) |child_val| {
-                    try loadChildEntity(game, entity, child_val, prefab_cache, depth, entity_pos, ref_ctx);
+                    try loadChildEntity(game, entity, child_val, prefab_cache, depth, entity_pos, ref_ctx, child_targets);
                 }
             }
+
+            // The reference's body (component-field entities + prefab
+            // children, recursively) is fully instantiated — every
+            // `@` target this entry declared must have matched at
+            // least one ref-named entity in it. An unmatched target
+            // is a hard load error: the silent no-op is the exact
+            // failure #801 exists to kill.
+            if (own_targets) |tctx| try to.checkAllMatched(tctx, game.log);
 
             // Save/load: tag prefab-sourced entities with
             // `PrefabInstance` (root) + `PrefabChild` (each
@@ -274,7 +355,11 @@ pub fn EntityWalker(comptime GameType: type, comptime Components: type, comptime
 
             if (entity_obj.getArray("children")) |children| {
                 for (children.items) |child_val| {
-                    try loadChildEntity(game, entity, child_val, prefab_cache, depth, entity_pos, ref_ctx);
+                    // Scene-declared children only exist on inline
+                    // entities (§B2 forbids them on references), so
+                    // `child_targets == inherited_targets` here — the
+                    // enclosing prefab body's targets flow through.
+                    try loadChildEntity(game, entity, child_val, prefab_cache, depth, entity_pos, ref_ctx, child_targets);
                 }
             }
 
@@ -293,6 +378,7 @@ pub fn EntityWalker(comptime GameType: type, comptime Components: type, comptime
             depth: usize,
             parent_pos: Position,
             ref_ctx: ?*RefContext,
+            targets: ?*to.TargetCtx,
         ) Self.LoadEntityError!void {
             const child_obj = child_val.asObject();
             const child_is_prefab = if (child_obj) |cobj| cobj.getString("prefab") != null else false;
@@ -309,7 +395,7 @@ pub fn EntityWalker(comptime GameType: type, comptime Components: type, comptime
                 var local_ctx = RefContext.init(game.allocator, ref_ctx);
                 defer local_ctx.deinit();
 
-                const c = try loadEntityInternal(game, child_val, prefab_cache, depth + 1, parent_pos, &local_ctx);
+                const c = try loadEntityInternal(game, child_val, prefab_cache, depth + 1, parent_pos, &local_ctx, targets);
 
                 // If the child was given a scene-level ref
                 // override, bubble it up to the parent scope so
@@ -340,13 +426,123 @@ pub fn EntityWalker(comptime GameType: type, comptime Components: type, comptime
             } else
                 // Plain child: uses the parent's `ref_ctx` so
                 // scene-level cross-references still work.
-                try loadEntityInternal(game, child_val, prefab_cache, depth + 1, parent_pos, ref_ctx);
+                try loadEntityInternal(game, child_val, prefab_cache, depth + 1, parent_pos, ref_ctx, targets);
 
             // Save world pos before setParent to avoid
             // double-offset (#417).
             const world_pos = game.getPosition(child);
             game.setParent(child, parent_entity, .{});
             game.setWorldPosition(child, world_pos);
+        }
+
+        /// Warn once per (prefab, key): a `@` key on a prefab ROOT is
+        /// skipped, not applied — target keys only mean something on
+        /// a *reference* (#801). Visible because a silent drop is the
+        /// failure mode this feature exists to kill.
+        fn warnPrefabRootTarget(game: *GameType, entity_obj: Value.Object, key: []const u8) void {
+            const pname = entity_obj.getString("prefab") orelse "<inline>";
+            var buf: [256]u8 = undefined;
+            const dedup = std.fmt.bufPrint(&buf, "prefab-root-target:{s}:{s}", .{ pname, key }) catch return;
+            uf.warnOnceKey(game.log, dedup, "[target-override] prefab '{s}' declares \"{s}\" on its ROOT — `@` targets belong on a reference's overrides, not a prefab root; skipped (#801).", .{ pname, key });
+        }
+
+        /// A logger that swallows everything — the nested-component
+        /// scan below re-parses patch views purely to read key names;
+        /// the instantiation pass already emitted any warnings.
+        const SilentLog = struct {
+            pub fn warn(_: @This(), comptime _: []const u8, _: anytype) void {}
+            pub fn err(_: @This(), comptime _: []const u8, _: anytype) void {}
+        };
+
+        /// Tree-walker visitor that collects the component names
+        /// declared by every entity in a prefab's body (patch keys +
+        /// resolved prefab-root components), excluding the walk root.
+        const NestedComponentNames = struct {
+            pub const VisitError = error{OutOfMemory};
+            set: *std.StringHashMap(void),
+            arena: std.mem.Allocator,
+
+            pub fn visit(self: @This(), node: tree_walker.Node(VisitError)) VisitError!void {
+                if (node.origin == .root) return;
+                if (uf.entityPatch(node.obj, self.arena, SilentLog{}) catch null) |patch| {
+                    for (patch.entries) |e| {
+                        if (!uf.isTargetKey(e.key)) try self.set.put(e.key, {});
+                    }
+                }
+                if (node.prefab_root) |pr| {
+                    if (uf.prefabComponents(pr, self.arena, SilentLog{}) catch null) |pc| {
+                        for (pc.entries) |e| {
+                            if (!uf.isTargetKey(e.key)) try self.set.put(e.key, {});
+                        }
+                    }
+                }
+            }
+        };
+
+        /// #801: warn (once per prefab+component) when a reference's
+        /// bare override names a component the prefab ROOT does not
+        /// declare while an entity nested in the prefab's body DOES
+        /// carry it — the override lands on the root, which is almost
+        /// never what the author meant. Best-effort: any walk failure
+        /// just skips the warning (the real load reports real errors).
+        fn warnOverrideOnlyNestedComponents(
+            game: *GameType,
+            entity_obj: Value.Object,
+            override_components: ?Value.Object,
+            prefab_components: ?Value.Object,
+            prefab_cache: *PrefabCache,
+        ) void {
+            const sc = override_components orelse return;
+            const pname = entity_obj.getString("prefab") orelse return;
+
+            // Fast path: every override key is declared on the root
+            // (the overwhelmingly common case) — no walk needed.
+            var any_orphan = false;
+            for (sc.entries) |e| {
+                if (e.value == .null_value) continue;
+                const on_root = blk: {
+                    const pc = prefab_components orelse break :blk false;
+                    for (pc.entries) |pe| {
+                        if (std.mem.eql(u8, pe.key, e.key)) break :blk true;
+                    }
+                    break :blk false;
+                };
+                if (!on_root) {
+                    any_orphan = true;
+                    break;
+                }
+            }
+            if (!any_orphan) return;
+
+            const prefab_val = prefab_cache.get(pname) orelse return;
+
+            var arena = std.heap.ArenaAllocator.init(game.allocator);
+            defer arena.deinit();
+            var names = std.StringHashMap(void).init(arena.allocator());
+            var wctx = tree_walker.WalkContext.init(arena.allocator());
+            defer wctx.deinit();
+            const collector = NestedComponentNames{ .set = &names, .arena = arena.allocator() };
+            tree_walker.walk(&wctx, cycle_detect.prefabResolver(prefab_cache), prefab_val, collector) catch return;
+
+            for (sc.entries) |e| {
+                if (e.value == .null_value) continue;
+                const on_root = blk: {
+                    const pc = prefab_components orelse break :blk false;
+                    for (pc.entries) |pe| {
+                        if (std.mem.eql(u8, pe.key, e.key)) break :blk true;
+                    }
+                    break :blk false;
+                };
+                if (on_root or !names.contains(e.key)) continue;
+                var buf: [256]u8 = undefined;
+                const dedup = std.fmt.bufPrint(&buf, "override-root-attach:{s}:{s}", .{ pname, e.key }) catch continue;
+                uf.warnOnceKey(
+                    game.log,
+                    dedup,
+                    "[SceneLoader] override on prefab '{s}' names component '{s}', which the prefab root does not declare — it is ADDED to the root entity. An entity nested in the prefab's body does carry this component; use \"@<ref>\": {{ \"{s}\": ... }} to target it (#801).",
+                    .{ pname, e.key, e.key },
+                );
+            }
         }
     };
 }

--- a/src/jsonc/scene_loader/entity_walker.zig
+++ b/src/jsonc/scene_loader/entity_walker.zig
@@ -249,7 +249,7 @@ pub fn EntityWalker(comptime GameType: type, comptime Components: type, comptime
             if (prefab_components) |pc| {
                 for (pc.entries) |entry| {
                     if (uf.isTargetKey(entry.key)) {
-                        warnPrefabRootTarget(game, entity_obj, entry.key);
+                        to.warnPrefabRootTarget(game.log, entity_obj.getString("prefab") orelse "<inline>", entry.key);
                         continue;
                     }
                     if (!applied.contains(entry.key)) {
@@ -435,17 +435,6 @@ pub fn EntityWalker(comptime GameType: type, comptime Components: type, comptime
             game.setWorldPosition(child, world_pos);
         }
 
-        /// Warn once per (prefab, key): a `@` key on a prefab ROOT is
-        /// skipped, not applied — target keys only mean something on
-        /// a *reference* (#801). Visible because a silent drop is the
-        /// failure mode this feature exists to kill.
-        fn warnPrefabRootTarget(game: *GameType, entity_obj: Value.Object, key: []const u8) void {
-            const pname = entity_obj.getString("prefab") orelse "<inline>";
-            var buf: [256]u8 = undefined;
-            const dedup = std.fmt.bufPrint(&buf, "prefab-root-target:{s}:{s}", .{ pname, key }) catch return;
-            uf.warnOnceKey(game.log, dedup, "[target-override] prefab '{s}' declares \"{s}\" on its ROOT — `@` targets belong on a reference's overrides, not a prefab root; skipped (#801).", .{ pname, key });
-        }
-
         /// A logger that swallows everything — the nested-component
         /// scan below re-parses patch views purely to read key names;
         /// the instantiation pass already emitted any warnings.
@@ -513,6 +502,22 @@ pub fn EntityWalker(comptime GameType: type, comptime Components: type, comptime
                 }
             }
             if (!any_orphan) return;
+
+            // The walk below is pure diagnostics — skip it when every
+            // orphan key has already produced its (deduplicated)
+            // warning, so N instances of one prefab pay for one walk,
+            // not N (CodeRabbit on #802).
+            var any_unwarned = false;
+            for (sc.entries) |e| {
+                if (e.value == .null_value) continue;
+                var kbuf: [256]u8 = undefined;
+                const k = std.fmt.bufPrint(&kbuf, "override-root-attach:{s}:{s}", .{ pname, e.key }) catch continue;
+                if (!uf.alreadyWarnedKey(k)) {
+                    any_unwarned = true;
+                    break;
+                }
+            }
+            if (!any_unwarned) return;
 
             const prefab_val = prefab_cache.get(pname) orelse return;
 

--- a/src/jsonc/scene_loader/entity_walker.zig
+++ b/src/jsonc/scene_loader/entity_walker.zig
@@ -486,9 +486,12 @@ pub fn EntityWalker(comptime GameType: type, comptime Components: type, comptime
 
             // Fast path: every override key is declared on the root
             // (the overwhelmingly common case) — no walk needed.
+            // `null` removals are NOT skipped: removing a component
+            // the root never carried is the same trap in removal
+            // clothing — the nested entity keeps its component while
+            // the scene reads like it was removed (codex P2 on #802).
             var any_orphan = false;
             for (sc.entries) |e| {
-                if (e.value == .null_value) continue;
                 const on_root = blk: {
                     const pc = prefab_components orelse break :blk false;
                     for (pc.entries) |pe| {
@@ -509,7 +512,6 @@ pub fn EntityWalker(comptime GameType: type, comptime Components: type, comptime
             // not N (CodeRabbit on #802).
             var any_unwarned = false;
             for (sc.entries) |e| {
-                if (e.value == .null_value) continue;
                 var kbuf: [256]u8 = undefined;
                 const k = std.fmt.bufPrint(&kbuf, "override-root-attach:{s}:{s}", .{ pname, e.key }) catch continue;
                 if (!uf.alreadyWarnedKey(k)) {
@@ -519,7 +521,17 @@ pub fn EntityWalker(comptime GameType: type, comptime Components: type, comptime
             }
             if (!any_unwarned) return;
 
-            const prefab_val = prefab_cache.get(pname) orelse return;
+            // Walk a SYNTHETIC reference to the prefab rather than
+            // the raw cached file value: the walker only unwraps the
+            // unified `{ "root": { ... } }` shape when it resolves a
+            // reference, so a raw wrapped file would scan as empty
+            // and the diagnostic would silently never fire for
+            // root-wrapped prefabs (codex P2 on #802). Mirrors the
+            // synthetic-entry trick in `prefab_spawn`'s cycle check.
+            var ref_entries = [_]Value.Object.Entry{
+                .{ .key = "prefab", .value = .{ .string = pname } },
+            };
+            const ref_entry = Value{ .object = .{ .entries = &ref_entries } };
 
             var arena = std.heap.ArenaAllocator.init(game.allocator);
             defer arena.deinit();
@@ -527,10 +539,9 @@ pub fn EntityWalker(comptime GameType: type, comptime Components: type, comptime
             var wctx = tree_walker.WalkContext.init(arena.allocator());
             defer wctx.deinit();
             const collector = NestedComponentNames{ .set = &names, .arena = arena.allocator() };
-            tree_walker.walk(&wctx, cycle_detect.prefabResolver(prefab_cache), prefab_val, collector) catch return;
+            tree_walker.walk(&wctx, cycle_detect.prefabResolver(prefab_cache), ref_entry, collector) catch return;
 
             for (sc.entries) |e| {
-                if (e.value == .null_value) continue;
                 const on_root = blk: {
                     const pc = prefab_components orelse break :blk false;
                     for (pc.entries) |pe| {
@@ -541,12 +552,21 @@ pub fn EntityWalker(comptime GameType: type, comptime Components: type, comptime
                 if (on_root or !names.contains(e.key)) continue;
                 var buf: [256]u8 = undefined;
                 const dedup = std.fmt.bufPrint(&buf, "override-root-attach:{s}:{s}", .{ pname, e.key }) catch continue;
-                uf.warnOnceKey(
-                    game.log,
-                    dedup,
-                    "[SceneLoader] override on prefab '{s}' names component '{s}', which the prefab root does not declare — it is ADDED to the root entity. An entity nested in the prefab's body does carry this component; use \"@<ref>\": {{ \"{s}\": ... }} to target it (#801).",
-                    .{ pname, e.key, e.key },
-                );
+                if (e.value == .null_value) {
+                    uf.warnOnceKey(
+                        game.log,
+                        dedup,
+                        "[SceneLoader] override on prefab '{s}' removes component '{s}', which the prefab root does not declare — the removal is a NO-OP. An entity nested in the prefab's body does carry this component; use \"@<ref>\": {{ \"{s}\": null }} to remove it there (#801).",
+                        .{ pname, e.key, e.key },
+                    );
+                } else {
+                    uf.warnOnceKey(
+                        game.log,
+                        dedup,
+                        "[SceneLoader] override on prefab '{s}' names component '{s}', which the prefab root does not declare — it is ADDED to the root entity. An entity nested in the prefab's body does carry this component; use \"@<ref>\": {{ \"{s}\": ... }} to target it (#801).",
+                        .{ pname, e.key, e.key },
+                    );
+                }
             }
         }
     };

--- a/src/jsonc/scene_loader/nested_spawn.zig
+++ b/src/jsonc/scene_loader/nested_spawn.zig
@@ -304,11 +304,17 @@ pub fn NestedSpawn(comptime GameType: type, comptime Components: type, comptime 
                             }
                             // Prefab defaults. `@` keys on a prefab
                             // ROOT are meaningless (targets belong on
-                            // a reference, #801) — skip them here;
-                            // the top-level walker warns once.
+                            // a reference, #801) — warn once and skip.
+                            // The warning must live HERE too: a prefab
+                            // referenced only from a component array
+                            // never passes through the top-level
+                            // walker's apply pass (CodeRabbit on #802).
                             if (child_prefab_comps) |pc| {
                                 for (pc.entries) |e| {
-                                    if (uf.isTargetKey(e.key)) continue;
+                                    if (uf.isTargetKey(e.key)) {
+                                        to.warnPrefabRootTarget(game.log, child_obj.getString("prefab") orelse "<inline>", e.key);
+                                        continue;
+                                    }
                                     const already_set = if (child_scene_comps) |sc| blk: {
                                         for (sc.entries) |se| {
                                             if (std.mem.eql(u8, se.key, e.key)) break :blk true;

--- a/src/jsonc/scene_loader/nested_spawn.zig
+++ b/src/jsonc/scene_loader/nested_spawn.zig
@@ -18,6 +18,7 @@ const Position = core.Position;
 const prefab_cache_mod = @import("../prefab_cache.zig");
 const PrefabCache = prefab_cache_mod.PrefabCache;
 const uf = @import("../unified_format.zig");
+const to = @import("../target_overrides.zig");
 const ref_resolver_mod = @import("../ref_resolver.zig");
 const component_apply_mod = @import("../component_apply.zig");
 const on_ready_mod = @import("../on_ready.zig");
@@ -47,6 +48,11 @@ pub fn NestedSpawn(comptime GameType: type, comptime Components: type, comptime 
         /// Spawn entity-like objects nested inside a component's
         /// fields, collect their entity IDs, and patch them back
         /// into the component's `[]const u64` fields.
+        ///
+        /// `targets` is the chain of enclosing references' `@`-target
+        /// patches (#801): a nested entity whose effective `ref`
+        /// matches a chain entry gets that patch folded onto its own
+        /// (outermost author wins) before components apply.
         pub fn spawnAndLinkNestedEntities(
             game: *GameType,
             parent_entity: Entity,
@@ -56,6 +62,7 @@ pub fn NestedSpawn(comptime GameType: type, comptime Components: type, comptime 
             prefab_cache: *PrefabCache,
             depth: usize,
             ref_ctx: ?*RefContext,
+            targets: ?*to.TargetCtx,
         ) Self.LoadEntityError!void {
             const obj = comp_value.asObject() orelse return;
 
@@ -104,10 +111,12 @@ pub fn NestedSpawn(comptime GameType: type, comptime Components: type, comptime 
                         if (item.asObject()) |child_obj| {
                             var child_prefab_comps: ?Value.Object = null;
                             var child_prefab_children: ?Value.Array = null;
+                            var child_prefab_ref: ?[]const u8 = null;
                             if (child_obj.getString("prefab")) |pname| {
                                 if (prefab_cache.get(pname)) |pval| {
                                     if (pval.asObject()) |pobj| {
                                         const proot = uf.rootObject(pobj);
+                                        child_prefab_ref = proot.getString("ref");
                                         // RFC #560 §B2: re-validate
                                         // the resolved prefab's own
                                         // root for the
@@ -178,14 +187,7 @@ pub fn NestedSpawn(comptime GameType: type, comptime Components: type, comptime 
                             {
                                 const entity_id: u64 = @intCast(child);
                                 const scene_ref = child_obj.getString("ref");
-                                var prefab_ref: ?[]const u8 = null;
-                                if (child_obj.getString("prefab")) |pname| {
-                                    if (prefab_cache.get(pname)) |pval| {
-                                        if (pval.asObject()) |pobj| {
-                                            prefab_ref = uf.rootObject(pobj).getString("ref");
-                                        }
-                                    }
-                                }
+                                const prefab_ref: ?[]const u8 = child_prefab_ref;
                                 if (prefab_ref) |prn| {
                                     local_ref_ctx.ref_map.put(prn, entity_id) catch {};
                                 }
@@ -199,14 +201,49 @@ pub fn NestedSpawn(comptime GameType: type, comptime Components: type, comptime 
 
                             // Reference entry → `overrides`; inline → `components`.
                             // Flat shape (RFC #596) synthesizes the
-                            // view from PascalCase keys; the entries
-                            // slice lives in `merge_arena` (declared
-                            // at the top of `spawnAndLinkNestedEntities`).
-                            const child_scene_comps = try uf.entityPatch(child_obj, merge_arena.allocator(), game.log);
+                            // view from PascalCase + `@` keys; the
+                            // entries slice lives in `merge_arena`
+                            // (declared at the top of
+                            // `spawnAndLinkNestedEntities`).
+                            const child_raw_patch = try uf.entityPatch(child_obj, merge_arena.allocator(), game.log);
+
+                            const child_is_reference = child_obj.getString("prefab") != null;
+
+                            // ── `@`-target overrides (#801) ─────
+                            // Partition off this entry's own `@`
+                            // keys, then fold enclosing references'
+                            // matching patches onto its component
+                            // half (outermost author wins). The
+                            // entry's effective ref uses the same
+                            // precedence ref registration does:
+                            // entry-level `ref`, else the referenced
+                            // prefab root's.
+                            const child_parts = try to.splitPatch(child_raw_patch, merge_arena.allocator());
+                            if (child_parts.targets != null and !child_is_reference) {
+                                game.log.err(
+                                    "[target-override] `@` keys are only valid on a prefab reference (#801) — an inline nested entity authors its content directly, so put the override on the entry itself.",
+                                    .{},
+                                );
+                                return error.InvalidFormat;
+                            }
+                            const child_effective_ref: ?[]const u8 = child_obj.getString("ref") orelse child_prefab_ref;
+                            const child_fold = try to.foldMatches(targets, child_effective_ref, child_parts.components, merge_arena.allocator());
+                            const child_scene_comps = child_fold.patch;
 
                             // `null`-as-removal is scoped to a
-                            // reference entry's `overrides` (RFC #562).
-                            const child_is_reference = child_obj.getString("prefab") != null;
+                            // reference entry's `overrides` (RFC
+                            // #562) — and (#801) to any patch a `@`
+                            // target contributed.
+                            const child_removal_active = child_is_reference or child_fold.matched;
+
+                            const child_own_targets: ?*to.TargetCtx = try to.buildCtx(
+                                child_parts.targets,
+                                child_obj.getString("prefab") orelse "<inline>",
+                                targets,
+                                merge_arena.allocator(),
+                                game.log,
+                            );
+                            const child_targets = child_own_targets orelse targets;
 
                             // Precompute the effective (merged) value
                             // for each override entry once, in
@@ -218,7 +255,7 @@ pub fn NestedSpawn(comptime GameType: type, comptime Components: type, comptime 
                             const child_effective: ?[]?Value = if (child_scene_comps) |sc| blk: {
                                 const slice = merge_arena.allocator().alloc(?Value, sc.entries.len) catch break :blk null;
                                 for (sc.entries, 0..) |e, i| {
-                                    if (child_is_reference and e.value == .null_value) {
+                                    if (child_removal_active and e.value == .null_value) {
                                         slice[i] = null;
                                     } else if (uf.mergedOverride(child_prefab_comps, e.key, e.value, merge_arena.allocator())) |eff| {
                                         slice[i] = eff;
@@ -246,9 +283,13 @@ pub fn NestedSpawn(comptime GameType: type, comptime Components: type, comptime 
                                     };
                                 }
                             }
-                            // Prefab defaults.
+                            // Prefab defaults. `@` keys on a prefab
+                            // ROOT are meaningless (targets belong on
+                            // a reference, #801) — skip them here;
+                            // the top-level walker warns once.
                             if (child_prefab_comps) |pc| {
                                 for (pc.entries) |e| {
+                                    if (uf.isTargetKey(e.key)) continue;
                                     const already_set = if (child_scene_comps) |sc| blk: {
                                         for (sc.entries) |se| {
                                             if (std.mem.eql(u8, se.key, e.key)) break :blk true;
@@ -270,11 +311,12 @@ pub fn NestedSpawn(comptime GameType: type, comptime Components: type, comptime 
                             if (child_scene_comps) |sc| {
                                 for (sc.entries, 0..) |e, i| {
                                     const effective = (child_effective orelse break)[i] orelse continue;
-                                    try spawnAndLinkNestedEntities(game, child, e.key, effective, child_pos, prefab_cache, depth + 1, nested_ref_ctx);
+                                    try spawnAndLinkNestedEntities(game, child, e.key, effective, child_pos, prefab_cache, depth + 1, nested_ref_ctx, child_targets);
                                 }
                             }
                             if (child_prefab_comps) |pc| {
                                 for (pc.entries) |e| {
+                                    if (uf.isTargetKey(e.key)) continue;
                                     const already_set = if (child_scene_comps) |sc| blk: {
                                         for (sc.entries) |se| {
                                             if (std.mem.eql(u8, se.key, e.key)) break :blk true;
@@ -282,7 +324,7 @@ pub fn NestedSpawn(comptime GameType: type, comptime Components: type, comptime 
                                         break :blk false;
                                     } else false;
                                     if (!already_set) {
-                                        try spawnAndLinkNestedEntities(game, child, e.key, e.value, child_pos, prefab_cache, depth + 1, nested_ref_ctx);
+                                        try spawnAndLinkNestedEntities(game, child, e.key, e.value, child_pos, prefab_cache, depth + 1, nested_ref_ctx, child_targets);
                                     }
                                 }
                             }
@@ -293,7 +335,7 @@ pub fn NestedSpawn(comptime GameType: type, comptime Components: type, comptime 
                             // avoid double-offset (#417).
                             if (child_prefab_children) |children| {
                                 for (children.items) |child_val| {
-                                    const grandchild = Self.loadEntityInternal(game, child_val, prefab_cache, depth + 1, child_pos, nested_ref_ctx) catch |err| {
+                                    const grandchild = Self.loadEntityInternal(game, child_val, prefab_cache, depth + 1, child_pos, nested_ref_ctx, child_targets) catch |err| {
                                         game.log.err("[NestedEntity] Failed to load child: {s}", .{@errorName(err)});
                                         continue;
                                     };
@@ -304,7 +346,7 @@ pub fn NestedSpawn(comptime GameType: type, comptime Components: type, comptime 
                             }
                             if (child_obj.getArray("children")) |children| {
                                 for (children.items) |child_val| {
-                                    const grandchild = Self.loadEntityInternal(game, child_val, prefab_cache, depth + 1, child_pos, nested_ref_ctx) catch |err| {
+                                    const grandchild = Self.loadEntityInternal(game, child_val, prefab_cache, depth + 1, child_pos, nested_ref_ctx, child_targets) catch |err| {
                                         game.log.err("[NestedEntity] Failed to load child: {s}", .{@errorName(err)});
                                         continue;
                                     };
@@ -313,6 +355,11 @@ pub fn NestedSpawn(comptime GameType: type, comptime Components: type, comptime 
                                     game.setWorldPosition(grandchild, gc_world);
                                 }
                             }
+
+                            // This nested reference's body is fully
+                            // instantiated — its own `@` targets must
+                            // all have matched (#801).
+                            if (child_own_targets) |tctx| try to.checkAllMatched(tctx, game.log);
 
                             // Patch deferred refs from the local
                             // context. Lookups walk up the parent
@@ -349,7 +396,7 @@ pub fn NestedSpawn(comptime GameType: type, comptime Components: type, comptime 
                                     nested_applied.put(e.key, {}) catch {};
                                 }
                             }
-                            OnReadyHelpers.fireOnReadyAll(game, child, child_scene_comps, child_prefab_comps, &nested_applied, child_is_reference);
+                            OnReadyHelpers.fireOnReadyAll(game, child, child_scene_comps, child_prefab_comps, &nested_applied, child_removal_active);
                         }
 
                         ids[idx] = @intCast(child);

--- a/src/jsonc/scene_loader/nested_spawn.zig
+++ b/src/jsonc/scene_loader/nested_spawn.zig
@@ -103,10 +103,29 @@ pub fn NestedSpawn(comptime GameType: type, comptime Components: type, comptime 
                 // the game's lifetime.
                 const ids = persistent_id_allocator.alloc(u64, entity_count) catch continue;
                 var idx: usize = 0;
+                // The `@`-target hard errors below (#801: malformed
+                // map, unmatched target) can abort mid-array — after
+                // children were created but BEFORE the ids are patched
+                // into the parent and registered for cascade
+                // destruction. Destroy the already-spawned children
+                // (and free the never-transferred id array) so a
+                // failed load doesn't strand live, tracked entities
+                // (codex P2 on #802).
+                errdefer {
+                    for (ids[0..idx]) |cid| {
+                        const c: Entity = @intCast(cid);
+                        game.destroyEntity(c);
+                    }
+                    persistent_id_allocator.free(ids);
+                }
                 for (arr.items) |item| {
                     if (ApplyHelpers.isEntityLike(item)) {
                         const child = game.createEntity();
                         game.trackSceneEntity(child);
+                        // Covers an error raised later in THIS
+                        // iteration, before `child` lands in `ids`
+                        // (the outer errdefer only sees ids[0..idx]).
+                        errdefer game.destroyEntity(child);
 
                         if (item.asObject()) |child_obj| {
                             var child_prefab_comps: ?Value.Object = null;
@@ -335,9 +354,17 @@ pub fn NestedSpawn(comptime GameType: type, comptime Components: type, comptime 
                             // avoid double-offset (#417).
                             if (child_prefab_children) |children| {
                                 for (children.items) |child_val| {
-                                    const grandchild = Self.loadEntityInternal(game, child_val, prefab_cache, depth + 1, child_pos, nested_ref_ctx, child_targets) catch |err| {
-                                        game.log.err("[NestedEntity] Failed to load child: {s}", .{@errorName(err)});
-                                        continue;
+                                    const grandchild = Self.loadEntityInternal(game, child_val, prefab_cache, depth + 1, child_pos, nested_ref_ctx, child_targets) catch |err| switch (err) {
+                                        // `@`-target semantics are hard
+                                        // errors (#801) — degrading to a
+                                        // partial load here would report
+                                        // success while silently omitting
+                                        // the child (codex P2 on #802).
+                                        error.InvalidFormat => return err,
+                                        else => {
+                                            game.log.err("[NestedEntity] Failed to load child: {s}", .{@errorName(err)});
+                                            continue;
+                                        },
                                     };
                                     const gc_world = game.getPosition(grandchild);
                                     game.setParent(grandchild, child, .{});
@@ -346,9 +373,17 @@ pub fn NestedSpawn(comptime GameType: type, comptime Components: type, comptime 
                             }
                             if (child_obj.getArray("children")) |children| {
                                 for (children.items) |child_val| {
-                                    const grandchild = Self.loadEntityInternal(game, child_val, prefab_cache, depth + 1, child_pos, nested_ref_ctx, child_targets) catch |err| {
-                                        game.log.err("[NestedEntity] Failed to load child: {s}", .{@errorName(err)});
-                                        continue;
+                                    const grandchild = Self.loadEntityInternal(game, child_val, prefab_cache, depth + 1, child_pos, nested_ref_ctx, child_targets) catch |err| switch (err) {
+                                        // `@`-target semantics are hard
+                                        // errors (#801) — degrading to a
+                                        // partial load here would report
+                                        // success while silently omitting
+                                        // the child (codex P2 on #802).
+                                        error.InvalidFormat => return err,
+                                        else => {
+                                            game.log.err("[NestedEntity] Failed to load child: {s}", .{@errorName(err)});
+                                            continue;
+                                        },
                                     };
                                     const gc_world = game.getPosition(grandchild);
                                     game.setParent(grandchild, child, .{});

--- a/src/jsonc/scene_loader/prefab_refresh.zig
+++ b/src/jsonc/scene_loader/prefab_refresh.zig
@@ -202,6 +202,7 @@ pub fn PrefabRefresh(comptime GameType: type, comptime Components: type) type {
                 return &.{};
             var list: std.ArrayList(Declared) = .empty;
             for (comps.entries) |entry| {
+                if (uf.isTargetKey(entry.key)) continue; // `@` targets are not components (#801)
                 if (entry.value == .null_value) continue;
                 list.append(a, .{ .key = entry.key, .value = entry.value }) catch return null;
             }
@@ -222,6 +223,7 @@ pub fn PrefabRefresh(comptime GameType: type, comptime Components: type) type {
                 const comps = patch orelse return &.{};
                 var list: std.ArrayList(Declared) = .empty;
                 for (comps.entries) |entry| {
+                    if (uf.isTargetKey(entry.key)) continue; // `@` targets are not components (#801)
                     if (entry.value == .null_value) continue;
                     list.append(a, .{ .key = entry.key, .value = entry.value }) catch return null;
                 }
@@ -235,6 +237,13 @@ pub fn PrefabRefresh(comptime GameType: type, comptime Components: type) type {
             var list: std.ArrayList(Declared) = .empty;
             if (patch) |p| {
                 for (p.entries) |entry| {
+                    // `@` targets patch entities NESTED in the
+                    // referenced prefab, not this node (#801). The
+                    // refresh diff tracks only the node's own
+                    // components; live re-application of refreshed
+                    // `@` patches to already-spawned nested entities
+                    // is a follow-up.
+                    if (uf.isTargetKey(entry.key)) continue;
                     handled.put(entry.key, {}) catch return null;
                     if (entry.value == .null_value) continue; // removal
                     const merged = uf.mergedOverride(base, entry.key, entry.value, a) catch return null;
@@ -243,6 +252,7 @@ pub fn PrefabRefresh(comptime GameType: type, comptime Components: type) type {
             }
             if (base) |b| {
                 for (b.entries) |entry| {
+                    if (uf.isTargetKey(entry.key)) continue; // `@` on a prefab root is never applied (#801)
                     if (handled.contains(entry.key)) continue;
                     if (entry.value == .null_value) continue;
                     list.append(a, .{ .key = entry.key, .value = entry.value }) catch return null;

--- a/src/jsonc/scene_loader/prefab_spawn.zig
+++ b/src/jsonc/scene_loader/prefab_spawn.zig
@@ -16,6 +16,7 @@ const Position = core.Position;
 const prefab_cache_mod = @import("../prefab_cache.zig");
 const PrefabCache = prefab_cache_mod.PrefabCache;
 const uf = @import("../unified_format.zig");
+const to = @import("../target_overrides.zig");
 const tree_walker = @import("../tree_walker.zig");
 const component_apply_mod = @import("../component_apply.zig");
 const on_ready_mod = @import("../on_ready.zig");
@@ -97,6 +98,13 @@ pub fn PrefabSpawn(comptime GameType: type, comptime Components: type, comptime 
             // parent_offset so prefab positions are relative to the
             // spawn point.
             for (prefab_components.entries) |entry| {
+                // `@` keys on a prefab ROOT are never applied (#801)
+                // — warn once and skip, same rule as the scene-load
+                // paths (CodeRabbit on #802).
+                if (uf.isTargetKey(entry.key)) {
+                    to.warnPrefabRootTarget(game.log, name, entry.key);
+                    continue;
+                }
                 ApplyHelpers.applyComponent(game, entity, entry.key, entry.value, pos);
             }
 
@@ -108,8 +116,15 @@ pub fn PrefabSpawn(comptime GameType: type, comptime Components: type, comptime 
             // malformed and shouldn't appear in the world).
             const entity_pos = game.getPosition(entity);
             for (prefab_components.entries) |entry| {
+                if (uf.isTargetKey(entry.key)) continue; // warned in the apply loop
                 Self.spawnAndLinkNestedEntities(game, entity, entry.key, entry.value, entity_pos, prefab_cache, 0, null, null) catch |err| {
                     game.log.err("[spawnPrefab] '{s}' nested-entity load failed: {s}", .{ name, @errorName(err) });
+                    // The nested loader already destroyed its own
+                    // untransferred children — but the ROOT was
+                    // created and tracked above and would otherwise
+                    // linger as a half-built entity behind a `null`
+                    // return (codex P2 on #802).
+                    game.destroyEntity(entity);
                     return null;
                 };
             }
@@ -124,7 +139,20 @@ pub fn PrefabSpawn(comptime GameType: type, comptime Components: type, comptime 
             // Process children — save world pos, set parent, restore (#417).
             if (prefab_root.getArray("children")) |children| {
                 for (children.items) |child_val| {
-                    const child = Self.loadEntityInternal(game, child_val, prefab_cache, 1, entity_pos, null, null) catch continue;
+                    const child = Self.loadEntityInternal(game, child_val, prefab_cache, 1, entity_pos, null, null) catch |err| switch (err) {
+                        // `@`-target semantics are hard errors (#801)
+                        // — a runtime spawn must not report a
+                        // successful-looking root while silently
+                        // omitting the failed child (codex P2 on
+                        // #802). Destroy the root (cascades through
+                        // already-attached children) and bail.
+                        error.InvalidFormat => {
+                            game.log.err("[spawnPrefab] '{s}' child load failed: {s}", .{ name, @errorName(err) });
+                            game.destroyEntity(entity);
+                            return null;
+                        },
+                        else => continue,
+                    };
                     const world_pos = game.getPosition(child);
                     game.setParent(child, entity, .{});
                     game.setWorldPosition(child, world_pos);

--- a/src/jsonc/scene_loader/prefab_spawn.zig
+++ b/src/jsonc/scene_loader/prefab_spawn.zig
@@ -108,7 +108,7 @@ pub fn PrefabSpawn(comptime GameType: type, comptime Components: type, comptime 
             // malformed and shouldn't appear in the world).
             const entity_pos = game.getPosition(entity);
             for (prefab_components.entries) |entry| {
-                Self.spawnAndLinkNestedEntities(game, entity, entry.key, entry.value, entity_pos, prefab_cache, 0, null) catch |err| {
+                Self.spawnAndLinkNestedEntities(game, entity, entry.key, entry.value, entity_pos, prefab_cache, 0, null, null) catch |err| {
                     game.log.err("[spawnPrefab] '{s}' nested-entity load failed: {s}", .{ name, @errorName(err) });
                     return null;
                 };
@@ -124,7 +124,7 @@ pub fn PrefabSpawn(comptime GameType: type, comptime Components: type, comptime 
             // Process children — save world pos, set parent, restore (#417).
             if (prefab_root.getArray("children")) |children| {
                 for (children.items) |child_val| {
-                    const child = Self.loadEntityInternal(game, child_val, prefab_cache, 1, entity_pos, null) catch continue;
+                    const child = Self.loadEntityInternal(game, child_val, prefab_cache, 1, entity_pos, null, null) catch continue;
                     const world_pos = game.getPosition(child);
                     game.setParent(child, entity, .{});
                     game.setWorldPosition(child, world_pos);

--- a/src/jsonc/scene_loader/scene_process.zig
+++ b/src/jsonc/scene_loader/scene_process.zig
@@ -221,7 +221,7 @@ pub fn SceneProcess(comptime GameType: type, comptime Components: type, comptime
             // Pass 1: create entities, apply components (with
             // `@ref` → 0), collect refs.
             for (entities_arr.items) |entity_val| {
-                _ = try Self.loadEntityInternal(game, entity_val, prefab_cache, 0, .{ .x = 0, .y = 0 }, ref_ctx);
+                _ = try Self.loadEntityInternal(game, entity_val, prefab_cache, 0, .{ .x = 0, .y = 0 }, ref_ctx, null);
             }
 
             // Pass 2: patch `@ref` fields with resolved entity IDs.

--- a/src/jsonc/target_overrides.zig
+++ b/src/jsonc/target_overrides.zig
@@ -1,0 +1,204 @@
+//! `@ref`-targeted overrides (#801).
+//!
+//! A prefab reference's override map may carry `"@<ref>"` keys whose
+//! values are ordinary component maps. Each `@` patch applies to every
+//! entity inside the reference's instantiated prefab body whose
+//! effective `ref` is `<ref>` — component-field nested entities
+//! (`Room.workstations`) and prefab children alike, recursively
+//! through sub-prefabs. Bare component keys keep their existing
+//! meaning (they patch the reference's root entity).
+//!
+//! Semantics (per the RFC on #801):
+//!
+//!   - **Whole subtree, every match.** A ref name denotes a role; a
+//!     prefab that wants distinct targets gives entities distinct
+//!     refs. The search is structural (down-tree) — deliberately
+//!     unlike `@ref` *value* resolution, which is lexical (up-scope,
+//!     per-instance private, #425).
+//!   - **Precedence, outermost author wins.** Prefab defaults < the
+//!     nested entry's own overrides < the enclosing reference's `@`
+//!     patch < the next-outer reference's `@` patch, and so on out to
+//!     the scene. Implemented by folding matched patches onto the
+//!     entity's own patch innermost-first, so the outermost merge
+//!     lands last.
+//!   - **RFC #562 rides along.** A target patch deep-merges via the
+//!     same `mergeValues` path as bare overrides; a `"Comp": null`
+//!     inside a target patch removes that component from the target.
+//!   - **Unmatched `@` is a hard error.** The target is explicit, so
+//!     a typo can only be a mistake — `error.InvalidFormat` at load,
+//!     after the reference's whole body has been walked.
+//!   - **`"@name": null` (removing the target entity) is rejected**
+//!     — entity removal would change the shape of patched-back
+//!     `[]const u64` id arrays and the cascade-destruction wiring;
+//!     out of scope for #801.
+//!
+//! The context chain lives in the enclosing loader call's merge arena
+//! (`TargetCtx` instances and their entry slices are arena-allocated),
+//! so hit counters stay valid exactly as long as the body walk that
+//! updates them.
+
+const std = @import("std");
+const jsonc = @import("jsonc");
+const Value = jsonc.Value;
+const uf = @import("unified_format.zig");
+
+/// One `"@name"` entry: the bare ref name (leading `@` stripped), the
+/// component-map patch, and how many entities it has matched so far.
+pub const TargetEntry = struct {
+    name: []const u8,
+    patch: Value,
+    hits: usize = 0,
+};
+
+/// The targets a single reference entry declared, chained to the
+/// enclosing reference's targets. Matching walks the whole chain
+/// (inner and outer targets can both hit one entity); accounting is
+/// per-context, checked when the declaring reference's body finishes
+/// loading.
+pub const TargetCtx = struct {
+    parent: ?*TargetCtx,
+    entries: []TargetEntry,
+    /// Prefab name of the declaring reference — for error messages.
+    prefab_name: []const u8,
+};
+
+/// Split a patch object (an `overrides:` map or the synthesized flat
+/// view) into its bare-component half and its `@`-target half. Either
+/// half is `null` when empty. Entry slices live in `allocator`
+/// (caller's arena); leaf values are shared with `patch`.
+pub const PatchParts = struct {
+    components: ?Value.Object,
+    targets: ?Value.Object,
+};
+
+pub fn splitPatch(patch: ?Value.Object, allocator: std.mem.Allocator) error{OutOfMemory}!PatchParts {
+    const p = patch orelse return .{ .components = null, .targets = null };
+    var target_count: usize = 0;
+    for (p.entries) |e| {
+        if (uf.isTargetKey(e.key)) target_count += 1;
+    }
+    // Overwhelmingly common: no `@` keys — the patch IS the component
+    // half, no allocation.
+    if (target_count == 0) return .{ .components = p, .targets = null };
+
+    const comps = try allocator.alloc(Value.Object.Entry, p.entries.len - target_count);
+    const targs = try allocator.alloc(Value.Object.Entry, target_count);
+    var ci: usize = 0;
+    var ti: usize = 0;
+    for (p.entries) |e| {
+        if (uf.isTargetKey(e.key)) {
+            targs[ti] = e;
+            ti += 1;
+        } else {
+            comps[ci] = e;
+            ci += 1;
+        }
+    }
+    return .{
+        .components = if (comps.len == 0) null else Value.Object{ .entries = comps },
+        .targets = Value.Object{ .entries = targs },
+    };
+}
+
+/// Build a `TargetCtx` from the `@`-half of a split patch, validating
+/// each entry: the value must be a component map (an Object) whose
+/// keys are themselves component names — `"@name": null` (entity
+/// removal) and nested `@` keys are rejected. Returns `null` when
+/// `targets` is null/empty. The context and its entries live in
+/// `allocator` (the loader's merge arena).
+pub fn buildCtx(
+    targets: ?Value.Object,
+    prefab_name: []const u8,
+    parent: ?*TargetCtx,
+    allocator: std.mem.Allocator,
+    log: anytype,
+) error{ OutOfMemory, InvalidFormat }!?*TargetCtx {
+    const t = targets orelse return null;
+    if (t.entries.len == 0) return null;
+
+    const entries = try allocator.alloc(TargetEntry, t.entries.len);
+    for (t.entries, 0..) |e, i| {
+        if (e.value == .null_value) {
+            log.err(
+                "[target-override] \"{s}\": null on prefab '{s}' — removing a targeted entity is not supported (#801); remove individual components with \"{s}\": {{ \"Comp\": null }} instead.",
+                .{ e.key, prefab_name, e.key },
+            );
+            return error.InvalidFormat;
+        }
+        const patch_obj = e.value.asObject() orelse {
+            log.err(
+                "[target-override] the value of \"{s}\" on prefab '{s}' must be a component map (an object of PascalCase component keys) (#801).",
+                .{ e.key, prefab_name },
+            );
+            return error.InvalidFormat;
+        };
+        for (patch_obj.entries) |pe| {
+            if (uf.isTargetKey(pe.key)) {
+                log.err(
+                    "[target-override] \"{s}\" inside \"{s}\" on prefab '{s}': nested targets are not supported (#801) — target the inner entity's ref directly from the same override map.",
+                    .{ pe.key, e.key, prefab_name },
+                );
+                return error.InvalidFormat;
+            }
+        }
+        entries[i] = .{ .name = e.key[1..], .patch = e.value };
+    }
+    const ctx = try allocator.create(TargetCtx);
+    ctx.* = .{ .parent = parent, .entries = entries, .prefab_name = prefab_name };
+    return ctx;
+}
+
+/// Result of folding matched target patches into an entity's own
+/// patch. `matched` is true when at least one target hit — the caller
+/// widens `null`-removal semantics to the merged patch in that case
+/// (a `null` arriving through a target patch removes the component
+/// even on an inline nested entity).
+pub const FoldResult = struct {
+    patch: ?Value.Object,
+    matched: bool,
+};
+
+/// Fold every target patch in the chain whose name equals `ref_name`
+/// onto `own_patch`, innermost context first — so the outermost
+/// author's patch merges last and wins conflicting keys (RFC #562
+/// deep-merge per step). Increments each matched entry's hit count.
+/// Returns the (possibly unchanged) patch.
+pub fn foldMatches(
+    ctx: ?*TargetCtx,
+    ref_name: ?[]const u8,
+    own_patch: ?Value.Object,
+    arena: std.mem.Allocator,
+) error{OutOfMemory}!FoldResult {
+    const name = ref_name orelse return .{ .patch = own_patch, .matched = false };
+    var matched = false;
+    var current: ?Value.Object = own_patch;
+    var c = ctx;
+    while (c) |chain| : (c = chain.parent) {
+        for (chain.entries) |*entry| {
+            if (!std.mem.eql(u8, entry.name, name)) continue;
+            entry.hits += 1;
+            matched = true;
+            const base: Value = .{ .object = current orelse Value.Object{ .entries = &.{} } };
+            const merged = try uf.mergeValues(base, entry.patch, arena);
+            current = merged.asObject().?;
+        }
+    }
+    return .{ .patch = current, .matched = matched };
+}
+
+/// After the declaring reference's body has fully loaded: every
+/// target must have matched at least one entity. An unmatched `@` is
+/// a typo or a prefab that renamed/removed the ref — fail loudly
+/// (that silence is the entire point of #801).
+pub fn checkAllMatched(ctx: *const TargetCtx, log: anytype) error{InvalidFormat}!void {
+    var failed = false;
+    for (ctx.entries) |entry| {
+        if (entry.hits != 0) continue;
+        log.err(
+            "[target-override] \"@{s}\" on prefab '{s}' matched no entity — no `ref: \"{s}\"` anywhere in the prefab's body. Check the ref names inside the prefab (#801).",
+            .{ entry.name, ctx.prefab_name, entry.name },
+        );
+        failed = true;
+    }
+    if (failed) return error.InvalidFormat;
+}

--- a/src/jsonc/target_overrides.zig
+++ b/src/jsonc/target_overrides.zig
@@ -143,11 +143,12 @@ pub fn buildCtx(
             // A target patch's keys are component names: PascalCase
             // (RFC #596) or pack-namespaced (`industry__Workstation`,
             // #440 — these start lowercase, so PascalCase alone is
-            // the wrong test). A bare data key like `"capacity"`
-            // would silently no-op through `applyComponent` — the
-            // exact silence #801 kills — so reject it loudly (codex
-            // P2 on #802).
-            if (!uf.isPascalCase(pe.key) and std.mem.indexOf(u8, pe.key, "__") == null) {
+            // the wrong test). A bare data key like `"capacity"` —
+            // or a namespaced-looking one with a non-Pascal suffix
+            // like `"capacity__oops"` — would silently no-op through
+            // `applyComponent`, the exact silence #801 kills; reject
+            // loudly (codex P2 ×2 on #802).
+            if (!isComponentKeyShape(pe.key)) {
                 log.err(
                     "[target-override] \"{s}\" inside \"{s}\" on prefab '{s}' is not a component name (PascalCase or pack-namespaced) — did you mean \"{s}\": {{ \"SomeComponent\": {{ \"{s}\": ... }} }}? (#801)",
                     .{ pe.key, e.key, prefab_name, e.key, pe.key },
@@ -160,6 +161,17 @@ pub fn buildCtx(
     const ctx = try allocator.create(TargetCtx);
     ctx.* = .{ .parent = parent, .entries = entries, .prefab_name = prefab_name };
     return ctx;
+}
+
+/// A key shaped like a component name: PascalCase (RFC #596), or the
+/// pack-namespaced `<prefix>__<Pascal>` form (#440) — nonempty prefix,
+/// PascalCase suffix after the LAST `__` (so `capacity__oops` is
+/// rejected, `industry__TendableWorkstation` accepted).
+fn isComponentKeyShape(key: []const u8) bool {
+    if (uf.isPascalCase(key)) return true;
+    const i = std.mem.lastIndexOf(u8, key, "__") orelse return false;
+    if (i == 0) return false;
+    return uf.isPascalCase(key[i + 2 ..]);
 }
 
 /// Result of folding matched target patches into an entity's own

--- a/src/jsonc/target_overrides.zig
+++ b/src/jsonc/target_overrides.zig
@@ -140,6 +140,20 @@ pub fn buildCtx(
                 );
                 return error.InvalidFormat;
             }
+            // A target patch's keys are component names: PascalCase
+            // (RFC #596) or pack-namespaced (`industry__Workstation`,
+            // #440 — these start lowercase, so PascalCase alone is
+            // the wrong test). A bare data key like `"capacity"`
+            // would silently no-op through `applyComponent` — the
+            // exact silence #801 kills — so reject it loudly (codex
+            // P2 on #802).
+            if (!uf.isPascalCase(pe.key) and std.mem.indexOf(u8, pe.key, "__") == null) {
+                log.err(
+                    "[target-override] \"{s}\" inside \"{s}\" on prefab '{s}' is not a component name (PascalCase or pack-namespaced) — did you mean \"{s}\": {{ \"SomeComponent\": {{ \"{s}\": ... }} }}? (#801)",
+                    .{ pe.key, e.key, prefab_name, e.key, pe.key },
+                );
+                return error.InvalidFormat;
+            }
         }
         entries[i] = .{ .name = e.key[1..], .patch = e.value };
     }
@@ -184,6 +198,20 @@ pub fn foldMatches(
         }
     }
     return .{ .patch = current, .matched = matched };
+}
+
+/// Warn once per (prefab, key): a `@` key on a prefab ROOT is
+/// skipped, not applied — target keys only mean something on a
+/// *reference* (#801). Shared by every loader path that consumes
+/// prefab-root components (entity_walker, nested_spawn,
+/// prefab_spawn), because a prefab referenced only from a component
+/// array or runtime spawn never passes through the top-level apply
+/// pass (CodeRabbit on #802). Visible because a silent drop is the
+/// failure mode this feature exists to kill.
+pub fn warnPrefabRootTarget(log: anytype, prefab_name: []const u8, key: []const u8) void {
+    var buf: [256]u8 = undefined;
+    const dedup = std.fmt.bufPrint(&buf, "prefab-root-target:{s}:{s}", .{ prefab_name, key }) catch return;
+    uf.warnOnceKey(log, dedup, "[target-override] prefab '{s}' declares \"{s}\" on its ROOT — `@` targets belong on a reference's overrides, not a prefab root; skipped (#801).", .{ prefab_name, key });
 }
 
 /// After the declaring reference's body has fully loaded: every

--- a/src/jsonc/tree_walker.zig
+++ b/src/jsonc/tree_walker.zig
@@ -364,11 +364,16 @@ fn effectiveComponents(
     patch: ?Value.Object,
 ) error{OutOfMemory}!?Value.Object {
     // Inline entry (no prefab) — its `components` ARE the effective
-    // set; nothing to merge.
+    // set; nothing to merge. (The caller already stripped `@` keys
+    // from the patch via `splitPatch`, so this path is `@`-free.)
     const pc = prefab_components orelse return patch;
-    // Reference entry with no `overrides` — the prefab components
-    // are the effective set unchanged.
-    const ov = patch orelse return pc;
+    // Reference entry with no `overrides` — route through the merge
+    // loop with an EMPTY patch rather than returning `pc` verbatim:
+    // the loop is where prefab-root `@` keys get filtered, and an
+    // unfiltered return would let `walkComponentFields` descend into
+    // a `@` value the loader never instantiates — a spurious
+    // `PrefabCycle` source (codex P2 + CodeRabbit on #802).
+    const ov = patch orelse Value.Object{ .entries = &.{} };
 
     const a = merge_arena.allocator();
     var entries: std.ArrayListUnmanaged(Value.Object.Entry) = .empty;

--- a/src/jsonc/tree_walker.zig
+++ b/src/jsonc/tree_walker.zig
@@ -54,6 +54,7 @@ const std = @import("std");
 const jsonc = @import("jsonc");
 const Value = jsonc.Value;
 const uf = @import("unified_format.zig");
+const to = @import("target_overrides.zig");
 
 /// Per-walk scratch allocations — the merged effective-component
 /// trees built while reasoning about `overrides` (RFC #562). Owned by
@@ -191,7 +192,7 @@ pub fn walk(
 ) (WalkError || @TypeOf(visitor).VisitError)!void {
     var merge_arena = MergeArena.init(ctx.allocator);
     defer merge_arena.deinit();
-    try walkEntry(ctx, &merge_arena, resolver, root_value, .root, 0, null, visitor);
+    try walkEntry(ctx, &merge_arena, resolver, root_value, .root, 0, null, null, visitor);
 }
 
 fn walkEntry(
@@ -202,6 +203,7 @@ fn walkEntry(
     origin: Origin,
     depth: usize,
     component_name: ?[]const u8,
+    targets: ?*to.TargetCtx,
     visitor: anytype,
 ) (WalkError || @TypeOf(visitor).VisitError)!void {
     const VisitError = @TypeOf(visitor).VisitError;
@@ -259,11 +261,42 @@ fn walkEntry(
     };
     try visitor.visit(node);
 
+    // ── `@`-target overrides (#801) ─────────────────────────────
+    // The walk must model the same tree the loader instantiates: a
+    // matched `@` patch merges onto this entry's own patch (arrays
+    // replace outright, so a patch can splice a NEW prefab reference
+    // into an entity-bearing field — a cycle source the raw tree
+    // doesn't show), and this entry's own `@` keys extend the chain
+    // for its body. Format errors in the `@` shape are the loader's
+    // to report — the walker degrades to "no targets" and keeps
+    // detecting cycles in the rest of the tree.
+    const parts: to.PatchParts = blk: {
+        const raw_patch = uf.entityPatch(obj, merge_arena.allocator(), NoopLog{}) catch |e| switch (e) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.InvalidFormat => break :blk .{ .components = null, .targets = null },
+        };
+        break :blk try to.splitPatch(raw_patch, merge_arena.allocator());
+    };
+    const own_ref: ?[]const u8 = obj.getString("ref") orelse
+        if (prefab_root) |proot| proot.getString("ref") else null;
+    const fold = try to.foldMatches(targets, own_ref, parts.components, merge_arena.allocator());
+    const own_targets: ?*to.TargetCtx = to.buildCtx(
+        parts.targets,
+        obj.getString("prefab") orelse "<inline>",
+        targets,
+        merge_arena.allocator(),
+        NoopLog{},
+    ) catch |e| switch (e) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.InvalidFormat => null, // loader reports; stay structural
+    };
+    const child_targets = own_targets orelse targets;
+
     // ── 1. prefab-defined children ──────────────────────────────
     if (prefab_root) |proot| {
         if (proot.getArray("children")) |children| {
             for (children.items) |child_val| {
-                try walkEntry(ctx, merge_arena, resolver, child_val, .prefab_child, depth + 1, null, visitor);
+                try walkEntry(ctx, merge_arena, resolver, child_val, .prefab_child, depth + 1, null, child_targets, visitor);
             }
         }
     }
@@ -287,20 +320,14 @@ fn walkEntry(
         // expose their components as flat PascalCase keys (no
         // `"components"` / `"overrides"` wrapper). Synthesize the
         // views into `merge_arena` so the cycle walk sees the same
-        // effective component tree the loader will instantiate.
+        // effective component tree the loader will instantiate. The
+        // entry's patch was already computed (and `@`-target-folded)
+        // above — `fold.patch` carries only bare component keys, so
+        // no `@` key can masquerade as an override-only component.
         const prefab_components: ?Value.Object =
             if (prefab_root) |proot| try uf.prefabComponents(proot, merge_arena.allocator(), NoopLog{}) else null;
-        // This is the cycle-detection pre-pass, not the loader. A
-        // legacy `"components"`-on-reference form (rejected in v2.0,
-        // #592) surfaces its `error.InvalidFormat` from the real
-        // loader; here we treat it as "no patch" so cycle detection
-        // still runs over the rest of the tree.
-        const patch = uf.entityPatch(obj, merge_arena.allocator(), NoopLog{}) catch |e| switch (e) {
-            error.OutOfMemory => return error.OutOfMemory,
-            error.InvalidFormat => null,
-        };
-        if (try effectiveComponents(merge_arena, prefab_components, patch)) |eff| {
-            try walkComponentFields(ctx, merge_arena, resolver, eff, depth, visitor);
+        if (try effectiveComponents(merge_arena, prefab_components, fold.patch)) |eff| {
+            try walkComponentFields(ctx, merge_arena, resolver, eff, depth, child_targets, visitor);
         }
     }
 
@@ -315,7 +342,7 @@ fn walkEntry(
     // ── 3. the entry's own children array ───────────────────────
     if (obj.getArray("children")) |children| {
         for (children.items) |child_val| {
-            try walkEntry(ctx, merge_arena, resolver, child_val, .child, depth + 1, null, visitor);
+            try walkEntry(ctx, merge_arena, resolver, child_val, .child, depth + 1, null, child_targets, visitor);
         }
     }
 }
@@ -348,7 +375,11 @@ fn effectiveComponents(
 
     // Start from the prefab components, dropping any the override
     // removes via a JSONC `null` (component-level removal, #562).
+    // `@` keys on a prefab ROOT are skipped — the loader never
+    // applies them (#801), so walking their contents would descend a
+    // tree the runtime doesn't instantiate.
     for (pc.entries) |pe| {
+        if (uf.isTargetKey(pe.key)) continue;
         const removed = blk: {
             for (ov.entries) |oe| {
                 if (std.mem.eql(u8, oe.key, pe.key))
@@ -397,6 +428,7 @@ fn walkComponentFields(
     resolver: Resolver,
     components: Value.Object,
     depth: usize,
+    targets: ?*to.TargetCtx,
     visitor: anytype,
 ) (WalkError || @TypeOf(visitor).VisitError)!void {
     for (components.entries) |entry| {
@@ -406,7 +438,7 @@ fn walkComponentFields(
             if (arr.items.len == 0) continue;
             for (arr.items) |item| {
                 if (!isEntityLike(item)) continue;
-                try walkEntry(ctx, merge_arena, resolver, item, .component_field, depth + 1, entry.key, visitor);
+                try walkEntry(ctx, merge_arena, resolver, item, .component_field, depth + 1, entry.key, targets, visitor);
             }
         }
     }

--- a/src/jsonc/unified_format.zig
+++ b/src/jsonc/unified_format.zig
@@ -105,6 +105,14 @@ fn warnOnce(log: anytype, comptime msg: []const u8) void {
 // above — load is single-threaded today.
 var warned_runtime: ?std.StringHashMap(void) = null;
 
+/// True iff `warnOnceKey` has already fired for `key` — lets a caller
+/// skip EXPENSIVE diagnostic work (a tree walk) whose only output would
+/// be a deduplicated log line (CodeRabbit on #802).
+pub fn alreadyWarnedKey(key: []const u8) bool {
+    const set = warned_runtime orelse return false;
+    return set.contains(key);
+}
+
 /// Warn-once for a runtime-formatted message. The first call with a
 /// given `key` logs `msg`; later calls with an equal `key` are
 /// suppressed. `key` is duped into the process-lifetime allocator on
@@ -377,15 +385,15 @@ pub fn entityPatch(entity_obj: Value.Object, allocator: std.mem.Allocator, log: 
             return error.InvalidFormat;
         }
         if (entity_obj.getObject("overrides")) |overrides| {
-            if (hasPascalCaseKey(entity_obj)) {
-                warnOnce(log, "[unified-format] reference entry has both an \"overrides\" wrapper and flat PascalCase keys — \"overrides\" wins. Drop one shape (RFC #596).");
+            if (hasFlatPatchKey(entity_obj)) {
+                warnOnce(log, "[unified-format] reference entry has both an \"overrides\" wrapper and flat PascalCase/`@` keys — \"overrides\" wins and the flat keys are DROPPED. Drop one shape (RFC #596, #801).");
             }
             return overrides;
         }
     } else {
         if (entity_obj.getObject("components")) |components| {
-            if (hasPascalCaseKey(entity_obj)) {
-                warnOnce(log, "[unified-format] inline entity has both a \"components\" wrapper and flat PascalCase keys — wrapper wins. Drop one shape (RFC #596).");
+            if (hasFlatPatchKey(entity_obj)) {
+                warnOnce(log, "[unified-format] inline entity has both a \"components\" wrapper and flat PascalCase/`@` keys — wrapper wins and the flat keys are DROPPED. Drop one shape (RFC #596, #801).");
             }
             return components;
         }
@@ -403,7 +411,7 @@ pub fn entityPatch(entity_obj: Value.Object, allocator: std.mem.Allocator, log: 
 /// PascalCase component (RFC #596 Axis 2) or `@`-target (#801) — at
 /// its top level. Used to detect the flat shape without allocating a
 /// synthetic Object — and to warn when wrapped + flat are mixed.
-fn hasPascalCaseKey(entity_obj: Value.Object) bool {
+fn hasFlatPatchKey(entity_obj: Value.Object) bool {
     for (entity_obj.entries) |e| {
         if (isFlatComponentKey(e.key)) return true;
     }
@@ -463,8 +471,8 @@ fn synthesizeFlatComponents(entity_obj: Value.Object, allocator: std.mem.Allocat
 /// inline entries.
 pub fn prefabComponents(prefab_root: Value.Object, allocator: std.mem.Allocator, log: anytype) error{OutOfMemory}!?Value.Object {
     if (prefab_root.getObject("components")) |c| {
-        if (hasPascalCaseKey(prefab_root)) {
-            warnOnce(log, "[unified-format] prefab root has both a \"components\" wrapper and flat PascalCase keys — wrapper wins. Drop one shape (RFC #596).");
+        if (hasFlatPatchKey(prefab_root)) {
+            warnOnce(log, "[unified-format] prefab root has both a \"components\" wrapper and flat PascalCase/`@` keys — wrapper wins and the flat keys are DROPPED. Drop one shape (RFC #596, #801).");
         }
         return c;
     }

--- a/src/jsonc/unified_format.zig
+++ b/src/jsonc/unified_format.zig
@@ -109,7 +109,10 @@ var warned_runtime: ?std.StringHashMap(void) = null;
 /// given `key` logs `msg`; later calls with an equal `key` are
 /// suppressed. `key` is duped into the process-lifetime allocator on
 /// first sight so the caller's buffer can free safely.
-fn warnOnceKey(log: anytype, key: []const u8, comptime fmt: []const u8, args: anytype) void {
+///
+/// pub for the loader's rare-path diagnostics (#801: `@` keys on a
+/// prefab ROOT are skipped, not applied — the skip must be visible).
+pub fn warnOnceKey(log: anytype, key: []const u8, comptime fmt: []const u8, args: anytype) void {
     if (warned_runtime == null) {
         warned_runtime = std.StringHashMap(void).init(warned_allocator);
     }
@@ -135,6 +138,25 @@ fn warnOnceKey(log: anytype, key: []const u8, comptime fmt: []const u8, args: an
 pub fn isPascalCase(name: []const u8) bool {
     if (name.len == 0) return false;
     return name[0] >= 'A' and name[0] <= 'Z';
+}
+
+/// True if `name` is a target-override key (#801): a leading `@`
+/// followed by a ref name. On a prefab reference's override map,
+/// `"@tender": { ... }` patches the entity (or entities) inside the
+/// referenced prefab's body whose effective `ref` is `tender`,
+/// instead of the reference's root entity. A bare `"@"` is not a
+/// target (no name to match) and stays classified as structural.
+pub fn isTargetKey(name: []const u8) bool {
+    return name.len > 1 and name[0] == '@';
+}
+
+/// True if `name` participates in the flat override/component shape
+/// at entity scope: PascalCase component keys (RFC #596 Axis 2) plus
+/// `@`-target keys (#801). Both are patch *content* — everything
+/// else at entity scope is structural (`prefab`, `children`, `meta`,
+/// `ref`).
+pub fn isFlatComponentKey(name: []const u8) bool {
+    return isPascalCase(name) or isTargetKey(name);
 }
 
 /// Warn once that an unknown PascalCase component appeared on an
@@ -305,7 +327,7 @@ fn isFileHeader(obj: Value.Object) bool {
         if (std.mem.eql(u8, e.key, "components")) return false;
         if (std.mem.eql(u8, e.key, "overrides")) return false;
         if (std.mem.eql(u8, e.key, "ref")) return false;
-        if (isPascalCase(e.key)) return false;
+        if (isFlatComponentKey(e.key)) return false;
         // Other lowercase keys (e.g. unknown future structural
         // keys) are tolerated on the header — `meta`-shaped side
         // data.
@@ -377,22 +399,29 @@ pub fn entityPatch(entity_obj: Value.Object, allocator: std.mem.Allocator, log: 
     return try synthesizeFlatComponents(entity_obj, allocator);
 }
 
-/// Whether `entity_obj` has at least one PascalCase key at its top
-/// level. Used to detect the flat shape without allocating a
+/// Whether `entity_obj` has at least one flat patch-content key —
+/// PascalCase component (RFC #596 Axis 2) or `@`-target (#801) — at
+/// its top level. Used to detect the flat shape without allocating a
 /// synthetic Object — and to warn when wrapped + flat are mixed.
 fn hasPascalCaseKey(entity_obj: Value.Object) bool {
     for (entity_obj.entries) |e| {
-        if (isPascalCase(e.key)) return true;
+        if (isFlatComponentKey(e.key)) return true;
     }
     return false;
 }
 
-/// Build a `Value.Object` whose entries are the entity's PascalCase
-/// keys — the components view for the flat shape (RFC #596 Axis 2).
+/// Build a `Value.Object` whose entries are the entity's flat
+/// patch-content keys — PascalCase components (RFC #596 Axis 2) plus
+/// `@`-target keys (#801) — the patch view for the flat shape.
 /// `meta` and other lowercase keys are skipped. Returns `null` when
-/// there are no PascalCase keys at all (parity with the wrapped
-/// path's "no components" return; lets the caller treat an entity
-/// with only `prefab` and `meta` as a no-op spawn).
+/// there are no such keys at all (parity with the wrapped path's "no
+/// components" return; lets the caller treat an entity with only
+/// `prefab` and `meta` as a no-op spawn).
+///
+/// The loader partitions the result into bare components vs `@`
+/// targets afterwards (`target_overrides.splitPatch`) — this view
+/// deliberately carries both so flat and wrapped shapes converge on
+/// one representation before that split.
 ///
 /// Entries slice lives in `allocator` (caller's arena). Leaf values
 /// are shared with `entity_obj`, so the synthesized Object must not
@@ -400,14 +429,14 @@ fn hasPascalCaseKey(entity_obj: Value.Object) bool {
 fn synthesizeFlatComponents(entity_obj: Value.Object, allocator: std.mem.Allocator) error{OutOfMemory}!?Value.Object {
     var count: usize = 0;
     for (entity_obj.entries) |e| {
-        if (isPascalCase(e.key)) count += 1;
+        if (isFlatComponentKey(e.key)) count += 1;
     }
     if (count == 0) return null;
 
     const entries = try allocator.alloc(Value.Object.Entry, count);
     var i: usize = 0;
     for (entity_obj.entries) |e| {
-        if (isPascalCase(e.key)) {
+        if (isFlatComponentKey(e.key)) {
             entries[i] = e;
             i += 1;
         }

--- a/test/jsonc/target_overrides_test.zig
+++ b/test/jsonc/target_overrides_test.zig
@@ -376,3 +376,63 @@ test "a cycle spliced in via a @ patch is caught as PrefabCycle" {
     );
     try testing.expectError(error.PrefabCycle, result);
 }
+
+// ── Regression: the pre-@ workarounds keep working ─────────────────
+
+test "array restatement in a scene override still works (the pre-@ workaround)" {
+    // Verified against v2.10.0 before this feature: a scene may
+    // restate a prefab's entity-bearing array outright (arrays
+    // replace in mergeValues), with entry-level overrides on the
+    // restated entries. The @ fold sits upstream of that path now —
+    // this pins that it changed nothing.
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    try loadWithPrefabs(&game, &.{
+        .{ .name = "machine", .data = machine_prefab },
+        .{ .name = "storage_slot", .data = storage_slot_prefab },
+    },
+        \\{ "children": [
+        \\  { "prefab": "machine",
+        \\    "Machine": { "slots": [
+        \\      { "prefab": "storage_slot", "ref": "input" },
+        \\      { "prefab": "storage_slot", "Storage": { "capacity": 12 } }
+        \\    ] } }
+        \\] }
+    );
+    var buf: [8]u32 = undefined;
+    try testing.expectEqualSlices(u32, &.{ 5, 12 }, storageCapacities(&game, &buf));
+
+    var view = game.ecs_backend.view(.{Machine}, .{});
+    defer view.deinit();
+    const m = game.ecs_backend.getComponent(view.next().?, Machine).?;
+    try testing.expectEqual(@as(usize, 2), m.slots.len);
+}
+
+test "an override-only bare component still attaches to the root (now warned, #801)" {
+    // The original trap's BEHAVIOR is unchanged — adding a component
+    // to the reference root stays legal — it just warns now when a
+    // nested entity carries the component. This pins the behavior;
+    // the warning is a log line.
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    try loadWithPrefabs(&game, &.{
+        .{ .name = "machine", .data = machine_prefab },
+        .{ .name = "storage_slot", .data = storage_slot_prefab },
+    },
+        \\{ "children": [
+        \\  { "prefab": "machine", "Storage": { "capacity": 12 } }
+        \\] }
+    );
+
+    var view = game.ecs_backend.view(.{Machine}, .{});
+    defer view.deinit();
+    const machine = view.next().?;
+    const root_storage = game.ecs_backend.getComponent(machine, Storage) orelse return error.TestExpectedEntity;
+    try testing.expectEqual(@as(u32, 12), root_storage.capacity);
+    // Nested slots keep their defaults — the override did NOT reach them.
+    const m = game.ecs_backend.getComponent(machine, Machine).?;
+    for (m.slots) |sid| {
+        const s = game.ecs_backend.getComponent(@intCast(sid), Storage).?;
+        try testing.expectEqual(@as(u32, 5), s.capacity);
+    }
+}

--- a/test/jsonc/target_overrides_test.zig
+++ b/test/jsonc/target_overrides_test.zig
@@ -34,10 +34,15 @@ const Storage = struct {
     capacity: u32 = 5,
 };
 
+const NamespacedStorage = struct {
+    capacity: u32 = 5,
+};
+
 const Components = engine.ComponentRegistry(.{
     .Machine = Machine,
     .Room = Room,
     .Storage = Storage,
+    .industry__Storage = NamespacedStorage,
 });
 
 const Game = engine.Game;
@@ -435,4 +440,114 @@ test "an override-only bare component still attaches to the root (now warned, #8
         const s = game.ecs_backend.getComponent(@intCast(sid), Storage).?;
         try testing.expectEqual(@as(u32, 5), s.capacity);
     }
+}
+
+// ── Round 2 (bot-review hardening) ─────────────────────────────────
+
+test "a bare data key inside a @ patch is rejected" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    const result = loadWithPrefabs(&game, &.{
+        .{ .name = "machine", .data = machine_prefab },
+        .{ .name = "storage_slot", .data = storage_slot_prefab },
+    },
+        // `capacity` is component DATA, not a component — applying it
+        // would silently no-op. Hard error with a did-you-mean.
+        \\{ "children": [
+        \\  { "prefab": "machine", "@slot": { "capacity": 12 } }
+        \\] }
+    );
+    try testing.expectError(error.InvalidFormat, result);
+}
+
+test "a pack-namespaced component key inside a @ patch is accepted" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    try loadWithPrefabs(&game, &.{
+        .{
+            .name = "nmachine",
+            .data =
+            \\{ "Machine": { "slots": [ { "prefab": "nslot" } ] } }
+            ,
+        },
+        .{
+            // Namespaced keys start lowercase, so the wrapped form is
+            // required prefab-side (flat keeps PascalCase + `@` only).
+            .name = "nslot",
+            .data =
+            \\{ "ref": "nslot", "components": { "industry__Storage": { "capacity": 5 } } }
+            ,
+        },
+    },
+        \\{ "children": [
+        \\  { "prefab": "nmachine", "@nslot": { "industry__Storage": { "capacity": 12 } } }
+        \\] }
+    );
+    var view = game.ecs_backend.view(.{NamespacedStorage}, .{});
+    defer view.deinit();
+    const e = view.next() orelse return error.TestExpectedEntity;
+    try testing.expectEqual(@as(u32, 12), game.ecs_backend.getComponent(e, NamespacedStorage).?.capacity);
+    try testing.expect(view.next() == null);
+}
+
+test "prefab-root @ keys are skipped without spawning or cycling" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    // The root-level `@junk` even references the prefab itself — the
+    // loader must neither spawn from it nor report a cycle, because
+    // that content is never instantiated. Exercises BOTH the merged
+    // path (entry with overrides) and the no-patch early return.
+    const selfy =
+        \\{ "Storage": { "capacity": 3 },
+        \\  "@junk": { "Machine": { "slots": [ { "prefab": "selfy" } ] } } }
+    ;
+    try loadWithPrefabs(&game, &.{.{ .name = "selfy", .data = selfy }},
+        \\{ "children": [
+        \\  { "prefab": "selfy" },
+        \\  { "prefab": "selfy", "Storage": { "capacity": 4 } }
+        \\] }
+    );
+    var buf: [8]u32 = undefined;
+    try testing.expectEqualSlices(u32, &.{ 3, 4 }, storageCapacities(&game, &buf));
+    var view = game.ecs_backend.view(.{Machine}, .{});
+    defer view.deinit();
+    try testing.expect(view.next() == null);
+}
+
+test "runtime spawnFromPrefab fails loudly (and cleanly) on an unmatched @ in the body" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    try tmp_dir.dir.createDir(std.testing.io, "prefabs", .default_dir);
+    try tmp_dir.dir.writeFile(std.testing.io, .{
+        .sub_path = "prefabs/machine.jsonc",
+        .data = machine_prefab,
+    });
+    try tmp_dir.dir.writeFile(std.testing.io, .{
+        .sub_path = "prefabs/storage_slot.jsonc",
+        .data = storage_slot_prefab,
+    });
+    try tmp_dir.dir.writeFile(std.testing.io, .{
+        .sub_path = "prefabs/broken.jsonc",
+        .data =
+        \\{ "children": [
+        \\  { "prefab": "machine", "@nosuch": { "Storage": { "capacity": 12 } } }
+        \\] }
+        ,
+    });
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const len = try tmp_dir.dir.realPath(std.testing.io, &path_buf);
+    const prefab_path = try std.fmt.allocPrint(testing.allocator, "{s}/prefabs", .{path_buf[0..len]});
+    defer testing.allocator.free(prefab_path);
+
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    try Bridge.loadSceneFromSource(&game,
+        \\{ "children": [] }
+    , prefab_path);
+
+    try testing.expect(game.spawnFromPrefab("broken", .{ .x = 0, .y = 0 }) == null);
+    // Nothing half-built stays behind: no Storage entities linger.
+    var view = game.ecs_backend.view(.{Storage}, .{});
+    defer view.deinit();
+    try testing.expect(view.next() == null);
 }

--- a/test/jsonc/target_overrides_test.zig
+++ b/test/jsonc/target_overrides_test.zig
@@ -551,3 +551,44 @@ test "runtime spawnFromPrefab fails loudly (and cleanly) on an unmatched @ in th
     defer view.deinit();
     try testing.expect(view.next() == null);
 }
+
+test "a namespaced-looking key with a non-Pascal suffix is rejected" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    const result = loadWithPrefabs(&game, &.{
+        .{ .name = "machine", .data = machine_prefab },
+        .{ .name = "storage_slot", .data = storage_slot_prefab },
+    },
+        // `capacity__oops` has the namespace delimiter but no Pascal
+        // suffix — it can never match a registered component, so
+        // accepting it would be a silent no-op (codex round 3).
+        \\{ "children": [
+        \\  { "prefab": "machine", "@slot": { "capacity__oops": 12 } }
+        \\] }
+    );
+    try testing.expectError(error.InvalidFormat, result);
+}
+
+test "@ works against a root-wrapped (unified v1.x) prefab" {
+    // `{ "root": { ... } }` files must unwrap on every path — the
+    // diagnostic walk included (codex round 3).
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    try loadWithPrefabs(&game, &.{
+        .{
+            .name = "wrapped",
+            .data =
+            \\{ "root": { "Machine": { "slots": [
+            \\    { "prefab": "storage_slot" }
+            \\] } } }
+            ,
+        },
+        .{ .name = "storage_slot", .data = storage_slot_prefab },
+    },
+        \\{ "children": [
+        \\  { "prefab": "wrapped", "@slot": { "Storage": { "capacity": 12 } } }
+        \\] }
+    );
+    var buf: [8]u32 = undefined;
+    try testing.expectEqualSlices(u32, &.{12}, storageCapacities(&game, &buf));
+}

--- a/test/jsonc/target_overrides_test.zig
+++ b/test/jsonc/target_overrides_test.zig
@@ -1,0 +1,378 @@
+//! Tests for `@ref`-targeted overrides (#801).
+//!
+//! A prefab reference's override map may carry `"@<ref>"` keys that
+//! patch ref-named entities inside the referenced prefab's body —
+//! component-field nested entities and prefab children alike,
+//! recursively. Covered here:
+//!
+//!   - match via entry-level `ref` and via the nested prefab root's
+//!     own `ref` (same precedence as ref registration),
+//!   - match on prefab children (inline entities included),
+//!   - multi-match fan-out (a ref used as a role),
+//!   - reach through a sub-prefab (two levels down),
+//!   - precedence: scene `@` patch beats the prefab body's own
+//!     entry-level override (outermost author wins),
+//!   - `null`-removal through a `@` patch (RFC #562 rides along),
+//!   - hard errors: unmatched `@`, `@` on an inline entity,
+//!     `"@name": null`, nested `@`-in-`@`,
+//!   - flat-form / wrapped-form parity,
+//!   - a cycle spliced in via a `@` patch is caught as `PrefabCycle`.
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+
+const Machine = struct {
+    slots: []const u64 = &.{},
+};
+
+const Room = struct {
+    workstations: []const u64 = &.{},
+};
+
+const Storage = struct {
+    capacity: u32 = 5,
+};
+
+const Components = engine.ComponentRegistry(.{
+    .Machine = Machine,
+    .Room = Room,
+    .Storage = Storage,
+});
+
+const Game = engine.Game;
+const Bridge = engine.JsoncSceneBridge(Game, Components);
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+const PrefabFile = struct {
+    name: []const u8,
+    data: []const u8,
+};
+
+/// Write `prefabs` into a tmp dir and load `scene_src` against them.
+fn loadWithPrefabs(game: *Game, prefabs: []const PrefabFile, scene_src: []const u8) !void {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    try tmp_dir.dir.createDir(std.testing.io, "prefabs", .default_dir);
+    for (prefabs) |p| {
+        var buf: [128]u8 = undefined;
+        const sub = try std.fmt.bufPrint(&buf, "prefabs/{s}.jsonc", .{p.name});
+        try tmp_dir.dir.writeFile(std.testing.io, .{ .sub_path = sub, .data = p.data });
+    }
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const len = try tmp_dir.dir.realPath(std.testing.io, &path_buf);
+    const prefab_path = try std.fmt.allocPrint(testing.allocator, "{s}/prefabs", .{path_buf[0..len]});
+    defer testing.allocator.free(prefab_path);
+    try Bridge.loadSceneFromSource(game, scene_src, prefab_path);
+}
+
+/// Collect the capacities of every entity carrying `Storage`,
+/// ascending, into `out`. Returns the slice actually filled.
+fn storageCapacities(game: *Game, out: []u32) []u32 {
+    var n: usize = 0;
+    var view = game.ecs_backend.view(.{Storage}, .{});
+    defer view.deinit();
+    while (view.next()) |e| {
+        out[n] = game.ecs_backend.getComponent(e, Storage).?.capacity;
+        n += 1;
+    }
+    std.mem.sort(u32, out[0..n], {}, std.sort.asc(u32));
+    return out[0..n];
+}
+
+const machine_prefab =
+    \\{ "Machine": { "slots": [
+    \\    { "prefab": "storage_slot", "ref": "input" },
+    \\    { "prefab": "storage_slot" }
+    \\] } }
+;
+
+// Root-level `ref` — a nested entry without its own `ref` inherits it.
+const storage_slot_prefab =
+    \\{ "ref": "slot", "Storage": { "capacity": 5 } }
+;
+
+// ── Matching ───────────────────────────────────────────────────────
+
+test "@ matches a component-array entry via the nested prefab root's ref" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    try loadWithPrefabs(&game, &.{
+        .{ .name = "machine", .data = machine_prefab },
+        .{ .name = "storage_slot", .data = storage_slot_prefab },
+    },
+        \\{ "children": [
+        \\  { "prefab": "machine", "@slot": { "Storage": { "capacity": 12 } } }
+        \\] }
+    );
+
+    var buf: [8]u32 = undefined;
+    // Entry 1 has entry-level ref "input" (beats the root's "slot"),
+    // so only entry 2 matches `@slot`.
+    try testing.expectEqualSlices(u32, &.{ 5, 12 }, storageCapacities(&game, &buf));
+
+    // The ref-array patch-back is unaffected by the fold.
+    var view = game.ecs_backend.view(.{Machine}, .{});
+    defer view.deinit();
+    const m = game.ecs_backend.getComponent(view.next().?, Machine).?;
+    try testing.expectEqual(@as(usize, 2), m.slots.len);
+}
+
+test "@ matches an entry-level ref" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    try loadWithPrefabs(&game, &.{
+        .{ .name = "machine", .data = machine_prefab },
+        .{ .name = "storage_slot", .data = storage_slot_prefab },
+    },
+        \\{ "children": [
+        \\  { "prefab": "machine", "@input": { "Storage": { "capacity": 3 } } }
+        \\] }
+    );
+    var buf: [8]u32 = undefined;
+    try testing.expectEqualSlices(u32, &.{ 3, 5 }, storageCapacities(&game, &buf));
+}
+
+test "@ matches an inline prefab child" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    try loadWithPrefabs(&game, &.{
+        .{
+            .name = "house",
+            .data =
+            \\{ "children": [
+            \\  { "ref": "door", "components": { "Storage": { "capacity": 1 } } }
+            \\] }
+            ,
+        },
+    },
+        \\{ "children": [
+        \\  { "prefab": "house", "@door": { "Storage": { "capacity": 9 } } }
+        \\] }
+    );
+    var buf: [8]u32 = undefined;
+    try testing.expectEqualSlices(u32, &.{9}, storageCapacities(&game, &buf));
+}
+
+test "@ fans out to every entity sharing the ref" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    try loadWithPrefabs(&game, &.{
+        .{
+            .name = "machine2",
+            .data =
+            \\{ "Machine": { "slots": [
+            \\    { "prefab": "storage_slot", "ref": "buffer" },
+            \\    { "prefab": "storage_slot", "ref": "buffer" },
+            \\    { "prefab": "storage_slot", "ref": "buffer" }
+            \\] } }
+            ,
+        },
+        .{ .name = "storage_slot", .data = storage_slot_prefab },
+    },
+        \\{ "children": [
+        \\  { "prefab": "machine2", "@buffer": { "Storage": { "capacity": 12 } } }
+        \\] }
+    );
+    var buf: [8]u32 = undefined;
+    try testing.expectEqualSlices(u32, &.{ 12, 12, 12 }, storageCapacities(&game, &buf));
+}
+
+test "@ reaches through a sub-prefab (two levels down)" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    try loadWithPrefabs(&game, &.{
+        .{
+            .name = "room",
+            .data =
+            \\{ "Room": { "workstations": [ { "prefab": "machine" } ] } }
+            ,
+        },
+        .{ .name = "machine", .data = machine_prefab },
+        .{ .name = "storage_slot", .data = storage_slot_prefab },
+    },
+        \\{ "children": [
+        \\  { "prefab": "room", "@slot": { "Storage": { "capacity": 12 } } }
+        \\] }
+    );
+    var buf: [8]u32 = undefined;
+    try testing.expectEqualSlices(u32, &.{ 5, 12 }, storageCapacities(&game, &buf));
+}
+
+test "@ does not leak into sibling instances" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    try loadWithPrefabs(&game, &.{
+        .{ .name = "machine", .data = machine_prefab },
+        .{ .name = "storage_slot", .data = storage_slot_prefab },
+    },
+        \\{ "children": [
+        \\  { "prefab": "machine", "@slot": { "Storage": { "capacity": 12 } } },
+        \\  { "prefab": "machine" }
+        \\] }
+    );
+    var buf: [8]u32 = undefined;
+    // Machine 1: input 5 + slot 12. Machine 2: untouched 5 + 5.
+    try testing.expectEqualSlices(u32, &.{ 5, 5, 5, 12 }, storageCapacities(&game, &buf));
+}
+
+// ── Precedence + merge semantics ───────────────────────────────────
+
+test "scene @ patch beats the prefab body's own entry-level override" {
+    const machine3 =
+        \\{ "Machine": { "slots": [
+        \\    { "prefab": "storage_slot", "ref": "out2", "Storage": { "capacity": 7 } }
+        \\] } }
+    ;
+    // Control: the body's own override applies without a scene patch.
+    {
+        var game = Game.init(testing.allocator);
+        defer game.deinit();
+        try loadWithPrefabs(&game, &.{
+            .{ .name = "machine3", .data = machine3 },
+            .{ .name = "storage_slot", .data = storage_slot_prefab },
+        },
+            \\{ "children": [ { "prefab": "machine3" } ] }
+        );
+        var buf: [8]u32 = undefined;
+        try testing.expectEqualSlices(u32, &.{7}, storageCapacities(&game, &buf));
+    }
+    // The scene's @ patch is the outermost author — it wins.
+    {
+        var game = Game.init(testing.allocator);
+        defer game.deinit();
+        try loadWithPrefabs(&game, &.{
+            .{ .name = "machine3", .data = machine3 },
+            .{ .name = "storage_slot", .data = storage_slot_prefab },
+        },
+            \\{ "children": [
+            \\  { "prefab": "machine3", "@out2": { "Storage": { "capacity": 12 } } }
+            \\] }
+        );
+        var buf: [8]u32 = undefined;
+        try testing.expectEqualSlices(u32, &.{12}, storageCapacities(&game, &buf));
+    }
+}
+
+test "a null component inside a @ patch removes it from the target" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    try loadWithPrefabs(&game, &.{
+        .{
+            .name = "house",
+            .data =
+            \\{ "children": [
+            \\  { "ref": "door", "components": { "Storage": { "capacity": 1 } } }
+            \\] }
+            ,
+        },
+    },
+        \\{ "children": [
+        \\  { "prefab": "house", "@door": { "Storage": null } }
+        \\] }
+    );
+    var buf: [8]u32 = undefined;
+    try testing.expectEqual(@as(usize, 0), storageCapacities(&game, &buf).len);
+}
+
+test "wrapped-form overrides carry @ keys identically" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    try loadWithPrefabs(&game, &.{
+        .{ .name = "machine", .data = machine_prefab },
+        .{ .name = "storage_slot", .data = storage_slot_prefab },
+    },
+        \\{ "children": [
+        \\  { "prefab": "machine", "overrides": {
+        \\      "@slot": { "Storage": { "capacity": 12 } }
+        \\  } }
+        \\] }
+    );
+    var buf: [8]u32 = undefined;
+    try testing.expectEqualSlices(u32, &.{ 5, 12 }, storageCapacities(&game, &buf));
+}
+
+// ── Hard errors ────────────────────────────────────────────────────
+
+test "an unmatched @ target is a load-time error" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    const result = loadWithPrefabs(&game, &.{
+        .{ .name = "machine", .data = machine_prefab },
+        .{ .name = "storage_slot", .data = storage_slot_prefab },
+    },
+        \\{ "children": [
+        \\  { "prefab": "machine", "@nosuch": { "Storage": { "capacity": 12 } } }
+        \\] }
+    );
+    try testing.expectError(error.InvalidFormat, result);
+}
+
+test "@ on an inline entity is a load-time error" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    const result = loadWithPrefabs(&game, &.{},
+        \\{ "children": [
+        \\  { "Storage": { "capacity": 1 }, "@x": { "Storage": { "capacity": 2 } } }
+        \\] }
+    );
+    try testing.expectError(error.InvalidFormat, result);
+}
+
+test "removing a whole target entity via @: null is rejected" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    const result = loadWithPrefabs(&game, &.{
+        .{ .name = "machine", .data = machine_prefab },
+        .{ .name = "storage_slot", .data = storage_slot_prefab },
+    },
+        \\{ "children": [
+        \\  { "prefab": "machine", "@slot": null }
+        \\] }
+    );
+    try testing.expectError(error.InvalidFormat, result);
+}
+
+test "nested @ inside a @ patch is rejected" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    const result = loadWithPrefabs(&game, &.{
+        .{ .name = "machine", .data = machine_prefab },
+        .{ .name = "storage_slot", .data = storage_slot_prefab },
+    },
+        \\{ "children": [
+        \\  { "prefab": "machine", "@slot": { "@deeper": { "Storage": {} } } }
+        \\] }
+    );
+    try testing.expectError(error.InvalidFormat, result);
+}
+
+// ── Cycle safety ───────────────────────────────────────────────────
+
+test "a cycle spliced in via a @ patch is caught as PrefabCycle" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    const result = loadWithPrefabs(&game, &.{
+        .{
+            .name = "a",
+            .data =
+            \\{ "Machine": { "slots": [ { "prefab": "b" } ] } }
+            ,
+        },
+        .{
+            .name = "b",
+            .data =
+            \\{ "ref": "hole", "Storage": { "capacity": 5 } }
+            ,
+        },
+    },
+        // The @ patch replaces b's (empty) Machine with one whose
+        // slots reference `a` again — a cycle only visible on the
+        // patched tree.
+        \\{ "children": [
+        \\  { "prefab": "a", "@hole": { "Machine": { "slots": [ { "prefab": "a" } ] } } }
+        \\] }
+    );
+    try testing.expectError(error.PrefabCycle, result);
+}


### PR DESCRIPTION
Implements the RFC on #801 (rev 3): a prefab reference's override map may carry `"@<ref>"` keys that patch ref-named entities nested inside the referenced prefab's body — the mechanism that makes QA/tuning scenes authorable without duplicating room-sized prefabs.

## Syntax

```jsonc
// flat form (idiomatic)
{ "prefab": "hydroponics", "Position": { "x": 156, "y": 0 },
  "@tender": { "industry__TendableWorkstation": { "level": 5, "growth": 0.9 } } }
```

Strictly additive: `@` keys were dead key-space (treated as an unknown component and dropped), so no existing valid scene changes meaning.

## Semantics (per the RFC)

- **Whole subtree, every match** — component-field entities and prefab children, recursively through sub-prefabs. Effective ref = entry-level `ref`, else the referenced prefab root's (same precedence as ref registration).
- **Outermost author wins** — prefab defaults < entry's own overrides < enclosing `@` patches, innermost-to-outermost.
- **RFC #562 rides along** — deep-merge; `"Comp": null` inside a `@` patch removes the component from the target (including inline nested entities).
- **Loud failures** — unmatched `@` is `error.InvalidFormat` after the body loads; `@` on an inline entity, `"@name": null`, and nested `@`-in-`@` are rejected with actionable messages.
- **Cycle-safe** — `tree_walker` applies `@` patches during the cycle pre-pass, so a patch that splices a prefab reference into an entity-bearing array is caught as `PrefabCycle`, not a stack overflow.
- **The original trap is loud even without `@`** — an override-only bare component that an entity nested in the prefab body carries now warns once, naming the `@` syntax as the fix.
- `prefab_refresh` skips `@` keys (live re-application of refreshed `@` patches to spawned nested entities is an explicit follow-up).

## Tests

`test/jsonc/target_overrides_test.zig` — 14 tests: both ref sources, prefab children, fan-out, two-level sub-prefab reach, sibling isolation, precedence (with control), null-removal, wrapped/flat parity, all four hard errors, spliced-cycle detection. Full suite green.

## Cross-repo

Assembler counterpart (labelle-toolkit/labelle-assembler PR, incoming): pack-rewrite `@` scope handling + HybridForm/flat-key classification + a generate-time gate that hard-errors when `@` is used against an engine pin older than **2.11.0** (this feature's release), since MAJOR-only compat would otherwise let an old engine silently drop `@` keys.

Closes #801.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-engine/pr/802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788382597&installation_model_id=427192&pr_number=802&repository=labelle-toolkit%2Flabelle-engine&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-engine%2Fpull%2F802&signature=4c1fdfb5ed323a9378c497b4b3dad873c28564eb74309eb0d77a35554e8d57e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->