### PR TITLE
feat: frame-boundary hook — the i18n resetFrameArena splice point

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -130,6 +130,10 @@ pub fn build(b: *std.Build) void {
         "test/sprite_by_field_tick_test.zig",
         "test/scene_assets_hooks_test.zig",
         "test/pause_hook_test.zig",
+        // RFC-I18N §4 — frame-boundary hook: the generated main wires the
+        // i18n module's `resetFrameArena` into the top of `tick` (every
+        // frame, paused included) via `setFrameBoundaryFn`.
+        "test/frame_boundary_test.zig",
         "test/fixed_timestep_test.zig",
         // #578 — `pub const Events` on the engine, dual-emit through
         // the buffered event path so flows can listen to lifecycle

--- a/src/editor_api.zig
+++ b/src/editor_api.zig
@@ -165,6 +165,20 @@ pub fn shouldTick() bool {
 /// A no-op when neither is active, and a comptime no-op for games whose
 /// renderer has no camera (or no `Camera` seed path).
 pub fn frame(g: anytype) void {
+    // Frame boundary on TICK-SKIPPED frames (RFC-I18N §4; codex on #812):
+    // a paused preview still runs this pass and `g.render()`, and editor-
+    // drawn translated UI produces `tf()` results on those frames too —
+    // without a reset here the arena's once-per-frame lifetime breaks on
+    // exactly the pause the editor lives in. Ticked frames (unpaused, or a
+    // consumed `editor_step`) already fired it first-thing in `tick()`, and
+    // firing twice would free that frame's strings before render reads them.
+    // `@hasField`-gated like the camera paths below: editor_api's tests
+    // (and any embedder) may drive `frame` with a reduced game fixture.
+    if (comptime @hasField(@TypeOf(g.*), "frame_boundary_fn")) {
+        if (editor_paused and !stepped_this_frame) {
+            if (g.frame_boundary_fn) |frame_boundary_fn| frame_boundary_fn();
+        }
+    }
     if (editor_paused and camera_override == null and !stepped_this_frame) applyCameraComponentTo(g);
     if (camera_override) |c| applyCameraTo(g, c);
 }

--- a/src/game.zig
+++ b/src/game.zig
@@ -763,6 +763,24 @@ pub fn GameConfigWithYAxis(
 
         gizmo_reconcile_fn: ?*const fn (*Self) void = null,
 
+        /// Frame-boundary callback (RFC-I18N §4 / Open Question 1). Fired at
+        /// the very TOP of `tick()` — before the pause gate, so it runs
+        /// exactly once per frame on EVERY frame, paused ones included (a
+        /// pause menu still renders `tf()` text). This is the splice point
+        /// for per-frame resets owned by assembler-generated modules: the
+        /// generated `main.zig` wires the i18n module's frame arena with
+        /// `game.setFrameBoundaryFn(i18n.resetFrameArena)` so `tf()` results
+        /// get the documented "valid for the current frame" lifetime.
+        ///
+        /// Deliberately a SINGLE `fn () void` slot, not a registry: the only
+        /// registrant is generated code, which has one author (the
+        /// assembler) and can compose multiple per-frame resets into one
+        /// generated function if a second concern ever appears. Same
+        /// generated-code splice idiom as `gizmo_reconcile_fn` /
+        /// `spawn_prefab_fn` above. `null` (the default) costs one branch
+        /// per frame — zero-cost for games without i18n.
+        frame_boundary_fn: ?*const fn () void = null,
+
         // Prefab spawning — set by JSONC scene bridge during loadScene.
         prefab_dir: ?[]const u8 = null,
         spawn_prefab_fn: ?*const fn (*Self, []const u8, Position) ?Entity = null,
@@ -1434,6 +1452,10 @@ pub fn GameConfigWithYAxis(
         // fullscreen flag — the generated `main.zig` drains
         // `takeFullscreenRequest()` and forwards it to the window backend,
         // keeping the library backend-agnostic.
+        // Frame-boundary hook (RFC-I18N §4): the generated main wires
+        // per-frame module resets (i18n frame arena) through this; fired
+        // at the top of every `tick`, paused frames included.
+        pub const setFrameBoundaryFn = LifecycleMixin.setFrameBoundaryFn;
         pub const quit = LifecycleMixin.quit;
         pub const isRunning = LifecycleMixin.isRunning;
         pub const setFullscreen = LifecycleMixin.setFullscreen;

--- a/src/game/lifecycle_mixin.zig
+++ b/src/game/lifecycle_mixin.zig
@@ -183,6 +183,17 @@ pub fn Mixin(comptime Game: type) type {
 
         // ── Game Loop ─────────────────────────────────────────────
 
+        /// Register (or clear, with `null`) the frame-boundary callback —
+        /// fired at the very top of `tick()`, before the pause gate, once
+        /// per frame on every frame. The splice point for per-frame resets
+        /// owned by assembler-generated modules; the canonical registrant is
+        /// the generated `main.zig` wiring the i18n module's
+        /// `resetFrameArena` (RFC-I18N §4). See the `frame_boundary_fn`
+        /// field doc in `game.zig` for why this is a single slot.
+        pub fn setFrameBoundaryFn(self: *Game, callback: ?*const fn () void) void {
+            self.frame_boundary_fn = callback;
+        }
+
         pub fn quit(self: *Game) void {
             self.running = false;
         }

--- a/src/game/loop_mixin.zig
+++ b/src/game/loop_mixin.zig
@@ -23,6 +23,18 @@ pub fn Mixin(comptime Game: type) type {
 
     return struct {
         pub fn tick(self: *Game, dt: f32) void {
+            // Frame boundary (RFC-I18N §4). First thing in the frame, BEFORE
+            // the pause gate below, so it fires exactly once per frame on
+            // every frame — a paused game still renders translated UI, and
+            // the i18n frame arena's "results live for the current frame"
+            // contract has to hold there too. Runs before anything that
+            // could produce a `tf()` result this frame (scripts, GUI, and
+            // the post-`tick` render all come later in the frame). `null`
+            // (no generated module registered) is a single branch.
+            if (self.frame_boundary_fn) |frame_boundary_fn| {
+                frame_boundary_fn();
+            }
+
             // FPS / frame-time tracking for the debug inspector (#380).
             // Record the REAL (unscaled) dt every frame — including paused
             // frames that early-return below — so the inspector's FPS

--- a/src/game/loop_mixin.zig
+++ b/src/game/loop_mixin.zig
@@ -31,6 +31,11 @@ pub fn Mixin(comptime Game: type) type {
             // could produce a `tf()` result this frame (scripts, GUI, and
             // the post-`tick` render all come later in the frame). `null`
             // (no generated module registered) is a single branch.
+            //
+            // Studio preview is the one loop that renders frames WITHOUT
+            // ticking (paused, no pending step) — `editor_api.frame`
+            // fires the boundary for those frames, gated so a ticked
+            // frame never fires twice.
             if (self.frame_boundary_fn) |frame_boundary_fn| {
                 frame_boundary_fn();
             }

--- a/test/frame_boundary_test.zig
+++ b/test/frame_boundary_test.zig
@@ -142,3 +142,32 @@ test "generated-main wiring shape: i18n.resetFrameArena through the hook" {
     game.tick(0.016);
     try testing.expectEqual(@as(usize, 0), mock_i18n.frame_len);
 }
+
+test "preview: a paused, tick-skipped frame still fires the boundary via editor_api.frame (codex on #812)" {
+    boundary_count = 0;
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+    game.setFrameBoundaryFn(countBoundary);
+
+    const editor_api = engine.editor_api;
+    editor_api.editor_pause(1);
+    defer editor_api.editor_pause(0);
+
+    // Paused, no pending step: the generated preview loop skips g.tick()
+    // but still runs editor_api.frame + g.render — the boundary must come
+    // from frame() on those frames.
+    try testing.expect(!editor_api.shouldTick());
+    editor_api.frame(&game);
+    try testing.expectEqual(@as(usize, 1), boundary_count);
+    try testing.expect(!editor_api.shouldTick());
+    editor_api.frame(&game);
+    try testing.expectEqual(@as(usize, 2), boundary_count);
+
+    // A stepped frame ticks: tick() fires the boundary, frame() must NOT
+    // fire it again (double reset would free the frame's strings).
+    editor_api.editor_step(1);
+    try testing.expect(editor_api.shouldTick());
+    game.tick(0.016);
+    editor_api.frame(&game);
+    try testing.expectEqual(@as(usize, 3), boundary_count);
+}

--- a/test/frame_boundary_test.zig
+++ b/test/frame_boundary_test.zig
@@ -170,4 +170,11 @@ test "preview: a paused, tick-skipped frame still fires the boundary via editor_
     game.tick(0.016);
     editor_api.frame(&game);
     try testing.expectEqual(@as(usize, 3), boundary_count);
+
+    // Clear ALL editor module state, not just the pause flag: the deferred
+    // editor_pause(0) discards pending steps, but `stepped_this_frame`
+    // stays true until the next unpaused shouldTick() — run one here so a
+    // later test in this binary starts from the module's resting state.
+    editor_api.editor_pause(0);
+    try testing.expect(editor_api.shouldTick());
 }

--- a/test/frame_boundary_test.zig
+++ b/test/frame_boundary_test.zig
@@ -1,0 +1,144 @@
+/// Tests for the frame-boundary hook (RFC-I18N §4 / Open Question 1).
+///
+/// `Game.setFrameBoundaryFn` registers a `fn () void` fired at the very
+/// top of `tick()` — before the pause gate — so it runs exactly once per
+/// frame on every frame, paused ones included. It is the splice point the
+/// assembler-generated `main.zig` uses to wire the generated i18n module's
+/// `resetFrameArena` (the `tf()` ring buffer's "results live for the
+/// current frame" contract).
+
+const std = @import("std");
+const testing = std.testing;
+const engine = @import("engine");
+
+const game_mod = engine.game_mod;
+
+// ── Callback counter ────────────────────────────────────────────────────
+// The hook is a bare `fn () void` (matching the generated i18n module's
+// `resetFrameArena` signature), so the test observes it through a
+// file-scope counter rather than a captured context.
+
+var boundary_count: usize = 0;
+
+fn countBoundary() void {
+    boundary_count += 1;
+}
+
+// ── Mock generated i18n module ──────────────────────────────────────────
+// The exact shape the assembler generates: a module-owned buffer cursor
+// plus a `resetFrameArena` that rewinds it. Wiring it through the hook is
+// the whole integration.
+
+const mock_i18n = struct {
+    var frame_len: usize = 0;
+
+    pub fn resetFrameArena() void {
+        frame_len = 0;
+    }
+};
+
+// ── Hook recorder (ordering) ────────────────────────────────────────────
+
+const FrameStartRecorder = struct {
+    /// `boundary_count` snapshot taken inside the `frame_start` hook.
+    seen_at_frame_start: ?usize = null,
+    game_ptr: ?*anyopaque = null,
+
+    pub fn frame_start(self: *FrameStartRecorder, info: anytype) void {
+        _ = info;
+        self.seen_at_frame_start = boundary_count;
+    }
+};
+
+const Game = game_mod.Game;
+const HookedGame = game_mod.GameWith(*FrameStartRecorder);
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+test "no callback registered — tick runs and the slot stays null" {
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    try testing.expect(game.frame_boundary_fn == null);
+    game.tick(0.016); // must not crash on the null slot
+    try testing.expectEqual(@as(u64, 1), game.frame_number);
+}
+
+test "callback fires exactly once per tick" {
+    boundary_count = 0;
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    game.setFrameBoundaryFn(countBoundary);
+
+    game.tick(0.016);
+    try testing.expectEqual(@as(usize, 1), boundary_count);
+    game.tick(0.016);
+    game.tick(0.016);
+    try testing.expectEqual(@as(usize, 3), boundary_count);
+}
+
+test "callback fires on paused frames too" {
+    // The pause gate early-returns out of `tick` before scripts run, but
+    // a paused game still renders translated UI (the pause menu is the
+    // i18n-heaviest screen) — the boundary must fire there as well.
+    boundary_count = 0;
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    game.setFrameBoundaryFn(countBoundary);
+
+    game.setPaused(true); // paused flag path (#465), time_scale stays 1.0
+    game.tick(0.016);
+    try testing.expectEqual(@as(usize, 1), boundary_count);
+
+    game.setPaused(false);
+    game.pause(); // time_scale == 0 path
+    game.tick(0.016);
+    try testing.expectEqual(@as(usize, 2), boundary_count);
+}
+
+test "callback runs before the frame_start hook" {
+    // The boundary is the FIRST thing in `tick`, so by the time the
+    // `frame_start` lifecycle hook fires the reset has already happened —
+    // no `tf()` result produced this frame can predate it.
+    boundary_count = 0;
+    var recorder = FrameStartRecorder{};
+
+    var game = HookedGame.init(testing.allocator);
+    defer game.deinit();
+    game.setHooks(&recorder);
+    game.setFrameBoundaryFn(countBoundary);
+
+    game.tick(0.016);
+
+    // frame_start saw the boundary already counted for this frame.
+    try testing.expectEqual(@as(usize, 1), recorder.seen_at_frame_start.?);
+}
+
+test "setFrameBoundaryFn(null) clears the slot" {
+    boundary_count = 0;
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    game.setFrameBoundaryFn(countBoundary);
+    game.tick(0.016);
+    try testing.expectEqual(@as(usize, 1), boundary_count);
+
+    game.setFrameBoundaryFn(null);
+    game.tick(0.016);
+    try testing.expectEqual(@as(usize, 1), boundary_count); // unchanged
+}
+
+test "generated-main wiring shape: i18n.resetFrameArena through the hook" {
+    // Exactly what the assembler emits:
+    //   game.setFrameBoundaryFn(i18n.resetFrameArena);
+    var game = Game.init(testing.allocator);
+    defer game.deinit();
+
+    game.setFrameBoundaryFn(mock_i18n.resetFrameArena);
+
+    mock_i18n.frame_len = 12345; // pretend tf() filled the ring last frame
+    game.tick(0.016);
+    try testing.expectEqual(@as(usize, 0), mock_i18n.frame_len);
+}


### PR DESCRIPTION
## What

Adds the engine-side splice point RFC-I18N §4 needs: a frame-boundary hook the assembler-generated `main.zig` uses to reset the generated i18n module's `tf()` frame arena once per frame.

- `Game.frame_boundary_fn: ?*const fn () void = null` — new field
- `Game.setFrameBoundaryFn(callback)` — registration (lifecycle mixin)
- Invoked as the **first** thing in `tick()`, **before the pause gate**, so it fires exactly once per frame on every frame — paused ones included (the pause menu is the i18n-heaviest screen, so the "tf() results live for the current frame" contract must hold there too)
- `test/frame_boundary_test.zig` — fires once per tick, fires on both pause paths (`paused` flag and `time_scale == 0`), runs before the `frame_start` hook, null slot is safe/clearable, plus the exact generated-main wiring shape against a mock i18n module

The generated main will wire it with one line:

```zig
game.setFrameBoundaryFn(i18n.resetFrameArena);
```

## Why this mechanism

Matches the engine's established generated-code splice idiom — a nullable function-pointer field set at startup (`gizmo_reconcile_fn`, `spawn_prefab_fn`, `active_scene_update_fn`) — rather than inventing a registry. Two alternatives were rejected:

- **The `frame_start` hook payload**: fires only on *unpaused* frames (wrong lifetime for a pause menu rendering translated text) and routes through the game's script-hook receivers — dispatcher ceremony for a fixed, engine-known concern.
- **A callback list**: the only registrant is generated code with a single author (the assembler), which can compose multiple per-frame resets into one generated function if a second concern ever appears. A single `fn () void` slot — signature-identical to the generated `resetFrameArena` — keeps the wiring to one line and the cost for games without i18n to one branch per frame (RFC Goal 6).

RFC-I18N's frame-arena section + Open Question 1 are updated on the RFC's own branch (#811, commit 2baf381): ownership resolves as *module-owned buffer, engine-owned reset*.

Assembler follow-up: emit the `setFrameBoundaryFn` call in the generated main when the project has a `locales/` directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pbwN1ytAa8tctZMaTMjAk

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/labelle-toolkit/codesmith/labelle-engine/pr/812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788737839&installation_model_id=427192&pr_number=812&repository=labelle-toolkit%2Flabelle-engine&return_to=https%3A%2F%2Fgithub.com%2Flabelle-toolkit%2Flabelle-engine%2Fpull%2F812&signature=5361adad2e21ff610aaee0e3d2a76e76b74307ff687ca3a0be0281948af0343e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->