### PR TITLE
docs(rfc): i18n and game constants

### DIFF
--- a/RFC-CONSTANTS.md
+++ b/RFC-CONSTANTS.md
@@ -29,7 +29,17 @@ Decay rates cluster in `libs/needs_machine/src/config.zig`, which is the closest
 
 1. **One folder.** `constants/` at project root; every tuning value in the game reachable from one place.
 2. **One file per domain**, named for the domain — `construction.yaml`, `decay.yaml` — so related values sit together and a diff reads as a balance change.
-3. **YAML**, for hand-editing by whoever is balancing the game.
+3. **YAML**, for hand-editing by whoever is balancing the game. This is a
+   deliberate divergence from [RFC-I18N](./RFC-I18N.md) §1, whose argument —
+   "a second config dialect and a new parser dependency for one feature" —
+   applies here too and is overridden, decided, for two reasons. A balance
+   file is the one place the toolkit's files are edited by someone tuning
+   numbers rather than writing code, and `rate: 0.02` with no quotes or
+   braces is the shape that audience edits without breaking. And the parser
+   is not a dependency: it is a hand-written strict subset (§2, Open
+   Question 1 — resolved), small enough that the "new parser" cost is a few
+   hundred lines the assembler owns. The remaining cost is honest: §6's
+   shared pass runs two parsers, one per dialect.
 4. **Zero runtime cost.** Values inline exactly as the `const` literals they replace. A shipped game reads no files and carries no parser.
 5. **A misspelled constant does not compile**, the same property [RFC-I18N](./RFC-I18N.md) §3 gives keys.
 6. **Packs bring their own**, namespaced, so a pack stays drop-in.
@@ -180,7 +190,7 @@ The door is not closed, and it is worth recording the shape now so the decision 
 
 Mirroring [RFC-I18N](./RFC-I18N.md) §3.1: the assembler scans game and pack sources for `C.<path>` references and **warns on constants nothing reads**. A tuning value no code consumes is either dead or a symptom of a rename that missed a call site, and in a folder whose purpose is discoverability, stale entries are the main way it would rot.
 
-Sound for the same reason it is sound there — the accessor path is the only way to name a constant, and it cannot be assembled from a runtime string.
+Sound for the same reason it is sound there — the accessor path is the only way to name a constant, and it cannot be assembled from a runtime string — **with one caveat the scanner must handle: namespace aliasing.** `const cfg = C.decay.hunger;` followed by `cfg.rate` is ordinary Zig, and a textual scan for `C.<path>` misses it, producing a false "unused" warning that trains people to ignore the lint. Ruled: **conservative alias widening** — the scanner detects `= C`-rooted aliases and marks the aliased subtree used. Sound (no warning is wrongly suppressed, no false positive fires); the cost is precision, since an aliased subtree's genuinely dead entries go unreported. The same ruling covers RFC-I18N's `K` (its §3.1).
 
 ### 6. Shared machinery with RFC-I18N
 
@@ -205,7 +215,7 @@ Phase 4 is deliberately last and deliberately incremental. New tuning values go 
 
 ## Open questions
 
