### PR TITLE
fix(scenes): warn on unknown pack-namespaced components, not just PascalCase (#803)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -92,6 +92,7 @@ pub fn build(b: *std.Build) void {
         "test/jsonc/bridge_leak_test.zig",
         "test/jsonc/nested_lifecycle_test.zig",
         "test/jsonc/target_overrides_test.zig",
+        "test/jsonc/unknown_component_warn_test.zig",
         // C2 — a project-registered component named `Tilemap` must win over
         // the engine built-in in the scene loader (no silent shadowing).
         "test/jsonc/tilemap_precedence_test.zig",

--- a/src/jsonc/component_apply.zig
+++ b/src/jsonc/component_apply.zig
@@ -204,16 +204,19 @@ pub fn ComponentApply(comptime GameType: type, comptime Components: type) type {
                 }
             }
 
-            // RFC #596 Axis 4: unknown PascalCase keys on an entity
-            // are treated as components, but we warn-once so typos
-            // (`Posiiton`) surface visibly. Lowercase names that
-            // reach here (e.g. legacy embedded structural keys that
-            // bypassed the structural / component split) are
+            // RFC #596 Axis 4: unknown component-shaped keys on an
+            // entity are treated as no-ops, but we warn-once so typos
+            // surface visibly — PascalCase (`Posiiton`) AND
+            // pack-namespaced (`industry__Storag`, #803: every pack
+            // component starts lowercase, so PascalCase alone missed
+            // the entire namespaced registry). Other lowercase names
+            // that reach here (e.g. legacy embedded structural keys
+            // that bypassed the structural / component split) stay
             // silently ignored — they're not authoring mistakes the
             // RFC catches. Position / Sprite / Shape are handled
             // above and returned before reaching this gate, so the
             // built-in components don't false-warn.
-            if (uf.isPascalCase(name)) {
+            if (uf.isComponentKeyShape(name)) {
                 uf.warnUnknownComponent(game.log, name);
             }
         }

--- a/src/jsonc/scene_loader/entity_walker.zig
+++ b/src/jsonc/scene_loader/entity_walker.zig
@@ -141,6 +141,11 @@ pub fn EntityWalker(comptime GameType: type, comptime Components: type, comptime
             // Fold enclosing references' matching `@` patches onto
             // this entity's own patch, outermost author last (wins).
             const fold = try to.foldMatches(inherited_targets, own_ref, parts.components, merge_arena.allocator());
+            // Removal-landing aggregation (#806): record whether THIS
+            // entity carried each matched removal's component; the
+            // declaring reference diagnoses never-landed removals
+            // once, after its whole fan-out resolved.
+            to.noteRemovalsCarried(fold, prefab_components, parts.components);
             const scene_components = fold.patch;
 
             // RFC #562 `null`-removal is scoped to reference
@@ -218,25 +223,15 @@ pub fn EntityWalker(comptime GameType: type, comptime Components: type, comptime
                 const slice = try merge_arena.allocator().alloc(?Value, sc.entries.len);
                 for (sc.entries, 0..) |entry, i| {
                     if (removal_active and entry.value == .null_value) {
-                        // Removal diagnostics: entries the reference
-                        // authored itself are owned by the
-                        // specialized nested-component walker (which
-                        // also handles the nested-carried case with
-                        // `@ref` guidance — avoid double-warning,
-                        // codex on #806). Only fold-CONTRIBUTED
-                        // removals (not in the pre-fold patch) are
-                        // checked here, with the fold's own
-                        // contributions as context.
-                        const in_own = own_blk: {
-                            const own = parts.components orelse break :own_blk false;
-                            for (own.entries) |oe| {
-                                if (std.mem.eql(u8, oe.key, entry.key)) break :own_blk true;
-                            }
-                            break :own_blk false;
-                        };
-                        if (!is_reference or !in_own) {
-                            to.warnNoopRemoval(game.log, entry.key, prefab_components, parts.components, fold.matched_patches);
-                        }
+                        // Removal diagnostics live elsewhere: entries
+                        // the reference authored itself are owned by
+                        // the specialized nested-component walker
+                        // (`@ref` guidance / no-op message), and
+                        // fold-CONTRIBUTED removals are aggregated
+                        // across the whole fan-out via
+                        // `noteRemovalsCarried` + `checkAllMatched`
+                        // (per-entity warnings misreport partial
+                        // fan-out removals — codex on #806).
                         slice[i] = null;
                     } else {
                         slice[i] = try uf.mergedOverride(prefab_components, entry.key, entry.value, merge_arena.allocator());
@@ -578,7 +573,7 @@ pub fn EntityWalker(comptime GameType: type, comptime Components: type, comptime
                     // shape-gated inside the helper. Additions stay
                     // silent (adding a novel component is legal).
                     if (e.value == .null_value) {
-                        to.warnNoopRemoval(game.log, e.key, null, null, &.{});
+                        to.warnNoopRemoval(game.log, e.key, null, null);
                     }
                     continue;
                 }

--- a/src/jsonc/scene_loader/entity_walker.zig
+++ b/src/jsonc/scene_loader/entity_walker.zig
@@ -218,6 +218,7 @@ pub fn EntityWalker(comptime GameType: type, comptime Components: type, comptime
                 const slice = try merge_arena.allocator().alloc(?Value, sc.entries.len);
                 for (sc.entries, 0..) |entry, i| {
                     if (removal_active and entry.value == .null_value) {
+                        to.warnNoopRemoval(game.log, entry.key, prefab_components, parts.components);
                         slice[i] = null;
                     } else {
                         slice[i] = try uf.mergedOverride(prefab_components, entry.key, entry.value, merge_arena.allocator());

--- a/src/jsonc/scene_loader/entity_walker.zig
+++ b/src/jsonc/scene_loader/entity_walker.zig
@@ -218,7 +218,25 @@ pub fn EntityWalker(comptime GameType: type, comptime Components: type, comptime
                 const slice = try merge_arena.allocator().alloc(?Value, sc.entries.len);
                 for (sc.entries, 0..) |entry, i| {
                     if (removal_active and entry.value == .null_value) {
-                        to.warnNoopRemoval(game.log, entry.key, prefab_components, parts.components);
+                        // Removal diagnostics: entries the reference
+                        // authored itself are owned by the
+                        // specialized nested-component walker (which
+                        // also handles the nested-carried case with
+                        // `@ref` guidance — avoid double-warning,
+                        // codex on #806). Only fold-CONTRIBUTED
+                        // removals (not in the pre-fold patch) are
+                        // checked here, with the fold's own
+                        // contributions as context.
+                        const in_own = own_blk: {
+                            const own = parts.components orelse break :own_blk false;
+                            for (own.entries) |oe| {
+                                if (std.mem.eql(u8, oe.key, entry.key)) break :own_blk true;
+                            }
+                            break :own_blk false;
+                        };
+                        if (!is_reference or !in_own) {
+                            to.warnNoopRemoval(game.log, entry.key, prefab_components, parts.components, fold.matched_patches);
+                        }
                         slice[i] = null;
                     } else {
                         slice[i] = try uf.mergedOverride(prefab_components, entry.key, entry.value, merge_arena.allocator());
@@ -514,7 +532,10 @@ pub fn EntityWalker(comptime GameType: type, comptime Components: type, comptime
             var any_unwarned = false;
             for (sc.entries) |e| {
                 var kbuf: [256]u8 = undefined;
-                const k = std.fmt.bufPrint(&kbuf, "override-root-attach:{s}:{s}", .{ pname, e.key }) catch continue;
+                const k = if (e.value == .null_value)
+                    std.fmt.bufPrint(&kbuf, "noop-removal:{s}", .{e.key}) catch continue
+                else
+                    std.fmt.bufPrint(&kbuf, "override-root-attach:{s}:{s}", .{ pname, e.key }) catch continue;
                 if (!uf.alreadyWarnedKey(k)) {
                     any_unwarned = true;
                     break;
@@ -550,7 +571,17 @@ pub fn EntityWalker(comptime GameType: type, comptime Components: type, comptime
                     }
                     break :blk false;
                 };
-                if (on_root or !names.contains(e.key)) continue;
+                if (on_root) continue;
+                if (!names.contains(e.key)) {
+                    // Carried NOWHERE in the prefab: a removal here is
+                    // a pure no-op (typo shape) — one generic warning,
+                    // shape-gated inside the helper. Additions stay
+                    // silent (adding a novel component is legal).
+                    if (e.value == .null_value) {
+                        to.warnNoopRemoval(game.log, e.key, null, null, &.{});
+                    }
+                    continue;
+                }
                 var buf: [256]u8 = undefined;
                 const dedup = std.fmt.bufPrint(&buf, "override-root-attach:{s}:{s}", .{ pname, e.key }) catch continue;
                 if (e.value == .null_value) {

--- a/src/jsonc/scene_loader/nested_spawn.zig
+++ b/src/jsonc/scene_loader/nested_spawn.zig
@@ -247,6 +247,9 @@ pub fn NestedSpawn(comptime GameType: type, comptime Components: type, comptime 
                             }
                             const child_effective_ref: ?[]const u8 = child_obj.getString("ref") orelse child_prefab_ref;
                             const child_fold = try to.foldMatches(targets, child_effective_ref, child_parts.components, merge_arena.allocator());
+                            // Removal-landing aggregation (#806) —
+                            // see `noteRemovalsCarried`.
+                            to.noteRemovalsCarried(child_fold, child_prefab_comps, child_parts.components);
                             const child_scene_comps = child_fold.patch;
 
                             // `null`-as-removal is scoped to a
@@ -275,7 +278,16 @@ pub fn NestedSpawn(comptime GameType: type, comptime Components: type, comptime 
                                 const slice = merge_arena.allocator().alloc(?Value, sc.entries.len) catch break :blk null;
                                 for (sc.entries, 0..) |e, i| {
                                     if (child_removal_active and e.value == .null_value) {
-                                        to.warnNoopRemoval(game.log, e.key, child_prefab_comps, child_parts.components, child_fold.matched_patches);
+                                        // Removal diagnostics are
+                                        // aggregated across the fan-out
+                                        // (`noteRemovalsCarried` /
+                                        // `checkAllMatched`, #806); a
+                                        // child's OWN typo'd removal is
+                                        // caught by the top-level
+                                        // reference's specialized walk
+                                        // when reachable, and stays a
+                                        // silent no-op otherwise —
+                                        // matching pre-#806 behavior.
                                         slice[i] = null;
                                     } else if (uf.mergedOverride(child_prefab_comps, e.key, e.value, merge_arena.allocator())) |eff| {
                                         slice[i] = eff;

--- a/src/jsonc/scene_loader/nested_spawn.zig
+++ b/src/jsonc/scene_loader/nested_spawn.zig
@@ -275,6 +275,7 @@ pub fn NestedSpawn(comptime GameType: type, comptime Components: type, comptime 
                                 const slice = merge_arena.allocator().alloc(?Value, sc.entries.len) catch break :blk null;
                                 for (sc.entries, 0..) |e, i| {
                                     if (child_removal_active and e.value == .null_value) {
+                                        to.warnNoopRemoval(game.log, e.key, child_prefab_comps, child_parts.components);
                                         slice[i] = null;
                                     } else if (uf.mergedOverride(child_prefab_comps, e.key, e.value, merge_arena.allocator())) |eff| {
                                         slice[i] = eff;

--- a/src/jsonc/scene_loader/nested_spawn.zig
+++ b/src/jsonc/scene_loader/nested_spawn.zig
@@ -275,7 +275,7 @@ pub fn NestedSpawn(comptime GameType: type, comptime Components: type, comptime 
                                 const slice = merge_arena.allocator().alloc(?Value, sc.entries.len) catch break :blk null;
                                 for (sc.entries, 0..) |e, i| {
                                     if (child_removal_active and e.value == .null_value) {
-                                        to.warnNoopRemoval(game.log, e.key, child_prefab_comps, child_parts.components);
+                                        to.warnNoopRemoval(game.log, e.key, child_prefab_comps, child_parts.components, child_fold.matched_patches);
                                         slice[i] = null;
                                     } else if (uf.mergedOverride(child_prefab_comps, e.key, e.value, merge_arena.allocator())) |eff| {
                                         slice[i] = eff;

--- a/src/jsonc/target_overrides.zig
+++ b/src/jsonc/target_overrides.zig
@@ -148,7 +148,7 @@ pub fn buildCtx(
             // like `"capacity__oops"` — would silently no-op through
             // `applyComponent`, the exact silence #801 kills; reject
             // loudly (codex P2 ×2 on #802).
-            if (!isComponentKeyShape(pe.key)) {
+            if (!uf.isComponentKeyShape(pe.key)) {
                 log.err(
                     "[target-override] \"{s}\" inside \"{s}\" on prefab '{s}' is not a component name (PascalCase or pack-namespaced) — did you mean \"{s}\": {{ \"SomeComponent\": {{ \"{s}\": ... }} }}? (#801)",
                     .{ pe.key, e.key, prefab_name, e.key, pe.key },
@@ -161,17 +161,6 @@ pub fn buildCtx(
     const ctx = try allocator.create(TargetCtx);
     ctx.* = .{ .parent = parent, .entries = entries, .prefab_name = prefab_name };
     return ctx;
-}
-
-/// A key shaped like a component name: PascalCase (RFC #596), or the
-/// pack-namespaced `<prefix>__<Pascal>` form (#440) — nonempty prefix,
-/// PascalCase suffix after the LAST `__` (so `capacity__oops` is
-/// rejected, `industry__TendableWorkstation` accepted).
-fn isComponentKeyShape(key: []const u8) bool {
-    if (uf.isPascalCase(key)) return true;
-    const i = std.mem.lastIndexOf(u8, key, "__") orelse return false;
-    if (i == 0) return false;
-    return uf.isPascalCase(key[i + 2 ..]);
 }
 
 /// Result of folding matched target patches into an entity's own

--- a/src/jsonc/target_overrides.zig
+++ b/src/jsonc/target_overrides.zig
@@ -171,6 +171,12 @@ pub fn buildCtx(
 pub const FoldResult = struct {
     patch: ?Value.Object,
     matched: bool,
+    /// The matched target patches, in application (inner→outer)
+    /// order. Diagnostics need them: an inner patch may ADD a
+    /// component that an outer patch legitimately removes, which the
+    /// merged map alone cannot distinguish from a removal that never
+    /// matched anything (codex on #806).
+    matched_patches: []const Value = &.{},
 };
 
 /// Fold every target patch in the chain whose name equals `ref_name`
@@ -187,18 +193,20 @@ pub fn foldMatches(
     const name = ref_name orelse return .{ .patch = own_patch, .matched = false };
     var matched = false;
     var current: ?Value.Object = own_patch;
+    var patches: std.ArrayListUnmanaged(Value) = .empty;
     var c = ctx;
     while (c) |chain| : (c = chain.parent) {
         for (chain.entries) |*entry| {
             if (!std.mem.eql(u8, entry.name, name)) continue;
             entry.hits += 1;
             matched = true;
+            try patches.append(arena, entry.patch);
             const base: Value = .{ .object = current orelse Value.Object{ .entries = &.{} } };
             const merged = try uf.mergeValues(base, entry.patch, arena);
             current = merged.asObject().?;
         }
     }
-    return .{ .patch = current, .matched = matched };
+    return .{ .patch = current, .matched = matched, .matched_patches = patches.items };
 }
 
 /// Warn once per (prefab, key): a `@` key on a prefab ROOT is
@@ -227,7 +235,13 @@ pub fn warnNoopRemoval(
     key: []const u8,
     prefab_components: ?Value.Object,
     own_pre_fold: ?Value.Object,
+    fold_contributions: []const Value,
 ) void {
+    // Only component-shaped keys participate — the widened unknown-
+    // component policy deliberately keeps data-shaped lowercase keys
+    // silent, and a `null` value must not change that classification
+    // (codex on #806).
+    if (!uf.isComponentKeyShape(key)) return;
     if (prefab_components) |pc| {
         for (pc.entries) |pe| {
             if (std.mem.eql(u8, pe.key, key) and pe.value != .null_value) return;
@@ -236,6 +250,16 @@ pub fn warnNoopRemoval(
     if (own_pre_fold) |own| {
         for (own.entries) |oe| {
             if (std.mem.eql(u8, oe.key, key) and oe.value != .null_value) return;
+        }
+    }
+    // An INNER matched target patch may have added the component the
+    // outer (higher-precedence) patch is removing — that removal
+    // matched something real (codex on #806).
+    for (fold_contributions) |patch| {
+        if (patch.asObject()) |po| {
+            for (po.entries) |fe| {
+                if (std.mem.eql(u8, fe.key, key) and fe.value != .null_value) return;
+            }
         }
     }
     var buf: [256]u8 = undefined;

--- a/src/jsonc/target_overrides.zig
+++ b/src/jsonc/target_overrides.zig
@@ -48,6 +48,18 @@ pub const TargetEntry = struct {
     name: []const u8,
     patch: Value,
     hits: usize = 0,
+    /// One tracker per `null`-valued key in `patch`. A removal
+    /// "lands" when ANY matched entity carries the component —
+    /// multi-match fan-out means per-entity checks misreport a
+    /// partially-applying removal as a no-op (codex on #806); the
+    /// verdict is aggregated here and diagnosed once, in
+    /// `checkAllMatched`.
+    removals: []RemovalTrack = &.{},
+};
+
+pub const RemovalTrack = struct {
+    key: []const u8,
+    landed: bool = false,
 };
 
 /// The targets a single reference entry declared, chained to the
@@ -156,7 +168,22 @@ pub fn buildCtx(
                 return error.InvalidFormat;
             }
         }
-        entries[i] = .{ .name = e.key[1..], .patch = e.value };
+        var removal_count: usize = 0;
+        for (patch_obj.entries) |pe| {
+            if (pe.value == .null_value) removal_count += 1;
+        }
+        var removals: []RemovalTrack = &.{};
+        if (removal_count > 0) {
+            removals = try allocator.alloc(RemovalTrack, removal_count);
+            var ri: usize = 0;
+            for (patch_obj.entries) |pe| {
+                if (pe.value == .null_value) {
+                    removals[ri] = .{ .key = pe.key };
+                    ri += 1;
+                }
+            }
+        }
+        entries[i] = .{ .name = e.key[1..], .patch = e.value, .removals = removals };
     }
     const ctx = try allocator.create(TargetCtx);
     ctx.* = .{ .parent = parent, .entries = entries, .prefab_name = prefab_name };
@@ -171,12 +198,12 @@ pub fn buildCtx(
 pub const FoldResult = struct {
     patch: ?Value.Object,
     matched: bool,
-    /// The matched target patches, in application (inner→outer)
+    /// The matched target ENTRIES, in application (inner→outer)
     /// order. Diagnostics need them: an inner patch may ADD a
-    /// component that an outer patch legitimately removes, which the
-    /// merged map alone cannot distinguish from a removal that never
-    /// matched anything (codex on #806).
-    matched_patches: []const Value = &.{},
+    /// component that an outer patch legitimately removes, and
+    /// removal-landing is aggregated per entry across every matched
+    /// entity (codex on #806).
+    matched_entries: []const *TargetEntry = &.{},
 };
 
 /// Fold every target patch in the chain whose name equals `ref_name`
@@ -193,20 +220,62 @@ pub fn foldMatches(
     const name = ref_name orelse return .{ .patch = own_patch, .matched = false };
     var matched = false;
     var current: ?Value.Object = own_patch;
-    var patches: std.ArrayListUnmanaged(Value) = .empty;
+    var matched_entries: std.ArrayListUnmanaged(*TargetEntry) = .empty;
     var c = ctx;
     while (c) |chain| : (c = chain.parent) {
         for (chain.entries) |*entry| {
             if (!std.mem.eql(u8, entry.name, name)) continue;
             entry.hits += 1;
             matched = true;
-            try patches.append(arena, entry.patch);
+            try matched_entries.append(arena, entry);
             const base: Value = .{ .object = current orelse Value.Object{ .entries = &.{} } };
             const merged = try uf.mergeValues(base, entry.patch, arena);
             current = merged.asObject().?;
         }
     }
-    return .{ .patch = current, .matched = matched, .matched_patches = patches.items };
+    return .{ .patch = current, .matched = matched, .matched_entries = matched_entries.items };
+}
+
+/// After a fold: mark, for every matched entry's removal keys, whether
+/// THIS entity carried the component — from its prefab, its own
+/// pre-fold patch, or another matched patch's non-null contribution.
+/// The aggregate verdict is diagnosed once per declaring reference in
+/// `checkAllMatched`.
+pub fn noteRemovalsCarried(
+    fold: FoldResult,
+    prefab_components: ?Value.Object,
+    own_pre_fold: ?Value.Object,
+) void {
+    for (fold.matched_entries) |entry| {
+        key_loop: for (entry.removals) |*track| {
+            if (track.landed) continue;
+            if (carriesNonNull(prefab_components, track.key) or
+                carriesNonNull(own_pre_fold, track.key))
+            {
+                track.landed = true;
+                continue;
+            }
+            for (fold.matched_entries) |other| {
+                if (other == entry) continue;
+                if (other.patch.asObject()) |po| {
+                    for (po.entries) |pe| {
+                        if (std.mem.eql(u8, pe.key, track.key) and pe.value != .null_value) {
+                            track.landed = true;
+                            continue :key_loop;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn carriesNonNull(obj: ?Value.Object, key: []const u8) bool {
+    const o = obj orelse return false;
+    for (o.entries) |e| {
+        if (std.mem.eql(u8, e.key, key) and e.value != .null_value) return true;
+    }
+    return false;
 }
 
 /// Warn once per (prefab, key): a `@` key on a prefab ROOT is
@@ -235,7 +304,6 @@ pub fn warnNoopRemoval(
     key: []const u8,
     prefab_components: ?Value.Object,
     own_pre_fold: ?Value.Object,
-    fold_contributions: []const Value,
 ) void {
     // Only component-shaped keys participate — the widened unknown-
     // component policy deliberately keeps data-shaped lowercase keys
@@ -252,16 +320,6 @@ pub fn warnNoopRemoval(
             if (std.mem.eql(u8, oe.key, key) and oe.value != .null_value) return;
         }
     }
-    // An INNER matched target patch may have added the component the
-    // outer (higher-precedence) patch is removing — that removal
-    // matched something real (codex on #806).
-    for (fold_contributions) |patch| {
-        if (patch.asObject()) |po| {
-            for (po.entries) |fe| {
-                if (std.mem.eql(u8, fe.key, key) and fe.value != .null_value) return;
-            }
-        }
-    }
     var buf: [256]u8 = undefined;
     const dedup = std.fmt.bufPrint(&buf, "noop-removal:{s}", .{key}) catch return;
     uf.warnOnceKey(log, dedup, "[SceneLoader] removal \"{s}\": null matches nothing — neither the prefab nor the entity carries that component, so the removal is a NO-OP. Check the spelling (#803).", .{key});
@@ -274,6 +332,14 @@ pub fn warnNoopRemoval(
 pub fn checkAllMatched(ctx: *const TargetCtx, log: anytype) error{InvalidFormat}!void {
     var failed = false;
     for (ctx.entries) |entry| {
+        // Removal keys that landed on NO matched entity: the authored
+        // removal is a no-op everywhere — a typo shape. One warning
+        // for the whole fan-out (codex on #806); shape-gated inside.
+        if (entry.hits != 0) {
+            for (entry.removals) |track| {
+                if (!track.landed) warnNoopRemoval(log, track.key, null, null);
+            }
+        }
         if (entry.hits != 0) continue;
         log.err(
             "[target-override] \"@{s}\" on prefab '{s}' matched no entity — no `ref: \"{s}\"` anywhere in the prefab's body. Check the ref names inside the prefab (#801).",

--- a/src/jsonc/target_overrides.zig
+++ b/src/jsonc/target_overrides.zig
@@ -215,6 +215,34 @@ pub fn warnPrefabRootTarget(log: anytype, prefab_name: []const u8, key: []const 
     uf.warnOnceKey(log, dedup, "[target-override] prefab '{s}' declares \"{s}\" on its ROOT — `@` targets belong on a reference's overrides, not a prefab root; skipped (#801).", .{ prefab_name, key });
 }
 
+/// Warn once when a `null` removal names a component that neither the
+/// resolved prefab nor the entity's own pre-fold patch carries with a
+/// value — the removal is a NO-OP, which for a typo'd key
+/// (`industry__Storag: null`) reads exactly like success (#803,
+/// codex on #806). `own_pre_fold` is the entity's own patch BEFORE
+/// `@` folds, so a legitimate removal of a component the entity
+/// declared itself stays silent.
+pub fn warnNoopRemoval(
+    log: anytype,
+    key: []const u8,
+    prefab_components: ?Value.Object,
+    own_pre_fold: ?Value.Object,
+) void {
+    if (prefab_components) |pc| {
+        for (pc.entries) |pe| {
+            if (std.mem.eql(u8, pe.key, key) and pe.value != .null_value) return;
+        }
+    }
+    if (own_pre_fold) |own| {
+        for (own.entries) |oe| {
+            if (std.mem.eql(u8, oe.key, key) and oe.value != .null_value) return;
+        }
+    }
+    var buf: [256]u8 = undefined;
+    const dedup = std.fmt.bufPrint(&buf, "noop-removal:{s}", .{key}) catch return;
+    uf.warnOnceKey(log, dedup, "[SceneLoader] removal \"{s}\": null matches nothing — neither the prefab nor the entity carries that component, so the removal is a NO-OP. Check the spelling (#803).", .{key});
+}
+
 /// After the declaring reference's body has fully loaded: every
 /// target must have matched at least one entity. An unmatched `@` is
 /// a typo or a prefab that renamed/removed the ref — fail loudly

--- a/src/jsonc/unified_format.zig
+++ b/src/jsonc/unified_format.zig
@@ -173,12 +173,18 @@ pub fn isTargetKey(name: []const u8) bool {
 }
 
 /// True if `name` participates in the flat override/component shape
-/// at entity scope: PascalCase component keys (RFC #596 Axis 2) plus
-/// `@`-target keys (#801). Both are patch *content* — everything
-/// else at entity scope is structural (`prefab`, `children`, `meta`,
+/// at entity scope: component-shaped keys — PascalCase (RFC #596
+/// Axis 2) AND pack-namespaced `<prefix>__<Pascal>` (#803) — plus
+/// `@`-target keys (#801). All are patch *content*; everything else
+/// at entity scope is structural (`prefab`, `children`, `meta`,
 /// `ref`).
+///
+/// Before #803 this accepted PascalCase only, which silently DROPPED
+/// flat namespaced keys in `synthesizeFlatComponents` — a registered
+/// `rooms__Room` authored flat on an entity never attached, and a
+/// typo'd one could never reach the unknown-component warning.
 pub fn isFlatComponentKey(name: []const u8) bool {
-    return isPascalCase(name) or isTargetKey(name);
+    return isComponentKeyShape(name) or isTargetKey(name);
 }
 
 /// Warn once that an unknown PascalCase component appeared on an

--- a/src/jsonc/unified_format.zig
+++ b/src/jsonc/unified_format.zig
@@ -148,6 +148,20 @@ pub fn isPascalCase(name: []const u8) bool {
     return name[0] >= 'A' and name[0] <= 'Z';
 }
 
+/// A key shaped like a component name: PascalCase (RFC #596), or the
+/// pack-namespaced `<prefix>__<Pascal>` form (#440) — nonempty prefix,
+/// PascalCase suffix after the LAST `__` (`industry__TendableWorkstation`
+/// accepted, `capacity__oops` rejected). Promoted from
+/// `target_overrides.zig` so the unknown-component diagnostic can share
+/// it (#803): namespaced keys start lowercase, so PascalCase alone
+/// misses every pack component.
+pub fn isComponentKeyShape(name: []const u8) bool {
+    if (isPascalCase(name)) return true;
+    const i = std.mem.lastIndexOf(u8, name, "__") orelse return false;
+    if (i == 0) return false;
+    return isPascalCase(name[i + 2 ..]);
+}
+
 /// True if `name` is a target-override key (#801): a leading `@`
 /// followed by a ref name. On a prefab reference's override map,
 /// `"@tender": { ... }` patches the entity (or entities) inside the

--- a/src/root.zig
+++ b/src/root.zig
@@ -894,6 +894,13 @@ pub const jsonc_deserializer = @import("jsonc/deserializer.zig");
 // downstream tooling (asset inference, editors) use one walker.
 pub const tree_walker = @import("jsonc/tree_walker.zig");
 
+// ── Unified-format accessors (RFC #560/#594/#596) ──
+// Key classification (`isPascalCase`, `isComponentKeyShape`,
+// `isTargetKey`) and the warn-once diagnostics dedup probe
+// (`alreadyWarnedKey`) — re-exported for tests and tooling that
+// need to agree with the loader's shape rules (#803).
+pub const unified_format = @import("jsonc/unified_format.zig");
+
 // ── Scene Value & JSONC Parser ──
 pub const SceneValue = jsonc_mod.Value;
 pub const JsoncParser = jsonc_mod.JsoncParser;

--- a/src/root.zig
+++ b/src/root.zig
@@ -900,6 +900,7 @@ pub const tree_walker = @import("jsonc/tree_walker.zig");
 // (`alreadyWarnedKey`) — re-exported for tests and tooling that
 // need to agree with the loader's shape rules (#803).
 pub const unified_format = @import("jsonc/unified_format.zig");
+pub const isComponentKeyShape = unified_format.isComponentKeyShape;
 
 // ── Scene Value & JSONC Parser ──
 pub const SceneValue = jsonc_mod.Value;

--- a/test/jsonc/unknown_component_warn_test.zig
+++ b/test/jsonc/unknown_component_warn_test.zig
@@ -88,3 +88,67 @@ test "a data-shaped lowercase key stays silent (not an authoring-mistake shape)"
     );
     try testing.expect(!uf.alreadyWarnedKey("unknown-component:just_data_803"));
 }
+
+test "flat-form typo'd namespaced key warns too (#806 round 1)" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    try loadScene(&game,
+        \\{ "children": [
+        \\  { "industry__Storag806": { "capacity": 12 } }
+        \\] }
+    );
+    try testing.expect(uf.alreadyWarnedKey("unknown-component:industry__Storag806"));
+}
+
+test "flat-form REGISTERED namespaced components now apply (#806 round 1)" {
+    // Before the isFlatComponentKey widening, a flat namespaced key
+    // was silently dropped by synthesizeFlatComponents — a registered
+    // pack component authored flat never attached.
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    try loadScene(&game,
+        \\{ "children": [
+        \\  { "industry__Storage": { "capacity": 21 } }
+        \\] }
+    );
+    var view = game.ecs_backend.view(.{Storage}, .{});
+    defer view.deinit();
+    const e = view.next() orelse return error.TestExpectedEntity;
+    try testing.expectEqual(@as(u32, 21), game.ecs_backend.getComponent(e, Storage).?.capacity);
+}
+
+test "a removal matching nothing warns; a legitimate removal stays silent" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    try tmp_dir.dir.createDir(std.testing.io, "prefabs", .default_dir);
+    try tmp_dir.dir.writeFile(std.testing.io, .{
+        .sub_path = "prefabs/crate806.jsonc",
+        .data =
+        \\{ "industry__Storage": { "capacity": 5 } }
+        ,
+    });
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const len = try tmp_dir.dir.realPath(std.testing.io, &buf);
+    const prefab_path = try std.fmt.allocPrint(testing.allocator, "{s}/prefabs", .{buf[0..len]});
+    defer testing.allocator.free(prefab_path);
+
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    try Bridge.loadSceneFromSource(&game,
+        \\{ "children": [
+        \\  { "prefab": "crate806", "industry__Storage": null },
+        \\  { "prefab": "crate806", "industry__Storag806b": null }
+        \\] }
+    , prefab_path);
+
+    // Typo'd removal (matches nothing) → warned.
+    try testing.expect(uf.alreadyWarnedKey("noop-removal:industry__Storag806b"));
+    // Legitimate removal of a prefab-carried component → silent…
+    try testing.expect(!uf.alreadyWarnedKey("noop-removal:industry__Storage"));
+    // …and it actually removed on entity 1 while entity 2 kept it.
+    var count: u32 = 0;
+    var view = game.ecs_backend.view(.{Storage}, .{});
+    defer view.deinit();
+    while (view.next()) |_| count += 1;
+    try testing.expectEqual(@as(u32, 1), count);
+}

--- a/test/jsonc/unknown_component_warn_test.zig
+++ b/test/jsonc/unknown_component_warn_test.zig
@@ -224,3 +224,66 @@ test "a lowercase data-shaped removal key stays outside the warning gate (#806 r
     , prefab_path);
     try testing.expect(!uf.alreadyWarnedKey("noop-removal:some_data_806"));
 }
+
+test "fan-out removal that lands on SOME matches is not a no-op (#806 round 3)" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    try tmp_dir.dir.createDir(std.testing.io, "prefabs", .default_dir);
+    // Two entities share the ref; only the first carries Storage.
+    try tmp_dir.dir.writeFile(std.testing.io, .{
+        .sub_path = "prefabs/rack806.jsonc",
+        .data =
+        \\{ "children": [
+        \\  { "ref": "cell806", "components": { "industry__Storage": { "capacity": 1 } } },
+        \\  { "ref": "cell806", "components": { "industry__Widget806": { "size": 1 } } }
+        \\] }
+        ,
+    });
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const len = try tmp_dir.dir.realPath(std.testing.io, &buf);
+    const prefab_path = try std.fmt.allocPrint(testing.allocator, "{s}/prefabs", .{buf[0..len]});
+    defer testing.allocator.free(prefab_path);
+
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    try Bridge.loadSceneFromSource(&game,
+        \\{ "children": [
+        \\  { "prefab": "rack806", "@cell806": { "industry__Storage": null } }
+        \\] }
+    , prefab_path);
+
+    // The removal landed on match #1 → no Storage anywhere, and NO
+    // "matches nothing" warning despite match #2 lacking the component.
+    var view = game.ecs_backend.view(.{Storage}, .{});
+    defer view.deinit();
+    try testing.expect(view.next() == null);
+    try testing.expect(!uf.alreadyWarnedKey("noop-removal:industry__Storage"));
+}
+
+test "a @ removal landing on NO match warns once for the whole fan-out (#806 round 3)" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    try tmp_dir.dir.createDir(std.testing.io, "prefabs", .default_dir);
+    try tmp_dir.dir.writeFile(std.testing.io, .{
+        .sub_path = "prefabs/rack806b.jsonc",
+        .data =
+        \\{ "children": [
+        \\  { "ref": "cell806b", "components": { "industry__Widget806": { "size": 1 } } },
+        \\  { "ref": "cell806b", "components": { "industry__Widget806": { "size": 2 } } }
+        \\] }
+        ,
+    });
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const len = try tmp_dir.dir.realPath(std.testing.io, &buf);
+    const prefab_path = try std.fmt.allocPrint(testing.allocator, "{s}/prefabs", .{buf[0..len]});
+    defer testing.allocator.free(prefab_path);
+
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    try Bridge.loadSceneFromSource(&game,
+        \\{ "children": [
+        \\  { "prefab": "rack806b", "@cell806b": { "industry__Storag806c": null } }
+        \\] }
+    , prefab_path);
+    try testing.expect(uf.alreadyWarnedKey("noop-removal:industry__Storag806c"));
+}

--- a/test/jsonc/unknown_component_warn_test.zig
+++ b/test/jsonc/unknown_component_warn_test.zig
@@ -1,0 +1,90 @@
+//! Unknown-component diagnostics for namespaced keys (#803).
+//!
+//! `warnUnknownComponent` (RFC #596 Axis 4) fired only for PascalCase
+//! names, so a typo'd pack-namespaced key — `industry__Storag` for
+//! `industry__Storage` — silently no-op'd in every override path.
+//! These tests pin the widened gate: namespaced-shaped unknowns warn,
+//! data-shaped lowercase keys stay silent, and registered namespaced
+//! components apply without warning.
+//!
+//! Warning observability: `uf.warnOnceKey` records fired keys in a
+//! process-lifetime dedup set probed via `engine.unified_format
+//! .alreadyWarnedKey` — no log capture needed. Component names are
+//! unique per test because that set never resets within a binary.
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+const uf = engine.unified_format;
+
+const Storage = struct {
+    capacity: u32 = 5,
+};
+
+const Components = engine.ComponentRegistry(.{
+    .industry__Storage = Storage,
+});
+
+const Game = engine.Game;
+const Bridge = engine.JsoncSceneBridge(Game, Components);
+
+fn loadScene(game: *Game, source: []const u8) !void {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    try tmp_dir.dir.createDir(std.testing.io, "prefabs", .default_dir);
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const len = try tmp_dir.dir.realPath(std.testing.io, &buf);
+    const prefab_path = try std.fmt.allocPrint(testing.allocator, "{s}/prefabs", .{buf[0..len]});
+    defer testing.allocator.free(prefab_path);
+    try Bridge.loadSceneFromSource(game, source, prefab_path);
+}
+
+test "isComponentKeyShape: PascalCase and <prefix>__<Pascal> only" {
+    try testing.expect(uf.isComponentKeyShape("Storage"));
+    try testing.expect(uf.isComponentKeyShape("industry__Storage"));
+    try testing.expect(uf.isComponentKeyShape("a__b__Pascal"));
+    try testing.expect(!uf.isComponentKeyShape("capacity"));
+    try testing.expect(!uf.isComponentKeyShape("capacity__oops"));
+    try testing.expect(!uf.isComponentKeyShape("__Storage"));
+    try testing.expect(!uf.isComponentKeyShape(""));
+    try testing.expect(!uf.isComponentKeyShape("prefab"));
+}
+
+test "a typo'd namespaced component warns instead of silently no-opping (#803)" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    try loadScene(&game,
+        \\{ "children": [
+        \\  { "components": { "industry__Storag803": { "capacity": 12 } } }
+        \\] }
+    );
+    // The scene loads (unknown components are no-ops, RFC #596) but
+    // the diagnostic fired.
+    try testing.expect(uf.alreadyWarnedKey("unknown-component:industry__Storag803"));
+}
+
+test "a registered namespaced component applies without warning" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    try loadScene(&game,
+        \\{ "children": [
+        \\  { "components": { "industry__Storage": { "capacity": 9 } } }
+        \\] }
+    );
+    var view = game.ecs_backend.view(.{Storage}, .{});
+    defer view.deinit();
+    const e = view.next() orelse return error.TestExpectedEntity;
+    try testing.expectEqual(@as(u32, 9), game.ecs_backend.getComponent(e, Storage).?.capacity);
+    try testing.expect(!uf.alreadyWarnedKey("unknown-component:industry__Storage"));
+}
+
+test "a data-shaped lowercase key stays silent (not an authoring-mistake shape)" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    try loadScene(&game,
+        \\{ "children": [
+        \\  { "components": { "just_data_803": { "x": 1 } } }
+        \\] }
+    );
+    try testing.expect(!uf.alreadyWarnedKey("unknown-component:just_data_803"));
+}

--- a/test/jsonc/unknown_component_warn_test.zig
+++ b/test/jsonc/unknown_component_warn_test.zig
@@ -21,8 +21,13 @@ const Storage = struct {
     capacity: u32 = 5,
 };
 
+const Widget = struct {
+    size: u32 = 1,
+};
+
 const Components = engine.ComponentRegistry(.{
     .industry__Storage = Storage,
+    .industry__Widget806 = Widget,
 });
 
 const Game = engine.Game;
@@ -151,4 +156,71 @@ test "a removal matching nothing warns; a legitimate removal stays silent" {
     defer view.deinit();
     while (view.next()) |_| count += 1;
     try testing.expectEqual(@as(u32, 1), count);
+}
+
+test "outer @ removal of an inner-@-added component is not a no-op warning (#806 round 2)" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    try tmp_dir.dir.createDir(std.testing.io, "prefabs", .default_dir);
+    // P: a machine-like prefab whose slot entity is ref-named.
+    try tmp_dir.dir.writeFile(std.testing.io, .{
+        .sub_path = "prefabs/p806.jsonc",
+        .data =
+        \\{ "children": [ { "ref": "s806", "components": { "industry__Storage": { "capacity": 1 } } } ] }
+        ,
+    });
+    // W: wrapper whose child reference ADDS Widget to @s806.
+    try tmp_dir.dir.writeFile(std.testing.io, .{
+        .sub_path = "prefabs/w806.jsonc",
+        .data =
+        \\{ "children": [
+        \\  { "prefab": "p806", "@s806": { "industry__Widget806": { "size": 7 } } }
+        \\] }
+        ,
+    });
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const len = try tmp_dir.dir.realPath(std.testing.io, &buf);
+    const prefab_path = try std.fmt.allocPrint(testing.allocator, "{s}/prefabs", .{buf[0..len]});
+    defer testing.allocator.free(prefab_path);
+
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    // Scene removes, at higher precedence, what the inner patch added.
+    try Bridge.loadSceneFromSource(&game,
+        \\{ "children": [
+        \\  { "prefab": "w806", "@s806": { "industry__Widget806": null } }
+        \\] }
+    , prefab_path);
+
+    // The removal matched a real (inner-added) component: no Widget
+    // spawned, and NO false no-op warning.
+    var view = game.ecs_backend.view(.{Widget}, .{});
+    defer view.deinit();
+    try testing.expect(view.next() == null);
+    try testing.expect(!uf.alreadyWarnedKey("noop-removal:industry__Widget806"));
+}
+
+test "a lowercase data-shaped removal key stays outside the warning gate (#806 round 2)" {
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    try tmp_dir.dir.createDir(std.testing.io, "prefabs", .default_dir);
+    try tmp_dir.dir.writeFile(std.testing.io, .{
+        .sub_path = "prefabs/crate806c.jsonc",
+        .data =
+        \\{ "industry__Storage": { "capacity": 5 } }
+        ,
+    });
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const len = try tmp_dir.dir.realPath(std.testing.io, &buf);
+    const prefab_path = try std.fmt.allocPrint(testing.allocator, "{s}/prefabs", .{buf[0..len]});
+    defer testing.allocator.free(prefab_path);
+
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    try Bridge.loadSceneFromSource(&game,
+        \\{ "children": [
+        \\  { "prefab": "crate806c", "some_data_806": null }
+        \\] }
+    , prefab_path);
+    try testing.expect(!uf.alreadyWarnedKey("noop-removal:some_data_806"));
 }


### PR DESCRIPTION
Closes #803 (split from codex round 4 on #802).

`warnUnknownComponent` (RFC #596 Axis 4) fired only for PascalCase names — but every pack component is `<prefix>__<Pascal>`-namespaced and starts lowercase, so a typo'd `industry__Storag` silently no-op'd in **every** override path: ordinary `overrides` maps, flat form, and `@`-target patches (where the target records a hit and the scene loads with an ineffective patch).

## Changes
- `isComponentKeyShape` promoted from `target_overrides.zig` to `unified_format.zig` and shared — one predicate for "could this key ever name a registered component" (nonempty prefix, PascalCase suffix after the last `__`).
- `applyComponent`'s unknown-name gate widened to it. Plain lowercase data-shaped keys (`just_data`) stay silent, exactly as before — they aren't the authoring-mistake shape the RFC targets.
- `unified_format` re-exported through `root.zig` so tests/tooling share the loader's shape rules (and the `alreadyWarnedKey` dedup probe, which is how the new tests observe warnings without log capture).

## Tests
`test/jsonc/unknown_component_warn_test.zig`: shape-predicate table; typo'd namespaced key warns; registered namespaced component applies **without** warning; data-shaped lowercase key stays silent. Full suite green.

No behavior change for healthy projects: the assembler registers every pack component, so the widened gate only fires where something was already silently broken.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-engine/pr/806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788442872&installation_model_id=427192&pr_number=806&repository=labelle-toolkit%2Flabelle-engine&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-engine%2Fpull%2F806&signature=e61a5a4845953d0e96fd6cc1f8a21a2bd6cd8b6e904c3812a8cb8b3c0d0db5e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->