-1. **Which YAML library?** The assembler has no YAML dependency today (checked). A pure-Zig parser keeps the toolchain dependency-free and cross-compiles trivially; libyaml through C is more battle-tested but adds a C dependency to a build tool. The strict subset in §2 is small enough that a hand-written parser is also credible — and would make the subset enforceable by construction rather than by post-validation.
+1. ~~**Which YAML library?**~~ **Resolved** (assembler#656): none. The parser is hand-written against the strict subset, which makes §2 enforceable by construction rather than by post-validation — nothing implements YAML 1.1 implicit typing, so nothing can silently apply it. The toolchain stays dependency-free and the subset's rejections are errors that name what was written.
 2. **Do constants and prefab data overlap?** `build_time` as a global vs. a per-workstation override in `prefabs/*.jsonc`. Declared a non-goal here, but the boundary will be contested the first time a designer wants one fast-building room.
 3. **Sequences.** Rejected in phase 1. But tiered values (`upgrade_costs: [10, 25, 60]`) are a natural fit and would generate a comptime array. Worth it, or does it invite structure that belongs in prefabs?
 4. **Units.** `build_time: 5.0` is seconds by convention and comment only. A suffix convention (`_s`, `_px`, `_per_s`) is nearly free and self-documenting; a real unit type is not. Is the convention worth mandating?

--- a/RFC-CONSTANTS.md
+++ b/RFC-CONSTANTS.md
@@ -108,6 +108,19 @@ simpler than i18n's — no "unless it is a new locale" branch — and it is what
 turns a pack renaming a constant in v2 into a build failure rather than a game's
 tuning silently reverting to the pack's default.
 
+In file form the rule follows from §1 — the filename is the namespace, and a
+pack's namespace is `<pack>__<file>` — so the game overrides by carrying the
+prefixed name as a filename:
+
+```yaml
+# constants/citizens__hunger.yaml — the game retuning the citizens pack
+drain_rate: 0.015
+```
+
+The `__` filename is deliberate, not pretty. It keeps "filename is the
+namespace" a single rule with no override-specific carve-out, and a directory
+listing of `constants/` then shows exactly which packs this game has retuned.
+
 An override must also keep the **scalar kind** it replaces: `5.0` stays `5.0`,
 not `5`. Values are emitted untyped and coerce at the use site (§3), so an
 int-for-float override can change behaviour without changing the number — the

--- a/RFC-CONSTANTS.md
+++ b/RFC-CONSTANTS.md
@@ -1,0 +1,162 @@
+# RFC: Game constants — one folder, YAML per domain, inlined at build time
+
+**Status:** Draft
+**Author:** Alexandre
+**Date:** 2026-08-06
+**Sibling RFC:** [RFC-I18N](./RFC-I18N.md) — shares the scan-and-codegen machinery (§6)
+
+## Problem
+
+Tuning values live wherever the code that reads them happens to live. In `flying-platform-labelle` today there are **38 such constants across 17 files**, and the pattern is not that they are hard to find — it is that nothing relates them to each other.
+
+The construction family:
+
+```
+packs/rooms/…/26_construction_progress.zig      BUILD_TIME              = 5.0
+packs/rooms/…/32_carcase_build_dispatcher.zig   CONSTRUCTION_DURATION_S = 5.0
+packs/rooms/…/40_repair_progress.zig            REPAIR_TIME             = 5.0
+packs/rooms/…/40_repair_progress.zig            PER_PIECE_TIME          = 5.0
+packs/rooms/…/29_deconstruction_progress.zig    DECONSTRUCT_TIME        = 4.0
+```
+
+Five timings, four files, four sharing the value `5.0` with no record of whether that is intent or coincidence. Changing "how long building takes" means finding all five and deciding, per site, whether it is one of the five.
+
+`SHIP_SPEED` is defined twice with different values — `280` in `packs/transport/scripts/playing/37_transport_delivery.zig`, `150` in `packs/combat/scripts/playing/ship_animation.zig`. Both are legitimate (different ships), but nothing says so, and nothing would catch it if one were meant to track the other.
+
+Decay rates cluster in `libs/needs_machine/src/config.zig`, which is the closest thing the game has to this proposal already — and it demonstrates the failure mode. It holds `health_drain_rate = 0.0`, a value with consequences big enough that the game's `CLAUDE.md` spends four paragraphs on it ("**When diagnosing a stalled colony, check for needs pinned at 0 instead of waiting for deaths**"). That warning exists because the value is invisible where it sits. A balance value that changes how the game fails should not be discoverable only by reading a plugin's source.
+
+## Goals
+
+1. **One folder.** `constants/` at project root; every tuning value in the game reachable from one place.
+2. **One file per domain**, named for the domain — `construction.yaml`, `decay.yaml` — so related values sit together and a diff reads as a balance change.
+3. **YAML**, for hand-editing by whoever is balancing the game.
+4. **Zero runtime cost.** Values inline exactly as the `const` literals they replace. A shipped game reads no files and carries no parser.
+5. **A misspelled constant does not compile**, the same property [RFC-I18N](./RFC-I18N.md) §3 gives keys.
+6. **Packs bring their own**, namespaced, so a pack stays drop-in.
+
+## Non-goals
+
+- **Hot reload / live tuning.** Explicitly out: values are inlined, so changing one is a rebuild. §4 covers why the door stays open and what it would cost to change our minds.
+- **Per-entity or per-prefab overrides.** A workstation that builds faster than the global rate is prefab data (`prefabs/*.jsonc`), not a global constant. This RFC is for values that are global to a domain.
+- **A settings / options system.** Player-facing toggles are runtime state that persists to disk. Unrelated machinery despite the surface similarity.
+- **Full YAML.** §2 defines the supported subset. Anchors, aliases, multi-document streams, custom tags, and flow-style collections are rejected, not silently mishandled.
+- **Units and dimensional analysis.** `build_time` is seconds because it is named so and commented so. Enforcing that in the type system is a much bigger idea (Open Question 4).
+
+## Design
+
+### 1. Directory convention
+
+```
+constants/
+  construction.yaml
+  decay.yaml
+  combat.yaml
+```
+
+Flat, scanned like `scripts/` and `locales/`. Filename is the namespace; adding `economy.yaml` adds `C.economy.*` with nothing to register.
+
+Packs use `packs/<name>/constants/*.yaml`, namespaced `<pack>__` exactly as pack components, scripts, prefabs, and locales already are — so `packs/combat/constants/ship.yaml` surfaces as `C.combat__ship.*`.
+
+```yaml
+# constants/construction.yaml
+# How long a room takes to go from carcase to finished, in seconds.
+build_time: 5.0
+repair_time: 5.0
+per_piece_time: 5.0
+deconstruct_time: 4.0
+```
+
+Nesting is allowed one or more levels and maps onto the accessor path:
+
+```yaml
+# constants/decay.yaml
+hunger:
+  rate: 0.02          # need units per second
+  yellow_threshold: 0.5
+  red_threshold: 0.2
+health:
+  drain_rate: 0.0     # DISABLED — see CLAUDE.md §Needs System
+```
+
+→ `C.decay.hunger.rate`, `C.decay.health.drain_rate`.
+
+### 2. YAML subset, and strict scalars
+
+YAML's implicit typing is the one real hazard in a constants file, and it is worth being blunt about because the failure is silent:
+
+| Written | YAML 1.1 infers | What the author meant |
+|---|---|---|
+| `enabled: no` | boolean `false` | possibly the string `"no"` |
+| `delay: 12:30` | sexagesimal `750` | `"12:30"` |
+| `version: 1.20` | float `1.2` | `"1.20"` |
+| `id: 0755` | octal `493` | `"0755"` |
+
+So the parser runs a **strict scalar policy**: numbers must match an unambiguous numeric literal (`-?\d+` or `-?\d+\.\d+`, optional exponent), booleans must be exactly `true` or `false`, and anything else is a string. `no` / `yes` / `on` / `off` as bare scalars are a **build error** naming the file and line and telling the author to write `false` or `"no"` explicitly. Sexagesimal and octal are not recognised at all. This is a deliberate narrowing of YAML, and it makes the format safe for the job rather than merely familiar.
+
+Supported: block mappings, nesting, scalars, comments. Rejected with a clear error: anchors (`&`/`*`), tags (`!!`), multi-doc (`---`), flow collections (`{a: 1}`), sequences (Open Question 3).
+
+### 3. Comptime, via codegen — not a comptime YAML parser
+
+"Comptime only" must not be read as `@embedFile` plus a comptime parse. YAML is far too large a grammar to parse pleasantly in Zig's comptime, and a comptime parser cannot call a C library.
+
+The assembler does it instead, and it is the same move it already makes everywhere else:
+
+```
+constants/*.yaml  →  assembler (native code, any YAML library)  →  generated constants.zig  →  game imports
+```
+
+```zig
+// generated — .labelle/<backend>_<platform>/constants.zig
+pub const C = struct {
+    pub const construction = struct {
+        pub const build_time = 5.0;
+        pub const deconstruct_time = 4.0;
+    };
+    pub const decay = struct {
+        pub const hunger = struct { pub const rate = 0.02; };
+    };
+};
+```
+
+Three consequences worth stating:
+
+1. **The YAML dependency is the assembler's, not the game's.** It is a build-time tool dependency; no parser is linked into the shipped binary and no `.yaml` file is shipped. That substantially defuses the "new dependency" cost of choosing YAML.
+2. **Values are emitted untyped** — `comptime_int` / `comptime_float` — so they coerce at the use site to whatever it needs (`f32`, `f64`, `usize`, `u32`) with no annotations in the YAML and no cast at the call site. This is strictly more flexible than declaring types in the file, and precision or range problems surface as ordinary Zig compile errors where the value is used.
+3. **`C.construction.buld_time` does not compile**, naming the missing declaration — goal 5, for free, because these are real Zig declarations.
+
+### 4. On hot reload
+
+Ruled out by the chosen tuning loop: inlined values cannot change without a rebuild. Edit → `labelle run` is the loop, and an incremental rebuild touching only the generated constants file is cheap.
+
+The door is not closed, and it is worth recording the shape now so the decision can be revisited without an API break: a debug-only path could make `C.x.y` a function call reading a mutable table loaded from disk, while release keeps the inlined constant. Same call sites, same names. The cost is that debug and release stop sharing a code path for every constant read, which is exactly the kind of divergence that hides bugs — the reason not to do it by default.
+
+### 5. Usage awareness
+
+Mirroring [RFC-I18N](./RFC-I18N.md) §3.1: the assembler scans game and pack sources for `C.<path>` references and **warns on constants nothing reads**. A tuning value no code consumes is either dead or a symptom of a rename that missed a call site, and in a folder whose purpose is discoverability, stale entries are the main way it would rot.
+
+Sound for the same reason it is sound there — the accessor path is the only way to name a constant, and it cannot be assembled from a runtime string.
+
+### 6. Shared machinery with RFC-I18N
+
+These two RFCs are the same shape: *scan a convention-named folder → generate nested namespaces of comptime-checked accessors → warn on entries nothing uses.* They should share one assembler pass — one directory scanner, one nested-namespace emitter, one `X.<path>` usage scanner parameterised by root symbol — rather than growing two near-identical implementations. Whichever lands first should be built with the second in mind.
+
+They differ in exactly one respect: locales need a runtime-selectable table because the active language changes while the game runs, whereas constants resolve to a single value at build time.
+
+## Phasing
+
+| Phase | Scope |
+|---|---|
+| 1 | `constants/` scan, strict-scalar YAML subset, codegen, `C.*` accessors |
+| 2 | Usage-awareness warnings (§5), shared with RFC-I18N's scanner |
+| 3 | Pack-scoped constants (`packs/<name>/constants/`, `<pack>__` namespacing) |
+| 4 | Migrate FP's 38 existing constants, domain by domain |
+
+Phase 4 is deliberately last and deliberately incremental. New tuning values go in `constants/` from phase 1; existing ones move when their domain is next touched. A big-bang migration of 17 files would be a large, untestable diff over gameplay-affecting values.
+
+## Open questions
+
+1. **Which YAML library?** The assembler has no YAML dependency today (checked). A pure-Zig parser keeps the toolchain dependency-free and cross-compiles trivially; libyaml through C is more battle-tested but adds a C dependency to a build tool. The strict subset in §2 is small enough that a hand-written parser is also credible — and would make the subset enforceable by construction rather than by post-validation.
+2. **Do constants and prefab data overlap?** `build_time` as a global vs. a per-workstation override in `prefabs/*.jsonc`. Declared a non-goal here, but the boundary will be contested the first time a designer wants one fast-building room.
+3. **Sequences.** Rejected in phase 1. But tiered values (`upgrade_costs: [10, 25, 60]`) are a natural fit and would generate a comptime array. Worth it, or does it invite structure that belongs in prefabs?
+4. **Units.** `build_time: 5.0` is seconds by convention and comment only. A suffix convention (`_s`, `_px`, `_per_s`) is nearly free and self-documenting; a real unit type is not. Is the convention worth mandating?
+5. **Cross-domain duplicate lint.** Should the assembler flag identical leaf names with differing values across domains — the `SHIP_SPEED` 280/150 case? It is legitimate there, so this would be a warning with a suppression, and it may be more noise than signal.

--- a/RFC-CONSTANTS.md
+++ b/RFC-CONSTANTS.md
@@ -57,6 +57,29 @@ Flat, scanned like `scripts/` and `locales/`. Filename is the namespace; adding 
 
 Packs use `packs/<name>/constants/*.yaml`, namespaced `<pack>__` exactly as pack components, scripts, prefabs, and locales already are — so `packs/combat/constants/ship.yaml` surfaces as `C.combat__ship.*`.
 
+```yaml
+# constants/construction.yaml
+# How long a room takes to go from carcase to finished, in seconds.
+build_time: 5.0
+repair_time: 5.0
+per_piece_time: 5.0
+deconstruct_time: 4.0
+```
+
+Nesting is allowed one or more levels and maps onto the accessor path:
+
+```yaml
+# constants/decay.yaml
+hunger:
+  rate: 0.02          # need units per second
+  yellow_threshold: 0.5
+  red_threshold: 0.2
+health:
+  drain_rate: 0.0     # DISABLED — see CLAUDE.md §Needs System
+```
+
+→ `C.decay.hunger.rate`, `C.decay.health.drain_rate`.
+
 ### 1.1 The game takes precedence over the pack
 
 Same rule as [RFC-I18N](./RFC-I18N.md) §2.1: a game overrides any of a pack's
@@ -89,29 +112,6 @@ An override must also keep the **scalar kind** it replaces: `5.0` stays `5.0`,
 not `5`. Values are emitted untyped and coerce at the use site (§3), so an
 int-for-float override can change behaviour without changing the number — the
 same class of silent failure the strict scalar policy in §2 exists to prevent.
-
-```yaml
-# constants/construction.yaml
-# How long a room takes to go from carcase to finished, in seconds.
-build_time: 5.0
-repair_time: 5.0
-per_piece_time: 5.0
-deconstruct_time: 4.0
-```
-
-Nesting is allowed one or more levels and maps onto the accessor path:
-
-```yaml
-# constants/decay.yaml
-hunger:
-  rate: 0.02          # need units per second
-  yellow_threshold: 0.5
-  red_threshold: 0.2
-health:
-  drain_rate: 0.0     # DISABLED — see CLAUDE.md §Needs System
-```
-
-→ `C.decay.hunger.rate`, `C.decay.health.drain_rate`.
 
 ### 2. YAML subset, and strict scalars
 

--- a/RFC-CONSTANTS.md
+++ b/RFC-CONSTANTS.md
@@ -57,6 +57,39 @@ Flat, scanned like `scripts/` and `locales/`. Filename is the namespace; adding 
 
 Packs use `packs/<name>/constants/*.yaml`, namespaced `<pack>__` exactly as pack components, scripts, prefabs, and locales already are — so `packs/combat/constants/ship.yaml` surfaces as `C.combat__ship.*`.
 
+### 1.1 The game takes precedence over the pack
+
+Same rule as [RFC-I18N](./RFC-I18N.md) §2.1: a game overrides any of a pack's
+constants, and the game wins. A `C.citizens__hunger.drain_rate` defined in the
+game's `constants/` replaces the pack's.
+
+No visibility gate — every pack constant is overridable. A gate would ask a pack
+author to predict which values a game will want to tune, and each wrong guess
+sends that game back to forking the pack or redefining the value somewhere else,
+which is the drift this RFC exists to remove. The evidence in §Problem is
+entirely of that shape: five construction timings across four files, `SHIP_SPEED`
+defined twice, `health_drain_rate` stranded in a plugin's `config.zig`.
+
+**The consequence, accepted deliberately: a pack's constant names are part of its
+compatibility surface.** Once a game overrides `citizens__hunger.drain_rate`,
+renaming it in the pack is a breaking change for that game. Packs already take
+this bargain elsewhere — RFC-packs makes a pack's `name` save-stable because it
+is the component prefix, so renaming a shipped pack is a save migration. Constant
+names join that list.
+
+**Every write under a pack's namespace is an override, and one that matches
+nothing is an error.** Constants have no counterpart to i18n's *adding* case:
+there is no second axis, so a value a pack does not define is simply the game's
+own constant in the game's own namespace. That makes the rule here strictly
+simpler than i18n's — no "unless it is a new locale" branch — and it is what
+turns a pack renaming a constant in v2 into a build failure rather than a game's
+tuning silently reverting to the pack's default.
+
+An override must also keep the **scalar kind** it replaces: `5.0` stays `5.0`,
+not `5`. Values are emitted untyped and coerce at the use site (§3), so an
+int-for-float override can change behaviour without changing the number — the
+same class of silent failure the strict scalar policy in §2 exists to prevent.
+
 ```yaml
 # constants/construction.yaml
 # How long a room takes to go from carcase to finished, in seconds.
@@ -140,7 +173,11 @@ Sound for the same reason it is sound there — the accessor path is the only wa
 
 These two RFCs are the same shape: *scan a convention-named folder → generate nested namespaces of comptime-checked accessors → warn on entries nothing uses.* They should share one assembler pass — one directory scanner, one nested-namespace emitter, one `X.<path>` usage scanner parameterised by root symbol — rather than growing two near-identical implementations. Whichever lands first should be built with the second in mind.
 
-They differ in exactly one respect: locales need a runtime-selectable table because the active language changes while the game runs, whereas constants resolve to a single value at build time.
+They differ in two respects, and both are small enough to be parameters of the shared pass rather than reasons to fork it.
+
+**Runtime selection.** Locales need a runtime-selectable table because the active language changes while the game runs; constants resolve to a single value at build time.
+
+**Override versus add.** Both share the precedence rule — the game beats the pack (§1.1, RFC-I18N §2.1) — and the check that a write under a pack's namespace must match a key the pack defines. i18n needs one branch constants do not: a game may *add* a locale a pack never shipped, so a `<pack>__` key appearing in a locale file the pack has no counterpart for is legitimate. Constants have no second axis and therefore no such case, which makes the constants rule a strict subset of the i18n one. Build the general form once and let constants use the simpler half.
 
 ## Phasing
 
@@ -148,7 +185,7 @@ They differ in exactly one respect: locales need a runtime-selectable table beca
 |---|---|
 | 1 | `constants/` scan, strict-scalar YAML subset, codegen, `C.*` accessors |
 | 2 | Usage-awareness warnings (§5), shared with RFC-I18N's scanner |
-| 3 | Pack-scoped constants (`packs/<name>/constants/`, `<pack>__` namespacing) |
+| 3 | Pack-scoped constants (`packs/<name>/constants/`, `<pack>__` namespacing), game override precedence and the must-exist check (§1.1) |
 | 4 | Migrate FP's 38 existing constants, domain by domain |
 
 Phase 4 is deliberately last and deliberately incremental. New tuning values go in `constants/` from phase 1; existing ones move when their domain is next touched. A big-bang migration of 17 files would be a large, untestable diff over gameplay-affecting values.

--- a/RFC-I18N.md
+++ b/RFC-I18N.md
@@ -259,7 +259,29 @@ order: reordering is legitimate translation, not drift.
 
 A literal `{` is written `{{` (and `}` as `}}`), matching `std.fmt`.
 
-`tf`'s buffer comes from a **frame arena** reset once per frame. UI strings are per-frame and short-lived; an arena avoids both a per-call allocation and any free discipline at the call site. The returned slice is valid until the next frame — documented, and the reason `tf` results must never be stored in a component. (Ownership is Open Question 1.)
+`tf`'s buffer comes from a **frame arena** reset once per frame. UI strings are per-frame and short-lived; an arena avoids both a per-call allocation and any free discipline at the call site. The returned slice is valid until the next frame — documented, and the reason `tf` results must never be stored in a component.
+
+**Ownership — resolved (Open Question 1): module-owned buffer, engine-owned
+reset.** The arena is a fixed 16 KiB ring inside the generated `i18n` module
+(no allocator, no wiring needed just to *call* `tf` — it degrades to
+wrap-between-results standalone), and the per-frame reset splices in through
+the engine's **frame-boundary hook** (labelle-engine `Game.setFrameBoundaryFn`):
+a single `?*const fn () void` slot fired as the first thing in `Game.tick()`,
+*before* the pause gate — so it runs exactly once per frame on every frame,
+paused ones included, which matters because the pause menu is the
+i18n-heaviest screen. The generated `main.zig` wires it with one line:
+
+```zig
+game.setFrameBoundaryFn(i18n.resetFrameArena);
+```
+
+Not the `frame_start` lifecycle hook, which fires only on unpaused frames and
+routes through the game's script-hook receivers; and deliberately a single
+slot rather than a registry — the registrant is generated code with one
+author (the assembler), which composes multiple per-frame resets into one
+generated function if a second concern ever appears. Games without a
+`locales/` directory never call `setFrameBoundaryFn`; the `null` slot costs
+one branch per frame, preserving Goal 6.
 
 ### 5. Storage and runtime switching
 
@@ -324,7 +346,7 @@ Phase 1 alone converts the FP menu and is independently useful.
 
 ## Open questions
 
-1. **Frame arena ownership.** Engine-owned and reset in the frame loop, or game-owned and passed in? Engine-owned is less ceremony but puts an allocator in the i18n module that single-language games never touch.
+1. ~~**Frame arena ownership.**~~ **Resolved** (§4): neither engine-owned nor game-owned — the buffer is a fixed ring *inside the generated module* (no allocator at all, so single-language games touch nothing), and the once-per-frame reset is the engine's job via the frame-boundary hook: the generated main registers `i18n.resetFrameArena` with `Game.setFrameBoundaryFn`, fired at the top of every `tick` (paused frames included).
 2. ~~**Strict by default?**~~ **Resolved** (§3 / §3.1): default is a *warning*, scoped to keys actually used in code; `i18n.strict = true` promotes it to a comptime error for release builds. Unused untranslated keys are silent. Remaining sub-question: should `strict` also be settable per-locale, so a game can ship `pt-BR` strictly while `fr` is still in progress?
 3. **Key type stability.** `@enumFromInt` indices are assigned by scan order. Reordering a locale file must not silently change what a key means — sort keys deterministically before assigning, and confirm nothing persists a `Key` value to disk.
 4. ~~**Pack key collisions.**~~ **Resolved** (§2.1): two packs both defining `ui.title` namespace to `a__ui.title` / `b__ui.title`. And yes — a game overrides a pack's string without forking it, and may add locales the pack never shipped. The game takes precedence.

--- a/RFC-I18N.md
+++ b/RFC-I18N.md
@@ -88,6 +88,19 @@ the override site it is `citizens__hunger.starving`. Both are true; the packs RF
 should say so, because it currently reads as "authors never type or see the
 prefix" without qualification.
 
+In file form, a pack's keys sit at the top level of the game's locale file
+under the prefixed name — the `__` form is exactly how the outside names them:
+
+```jsonc
+// locales/pt.jsonc — the game's own file
+{
+  "menu": { "new_game": "Novo Jogo" },   // the game's key
+  "citizens__hunger": {
+    "starving": "Faminto",               // a pack key: override, or pt addition
+  },
+}
+```
+
 **Overriding asserts the key exists; adding does not.** These are different
 operations and only one of them is a claim about the pack:
 
@@ -233,6 +246,19 @@ tf(K.hud.stock, .{ .cnt = 5, .max = 10 })     // compile error: no field 'cnt'
 
 Splitting them keeps the zero-cost path honest instead of hiding an allocation behind a uniform API. Codegen knows which keys have placeholders, so calling `t` on an interpolated key is itself a compile error.
 
+**Formatting is a per-locale segment walk, not a comptime format string.** Word
+order is the thing translation changes: `en` says `"{count} of {max} items"`,
+`de` says `"Von {max} Artikeln: {count}"`. The string is selected at *runtime*
+(the active locale) while the arguments are comptime, so the reference locale's
+placeholder order proves nothing about any other locale's — a naïve
+implementation that bakes the reference string into a comptime `std.fmt` format
+renders every reordering locale wrong. Codegen therefore emits, per
+(key, locale), a list of literal-and-placeholder segments, and `tf` walks the
+active locale's list. §3's parity check compares placeholder *sets*, never
+order: reordering is legitimate translation, not drift.
+
+A literal `{` is written `{{` (and `}` as `}}`), matching `std.fmt`.
+
 `tf`'s buffer comes from a **frame arena** reset once per frame. UI strings are per-frame and short-lived; an arena avoids both a per-call allocation and any free discipline at the call site. The returned slice is valid until the next frame — documented, and the reason `tf` results must never be stored in a component. (Ownership is Open Question 1.)
 
 ### 5. Storage and runtime switching
@@ -313,7 +339,20 @@ Phase 1 alone converts the FP menu and is independently useful.
 | gettext | `.po`/`.mo` | Runtime, falls back to msgid | Mature tooling, C-oriented |
 | Unity Localization | Asset tables | Runtime (editor warns) | GUI-driven table editing |
 | Mozilla Fluent | `.ftl` | Runtime | Richest grammar (genders, plurals as first-class) |
+| Android resources | XML per locale | **Compile time** — `R.string.foo` is a generated constant | Untranslated keys are lint warnings; default-locale fallback baked at build |
 
-All four check keys at runtime, because all four load translations at runtime. labelle's build already generates the game's wiring, so it can check at compile time instead — that is the one thing this design does that none of the prior art can.
+The first four check keys at runtime, because they load translations at
+runtime. **Android is the exception, and the validation**: `R.string.new_game`
+is a generated constant, so a missing key is a compile error while an
+untranslated string is a lint warning with default-locale fallback baked in —
+the same two-severity split §3 argues for, shipped at scale for fifteen years.
+Compile-checked keys are not novel; they are proven.
 
-The sharper distinction is §3.1. Every system above can report "locale *L* is missing key *k*"; none can reliably answer "…and is *k* actually rendered anywhere?", because in all four the key space is open — keys are strings assembled at runtime. labelle's keys are comptime symbols from a closed set, which turns coverage from a list you skim into a diagnostic that only fires on holes a player could see.
+What remains novel is §3.1. Every system above can report "locale *L* is
+missing key *k*"; none can reliably answer "…and is *k* actually rendered
+anywhere?". In the first four the key space is open — keys are strings
+assembled at runtime. Android generates constants but leaves the question open
+anyway: `getIdentifier()` resolves resources from runtime strings, so its lint
+must assume any string might be used. labelle's keys are comptime symbols from
+a closed set with no runtime lookup, which turns coverage from a list you skim
+into a diagnostic that only fires on holes a player could see.

--- a/RFC-I18N.md
+++ b/RFC-I18N.md
@@ -71,6 +71,71 @@ Flat, not recursive. Filename is the BCP-47 tag and the only place a locale is d
 
 **Packs ship their own.** `packs/<name>/locales/*.jsonc` is scanned too, with keys namespaced `<pack>__` exactly as pack components, scripts, and prefabs already are. A pack stays self-contained and drop-in.
 
+### 2.1 The game takes precedence over the pack
+
+A pack ships the languages its author had. A game shipping to a market the pack
+never considered cannot be made to fork it, so:
+
+- **The game overrides.** A `<pack>__` key defined in the game's `locales/` wins
+  over the pack's. Same for constants (RFC-CONSTANTS §5.1).
+- **The game adds.** A pack shipping `en` and `fr` does not stop a game adding
+  `pt`. The game writes the pack's keys into its own `pt.jsonc`.
+
+**The namespace is invisible inside a pack and explicit outside it.** Inside
+`packs/citizens` you write `hunger.starving` and never see the prefix, as
+RFC-packs promises. A game addressing that key has no other way to name it, so at
+the override site it is `citizens__hunger.starving`. Both are true; the packs RFC
+should say so, because it currently reads as "authors never type or see the
+prefix" without qualification.
+
+**Overriding asserts the key exists; adding does not.** These are different
+operations and only one of them is a claim about the pack:
+
+| the game writes | means | if no such key in the pack |
+|---|---|---|
+| a `<pack>__` key in a locale the pack ships | override | **error** |
+| a `<pack>__` key in a locale the pack lacks | add | **error** |
+
+Both error, and for the same reason: writing under a pack's namespace is a claim
+that the pack defines that key. §3.1 makes *unused* keys silent, which is right
+for pack-authored keys and wrong here — if a game writes
+`citizens__hunger.starvng`, or the pack renames the key in v2, the game silently
+gets the pack's string while believing it had replaced it. This check is the only
+thing that turns a pack upgrade breaking a game's translations into a build
+failure instead of a surprise in front of a player.
+
+What *adding* changes is coverage, not existence: a `pt` file for a pack that
+ships `en`/`fr` is new-locale-for-existing-key, so it is measured against the
+pack's key space rather than against a `pt` that does not exist yet.
+
+Placeholder parity (§4) applies unchanged, because overrides and additions go
+through the same codegen: a `pt` string that drops `{count}` fails exactly as a
+game's own would.
+
+### 2.2 A pack declares its own reference locale
+
+`.reference` in `project.labelle` (§8) is the backfill source that makes §3.1's
+table rectangular, and that is what lets §5 promise **no runtime fallback code
+needs to exist**. That promise assumes the reference locale contains every used
+key.
+
+For a pack's keys it does not. A pack ships `en` and `fr`; a studio authoring in
+Portuguese sets `.reference = "pt"`; the pack's keys are in neither the game's
+`pt` nor anywhere the project reference can see. There is nothing to backfill
+from and the table cannot be made rectangular.
+
+So `pack.labelle` declares its own `.reference`, and backfill resolves:
+
+```
+locale → pack reference → project reference
+```
+
+A `pt` player then reads the pack's English for strings nobody has translated
+yet, which is the right outcome, and the no-runtime-failure guarantee survives
+contact with a pack the game does not control. A pack that declares no
+`.reference` falls back to the project's, which is correct for in-tree packs
+authored alongside the game.
+
 ### 3. Key generation — the part Rails structurally cannot do
 
 The assembler scans `locales/`, reads the **reference locale** from `project.labelle` (§8), and generates a key type plus a string table.
@@ -144,7 +209,7 @@ So: **comptime enforces, the assembler advises.** Strict flips the policy from (
 
 The soundness of (b) rests on the closed key space — worth stating its one hole plainly: `@enumFromInt` can forge a `Key` that no `K.` path names, which would evade the scan. That is pathological, has no legitimate use, and is out of contract.
 
-**No runtime fallback logic is needed either way.** When a locale is missing a used key, codegen fills that table slot with the **reference locale's string**. The table is always rectangular and always complete, so §5's guarantee holds unchanged — the warning tells you a slot was backfilled, and the game renders reference-language text there rather than a blank or a `translation missing` marker.
+**No runtime fallback logic is needed either way.** When a locale is missing a used key, codegen fills that table slot with the **reference locale's string** — the pack's own reference for a `<pack>__` key, the project's otherwise (§2.2). The table is always rectangular and always complete, so §5's guarantee holds unchanged — the warning tells you a slot was backfilled, and the game renders reference-language text there rather than a blank or a `translation missing` marker.
 
 ### 4. Interpolation and argument checking
 
@@ -226,7 +291,7 @@ OS detection is deliberately absent (see Non-goals). If it lands later it slots 
 |---|---|
 | 1 | `locales/` scan, key codegen, static `t()`, usage-aware coverage diagnostics (§3.1), `setLocale` |
 | 2 | Interpolation: `tf()`, per-key `Args`, frame arena, placeholder-parity validation |
-| 3 | Pack-scoped locales (`packs/<name>/locales/`, `<pack>__` namespacing) |
+| 3 | Pack-scoped locales (`packs/<name>/locales/`, `<pack>__` namespacing), game override/add precedence and the must-exist check (§2.1), per-pack `.reference` (§2.2) |
 | 4 | Plurals — CLDR categories (`zero`/`one`/`two`/`few`/`many`/`other`) as a nested key convention with per-locale category sets |
 
 Phase 1 alone converts the FP menu and is independently useful.
@@ -236,7 +301,7 @@ Phase 1 alone converts the FP menu and is independently useful.
 1. **Frame arena ownership.** Engine-owned and reset in the frame loop, or game-owned and passed in? Engine-owned is less ceremony but puts an allocator in the i18n module that single-language games never touch.
 2. ~~**Strict by default?**~~ **Resolved** (§3 / §3.1): default is a *warning*, scoped to keys actually used in code; `i18n.strict = true` promotes it to a comptime error for release builds. Unused untranslated keys are silent. Remaining sub-question: should `strict` also be settable per-locale, so a game can ship `pt-BR` strictly while `fr` is still in progress?
 3. **Key type stability.** `@enumFromInt` indices are assigned by scan order. Reordering a locale file must not silently change what a key means — sort keys deterministically before assigning, and confirm nothing persists a `Key` value to disk.
-4. **Pack key collisions.** Two packs both defining `ui.title` namespace to `a__ui.title` / `b__ui.title` — but should a *game* be able to override a pack's string without forking the pack?
+4. ~~**Pack key collisions.**~~ **Resolved** (§2.1): two packs both defining `ui.title` namespace to `a__ui.title` / `b__ui.title`. And yes — a game overrides a pack's string without forking it, and may add locales the pack never shipped. The game takes precedence.
 5. **Binary-size ceiling** for strategy (a). At what locale count does baking everything stop being obviously right?
 6. **Font coverage interaction.** A locale needing glyphs outside the baked atlas renders blanks. Should the assembler cross-check locale codepoints against `FontBakeParams.ranges` (RFC-FONT-LOADER §2) and fail the build? That would be a genuinely novel check — and cheap, since both are build-time data.
 

--- a/RFC-I18N.md
+++ b/RFC-I18N.md
@@ -1,0 +1,254 @@
+# RFC: Internationalisation — locale files with comptime-checked keys
+
+**Status:** Draft
+**Author:** Alexandre
+**Date:** 2026-08-06
+**Tracking issue:** _(filed with this RFC — see below)_
+
+## Problem
+
+Games hardcode every user-visible string as a Zig literal. From `flying-platform-labelle/scripts/menu/menu_ui.zig`:
+
+```zig
+if (ui.button("New Game", BUTTON_WIDTH, BUTTON_HEIGHT, .accent)) { … }
+if (ui.button("Load Game", BUTTON_WIDTH, BUTTON_HEIGHT, .normal)) { … }
+```
+
+There is no way to ship a second language short of editing source and rebuilding a separate binary. Nothing in `labelle-core`, `labelle-engine`, `labelle-gui`, or `labelle-cli` mentions locales, translation, or i18n today — this is a clean slate.
+
+Rails is the reference point: one YAML file per locale, nested keys, `t("menu.new_game")`, interpolation. That shape is right. The *syntax* is not the transferable part, and neither is the runtime failure mode — Rails discovers a typo'd key as `translation missing: en.menu.new_game` rendered in front of a user, because nothing validates keys until the lookup happens.
+
+labelle's assembler already generates code at build time. That means the entire class of missing-key and wrong-argument bugs can be a **compile error** instead. That, not the file format, is the reason to build this rather than have each game roll its own string table.
+
+## Goals
+
+1. **One file per locale, convention-scanned.** A `locales/` directory at project root; no registry to keep in sync — the same rule `scripts/` already uses.
+2. **Nested keys with dotted access**, so keys group by screen/domain the way Rails' do.
+3. **A misspelled key does not compile. An untranslated key that is actually rendered warns.** Those are different failures and deserve different severities: a typo is always a bug, whereas a string the reference locale has and `fr` does not is routine mid-feature — unless something on screen draws it. Coverage diagnostics are therefore scoped to keys the game genuinely uses (§3.1).
+4. **Interpolation with comptime-checked arguments.** Passing the wrong placeholder name, or omitting one, is a compile error.
+5. **Runtime locale switching** without a restart — the Options menu is the motivating consumer.
+6. **Zero added cost for single-language games.** A game with one locale should pay nothing beyond the string table it would have written by hand.
+
+## Non-goals
+
+- **RTL / bidi layout and complex-script shaping.** Arabic and Indic text need shaping, which is a renderer concern — see RFC-FONT-LOADER §Non-goals, which defers shaping for the same reason. i18n produces *strings*; glyph coverage and layout are the font/renderer layer's problem. A game can ship a `he` locale today and get wrong-direction text; that is a font-stack gap, not an i18n gap.
+- **Locale-aware number, date, and currency formatting.** Separate concern with a much larger surface (CLDR data tables). A game that needs it can format before interpolating.
+- **Translator tooling.** No `.po`/`.xliff` import-export, no web editor, no machine-translation hook. Locale files are hand-edited JSONC.
+- **OS locale auto-detection.** Platform-specific (`CFLocale`, `GetUserDefaultLocaleName`, `LANG`) and best added once one game actually wants it. Startup locale comes from config or env — see §8.
+- **Per-entity or data-driven translation.** Item and workstation display names living in prefab `.jsonc` files are a plausible follow-up, but phase 1 covers UI strings written in scripts only.
+
+## Design
+
+### 1. Format: JSONC, not YAML
+
+labelle already parses JSONC for scenes and prefabs, and the runtime-scenes work extends that. Adding YAML would mean a second config dialect and a new parser dependency for one feature. Rails chose YAML because Rails is YAML-shaped; the transferable idea is one-file-per-locale with nested keys, which JSONC expresses just as well — and comments in locale files are genuinely useful for translator notes.
+
+```jsonc
+// locales/pt-BR.jsonc
+{
+  "menu": {
+    "new_game": "Novo Jogo",
+    "load_game": "Carregar Jogo",
+    "options": "Opções",
+    "exit": "Sair",
+  },
+  "hud": {
+    // {count} and {max} must match en.jsonc — the build checks this.
+    "stock": "{count} de {max}",
+  },
+}
+```
+
+### 2. Directory convention
+
+```
+locales/
+  en.jsonc
+  pt-BR.jsonc
+```
+
+Flat, not recursive. Filename is the BCP-47 tag and the only place a locale is declared — adding `fr.jsonc` adds French, deleting it removes it.
+
+**Packs ship their own.** `packs/<name>/locales/*.jsonc` is scanned too, with keys namespaced `<pack>__` exactly as pack components, scripts, and prefabs already are. A pack stays self-contained and drop-in.
+
+### 3. Key generation — the part Rails structurally cannot do
+
+The assembler scans `locales/`, reads the **reference locale** from `project.labelle` (§8), and generates a key type plus a string table.
+
+Naïvely flattening `menu.new_game` to `menu_new_game` collides: `a.b_c` and `a_b.c` produce the same identifier. Instead, generate nested namespaces of typed constants, which preserves the dotted call site *and* the tree:
+
+```zig
+// generated
+pub const Key = enum(u16) { _ };
+pub const K = struct {
+    pub const menu = struct {
+        pub const new_game: Key = @enumFromInt(0);
+        pub const load_game: Key = @enumFromInt(1);
+    };
+    pub const hud = struct {
+        pub const stock: Key = @enumFromInt(7);
+    };
+};
+```
+
+Call site:
+
+```zig
+if (ui.button(t(K.menu.new_game), BUTTON_WIDTH, BUTTON_HEIGHT, .accent)) { … }
+```
+
+`K.menu.new_gme` is a compile error at the point of use, naming the missing declaration. No lookup, no fallback, no runtime string comparison.
+
+**Build-time validation**, run by the assembler after the scan:
+
+| Condition | Result |
+|---|---|
+| Key **used in code**, present in reference, missing from locale *L* | **Warning**, naming the key and every locale missing it |
+| Key **unused**, missing from locale *L* | Silent (reported only under `--verbose`) |
+| Key in *L*, absent from reference | **Build error** — catches renames that updated one file only |
+| Placeholder set differs between reference and *L* | **Build error**, showing both placeholder sets |
+| `locales/` exists, no `i18n.default` declared | **Build error** (§8) |
+| `i18n.default` / `.reference` names a locale with no file | **Build error**, with "did you mean" against scanned tags |
+
+The first two rows are the important ones, and §3.1 is why they can be split at all.
+
+`i18n.strict = true` in `project.labelle` promotes row 1 to a hard error — the setting a release build turns on. Default is warn, because a key that no locale but the reference has yet is the *normal* state while a feature is being written, and blocking the build on it would make adding a string to `en.jsonc` an immediate cross-locale chore.
+
+### 3.1 Usage-aware diagnostics — why this works here and not in Rails
+
+A key sitting in `en.jsonc` that no locale translates and **no code renders** is dead weight, not a defect. A key that some screen actually draws and only the reference locale defines is a user-visible hole. Rails cannot tell these apart, because its keys are runtime strings and may be computed:
+
+```ruby
+t("menu.#{action}_label")   # what key is this? unknowable without running it
+```
+
+Static usage analysis of a Rails app is therefore unsound, so Rails checks nothing until lookup. labelle's key space is **closed and syntactically visible**: a `Key` can only be named as a `K.<path>` constant, it cannot be built from a runtime string, and there is no `t(comptime_string)` overload to leave one. That makes "which keys does this game actually use" a decidable, cheap build-time question — and it is the reason the warning above can be scoped to keys that matter.
+
+Two enforcement points, because they have different powers:
+
+**(a) Call site, at comptime — errors only.** `t` takes `comptime key: Key`, so it instantiates *only* for keys the game actually references. A coverage check inside it is usage-driven by construction, with no scan at all:
+
+```zig
+pub fn t(comptime key: Key) [:0]const u8 {
+    comptime if (strict and missing_in(key).len > 0)
+        @compileError("i18n: key '" ++ name(key) ++ "' missing from: " ++ missing_in_list(key));
+    return table[active][@intFromEnum(key)];
+}
+```
+
+The diagnostic lands on the exact line that would have rendered the missing string — better than any report a scanner can produce. But this path can only *fail*: Zig has no comptime warning. `@compileLog` is not one — it prints its values and then ends the build with `error: found compile log statement` (verified on 0.16.0). So comptime alone cannot express the default policy.
+
+**(b) Assembler, at build time — warnings.** The assembler already scans game and pack sources to discover scripts. The same pass collects `K.<path>` references into a used-set and diffs it against each locale, printing warnings for row 1. This is where the non-strict default lives.
+
+So: **comptime enforces, the assembler advises.** Strict flips the policy from (b) to (a).
+
+The soundness of (b) rests on the closed key space — worth stating its one hole plainly: `@enumFromInt` can forge a `Key` that no `K.` path names, which would evade the scan. That is pathological, has no legitimate use, and is out of contract.
+
+**No runtime fallback logic is needed either way.** When a locale is missing a used key, codegen fills that table slot with the **reference locale's string**. The table is always rectangular and always complete, so §5's guarantee holds unchanged — the warning tells you a slot was backfilled, and the game renders reference-language text there rather than a blank or a `translation missing` marker.
+
+### 4. Interpolation and argument checking
+
+Placeholders are `{name}`. Because codegen knows each key's placeholder set, it can generate a per-key argument type:
+
+```zig
+pub fn Args(comptime key: Key) type;   // generated: anonymous struct with exactly that key's placeholders
+pub fn tf(comptime key: Key, args: Args(key)) [:0]const u8;
+```
+
+```zig
+tf(K.hud.stock, .{ .count = 5, .max = 10 })   // ok
+tf(K.hud.stock, .{ .count = 5 })              // compile error: missing field 'max'
+tf(K.hud.stock, .{ .cnt = 5, .max = 10 })     // compile error: no field 'cnt'
+```
+
+**Two functions, because the costs genuinely differ:**
+
+- `t(key)` — no placeholders. Returns `[:0]const u8` straight out of the static table. No allocation, no formatting, and the sentinel means it hands directly to cimgui.
+- `tf(key, args)` — has placeholders. Must format into a buffer.
+
+Splitting them keeps the zero-cost path honest instead of hiding an allocation behind a uniform API. Codegen knows which keys have placeholders, so calling `t` on an interpolated key is itself a compile error.
+
+`tf`'s buffer comes from a **frame arena** reset once per frame. UI strings are per-frame and short-lived; an arena avoids both a per-call allocation and any free discipline at the call site. The returned slice is valid until the next frame — documented, and the reason `tf` results must never be stored in a component. (Ownership is Open Question 1.)
+
+### 5. Storage and runtime switching
+
+Two options, and they trade the same way everywhere:
+
+**(a) Bake every locale into the binary** as a comptime `[n_locales][n_keys][:0]const u8` table. Switching swaps an index. No I/O, no allocation, no failure path, instant.
+
+**(b) Bake only the reference**, load others from disk on switch. Smaller binary, but reintroduces a runtime failure path — a missing or malformed file at switch time — which is exactly the property §3 buys.
+
+**Recommend (a) for the first cut.** UI text is a few KB per locale, negligible next to art. It also preserves the strongest guarantee in this RFC: with the table made rectangular at build time (§3.1 — gaps backfilled with the reference string) and every locale resident, **no runtime path can fail and no fallback code needs to exist**. Revisit if a game ships enough locales for binary size to matter (Open Question 5).
+
+```zig
+pub fn setLocale(tag: []const u8) bool;   // false = unknown tag, active locale unchanged
+pub fn activeLocale() []const u8;
+pub fn locales() []const []const u8;      // for building the Options selector
+```
+
+### 6. No comptime interface slot
+
+Render, audio, and input are interface slots in `labelle-core` because each has multiple backends. i18n has **no backend variability** — it is pure data plus generated lookup. So it does not get an interface slot; the assembler injects a generated `i18n` module the way it already injects `gui_backend`, and scripts reach it with `@import("i18n")`. Adding a slot here would be ceremony with one implementation behind it.
+
+### 7. Consumer: the Options menu
+
+`flying-platform-labelle`'s Options view already has the shape a language selector needs — it gained kit-styled checkbox rows in FP#779. A locale row lands next to Fullscreen and Vsync, driven by `locales()` and `setLocale()`, and the menu's own strings become the first thing converted. That makes FP the proving ground for whether the ergonomics hold.
+
+### 8. Configuration — `project.labelle` declares the default language
+
+`project.labelle` is ZON, so the block nests like the existing `.asset_compression` / `.backend_package` entries:
+
+```zig
+.i18n = .{
+    .default = "pt-BR",   // REQUIRED — the locale the game starts in
+    .reference = "en",    // optional  — the locale keys are authored in (defaults to .default)
+    .strict = false,      // optional  — promote coverage warnings to errors (§3.1)
+},
+```
+
+**`.default` is mandatory whenever `locales/` exists.** No implicit `"en"`. A game's shipping language is a deliberate product decision, not something the build should guess from a filename — and an inferred default is exactly the kind of thing that goes unnoticed until someone launches in the wrong language. A `locales/` directory with no `i18n.default` is a build error; so is a `.default` naming a locale with no matching file (with "did you mean" against the scanned tags, since a BCP-47 typo like `pt_BR` for `pt-BR` is easy).
+
+Games with no `locales/` directory declare nothing and pay nothing — the whole block is absent and codegen emits no i18n module.
+
+**Two settings, because they answer different questions.** `.default` is *what the player sees at first launch*; `.reference` is *which locale defines the canonical key set* and is the backfill source for gaps (§3.1). They coincide for most games, which is why `.reference` falls back to `.default`. They come apart when a studio authors keys in English but ships Portuguese first — then `en` is the complete, canonical set while `pt-BR` is the startup language. Folding them into one field would make that project choose between an English launch and losing its authoring language as the coverage baseline.
+
+**Startup resolution**, first match wins:
+
+1. `LABELLE_LOCALE` env var — a *dev and CI* override, matching the existing `LABELLE_*` run knobs (`LABELLE_SCENE`, `LABELLE_HEADLESS`). It makes screenshotting every locale a loop over one variable. An unknown tag here is a warning and is ignored, not a crash — it must not be able to break a player's run if it leaks into a shipped environment.
+2. A persisted player choice, once `setLocale` is wired to settings (out of scope for phase 1).
+3. `i18n.default`.
+
+OS detection is deliberately absent (see Non-goals). If it lands later it slots in above `.default` and below the player's own choice.
+
+## Phasing
+
+| Phase | Scope |
+|---|---|
+| 1 | `locales/` scan, key codegen, static `t()`, usage-aware coverage diagnostics (§3.1), `setLocale` |
+| 2 | Interpolation: `tf()`, per-key `Args`, frame arena, placeholder-parity validation |
+| 3 | Pack-scoped locales (`packs/<name>/locales/`, `<pack>__` namespacing) |
+| 4 | Plurals — CLDR categories (`zero`/`one`/`two`/`few`/`many`/`other`) as a nested key convention with per-locale category sets |
+
+Phase 1 alone converts the FP menu and is independently useful.
+
+## Open questions
+
+1. **Frame arena ownership.** Engine-owned and reset in the frame loop, or game-owned and passed in? Engine-owned is less ceremony but puts an allocator in the i18n module that single-language games never touch.
+2. ~~**Strict by default?**~~ **Resolved** (§3 / §3.1): default is a *warning*, scoped to keys actually used in code; `i18n.strict = true` promotes it to a comptime error for release builds. Unused untranslated keys are silent. Remaining sub-question: should `strict` also be settable per-locale, so a game can ship `pt-BR` strictly while `fr` is still in progress?
+3. **Key type stability.** `@enumFromInt` indices are assigned by scan order. Reordering a locale file must not silently change what a key means — sort keys deterministically before assigning, and confirm nothing persists a `Key` value to disk.
+4. **Pack key collisions.** Two packs both defining `ui.title` namespace to `a__ui.title` / `b__ui.title` — but should a *game* be able to override a pack's string without forking the pack?
+5. **Binary-size ceiling** for strategy (a). At what locale count does baking everything stop being obviously right?
+6. **Font coverage interaction.** A locale needing glyphs outside the baked atlas renders blanks. Should the assembler cross-check locale codepoints against `FontBakeParams.ranges` (RFC-FONT-LOADER §2) and fail the build? That would be a genuinely novel check — and cheap, since both are build-time data.
+
+## Prior art
+
+| System | Format | Key checking | Notes |
+|---|---|---|---|
+| Rails i18n | YAML | Runtime — renders `translation missing: …` | The shape this RFC borrows |
+| gettext | `.po`/`.mo` | Runtime, falls back to msgid | Mature tooling, C-oriented |
+| Unity Localization | Asset tables | Runtime (editor warns) | GUI-driven table editing |
+| Mozilla Fluent | `.ftl` | Runtime | Richest grammar (genders, plurals as first-class) |
+
+All four check keys at runtime, because all four load translations at runtime. labelle's build already generates the game's wiring, so it can check at compile time instead — that is the one thing this design does that none of the prior art can.
+
+The sharper distinction is §3.1. Every system above can report "locale *L* is missing key *k*"; none can reliably answer "…and is *k* actually rendered anywhere?", because in all four the key space is open — keys are strings assembled at runtime. labelle's keys are comptime symbols from a closed set, which turns coverage from a list you skim into a diagnostic that only fires on holes a player could see.

--- a/RFC-I18N.md
+++ b/RFC-I18N.md
@@ -220,7 +220,7 @@ The diagnostic lands on the exact line that would have rendered the missing stri
 
 So: **comptime enforces, the assembler advises.** Strict flips the policy from (b) to (a).
 
-The soundness of (b) rests on the closed key space — worth stating its one hole plainly: `@enumFromInt` can forge a `Key` that no `K.` path names, which would evade the scan. That is pathological, has no legitimate use, and is out of contract.
+The soundness of (b) rests on the closed key space — worth stating its two holes plainly. `@enumFromInt` can forge a `Key` that no `K.` path names; that is pathological, has no legitimate use, and is out of contract. **Namespace aliasing is not**: `const S = K.settings;` then `t(S.volume)` is ordinary Zig that a textual `K.<path>` scan misses, silently suppressing exactly the missing-translation warning this section exists to give. Ruled: **conservative alias widening** — the scanner detects `= K`-rooted aliases and marks the aliased subtree used. No warning is wrongly suppressed; the cost is precision (an aliased subtree's unused keys go unreported). The comptime path (a) is unaffected either way, since `t` instantiates per real key regardless of how it was spelled. Same ruling for RFC-CONSTANTS `C` (its §5).
 
 **No runtime fallback logic is needed either way.** When a locale is missing a used key, codegen fills that table slot with the **reference locale's string** — the pack's own reference for a `<pack>__` key, the project's otherwise (§2.2). The table is always rectangular and always complete, so §5's guarantee holds unchanged — the warning tells you a slot was backfilled, and the game renders reference-language text there rather than a blank or a `translation missing` marker.
 

--- a/RFC-I18N.md
+++ b/RFC-I18N.md
@@ -77,7 +77,7 @@ A pack ships the languages its author had. A game shipping to a market the pack
 never considered cannot be made to fork it, so:
 
 - **The game overrides.** A `<pack>__` key defined in the game's `locales/` wins
-  over the pack's. Same for constants (RFC-CONSTANTS §5.1).
+  over the pack's. Same for constants (RFC-CONSTANTS §1.1).
 - **The game adds.** A pack shipping `en` and `fr` does not stop a game adding
   `pt`. The game writes the pack's keys into its own `pt.jsonc`.
 


### PR DESCRIPTION
Two sibling RFCs, no code. Tracked by #809 (i18n) and #810 (constants).

## `RFC-I18N.md` (#809)

Locale files with **comptime-checked keys**. Borrows Rails' shape — one file per locale, nested keys, interpolation — but not YAML, since labelle already parses JSONC for scenes and prefabs.

The part Rails structurally cannot do: its keys are runtime strings and may be computed (`t("menu.#{action}_label")`), so static usage analysis is unsound and every check defers to lookup, rendering `translation missing: …` at a player. labelle's key space is closed and syntactically visible — a `Key` is only nameable as a `K.<path>` constant — which makes coverage decidable at build time.

So diagnostics are **usage-aware**: a key used in code and missing from a locale warns; an unused one is silent. `i18n.strict` promotes it to a comptime error for release builds. Comptime enforces, the assembler advises — Zig has no comptime warning, and `@compileLog` is not one (it ends the build with `error: found compile log statement`, verified on 0.16.0).

`project.labelle` must declare `.default` — no implicit `"en"`. `.reference` (authoring locale, backfill source for gaps) is separate and defaults to it.

## `RFC-CONSTANTS.md` (#810)

`constants/` at project root, one YAML file per domain. Motivated by concrete drift in `flying-platform-labelle`: **38 tuning constants across 17 files**, five construction timings spread over four files with four sharing the value `5.0` and nothing recording whether that is intent, `SHIP_SPEED` defined twice with different values, and decay rates in a plugin's `config.zig` holding the `health_drain_rate = 0.0` that the game's CLAUDE.md spends four paragraphs warning about.

Comptime-only, but **not** via `@embedFile` + comptime parse — YAML is far too large a grammar and a comptime parser cannot call a C library. The assembler parses natively and emits Zig, so the YAML dependency is the assembler's rather than the game's, and values are emitted untyped and coerce at the use site.

Strict scalar policy, because YAML's implicit typing fails silently in exactly this kind of file (`enabled: no` → `false`, `delay: 12:30` → `750`, `id: 0755` → `493`).

## Why together

Both are the same shape: *scan a convention-named folder → generate nested namespaces of comptime-checked accessors → warn on entries nothing uses*. They should share one assembler pass parameterised by root symbol (`K.` / `C.`) rather than growing two near-identical implementations. They differ in one respect only: locales need a runtime-selectable table because the active language changes while the game runs; constants resolve to a single value at build time.

Open questions are listed at the end of each RFC — the load-bearing ones are which YAML library (the assembler has none today), and where the constants/prefab-data boundary sits.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-engine/pr/811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788659975&installation_model_id=427192&pr_number=811&repository=labelle-toolkit%2Flabelle-engine&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-engine%2Fpull%2F811&signature=4a0d7498d3e45d6c3262d9db88cad8e7a8bb4eb897178a123bb51815ec7a778d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->